### PR TITLE
Resolve nosetests conflicts in DynamicWeb report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,4 +30,4 @@ install:
 
 script:
     -  mkdir -p /home/travis/.gramps/grampsdb/
-    -  GRAMPS_RESOURCES=../gramps PYTHONPATH=../gramps nosetests3 -vv --exclude=DynamicWeb
+    -  GRAMPS_RESOURCES=../gramps PYTHONPATH=../gramps nosetests3 -vv

--- a/DynamicWeb/po/fr-local.po
+++ b/DynamicWeb/po/fr-local.po
@@ -26,16 +26,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 4.1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-05-28 21:23+0000\n"
-"PO-Revision-Date: 2015-05-28 19:15+0100\n"
-"Last-Translator: \n"
+"POT-Creation-Date: 2015-08-10 14:20+0000\n"
+"PO-Revision-Date: 2015-08-10 14:20-0000\n"
+"Last-Translator: Pierre Bélissent <pierre.belissent@gmail.com>\n"
 "Language-Team: French <traduc@traduc.org>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Lokalize 1.4\n"
+"X-Generator: Poedit 1.5.4\n"
 
 #: DynamicWeb/dynamicweb.gpr.py:15
 msgid "Dynamic Web Report"
@@ -45,286 +45,286 @@ msgstr "Rapport Web Dynamique"
 msgid "Produces dynamic web pages for the database"
 msgstr "Produit des pages web dynamiques pour la base de données"
 
-#: DynamicWeb/dynamicweb.py:241 DynamicWeb/dynamicweb.py:2273
+#: DynamicWeb/dynamicweb.py:245 DynamicWeb/dynamicweb.py:2278
 msgid "Person page"
 msgstr "Page d'individu"
 
 # L'espace finale est pour précéder le « : » codé en dur dans certains contextes.
 # /!\ vérifier double espace avec search bar "%(titre colonne)s contient"
-#: DynamicWeb/dynamicweb.py:241 DynamicWeb/dynamicweb.py:2275
+#: DynamicWeb/dynamicweb.py:245 DynamicWeb/dynamicweb.py:2280
 msgid "Person"
 msgstr "Individu "
 
-#: DynamicWeb/dynamicweb.py:242
+#: DynamicWeb/dynamicweb.py:246
 msgid "Surnames index page"
 msgstr "Page d'index des noms de famille"
 
-#: DynamicWeb/dynamicweb.py:242
+#: DynamicWeb/dynamicweb.py:246
 msgid "Surnames"
 msgstr "Noms de famille"
 
-#: DynamicWeb/dynamicweb.py:243
+#: DynamicWeb/dynamicweb.py:247
 msgid "Individuals index page"
 msgstr "Page d'index des individus"
 
-#: DynamicWeb/dynamicweb.py:243
+#: DynamicWeb/dynamicweb.py:247
 msgid "Individuals"
 msgstr "Individus"
 
-#: DynamicWeb/dynamicweb.py:244
+#: DynamicWeb/dynamicweb.py:248
 msgid "Families index page"
 msgstr "Page d'index des familles"
 
-#: DynamicWeb/dynamicweb.py:244
+#: DynamicWeb/dynamicweb.py:248
 msgid "Families"
 msgstr "Familles"
 
-#: DynamicWeb/dynamicweb.py:245
+#: DynamicWeb/dynamicweb.py:249
 msgid "Sources index page"
 msgstr "Page d'index des sources"
 
-#: DynamicWeb/dynamicweb.py:245 DynamicWeb/dynamicweb.py:2309
+#: DynamicWeb/dynamicweb.py:249 DynamicWeb/dynamicweb.py:2315
 msgid "Sources"
 msgstr "Sources"
 
-#: DynamicWeb/dynamicweb.py:246
+#: DynamicWeb/dynamicweb.py:250
 msgid "Media index page"
 msgstr "Page d'index des media"
 
-#: DynamicWeb/dynamicweb.py:246 DynamicWeb/dynamicweb.py:2261
+#: DynamicWeb/dynamicweb.py:250 DynamicWeb/dynamicweb.py:2266
 msgid "Media"
 msgstr "Media"
 
-#: DynamicWeb/dynamicweb.py:247
+#: DynamicWeb/dynamicweb.py:251
 msgid "Places index page"
 msgstr "Page d'index des lieux"
 
-#: DynamicWeb/dynamicweb.py:247
+#: DynamicWeb/dynamicweb.py:251
 msgid "Places"
 msgstr "Lieux"
 
-#: DynamicWeb/dynamicweb.py:248
+#: DynamicWeb/dynamicweb.py:252
 msgid "Addresses page"
 msgstr "Page des adresses"
 
-#: DynamicWeb/dynamicweb.py:248 DynamicWeb/dynamicweb.py:2217
+#: DynamicWeb/dynamicweb.py:252 DynamicWeb/dynamicweb.py:2222
 msgid "Addresses"
 msgstr "Adresses"
 
-#: DynamicWeb/dynamicweb.py:249
+#: DynamicWeb/dynamicweb.py:253
 msgid "Repositories index page"
 msgstr "Page d'index des dépôts"
 
-#: DynamicWeb/dynamicweb.py:249 DynamicWeb/dynamicweb.py:2289
+#: DynamicWeb/dynamicweb.py:253 DynamicWeb/dynamicweb.py:2294
 msgid "Repositories"
 msgstr "Dépôts"
 
-#: DynamicWeb/dynamicweb.py:250
+#: DynamicWeb/dynamicweb.py:254
 msgid "SVG graphical tree"
 msgstr "Arbre graphique SVG"
 
-#: DynamicWeb/dynamicweb.py:250
+#: DynamicWeb/dynamicweb.py:254
 msgid "Tree"
 msgstr "Arbre"
 
-#: DynamicWeb/dynamicweb.py:252 DynamicWeb/dynamicweb.py:3781
+#: DynamicWeb/dynamicweb.py:256 DynamicWeb/dynamicweb.py:3815
 #, python-format
 msgid "Custom page %(index)i"
 msgstr "Page personnalisée %(index)i"
 
-#: DynamicWeb/dynamicweb.py:252
+#: DynamicWeb/dynamicweb.py:256
 msgid "Custom"
 msgstr "Personnalisé"
 
-#: DynamicWeb/dynamicweb.py:271
+#: DynamicWeb/dynamicweb.py:275
 msgid "Ascending tree"
 msgstr "Arbre ascendant"
 
-#: DynamicWeb/dynamicweb.py:272
+#: DynamicWeb/dynamicweb.py:276
 msgid "Descending tree"
 msgstr "Arbre descendant"
 
-#: DynamicWeb/dynamicweb.py:273
+#: DynamicWeb/dynamicweb.py:277
 msgid "Descending tree with spouses"
 msgstr "Arbre descendant avec conjoints"
 
-#: DynamicWeb/dynamicweb.py:274
+#: DynamicWeb/dynamicweb.py:278
 msgid "Ascending and descending tree"
 msgstr "Arbre ascendant et descendant"
 
-#: DynamicWeb/dynamicweb.py:275
+#: DynamicWeb/dynamicweb.py:279
 msgid "Ascending and descending tree with spouses"
 msgstr "Arbre ascendant et descendant avec conjoints"
 
-#: DynamicWeb/dynamicweb.py:285
+#: DynamicWeb/dynamicweb.py:289
 msgid "Vertical (↓)"
 msgstr "Vertical (↓)"
 
-#: DynamicWeb/dynamicweb.py:286
+#: DynamicWeb/dynamicweb.py:290
 msgid "Vertical (↑)"
 msgstr "Vertical (↑)"
 
-#: DynamicWeb/dynamicweb.py:287
+#: DynamicWeb/dynamicweb.py:291
 msgid "Horizontal (→)"
 msgstr "Horizontal (→)"
 
-#: DynamicWeb/dynamicweb.py:288
+#: DynamicWeb/dynamicweb.py:292
 msgid "Horizontal (←)"
 msgstr "Horizontal (←)"
 
-#: DynamicWeb/dynamicweb.py:289
+#: DynamicWeb/dynamicweb.py:293
 msgid "Full Circle"
 msgstr "Cercle complet"
 
-#: DynamicWeb/dynamicweb.py:290
+#: DynamicWeb/dynamicweb.py:294
 msgid "Half Circle"
 msgstr "Demi-cercle"
 
-#: DynamicWeb/dynamicweb.py:291
+#: DynamicWeb/dynamicweb.py:295
 msgid "Quadrant"
 msgstr "Quadrant"
 
-#: DynamicWeb/dynamicweb.py:303
+#: DynamicWeb/dynamicweb.py:307
 msgid "Size proportional to number of ancestors"
 msgstr "Taille proportionnelle au nombre d'ascendants"
 
-#: DynamicWeb/dynamicweb.py:304
+#: DynamicWeb/dynamicweb.py:308
 msgid "Homogeneous parents distribution"
 msgstr "Distribution homogène des parents"
 
-#: DynamicWeb/dynamicweb.py:307
+#: DynamicWeb/dynamicweb.py:311
 msgid "Size proportional to number of descendants"
 msgstr "Taille proportionnelle au nombre de descendants"
 
-#: DynamicWeb/dynamicweb.py:308
+#: DynamicWeb/dynamicweb.py:312
 msgid "Homogeneous children distribution"
 msgstr "Distribution homogène des enfants"
 
-#: DynamicWeb/dynamicweb.py:315
+#: DynamicWeb/dynamicweb.py:319
 msgid "Gender colors"
 msgstr "Couleurs du genre"
 
-#: DynamicWeb/dynamicweb.py:316
+#: DynamicWeb/dynamicweb.py:320
 msgid "Generation based gradient"
 msgstr "Gradient basé sur la génération"
 
-#: DynamicWeb/dynamicweb.py:317
+#: DynamicWeb/dynamicweb.py:321
 msgid "Age based gradient"
 msgstr "Gradient basé sur l'âge"
 
-#: DynamicWeb/dynamicweb.py:318
+#: DynamicWeb/dynamicweb.py:322
 msgid "Single main (filter) color"
 msgstr "Couleur unique de filtrage"
 
-#: DynamicWeb/dynamicweb.py:319
+#: DynamicWeb/dynamicweb.py:323
 msgid "Time period based gradient"
 msgstr "Gradient basé sur une période temporelle"
 
-#: DynamicWeb/dynamicweb.py:320
+#: DynamicWeb/dynamicweb.py:324
 msgid "White"
 msgstr "Blanc"
 
-#: DynamicWeb/dynamicweb.py:321
+#: DynamicWeb/dynamicweb.py:325
 msgid "Color scheme classic report"
 msgstr "Schéma de couleur classique pour le rapport"
 
-#: DynamicWeb/dynamicweb.py:322
+#: DynamicWeb/dynamicweb.py:326
 msgid "Color scheme classic view"
 msgstr "Schéma de couleur classique pour la vue"
 
-#: DynamicWeb/dynamicweb.py:339
+#: DynamicWeb/dynamicweb.py:343
 msgid "Default"
 msgstr "Défaut"
 
-#: DynamicWeb/dynamicweb.py:340
+#: DynamicWeb/dynamicweb.py:344
 msgid "Mainz"
 msgstr "Mayence"
 
-#: DynamicWeb/dynamicweb.py:607
+#: DynamicWeb/dynamicweb.py:612
 #, python-format
 msgid "Neither %(current)s nor %(parent)s are directories"
 msgstr "Ni %(current)s ni %(parent)s ne sont des répertoires"
 
-#: DynamicWeb/dynamicweb.py:615 DynamicWeb/dynamicweb.py:620
+#: DynamicWeb/dynamicweb.py:620 DynamicWeb/dynamicweb.py:625
 #, python-format
 msgid "Could not create the directory: %(path)s"
 msgstr "Impossible de créer le répertoire: %(path)s"
 
-#: DynamicWeb/dynamicweb.py:645 DynamicWeb/dynamicweb.py:2961
-#: DynamicWeb/dynamicweb.py:2967
+#: DynamicWeb/dynamicweb.py:650 DynamicWeb/dynamicweb.py:2968
+#: DynamicWeb/dynamicweb.py:2974
 msgid "Dynamic Web Site Report"
 msgstr "Rapport en site web dynamique"
 
-#: DynamicWeb/dynamicweb.py:645
+#: DynamicWeb/dynamicweb.py:650
 msgid "Exporting family tree data ..."
 msgstr "Export des données de l'arbre familial ..."
 
-#: DynamicWeb/dynamicweb.py:1123
+#: DynamicWeb/dynamicweb.py:1128
 msgid "Author"
 msgstr "Auteur"
 
-#: DynamicWeb/dynamicweb.py:1124
+#: DynamicWeb/dynamicweb.py:1129
 msgid "Abbreviation"
 msgstr "Abréviation"
 
-#: DynamicWeb/dynamicweb.py:1125
+#: DynamicWeb/dynamicweb.py:1130
 msgid "Publication information"
 msgstr "Informations de publication"
 
-#: DynamicWeb/dynamicweb.py:1196 DynamicWeb/dynamicweb.py:2236
+#: DynamicWeb/dynamicweb.py:1201 DynamicWeb/dynamicweb.py:2241
 msgid "Date"
 msgstr "Date "
 
-#: DynamicWeb/dynamicweb.py:1197
+#: DynamicWeb/dynamicweb.py:1202
 msgid "Page"
 msgstr "Page"
 
-#: DynamicWeb/dynamicweb.py:1198
+#: DynamicWeb/dynamicweb.py:1203
 msgid "Confidence"
 msgstr "Niveau de confiance"
 
-#: DynamicWeb/dynamicweb.py:1491
+#: DynamicWeb/dynamicweb.py:1496
 #, python-format
 msgid "%(type)s: %(value)s"
 msgstr "%(type)s : %(value)s"
 
-#: DynamicWeb/dynamicweb.py:1728
+#: DynamicWeb/dynamicweb.py:1733
 #, python-format
 msgid "Impossible to convert \"%(path)s\" to a relative path."
 msgstr "Impossible de convertir \"%(path)s\" en chemin relatif."
 
-#: DynamicWeb/dynamicweb.py:2023
+#: DynamicWeb/dynamicweb.py:2028
 msgid ""
 "The pages configuration is not valid: several pages have the same content"
 msgstr ""
 "La configuration des pages n'est pas valide: Il y a plusieurs pages avec le "
 "même contenu"
 
-#: DynamicWeb/dynamicweb.py:2079
+#: DynamicWeb/dynamicweb.py:2084
 msgid "Search results"
 msgstr "Résultats de la recherche"
 
-#: DynamicWeb/dynamicweb.py:2209
+#: DynamicWeb/dynamicweb.py:2214
 msgid "(filtered from _MAX_ total entries)"
 msgstr "(filtrées parmi un total de _MAX_ éléments)"
 
-#: DynamicWeb/dynamicweb.py:2210
+#: DynamicWeb/dynamicweb.py:2215
 msgid "(sort by name)"
 msgstr "(tri par nom)"
 
-#: DynamicWeb/dynamicweb.py:2211
+#: DynamicWeb/dynamicweb.py:2216
 msgid "(sort by quantity)"
 msgstr "(tri par nombre)"
 
-#: DynamicWeb/dynamicweb.py:2212
+#: DynamicWeb/dynamicweb.py:2217
 msgid ": activate to sort column ascending"
 msgstr ": activer pour trier la colonne dans l'ordre croissant"
 
-#: DynamicWeb/dynamicweb.py:2213
+#: DynamicWeb/dynamicweb.py:2218
 msgid ": activate to sort column descending"
 msgstr ": activer pour trier la colonne dans l'ordre décroissant"
 
-#: DynamicWeb/dynamicweb.py:2214
+#: DynamicWeb/dynamicweb.py:2219
 msgid ""
 "<p>Click on a person to center the graph on this person.<br>When clicking on "
 "the center person, the person page is shown.<p>The type of graph could be "
@@ -341,7 +341,7 @@ msgstr ""
 "souris ou les boutons pour zoomer.<p>Le graphe peut aussi être affiché en "
 "plein écran."
 
-#: DynamicWeb/dynamicweb.py:2215
+#: DynamicWeb/dynamicweb.py:2220
 msgid ""
 "<p>This page provides the SVG raw code.<br>Copy the contents into a text "
 "editor and save as an SVG file.<br>Make sure that the text editor encoding "
@@ -352,432 +352,436 @@ msgstr ""
 "l'éditeur de texte est UTF-8.</p>"
 
 # L'espace finale est pour précéder le « : » codé en dur dans certains contextes.
-#: DynamicWeb/dynamicweb.py:2216
+#: DynamicWeb/dynamicweb.py:2221
 msgid "Address"
 msgstr "Adresse "
 
-#: DynamicWeb/dynamicweb.py:2218
+#: DynamicWeb/dynamicweb.py:2223
 msgid "Age at Death"
 msgstr "Âge au décès"
 
-#: DynamicWeb/dynamicweb.py:2219
+#: DynamicWeb/dynamicweb.py:2224
 msgid "Alternate Name"
 msgstr "Nom alternatif"
 
-#: DynamicWeb/dynamicweb.py:2220
+#: DynamicWeb/dynamicweb.py:2225
 msgid "Ancestors"
 msgstr "Ascendants"
 
-#: DynamicWeb/dynamicweb.py:2221
+#: DynamicWeb/dynamicweb.py:2226
 msgid "Associations"
 msgstr "Associations"
 
-#: DynamicWeb/dynamicweb.py:2222
+#: DynamicWeb/dynamicweb.py:2227
 msgid "Attribute"
 msgstr "Attribut"
 
-#: DynamicWeb/dynamicweb.py:2223
+#: DynamicWeb/dynamicweb.py:2228
 msgid "Attributes"
 msgstr "Attributs"
 
-#: DynamicWeb/dynamicweb.py:2224 DynamicWeb/dynamicweb.py:3723
+#: DynamicWeb/dynamicweb.py:2229 DynamicWeb/dynamicweb.py:3757
 msgid "Background"
 msgstr "Fond"
 
 # call name = prénom dans le context !
-#: DynamicWeb/dynamicweb.py:2225
+#: DynamicWeb/dynamicweb.py:2230
 msgid "Call Name"
 msgstr "Prénom usuel"
 
-#: DynamicWeb/dynamicweb.py:2226
+#: DynamicWeb/dynamicweb.py:2231
 msgid "Call Number"
 msgstr "Numéro d'identifiant"
 
-#: DynamicWeb/dynamicweb.py:2227
+#: DynamicWeb/dynamicweb.py:2232
 msgid "Children"
 msgstr "Enfants "
 
-#: DynamicWeb/dynamicweb.py:2228
+#: DynamicWeb/dynamicweb.py:2233
 msgid "Church Parish"
 msgstr "Paroisse"
 
 # L'espace finale est pour précéder le « : » codé en dur dans certains contextes.
 # /!\ vérifier double espace avec search bar "%(titre colonne)s contient"
-#: DynamicWeb/dynamicweb.py:2229
+#: DynamicWeb/dynamicweb.py:2234
 msgid "Citation"
 msgstr "Citation "
 
 # trunk
-#: DynamicWeb/dynamicweb.py:2230
+#: DynamicWeb/dynamicweb.py:2235
 msgid "Citations"
 msgstr "Citations"
 
 # L'espace finale est pour précéder le « : » codé en dur dans certains contextes.
 # /!\ vérifier double espace avec search bar "%(titre colonne)s contient"
-#: DynamicWeb/dynamicweb.py:2231
+#: DynamicWeb/dynamicweb.py:2236
 msgid "City"
 msgstr "Ville "
 
-#: DynamicWeb/dynamicweb.py:2232
+#: DynamicWeb/dynamicweb.py:2237
 msgid "Click on the map to show it full-screen"
 msgstr "Cliquer sur la carte pour l'afficher en plein écran"
 
-#: DynamicWeb/dynamicweb.py:2233
+#: DynamicWeb/dynamicweb.py:2238
 msgid "Configuration"
 msgstr "Configuration"
 
 # L'espace finale est pour précéder le « : » codé en dur dans certains contextes.
 # /!\ vérifier double espace avec search bar "%(titre colonne)s contient"
-#: DynamicWeb/dynamicweb.py:2234
+#: DynamicWeb/dynamicweb.py:2239
 msgid "Country"
 msgstr "Pays "
 
 # comté (Canada)
-#: DynamicWeb/dynamicweb.py:2235
+#: DynamicWeb/dynamicweb.py:2240
 msgid "County"
 msgstr "Comté (Départ.)"
 
-#: DynamicWeb/dynamicweb.py:2237
+#: DynamicWeb/dynamicweb.py:2242
 msgid "Descendants"
 msgstr "Descendants"
 
-#: DynamicWeb/dynamicweb.py:2238
+#: DynamicWeb/dynamicweb.py:2243
 msgid "Description"
 msgstr "Description"
 
 # L'espace finale est pour précéder le « : » codé en dur dans certains contextes.
 # /!\ vérifier double espace avec search bar "%(titre colonne)s contient"
-#: DynamicWeb/dynamicweb.py:2239
+#: DynamicWeb/dynamicweb.py:2244
 msgid "Event"
 msgstr "Événement "
 
-#: DynamicWeb/dynamicweb.py:2240
+#: DynamicWeb/dynamicweb.py:2245
 msgid "Events"
 msgstr "Événements"
 
-#: DynamicWeb/dynamicweb.py:2241
+#: DynamicWeb/dynamicweb.py:2246
 msgid "Expand"
 msgstr "Agrandir"
 
-#: DynamicWeb/dynamicweb.py:2242
+#: DynamicWeb/dynamicweb.py:2247
 msgid "Families Index"
 msgstr "Index des familles"
 
-#: DynamicWeb/dynamicweb.py:2243
+#: DynamicWeb/dynamicweb.py:2248
 msgid "Family Nick Name"
 msgstr "Surnom de la famille"
 
-#: DynamicWeb/dynamicweb.py:2244
+#: DynamicWeb/dynamicweb.py:2249
 msgid "Father"
 msgstr "Père "
 
-#: DynamicWeb/dynamicweb.py:2245
+#: DynamicWeb/dynamicweb.py:2250
 msgid "Female"
 msgstr "Féminin"
 
-#: DynamicWeb/dynamicweb.py:2246
+#: DynamicWeb/dynamicweb.py:2251
 msgid "File ready"
 msgstr "Fichier prêt"
 
-#: DynamicWeb/dynamicweb.py:2247
+#: DynamicWeb/dynamicweb.py:2252
 msgid "Gender"
 msgstr "Genre"
 
-#: DynamicWeb/dynamicweb.py:2248
+#: DynamicWeb/dynamicweb.py:2253
 msgid "Graph help"
 msgstr "Aide sur le graphe"
 
-#: DynamicWeb/dynamicweb.py:2249
+#: DynamicWeb/dynamicweb.py:2254
 msgid "Latitude"
 msgstr "Latitude"
 
-#: DynamicWeb/dynamicweb.py:2250
+#: DynamicWeb/dynamicweb.py:2255
 msgid "Link"
 msgstr "Lien"
 
 # Substantif (GNOME fr)
-#: DynamicWeb/dynamicweb.py:2251
+#: DynamicWeb/dynamicweb.py:2256
 msgid "Loading..."
 msgstr "En charge..."
 
 # L'espace finale est pour précéder le « : » codé en dur dans certains contextes.
 # /!\ vérifier double espace avec search bar "%(titre colonne)s contient"
-#: DynamicWeb/dynamicweb.py:2252
+#: DynamicWeb/dynamicweb.py:2257
 msgid "Locality"
 msgstr "Lieu-dit "
 
-#: DynamicWeb/dynamicweb.py:2253
+#: DynamicWeb/dynamicweb.py:2258
 msgid "Location"
 msgstr "Emplacement"
 
-#: DynamicWeb/dynamicweb.py:2254
+#: DynamicWeb/dynamicweb.py:2259
 msgid "Longitude"
 msgstr "Longitude"
 
-#: DynamicWeb/dynamicweb.py:2255
+#: DynamicWeb/dynamicweb.py:2260
 msgid "Male"
 msgstr "Masculin"
 
-#: DynamicWeb/dynamicweb.py:2256
+#: DynamicWeb/dynamicweb.py:2261
 msgid "Map"
 msgstr "Plan"
 
-#: DynamicWeb/dynamicweb.py:2257
+#: DynamicWeb/dynamicweb.py:2262
 msgid "Maximize"
 msgstr "Agrandir"
 
-#: DynamicWeb/dynamicweb.py:2258
+#: DynamicWeb/dynamicweb.py:2263
 msgid "Media found:"
 msgstr "Media trouvés:"
 
-#: DynamicWeb/dynamicweb.py:2259
+#: DynamicWeb/dynamicweb.py:2264
 msgid "Media Index"
 msgstr "Index des media"
 
-#: DynamicWeb/dynamicweb.py:2260
+#: DynamicWeb/dynamicweb.py:2265
 msgid "Media Type"
 msgstr "Type du media"
 
-#: DynamicWeb/dynamicweb.py:2262
+#: DynamicWeb/dynamicweb.py:2267
 msgid "Mother"
 msgstr "Mère "
 
 # L'espace finale est pour précéder le « : » codé en dur dans certains contextes.
-#: DynamicWeb/dynamicweb.py:2263
+#: DynamicWeb/dynamicweb.py:2268
 msgid "Name"
 msgstr "Nom "
 
-#: DynamicWeb/dynamicweb.py:2264
+#: DynamicWeb/dynamicweb.py:2269
 msgid "Nick Name"
 msgstr "Surnom"
 
-#: DynamicWeb/dynamicweb.py:2265
+#: DynamicWeb/dynamicweb.py:2270
 msgid "No data available in table"
 msgstr "Pas de données disponible dans la table"
 
-#: DynamicWeb/dynamicweb.py:2266
+#: DynamicWeb/dynamicweb.py:2271
 msgid "No matching records found"
 msgstr "Pas d'objets correspondant trouvés"
 
-#: DynamicWeb/dynamicweb.py:2267
+#: DynamicWeb/dynamicweb.py:2272
 msgid "No matching surname."
 msgstr "Il n'y a pas de nom correspondant."
 
-#: DynamicWeb/dynamicweb.py:2268
+#: DynamicWeb/dynamicweb.py:2273
 msgid "None."
 msgstr "Aucun."
 
-#: DynamicWeb/dynamicweb.py:2269
+#: DynamicWeb/dynamicweb.py:2274
 msgid "Notes"
 msgstr "Notes"
 
-#: DynamicWeb/dynamicweb.py:2270
+#: DynamicWeb/dynamicweb.py:2275
 msgid "OK"
 msgstr "OK"
 
-#: DynamicWeb/dynamicweb.py:2271
+#: DynamicWeb/dynamicweb.py:2276
 msgid "Parents"
 msgstr "Parents "
 
-#: DynamicWeb/dynamicweb.py:2272
+#: DynamicWeb/dynamicweb.py:2277
 msgid "Path"
 msgstr "Chemin"
 
-#: DynamicWeb/dynamicweb.py:2274
+#: DynamicWeb/dynamicweb.py:2279
 msgid "Person to search for"
 msgstr "Personne à rechercher"
 
-#: DynamicWeb/dynamicweb.py:2276
+#: DynamicWeb/dynamicweb.py:2281
 msgid "Persons found:"
 msgstr "Personnes trouvées:"
 
-#: DynamicWeb/dynamicweb.py:2277
+#: DynamicWeb/dynamicweb.py:2282
 msgid "Persons Index"
 msgstr "Index des personnes"
 
 # L'espace finale est pour précéder le « : » codé en dur dans certains contextes.
 # /!\ vérifier double espace avec search bar "%(titre colonne)s contient"
-#: DynamicWeb/dynamicweb.py:2278
+#: DynamicWeb/dynamicweb.py:2283
 msgid "Phone"
 msgstr "Téléphone "
 
 # L'espace finale est pour précéder le « : » codé en dur dans certains contextes.
 # /!\ vérifier double espace avec search bar "%(titre colonne)s contient"
-#: DynamicWeb/dynamicweb.py:2279
+#: DynamicWeb/dynamicweb.py:2284
 msgid "Place"
 msgstr "Lieu "
 
-#: DynamicWeb/dynamicweb.py:2280
+#: DynamicWeb/dynamicweb.py:2285
 msgid "Places found:"
 msgstr "Lieux trouvés:"
 
-#: DynamicWeb/dynamicweb.py:2281
+#: DynamicWeb/dynamicweb.py:2286
 msgid "Places Index"
 msgstr "Index des lieux"
 
 # Utilisation d'un terme général (Code lieu) car le code postal ne sert à rien en généalogie.
-#: DynamicWeb/dynamicweb.py:2282
+#: DynamicWeb/dynamicweb.py:2287
 msgid "Postal Code"
 msgstr "Code lieu"
 
-#: DynamicWeb/dynamicweb.py:2283
+#: DynamicWeb/dynamicweb.py:2288
 msgid "Preparing file ..."
 msgstr "Préparation du fichier ..."
 
-#: DynamicWeb/dynamicweb.py:2284
+#: DynamicWeb/dynamicweb.py:2289
 msgid "Processing..."
 msgstr "Traitement en cours..."
 
-#: DynamicWeb/dynamicweb.py:2285
+#: DynamicWeb/dynamicweb.py:2290
 msgid "References"
 msgstr "Références"
 
-#: DynamicWeb/dynamicweb.py:2286
+#: DynamicWeb/dynamicweb.py:2291
 msgid "Relationship to Father"
 msgstr "Relation au père"
 
-#: DynamicWeb/dynamicweb.py:2287
+#: DynamicWeb/dynamicweb.py:2292
 msgid "Relationship to Mother"
 msgstr "Relation à la mère"
 
-#: DynamicWeb/dynamicweb.py:2288
+#: DynamicWeb/dynamicweb.py:2293
 msgid "Relationship"
 msgstr "Relation "
 
 # L'espace finale est pour précéder le « : » codé en dur dans certains contextes.
 # /!\ vérifier double espace avec search bar "%(titre colonne)s contient"
-#: DynamicWeb/dynamicweb.py:2290
+#: DynamicWeb/dynamicweb.py:2295
 msgid "Repository"
 msgstr "Dépôt "
 
-#: DynamicWeb/dynamicweb.py:2291
+#: DynamicWeb/dynamicweb.py:2296
 msgid "Restore"
 msgstr "Restaurer"
 
-#: DynamicWeb/dynamicweb.py:2292
+#: DynamicWeb/dynamicweb.py:2297
 msgid "Save tree as file"
 msgstr "Enregistrer l'arbre dans un fichier"
 
-#: DynamicWeb/dynamicweb.py:2293
+#: DynamicWeb/dynamicweb.py:2298
 msgid "Search:"
 msgstr "Recherche:"
 
-#: DynamicWeb/dynamicweb.py:2294
+#: DynamicWeb/dynamicweb.py:2299
 msgid "Select the background color scheme"
 msgstr "Sélection de la trame de fond"
 
-#: DynamicWeb/dynamicweb.py:2295
+#: DynamicWeb/dynamicweb.py:2300
 msgid "Select the children distribution (fan charts only)"
 msgstr ""
 "Sélection de la répartition des enfants (pour les graphiques circulaires)"
 
-#: DynamicWeb/dynamicweb.py:2296
+#: DynamicWeb/dynamicweb.py:2301
 msgid "Select the number of ascending generations"
 msgstr "Sélection du nombre de générations ascendantes"
 
-#: DynamicWeb/dynamicweb.py:2297
+#: DynamicWeb/dynamicweb.py:2302
 msgid "Select the number of descending generations"
 msgstr "Sélection du nombre de générations descendantes"
 
-#: DynamicWeb/dynamicweb.py:2298
+#: DynamicWeb/dynamicweb.py:2303
 msgid "Select the parents distribution (fan charts only)"
 msgstr ""
 "Sélection de la répartition des parents (pour les graphiques circulaires)"
 
-#: DynamicWeb/dynamicweb.py:2299
+#: DynamicWeb/dynamicweb.py:2304
 msgid "Select the shape of graph"
 msgstr "Sélection de la forme du graphique"
 
-#: DynamicWeb/dynamicweb.py:2300
+#: DynamicWeb/dynamicweb.py:2305
 msgid "Select the type of graph"
 msgstr "Sélection du type de graphe"
 
-#: DynamicWeb/dynamicweb.py:2301
+#: DynamicWeb/dynamicweb.py:2306
 msgid "Several matches.<br>Precise your search or choose in the lists below."
 msgstr ""
 "Plusieurs correspondances.<br>Précisez votre recherche ou choisissez dans "
 "les listes ci-dessous."
 
-#: DynamicWeb/dynamicweb.py:2302
+#: DynamicWeb/dynamicweb.py:2307
 msgid "Show _MENU_ entries"
 msgstr "Afficher _MENU_ éléments"
 
-#: DynamicWeb/dynamicweb.py:2303
+#: DynamicWeb/dynamicweb.py:2308 DynamicWeb/dynamicweb.py:3769
+msgid "Show duplicates"
+msgstr "Affiche les doublons"
+
+#: DynamicWeb/dynamicweb.py:2309
 msgid "Showing 0 to 0 of 0 entries"
 msgstr "Eléments 0 à 0 affichés parmi 0"
 
-#: DynamicWeb/dynamicweb.py:2304
+#: DynamicWeb/dynamicweb.py:2310
 msgid "Showing _START_ to _END_ of _TOTAL_ entries"
 msgstr "Eléments _START_ à _END_ affichés parmi _TOTAL_"
 
-#: DynamicWeb/dynamicweb.py:2305
+#: DynamicWeb/dynamicweb.py:2311
 msgid "Siblings"
 msgstr "Frères et sœurs "
 
 # L'espace finale est pour précéder le « : » codé en dur dans certains contextes.
 # /!\ vérifier double espace avec search bar "%(titre colonne)s contient"
-#: DynamicWeb/dynamicweb.py:2306
+#: DynamicWeb/dynamicweb.py:2312
 msgid "Source"
 msgstr "Source "
 
-#: DynamicWeb/dynamicweb.py:2307
+#: DynamicWeb/dynamicweb.py:2313
 msgid "Sources found:"
 msgstr "Sources trouvées:"
 
-#: DynamicWeb/dynamicweb.py:2308
+#: DynamicWeb/dynamicweb.py:2314
 msgid "Sources Index"
 msgstr "Index des sources"
 
-#: DynamicWeb/dynamicweb.py:2310
+#: DynamicWeb/dynamicweb.py:2316
 msgid "Spouses"
 msgstr "Conjoints"
 
 # province (Canada, Belgique)
-#: DynamicWeb/dynamicweb.py:2311
+#: DynamicWeb/dynamicweb.py:2317
 msgid "State/ Province"
 msgstr "Région/Province"
 
-#: DynamicWeb/dynamicweb.py:2312
+#: DynamicWeb/dynamicweb.py:2318
 msgid "Street"
 msgstr "Rue"
 
-#: DynamicWeb/dynamicweb.py:2313
+#: DynamicWeb/dynamicweb.py:2319
 msgid "Surnames Index"
 msgstr "Index des patronymes"
 
-#: DynamicWeb/dynamicweb.py:2314 DynamicWeb/dynamicweb.py:3717
+#: DynamicWeb/dynamicweb.py:2320 DynamicWeb/dynamicweb.py:3751
 msgid "SVG tree children distribution"
 msgstr "Répartition des enfants dans l'arbre SVG"
 
-#: DynamicWeb/dynamicweb.py:2315 DynamicWeb/dynamicweb.py:3705
+#: DynamicWeb/dynamicweb.py:2321 DynamicWeb/dynamicweb.py:3739
 msgid "SVG tree graph shape"
 msgstr "Forme de l'arbre SVG"
 
-#: DynamicWeb/dynamicweb.py:2316 DynamicWeb/dynamicweb.py:3699
+#: DynamicWeb/dynamicweb.py:2322 DynamicWeb/dynamicweb.py:3733
 msgid "SVG tree graph type"
 msgstr "Type d'arbre graphique SVG"
 
-#: DynamicWeb/dynamicweb.py:2317 DynamicWeb/dynamicweb.py:3711
+#: DynamicWeb/dynamicweb.py:2323 DynamicWeb/dynamicweb.py:3745
 msgid "SVG tree parents distribution"
 msgstr "Répartition des parents dans l'arbre SVG"
 
-#: DynamicWeb/dynamicweb.py:2318
+#: DynamicWeb/dynamicweb.py:2324
 msgid "There is no matching name."
 msgstr "Il n'y a pas de nom correspondant."
 
-#: DynamicWeb/dynamicweb.py:2319
+#: DynamicWeb/dynamicweb.py:2325
 msgid "Title"
 msgstr "Titre"
 
-#: DynamicWeb/dynamicweb.py:2320
+#: DynamicWeb/dynamicweb.py:2326
 msgid "Type"
 msgstr "Type"
 
-#: DynamicWeb/dynamicweb.py:2321
+#: DynamicWeb/dynamicweb.py:2327
 msgid "Unknown"
 msgstr "Inconnu"
 
-#: DynamicWeb/dynamicweb.py:2322
+#: DynamicWeb/dynamicweb.py:2328
 msgid ""
 "Use the search box above in order to find a person.<br>Women are listed with "
 "their maiden name."
@@ -785,65 +789,73 @@ msgstr ""
 "Utilisez le formulaire de recherche ci-dessus pour trouver un individu."
 "<br>Les femmes sont référencées avec leur nom de jeune fille."
 
-#: DynamicWeb/dynamicweb.py:2323
+#: DynamicWeb/dynamicweb.py:2329
 msgid "Used for family"
 msgstr "Référencé par les familles"
 
-#: DynamicWeb/dynamicweb.py:2324
+#: DynamicWeb/dynamicweb.py:2330
 msgid "Used for media"
 msgstr "Référencé par les médias"
 
-#: DynamicWeb/dynamicweb.py:2325
+#: DynamicWeb/dynamicweb.py:2331
 msgid "Used for person"
 msgstr "Référencé par les personnes"
 
-#: DynamicWeb/dynamicweb.py:2326
+#: DynamicWeb/dynamicweb.py:2332
 msgid "Used for place"
 msgstr "Référencé par les lieux"
 
-#: DynamicWeb/dynamicweb.py:2327
+#: DynamicWeb/dynamicweb.py:2333
 msgid "Used for source"
 msgstr "Référencé par les sources"
 
-#: DynamicWeb/dynamicweb.py:2328
+#: DynamicWeb/dynamicweb.py:2334
 msgid "Value"
 msgstr "Valeur"
 
-#: DynamicWeb/dynamicweb.py:2329
+#: DynamicWeb/dynamicweb.py:2335
 msgid "Web Link"
 msgstr "Lien internet"
 
-#: DynamicWeb/dynamicweb.py:2330
+#: DynamicWeb/dynamicweb.py:2336
 msgid "Web Links"
 msgstr "Liens internet"
 
-#: DynamicWeb/dynamicweb.py:2331
+#: DynamicWeb/dynamicweb.py:2337 DynamicWeb/dynamicweb.py:3770
+msgid ""
+"Whether to use a special color for the persons that appear several times in "
+"the SVG tree"
+msgstr ""
+"Utiliser ou non une couleur spéciale pour les individus qui apparaissent "
+"plusieurs fois dans l'arbre SVG"
+
+#: DynamicWeb/dynamicweb.py:2338
 msgid "Without surname"
 msgstr "Sans patronyme"
 
-#: DynamicWeb/dynamicweb.py:2332
+#: DynamicWeb/dynamicweb.py:2339
 msgid "Zoom in"
 msgstr "Zoom avant"
 
-#: DynamicWeb/dynamicweb.py:2333
+#: DynamicWeb/dynamicweb.py:2340
 msgid "Zoom out"
 msgstr "Zoom arrière"
 
-#: DynamicWeb/dynamicweb.py:2581
+#: DynamicWeb/dynamicweb.py:2588
 #, python-format
 msgid "Copying error: %(error)s"
 msgstr "Erreur de copie: %(error)s"
 
-#: DynamicWeb/dynamicweb.py:2582
+#: DynamicWeb/dynamicweb.py:2589
 #, python-format
 msgid "Impossible to copy \"%(src)s\" to \"%(dst)s\""
 msgstr "Échec de la copie de \"%(src)s\" vers \"%(dst)s\""
 
-#: DynamicWeb/dynamicweb.py:2585
+#: DynamicWeb/dynamicweb.py:2592
 msgid "Possible destination error"
 msgstr "Possible erreur de destination"
 
-#: DynamicWeb/dynamicweb.py:2586
+#: DynamicWeb/dynamicweb.py:2593
 msgid ""
 "You appear to have set your target directory to a directory used for data "
 "storage. This could create problems with file management. It is recommended "
@@ -855,71 +867,71 @@ msgstr ""
 "recommandé d'utiliser un répertoire différent pour stocker les pages "
 "internet générées."
 
-#: DynamicWeb/dynamicweb.py:2613
+#: DynamicWeb/dynamicweb.py:2620
 #, python-format
 msgid "Unable to copy web site template files from \"%(path)s\""
 msgstr "Impossible de copier le modèle de site web depuis \"%(path)s\""
 
-#: DynamicWeb/dynamicweb.py:2648
+#: DynamicWeb/dynamicweb.py:2655
 #, python-format
 msgid "Keeping \"%(dst)s\" (newer than \"%(src)s\")"
 msgstr "Conserve \"%(dst)s\" (plus récent que \"%(src)s\")"
 
-#: DynamicWeb/dynamicweb.py:2651
+#: DynamicWeb/dynamicweb.py:2658
 #, python-format
 msgid "Copying \"%(src)s\" to \"%(dst)s\""
 msgstr "Copie de \"%(src)s\" vers \"%(dst)s\""
 
-#: DynamicWeb/dynamicweb.py:2669
+#: DynamicWeb/dynamicweb.py:2676
 msgid "Invalid file name"
 msgstr "Nom de fichier invalide"
 
-#: DynamicWeb/dynamicweb.py:2670
+#: DynamicWeb/dynamicweb.py:2677
 msgid "The archive file must be a file, not a directory"
 msgstr "L'archive doit être un fichier, pas un répertoire"
 
-#: DynamicWeb/dynamicweb.py:2680 DynamicWeb/dynamicweb.py:2698
+#: DynamicWeb/dynamicweb.py:2687 DynamicWeb/dynamicweb.py:2705
 #, python-format
 msgid "Unable to overwrite archive file \"%(path)s\""
 msgstr "Impossible de créer le fichier d'archive \"%(path)s\""
 
-#: DynamicWeb/dynamicweb.py:2690 DynamicWeb/dynamicweb.py:2705
+#: DynamicWeb/dynamicweb.py:2697 DynamicWeb/dynamicweb.py:2712
 #, python-format
 msgid "Unable to add file \"%(file)s\" to archive \"%(archive)s\""
 msgstr ""
 "Impossible d'ajouter le fichier \"%(file)s\" à l'archive \"%(archive)s\""
 
-#: DynamicWeb/dynamicweb.py:2757
+#: DynamicWeb/dynamicweb.py:2764
 #, python-format
 msgid "DynamicWebReport ignoring link type '%(class)s'"
 msgstr "DynamicWebReport ignore le type de lien '%(class)s'"
 
 # Substantif (GNOME fr)
-#: DynamicWeb/dynamicweb.py:2962
+#: DynamicWeb/dynamicweb.py:2969
 msgid "Applying Person Filter..."
 msgstr "Application du filtre individu..."
 
-#: DynamicWeb/dynamicweb.py:2968
+#: DynamicWeb/dynamicweb.py:2975
 msgid "Constructing list of other objects..."
 msgstr "Construction d'une liste d'autres objets..."
 
 # trunk
-#: DynamicWeb/dynamicweb.py:3102
+#: DynamicWeb/dynamicweb.py:3129
 #, python-format
 msgid "Family of %(husband)s and %(spouse)s"
 msgstr "Famille de %(husband)s et %(spouse)s"
 
-#: DynamicWeb/dynamicweb.py:3108
+#: DynamicWeb/dynamicweb.py:3135
 #, python-format
 msgid "Family of %(father)s"
 msgstr "Famille de %(father)s"
 
-#: DynamicWeb/dynamicweb.py:3112
+#: DynamicWeb/dynamicweb.py:3139
 #, python-format
 msgid "Family of %(mother)s"
 msgstr "Famille de %(mother)s"
 
-#: DynamicWeb/dynamicweb.py:3408
+#: DynamicWeb/dynamicweb.py:3442
 msgid ""
 "In this note, the following special words are processed:\n"
 "__SEARCH_FORM__ is replaced by a search form.\n"
@@ -956,166 +968,166 @@ msgstr ""
 "Les URL commençant par \"relative://relative.<link>\" sont remplacées par "
 "l'URL relative \"<link>\".\n"
 
-#: DynamicWeb/dynamicweb.py:3446
+#: DynamicWeb/dynamicweb.py:3480
 msgid "Report"
 msgstr "Rapport"
 
-#: DynamicWeb/dynamicweb.py:3451
+#: DynamicWeb/dynamicweb.py:3485
 msgid "Destination"
 msgstr "Destination"
 
-#: DynamicWeb/dynamicweb.py:3453
+#: DynamicWeb/dynamicweb.py:3487
 msgid "The destination directory for the web files"
 msgstr "Le répertoire de destination pour les fichiers internet"
 
-#: DynamicWeb/dynamicweb.py:3457
+#: DynamicWeb/dynamicweb.py:3491
 msgid "Store web pages in archive"
 msgstr "Enregistre les pages web dans un fichier archive"
 
-#: DynamicWeb/dynamicweb.py:3458
+#: DynamicWeb/dynamicweb.py:3492
 msgid ""
 "Whether to create an archive file (in ZIP or TGZ format) containing the web "
 "site"
 msgstr ""
 "Créer ou non un fichier archive (au format ZIP ou TGZ) contenant le site web"
 
-#: DynamicWeb/dynamicweb.py:3462
+#: DynamicWeb/dynamicweb.py:3496
 msgid "Archive file"
 msgstr "Fichier d'archive"
 
-#: DynamicWeb/dynamicweb.py:3464
+#: DynamicWeb/dynamicweb.py:3498
 msgid "The archive file name (with \".zip\" or \".tgz\" extension)"
 msgstr "Le nom du fichier archive (avec l'extension \".zip\" ou \".tgz\")"
 
-#: DynamicWeb/dynamicweb.py:3470
+#: DynamicWeb/dynamicweb.py:3504
 msgid "Web site title"
 msgstr "Titre du site"
 
-#: DynamicWeb/dynamicweb.py:3470
+#: DynamicWeb/dynamicweb.py:3504
 msgid "My Family Tree"
 msgstr "Mon arbre généalogique"
 
-#: DynamicWeb/dynamicweb.py:3471
+#: DynamicWeb/dynamicweb.py:3505
 msgid "The title of the web site"
 msgstr "Le titre du site internet"
 
-#: DynamicWeb/dynamicweb.py:3474
+#: DynamicWeb/dynamicweb.py:3508
 msgid "Filter"
 msgstr "Filtre"
 
-#: DynamicWeb/dynamicweb.py:3476
+#: DynamicWeb/dynamicweb.py:3510
 msgid "Select filter to restrict people that appear on web site"
 msgstr ""
 "Sélectionnez un filtre pour restreindre les individus qui apparaîtront dans "
 "le site web"
 
-#: DynamicWeb/dynamicweb.py:3480
+#: DynamicWeb/dynamicweb.py:3514
 msgid "Filter Person"
 msgstr "Filtre sur l'individu"
 
-#: DynamicWeb/dynamicweb.py:3481
+#: DynamicWeb/dynamicweb.py:3515
 msgid "The center person for the filter"
 msgstr "L'individu central pour ce filtre"
 
 # L'espace finale est pour précéder le « : » codé en dur.
-#: DynamicWeb/dynamicweb.py:3495
+#: DynamicWeb/dynamicweb.py:3529
 msgid "Name format"
 msgstr "Format des noms "
 
-#: DynamicWeb/dynamicweb.py:3498
+#: DynamicWeb/dynamicweb.py:3532
 msgid "Select the format to display the complete names"
 msgstr "Sélectionner le format d'affichage des noms complets"
 
-#: DynamicWeb/dynamicweb.py:3500
+#: DynamicWeb/dynamicweb.py:3534
 msgid "Name format (short)"
 msgstr "Format de nom (court)"
 
-#: DynamicWeb/dynamicweb.py:3503
+#: DynamicWeb/dynamicweb.py:3537
 msgid "Select the format to display a shorter version of the names"
 msgstr "Sélectionner le format d'affichage des versions courtes des noms"
 
-#: DynamicWeb/dynamicweb.py:3506
+#: DynamicWeb/dynamicweb.py:3540
 msgid "Web site template"
 msgstr "Modèle de site web"
 
-#: DynamicWeb/dynamicweb.py:3509
+#: DynamicWeb/dynamicweb.py:3543
 msgid "Select the template of the web site"
 msgstr "Sélectionner le modèle de site web"
 
-#: DynamicWeb/dynamicweb.py:3512
+#: DynamicWeb/dynamicweb.py:3546
 msgid "Copyright"
 msgstr "Licence"
 
-#: DynamicWeb/dynamicweb.py:3515
+#: DynamicWeb/dynamicweb.py:3549
 msgid "The copyright to be used for the web files"
 msgstr "Le droit d'auteur utilisé pour les fichiers internet"
 
-#: DynamicWeb/dynamicweb.py:3523
+#: DynamicWeb/dynamicweb.py:3557
 msgid "Privacy"
 msgstr "Vie privée"
 
-#: DynamicWeb/dynamicweb.py:3526
+#: DynamicWeb/dynamicweb.py:3560
 msgid "Include records marked private"
 msgstr "Inclure les données privées"
 
-#: DynamicWeb/dynamicweb.py:3527
+#: DynamicWeb/dynamicweb.py:3561
 msgid "Whether to include private objects"
 msgstr "Inclure ou non les objets privés"
 
-#: DynamicWeb/dynamicweb.py:3530
+#: DynamicWeb/dynamicweb.py:3564
 msgid "Export notes"
 msgstr "Exporter les notes"
 
-#: DynamicWeb/dynamicweb.py:3531
+#: DynamicWeb/dynamicweb.py:3565
 msgid "Whether to export notes in the web pages"
 msgstr "Exporter ou non les notes dans les pages web"
 
-#: DynamicWeb/dynamicweb.py:3534
+#: DynamicWeb/dynamicweb.py:3568
 msgid "Export sources"
 msgstr "Exporter les sources"
 
-#: DynamicWeb/dynamicweb.py:3535
+#: DynamicWeb/dynamicweb.py:3569
 msgid "Whether to export sources and citations in the web pages"
 msgstr "Exporter ou non les sources et citations dans les pages web"
 
-#: DynamicWeb/dynamicweb.py:3538
+#: DynamicWeb/dynamicweb.py:3572
 msgid "Export addresses"
 msgstr "Exporter les addresses"
 
-#: DynamicWeb/dynamicweb.py:3539
+#: DynamicWeb/dynamicweb.py:3573
 msgid "Whether to export addresses in the web pages"
 msgstr "Exporter ou non les addresses dans les pages web"
 
-#: DynamicWeb/dynamicweb.py:3542
+#: DynamicWeb/dynamicweb.py:3576
 msgid "Living People"
 msgstr "Individus vivants"
 
-#: DynamicWeb/dynamicweb.py:3545
+#: DynamicWeb/dynamicweb.py:3579
 msgid "Exclude"
 msgstr "Exclure"
 
-#: DynamicWeb/dynamicweb.py:3547
+#: DynamicWeb/dynamicweb.py:3581
 msgid "Include Last Name Only"
 msgstr "N'inclure que le nom"
 
-#: DynamicWeb/dynamicweb.py:3549
+#: DynamicWeb/dynamicweb.py:3583
 msgid "Include Full Name Only"
 msgstr "Inclure le nom complet"
 
-#: DynamicWeb/dynamicweb.py:3551
+#: DynamicWeb/dynamicweb.py:3585
 msgid "Include"
 msgstr "Inclure"
 
 # Substantif (GNOME fr)
-#: DynamicWeb/dynamicweb.py:3552
+#: DynamicWeb/dynamicweb.py:3586
 msgid "How to handle living people"
 msgstr "Gestion des individus vivants"
 
-#: DynamicWeb/dynamicweb.py:3556
+#: DynamicWeb/dynamicweb.py:3590
 msgid "Years from death to consider living"
 msgstr "Années depuis le décès"
 
-#: DynamicWeb/dynamicweb.py:3558
+#: DynamicWeb/dynamicweb.py:3592
 msgid ""
 "This allows you to restrict information on people who have not been dead for "
 "very long"
@@ -1123,31 +1135,31 @@ msgstr ""
 "Ceci vous permet de restreindre l'information sur les individus décédés il y "
 "a peu de temps"
 
-#: DynamicWeb/dynamicweb.py:3568
+#: DynamicWeb/dynamicweb.py:3602
 msgid "Options"
 msgstr "Options"
 
-#: DynamicWeb/dynamicweb.py:3571
+#: DynamicWeb/dynamicweb.py:3605
 msgid "Include repository pages"
 msgstr "Inclure les pages dépôt"
 
-#: DynamicWeb/dynamicweb.py:3572
+#: DynamicWeb/dynamicweb.py:3606
 msgid "Whether or not to include the Repository Pages."
 msgstr "Inclure ou non des pages dépôt."
 
-#: DynamicWeb/dynamicweb.py:3575
+#: DynamicWeb/dynamicweb.py:3609
 msgid "Include images and media objects"
 msgstr "Inclure images et objets media"
 
-#: DynamicWeb/dynamicweb.py:3576
+#: DynamicWeb/dynamicweb.py:3610
 msgid "Whether to include a media objects in the web pages"
 msgstr "Exporter ou non les objets multimédia dans les pages web"
 
-#: DynamicWeb/dynamicweb.py:3579
+#: DynamicWeb/dynamicweb.py:3613
 msgid "Copy images and media objects"
 msgstr "Copier les images et les objets multimédia"
 
-#: DynamicWeb/dynamicweb.py:3580
+#: DynamicWeb/dynamicweb.py:3614
 msgid ""
 "Whether to make a copy of the media objects. When the objects are not "
 "copied, they are referenced by their relative path name"
@@ -1155,27 +1167,27 @@ msgstr ""
 "Copier ou non les objets multimédia. Quand les objets ne sont pas copiés, "
 "ils sont référencés avec le chemin de fichier relatif"
 
-#: DynamicWeb/dynamicweb.py:3584
+#: DynamicWeb/dynamicweb.py:3618
 msgid "Print the notes type"
 msgstr "Imprimer le type des notes"
 
-#: DynamicWeb/dynamicweb.py:3585
+#: DynamicWeb/dynamicweb.py:3619
 msgid "Whether to print the notes type in the notes text"
 msgstr "Imprimer ou non le type des notes dans le texte des notes"
 
-#: DynamicWeb/dynamicweb.py:3588
+#: DynamicWeb/dynamicweb.py:3622
 msgid "Print place pages"
 msgstr "Afficher des pages pour les lieux"
 
-#: DynamicWeb/dynamicweb.py:3589
+#: DynamicWeb/dynamicweb.py:3623
 msgid "Whether to show pages for the places"
 msgstr "Affiche ou non les pages pour les lieux"
 
-#: DynamicWeb/dynamicweb.py:3593
+#: DynamicWeb/dynamicweb.py:3627
 msgid "Include Place map on Place Pages"
 msgstr "Inclure une carte dans les pages du lieu"
 
-#: DynamicWeb/dynamicweb.py:3595
+#: DynamicWeb/dynamicweb.py:3629
 msgid ""
 "Whether to include a place map on the Place Pages, where Latitude/ Longitude "
 "are available."
@@ -1184,12 +1196,12 @@ msgstr ""
 "Longitude est disponible."
 
 # traduction qui tient compte du résultat généré ...
-#: DynamicWeb/dynamicweb.py:3601
+#: DynamicWeb/dynamicweb.py:3635
 msgid "Include Family Map Pages with all places shown on the map"
 msgstr "Inclure des liens vers une carte avec tous les lieux familiaux"
 
 # traduction qui tient compte du résultat généré ...
-#: DynamicWeb/dynamicweb.py:3604
+#: DynamicWeb/dynamicweb.py:3638
 msgid ""
 "Whether or not to add an individual page map showing all the places on this "
 "page. This will allow you to see how your family traveled around the country."
@@ -1198,118 +1210,118 @@ msgstr ""
 "page de l'individu. Ceci vous permettra de voir votre famille à travers ses "
 "lieux."
 
-#: DynamicWeb/dynamicweb.py:3612
+#: DynamicWeb/dynamicweb.py:3646
 msgid "Google"
 msgstr "Google"
 
-#: DynamicWeb/dynamicweb.py:3613
+#: DynamicWeb/dynamicweb.py:3647
 msgid "OpenStreetMap"
 msgstr "OpenStreetMap"
 
-#: DynamicWeb/dynamicweb.py:3615
+#: DynamicWeb/dynamicweb.py:3649
 msgid "Map Service"
 msgstr "Service cartographique"
 
-#: DynamicWeb/dynamicweb.py:3618
+#: DynamicWeb/dynamicweb.py:3652
 msgid "Choose your choice of map service for creating the Place Map Pages"
 msgstr ""
 "Choisissez votre service cartographique pour la création des pages Carte du "
 "lieu"
 
 # trunk
-#: DynamicWeb/dynamicweb.py:3626
+#: DynamicWeb/dynamicweb.py:3660
 msgid "Advanced"
 msgstr "Avancé"
 
-#: DynamicWeb/dynamicweb.py:3629
+#: DynamicWeb/dynamicweb.py:3663
 msgid "Character set encoding"
 msgstr "Encodage de caractères"
 
-#: DynamicWeb/dynamicweb.py:3632
+#: DynamicWeb/dynamicweb.py:3666
 msgid "The encoding to be used for the web files"
 msgstr "L'encodage utilisé pour les fichiers internet"
 
-#: DynamicWeb/dynamicweb.py:3635
+#: DynamicWeb/dynamicweb.py:3669
 msgid "Include family pages"
 msgstr "Inclure les pages de la famille"
 
-#: DynamicWeb/dynamicweb.py:3636
+#: DynamicWeb/dynamicweb.py:3670
 msgid "Whether or not to include family pages"
 msgstr "Inclure ou non des pages de la famille"
 
-#: DynamicWeb/dynamicweb.py:3639
+#: DynamicWeb/dynamicweb.py:3673
 msgid "Include event pages"
 msgstr "Inclure les pages événement"
 
-#: DynamicWeb/dynamicweb.py:3640
+#: DynamicWeb/dynamicweb.py:3674
 msgid "Add a complete events list and relevant pages or not"
 msgstr "Ajouter ou non une liste complète des événements et pages liées"
 
-#: DynamicWeb/dynamicweb.py:3644
+#: DynamicWeb/dynamicweb.py:3678
 msgid "Include a column for birth dates on the index pages"
 msgstr "Inclure une colonne pour les dates de naissance dans les pages index"
 
-#: DynamicWeb/dynamicweb.py:3645
+#: DynamicWeb/dynamicweb.py:3679
 msgid "Whether to include a birth column"
 msgstr "Inclure ou non une colonne naissance"
 
-#: DynamicWeb/dynamicweb.py:3648
+#: DynamicWeb/dynamicweb.py:3682
 msgid "Include a column for death dates on the index pages"
 msgstr "Inclure une colonne pour les dates de décès dans les pages index"
 
-#: DynamicWeb/dynamicweb.py:3649
+#: DynamicWeb/dynamicweb.py:3683
 msgid "Whether to include a death column"
 msgstr "Inclure ou non une colonne décès"
 
-#: DynamicWeb/dynamicweb.py:3652
+#: DynamicWeb/dynamicweb.py:3686
 msgid "Include a column for marriage dates on the index pages"
 msgstr "Inclure un colonne "
 
-#: DynamicWeb/dynamicweb.py:3653
+#: DynamicWeb/dynamicweb.py:3687
 msgid "Whether to include a marriage column"
 msgstr "Inclure ou non une colonne mariage"
 
-#: DynamicWeb/dynamicweb.py:3656
+#: DynamicWeb/dynamicweb.py:3690
 msgid "Include a column for partners on the index pages"
 msgstr "Inclure une colonne pour les conjoints dans les pages index"
 
-#: DynamicWeb/dynamicweb.py:3657
+#: DynamicWeb/dynamicweb.py:3691
 msgid "Whether to include a partners column"
 msgstr "Inclure ou non une colonne conjoints"
 
-#: DynamicWeb/dynamicweb.py:3660
+#: DynamicWeb/dynamicweb.py:3694
 msgid "Include a column for parents on the index pages"
 msgstr "Inclure une colonne pour les parents dans les pages index"
 
-#: DynamicWeb/dynamicweb.py:3661
+#: DynamicWeb/dynamicweb.py:3695
 msgid "Whether to include a parents column"
 msgstr "Inclure ou non une colonne parents"
 
-#: DynamicWeb/dynamicweb.py:3664
+#: DynamicWeb/dynamicweb.py:3698
 msgid "Include half and/ or step-siblings on the individual pages"
 msgstr "Inclure les demi-frères et demi-sœurs sur la page de l'individu"
 
-#: DynamicWeb/dynamicweb.py:3665
+#: DynamicWeb/dynamicweb.py:3699
 msgid ""
 "Whether to include half and/ or step-siblings with the parents and siblings"
 msgstr ""
 "Inclure ou non les demi-frères et demi-sœurs avec les parents, frères et "
 "sœurs."
 
-#: DynamicWeb/dynamicweb.py:3668
+#: DynamicWeb/dynamicweb.py:3702
 msgid "Sort all children in birth order"
 msgstr "Trier les enfants selon la date de naissance"
 
-#: DynamicWeb/dynamicweb.py:3669
+#: DynamicWeb/dynamicweb.py:3703
 msgid "Whether to display children in birth order or in entry order?"
 msgstr ""
 "Affiche les enfants selon leurs dates de naissance ou selon l'ordre actuel ?"
 
-#: DynamicWeb/dynamicweb.py:3672
+#: DynamicWeb/dynamicweb.py:3706
 msgid "Include references in indexes"
 msgstr "Inclure les références dans les index"
 
-#: DynamicWeb/dynamicweb.py:3673
+#: DynamicWeb/dynamicweb.py:3707
 msgid ""
 "Whether to include the references to the items in the index pages. For "
 "example, in the media index page, the names of the individuals, families, "
@@ -1319,33 +1331,33 @@ msgstr ""
 "dans la page d'index des média, les noms des individus, familles, lieux, "
 "sources qui référencent chaque média."
 
-#: DynamicWeb/dynamicweb.py:3676
+#: DynamicWeb/dynamicweb.py:3710
 msgid "Include GENDEX file (/gendex.txt)"
 msgstr "Inclure un fichier GENDEX (gendex.txt)"
 
-#: DynamicWeb/dynamicweb.py:3677
+#: DynamicWeb/dynamicweb.py:3711
 msgid "Whether to include a GENDEX file or not"
 msgstr "Inclure ou non un fichier GENDEX"
 
-#: DynamicWeb/dynamicweb.py:3682
+#: DynamicWeb/dynamicweb.py:3716
 msgid "Trees"
 msgstr "Arbres"
 
-#: DynamicWeb/dynamicweb.py:3691
+#: DynamicWeb/dynamicweb.py:3725
 #, python-format
 msgid "Title for the tree \"%(name)s\""
 msgstr "Titre de l'arbre \"%(name)s\""
 
-#: DynamicWeb/dynamicweb.py:3692
+#: DynamicWeb/dynamicweb.py:3726
 #, python-format
 msgid "Name for the page that shows the tree \"%(name)s\""
 msgstr "Nom de la page qui présente l'arbre \"%(name)s\""
 
-#: DynamicWeb/dynamicweb.py:3695
+#: DynamicWeb/dynamicweb.py:3729
 msgid "Maximum number of  generations"
 msgstr "Nombre maximal de générations"
 
-#: DynamicWeb/dynamicweb.py:3696
+#: DynamicWeb/dynamicweb.py:3730
 msgid ""
 "The maximum number of generations to include in the ancestor and descendant "
 "trees and graphs"
@@ -1353,138 +1365,126 @@ msgstr ""
 "Le nombre mawimal de générations à inclure dans les arbres et graphiques, "
 "ascendants et descendants"
 
-#: DynamicWeb/dynamicweb.py:3702
+#: DynamicWeb/dynamicweb.py:3736
 msgid "Choose the default SVG tree graph type"
 msgstr "Sélection du type d'arbre SVG par défaut"
 
-#: DynamicWeb/dynamicweb.py:3708
+#: DynamicWeb/dynamicweb.py:3742
 msgid "Choose the default SVG tree graph shape"
 msgstr "Sélection de la forme d'arbre SVG par défaut"
 
-#: DynamicWeb/dynamicweb.py:3714
+#: DynamicWeb/dynamicweb.py:3748
 msgid "Choose the default SVG tree parents distribution (for fan charts only)"
 msgstr ""
 "Sélection de la répartition par défaut des parents dans l'arbre SVG (pour "
 "les graphiques circulaires)"
 
-#: DynamicWeb/dynamicweb.py:3720
+#: DynamicWeb/dynamicweb.py:3754
 msgid "Choose the default SVG tree children distribution (for fan charts only)"
 msgstr ""
 "Sélection de la répartition par défaut des enfants dans l'arbre SVG (pour "
 "les graphiques circulaires)"
 
-#: DynamicWeb/dynamicweb.py:3726
+#: DynamicWeb/dynamicweb.py:3760
 msgid ""
 "Choose the background color scheme for the persons in the SVG tree graph"
 msgstr ""
 "Sélection de la trame de fond par défaut des individus dans l'arbre SVG"
 
-#: DynamicWeb/dynamicweb.py:3729
+#: DynamicWeb/dynamicweb.py:3763
 msgid "Start gradient/Main color"
 msgstr "Gradient de départ/couleur principale"
 
-#: DynamicWeb/dynamicweb.py:3732
+#: DynamicWeb/dynamicweb.py:3766
 msgid "End gradient/2nd color"
 msgstr "Gradient de fin/deuxième couleur"
 
-#: DynamicWeb/dynamicweb.py:3735
-msgid "Show duplicates"
-msgstr "Affiche les doublons"
-
-#: DynamicWeb/dynamicweb.py:3736
-msgid ""
-"Whether to use a special color for the persons that appear several times in "
-"the SVG tree"
-msgstr ""
-"Utiliser ou non une couleur spéciale pour les individus qui apparaissent "
-"plusieurs fois dans l'arbre SVG"
-
-#: DynamicWeb/dynamicweb.py:3740
+#: DynamicWeb/dynamicweb.py:3774
 msgid "Color for duplicates"
 msgstr "Couleur des doublons"
 
-#: DynamicWeb/dynamicweb.py:3745
+#: DynamicWeb/dynamicweb.py:3779
 msgid "Pages"
 msgstr "Pages"
 
 # espace limité dans la fenêtre, bug #3596
-#: DynamicWeb/dynamicweb.py:3748
+#: DynamicWeb/dynamicweb.py:3782
 msgid "HTML user header"
 msgstr "En-tête HTML"
 
-#: DynamicWeb/dynamicweb.py:3749
+#: DynamicWeb/dynamicweb.py:3783
 msgid "A note to be used as the page header"
 msgstr "La note utilisée pour l'en-tête de la page"
 
 # espace limité dans la fenêtre, bug #3596
-#: DynamicWeb/dynamicweb.py:3752
+#: DynamicWeb/dynamicweb.py:3786
 msgid "HTML user footer"
 msgstr "Pied de page HTML"
 
-#: DynamicWeb/dynamicweb.py:3753
+#: DynamicWeb/dynamicweb.py:3787
 msgid "A note to be used as the page footer"
 msgstr "La note utilisée pour le pied de page"
 
-#: DynamicWeb/dynamicweb.py:3770
+#: DynamicWeb/dynamicweb.py:3804
 #, python-format
 msgid "Title for the page \"%(name)s\""
 msgstr "Titre pour la page \"%(name)s\""
 
-#: DynamicWeb/dynamicweb.py:3771
+#: DynamicWeb/dynamicweb.py:3805
 #, python-format
 msgid "Name for the page \"%(name)s\""
 msgstr "Nom de la page \"%(name)s\""
 
-#: DynamicWeb/dynamicweb.py:3776
+#: DynamicWeb/dynamicweb.py:3810
 msgid "Custom pages"
 msgstr "Pages personnalisées"
 
-#: DynamicWeb/dynamicweb.py:3781
+#: DynamicWeb/dynamicweb.py:3815
 #, python-format
 msgid "Title for the custom page %(index)i"
 msgstr "Titre de la page personnalisée %(index)i"
 
-#: DynamicWeb/dynamicweb.py:3782
+#: DynamicWeb/dynamicweb.py:3816
 #, python-format
 msgid "Name for the custom page %(index)i"
 msgstr "Nom de la page personnalisée %(index)i"
 
-#: DynamicWeb/dynamicweb.py:3785
+#: DynamicWeb/dynamicweb.py:3819
 #, python-format
 msgid "Note for custom page %(index)i"
 msgstr "Note pour la page personnalisée %(index)i"
 
-#: DynamicWeb/dynamicweb.py:3786
+#: DynamicWeb/dynamicweb.py:3820
 msgid "A note to be used for the custom page content.\n"
 msgstr "Une note à utiliser pour le contenu de la page personnalisée.\n"
 
-#: DynamicWeb/dynamicweb.py:3789
+#: DynamicWeb/dynamicweb.py:3823
 #, python-format
 msgid "Menu for the custom page %(index)i"
 msgstr "Menu de la page personnalisée %(index)i"
 
-#: DynamicWeb/dynamicweb.py:3790
+#: DynamicWeb/dynamicweb.py:3824
 msgid "Whether to print a menu for the custom page"
 msgstr "Afficher ou non un menu pour la page personnalisée"
 
-#: DynamicWeb/dynamicweb.py:3795
+#: DynamicWeb/dynamicweb.py:3829
 msgid "Pages selection"
 msgstr "Sélection des pages"
 
-#: DynamicWeb/dynamicweb.py:3798
+#: DynamicWeb/dynamicweb.py:3832
 msgid "Number of pages"
 msgstr "Nombre de pages"
 
-#: DynamicWeb/dynamicweb.py:3799
+#: DynamicWeb/dynamicweb.py:3833
 msgid "Number pages in the web site."
 msgstr "Nombre de pages du site web"
 
-#: DynamicWeb/dynamicweb.py:3821
+#: DynamicWeb/dynamicweb.py:3855
 #, python-format
 msgid "Contents of page %(index)i"
 msgstr "Contenu de la page %(index)i"
 
-#: DynamicWeb/dynamicweb.py:3824
+#: DynamicWeb/dynamicweb.py:3858
 msgid "Contents of the page"
 msgstr "Contenu de la page"
 

--- a/DynamicWeb/readme.txt
+++ b/DynamicWeb/readme.txt
@@ -8,20 +8,20 @@ It exports the database as web pages.
 See http://belissent.github.io/GrampsDynamicWebReport/ for more information and reports examples.
 
 
-Gramps branches master, 4.0 and 4.1 are supported, previous branches are not supported.
+Gramps branches 4.0, 4.1, 4.2, 5.0 (master) are supported, previous branches are not supported.
 
 
 
-Testing instructions:
+Instructions for generating report examples:
 
 - Import example database:
-  In the directory DynamicWeb/test
-  python dynamicweb_test.py -i
+  In the directory DynamicWeb
+  python run_dynamicweb.py -i
 
 - Run Gramps and set the base directory for media relative paths to %GRAMPS_RESOURCES%/examples/gramps
 
-- Run tests:
-  In the directory DynamicWeb/test
-  python dynamicweb_test.py
+- Generate the example reports:
+  In the directory DynamicWeb
+  python run_dynamicweb.py
 
-- Results are in the directory DynamicWeb/test_results
+- Results are in the directory DynamicWeb/reports

--- a/DynamicWeb/run_dynamicweb.py
+++ b/DynamicWeb/run_dynamicweb.py
@@ -23,11 +23,11 @@ Arguments = [-i] [test numbers]
 
 Usage examples:
 - Import example database
-	python dynamicweb_test.py -i
+	python run_dynamicweb.py -i
 - Run tests 0 and 2
-	python dynamicweb_test.py 0 2
+	python run_dynamicweb.py 0 2
 - Run all tests
-	python dynamicweb_test.py
+	python run_dynamicweb.py
 """
 
 from __future__ import print_function
@@ -282,7 +282,7 @@ def main(test_nums=None):
 		import_data()
 		test_nums = range(len(test_list))
 	# Create results directory
-	results_path = os.path.join(plugin_path, "test_results")
+	results_path = os.path.join(plugin_path, "reports")
 	results_path = os.path.abspath(results_path)
 	if (not os.path.isdir(results_path)): os.mkdir(results_path)
 	plugvers = plugin_version()
@@ -435,8 +435,8 @@ if __name__ == '__main__':
 				int(sys.argv[i])
 				for i in range(1, len(sys.argv))
 			]
-		# Launch tests
-		print("Performing tests: %s" % str(test_nums))
+		# Launch reports generation
+		print("Exporting reports: %s" % str(test_nums))
 		main(test_nums)
 	except Exception as ex:
 		sys.stderr.write(str(ex))


### PR DESCRIPTION
This PR should allow to pass the CI tests.
All the DynamicWeb tests were excluded from the nostests:
The example reports generation does not work because it seems that in the Travis test environment, the addons are not rebuild and not loaded in the USER_PLUGINS directory.