### PR TITLE
Remove useless clone in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,11 @@ language: c
 #    - 3.4
 
 install:
-    - git clone --depth=50 --branch=master git://github.com/gramps-project/gramps.git gramps-project/gramps
-    - cd gramps-project/gramps
+    # $TRAVIS_BUILD_DIR is set to the location of the cloned repository:
+    # for example: /home/travis/build/gramps-project/addons-source
+
+    - git clone --depth=50 --branch=$TRAVIS_BRANCH git://github.com/gramps-project/gramps.git $TRAVIS_BUILD_DIR/../gramps
+    - cd $TRAVIS_BUILD_DIR/../gramps
     - time sudo apt-get update
     - travis_retry sudo apt-get install gir1.2-pango gir1.2-gtk xdg-utils librsvg2-common libglib2.0-dev intltool 
     - travis_retry sudo apt-get install python3-gobject python3-gi python3-cairo python3-gi-cairo python3-bsddb3 python3-dev python3-nose
@@ -20,17 +23,15 @@ install:
     - travis_retry sudo pip3 install mock
     - python3 setup.py build
 
-    - cd ..
-    - git clone --depth=50 --branch=master git://github.com/gramps-project/addons-source.git addons-source
-    - cd addons-source
+    - cd $TRAVIS_BUILD_DIR
     - python3 -m compileall *
-    - mkdir -p /home/travis/.gramps/grampsdb/
-    - mkdir -p /home/travis/.gramps/gramps50/plugins
-    - cp -r * /home/travis/.gramps/gramps50/plugins/
+    - mkdir -p $HOME/.gramps/grampsdb/
+    - mkdir -p $HOME/.gramps/gramps50/plugins
+    - cp -r * $HOME/.gramps/gramps50/plugins/
 
 #before_script:
 #    - export DISPLAY=:0
 #    - sudo Xvfb :0 -ac -screen 0 1024x768x24 &
 
 script:
-    -  GRAMPS_RESOURCES=../gramps PYTHONPATH=../gramps nosetests3 -vv
+    -  GRAMPS_RESOURCES=$TRAVIS_BUILD_DIR/../gramps PYTHONPATH=$TRAVIS_BUILD_DIR/../gramps nosetests3 -vv


### PR DESCRIPTION
When working in a fork, this allows to make the Travis tests use the fork repository and not the git://github.com/gramps-project/* repository