### PR TITLE
GraphVeiw: fix 0009460 issue. Multiple spouses.

### DIFF
--- a/GraphView/graphview.py
+++ b/GraphView/graphview.py
@@ -1179,6 +1179,38 @@ class DotGenerator(object):
                             num_generations - 1,
                             person_handles)
 
+                # add all his spouses recursively
+                sp_person = self.database.get_person_from_handle(father_handle)
+                if sp_person:
+                  for sp_family_handle in sp_person.get_family_handle_list():
+                     sp_family = self.database.get_family_from_handle(sp_family_handle)
+                     if sp_family.get_mother_handle() and sp_family.get_mother_handle() not in person_handles:
+                        self.add_descendant(
+                          self.database.get_person_from_handle(sp_family.get_mother_handle()),
+                          1,
+                          person_handles)
+                     if sp_family.get_father_handle() and sp_family.get_father_handle() not in person_handles:
+                        self.add_descendant(
+                          self.database.get_person_from_handle(sp_family.get_father_handle()),
+                          1,
+                          person_handles)
+
+                # add all her spouses recursively
+                sp_person = self.database.get_person_from_handle(mother_handle)
+                if sp_person:
+                  for sp_family_handle in sp_person.get_family_handle_list():
+                     sp_family = self.database.get_family_from_handle(sp_family_handle)
+                     if sp_family.get_mother_handle() and sp_family.get_mother_handle() not in person_handles:
+                        self.add_descendant(
+                          self.database.get_person_from_handle(sp_family.get_mother_handle()),
+                          1,
+                          person_handles)
+                     if sp_family.get_father_handle() and sp_family.get_father_handle() not in person_handles:
+                        self.add_descendant(
+                          self.database.get_person_from_handle(sp_family.get_father_handle()),
+                          1,
+                          person_handles)
+
     def add_child_links_to_families(self):
         "returns string of GraphViz edges linking parents to families or \
          children"

--- a/GraphView/graphview.py
+++ b/GraphView/graphview.py
@@ -1141,7 +1141,7 @@ class DotGenerator(object):
                         self.add_descendant(
                           self.database.get_person_from_handle(sp_family.get_father_handle()),
                           1,
-                          person_handles))
+                          person_handles)
 
     def find_ancestors(self, active_person):
         "Spider the database from the active person"

--- a/GraphView/graphview.py
+++ b/GraphView/graphview.py
@@ -1166,14 +1166,18 @@ class DotGenerator(object):
                 family = self.database.get_family_from_handle(family_handle)
 
                 # Add every parent recursively
-                self.add_ancestor(
-                        self.database.get_person_from_handle(family.get_father_handle()),
-                        num_generations - 1,
-                        person_handles)
-                self.add_ancestor(
-                        self.database.get_person_from_handle(family.get_mother_handle()),
-                        num_generations - 1,
-                        person_handles)
+                father_handle = family.get_father_handle()
+                if father_handle:
+                    self.add_ancestor(
+                            self.database.get_person_from_handle(father_handle),
+                            num_generations - 1,
+                            person_handles)
+                mother_handle = family.get_mother_handle()
+                if mother_handle:
+                    self.add_ancestor(
+                            self.database.get_person_from_handle(mother_handle),
+                            num_generations - 1,
+                            person_handles)
 
     def add_child_links_to_families(self):
         "returns string of GraphViz edges linking parents to families or \

--- a/GraphView/graphview.py
+++ b/GraphView/graphview.py
@@ -1117,14 +1117,22 @@ class DotGenerator(object):
                         num_generations - 1,
                         person_handles)
 
-                # Add spouse
+                # Add spouses
                 if person.handle == family.get_father_handle():
                     spouse_handle = family.get_mother_handle()
                 else:
                     spouse_handle = family.get_father_handle()
 
+                # add spouse itself
                 if spouse_handle and spouse_handle not in person_handles:
-                    person_handles.append(spouse_handle)
+                   person_handles.append(spouse_handle)
+                # add all his spouses
+                sp_person = self.database.get_person_from_handle(spouse_handle)
+                if sp_person:
+                  for sp_family_handle in sp_person.get_family_handle_list():
+                     sp_family = self.database.get_family_from_handle(sp_family_handle)
+                     if sp_family.get_mother_handle() and sp_family.get_mother_handle() not in person_handles:
+                       person_handles.append(sp_family.get_mother_handle())
 
     def find_ancestors(self, active_person):
         "Spider the database from the active person"
@@ -1265,15 +1273,11 @@ class DotGenerator(object):
                           fam_handle, "",
                           self.arrowheadstyle,
                           self.arrowtailstyle)
-            # Include spouses from other marriage not selected by filter
-            self.person_handles.add(f_handle)
         if m_handle:
             self.add_link(m_handle,
                           fam_handle, "",
                           self.arrowheadstyle,
                           self.arrowtailstyle)
-            # Include spouses from other marriage not selected by filter
-            self.person_handles.add(m_handle)
         self.end_subgraph()
 
     def get_gender_style(self, person):

--- a/GraphView/graphview.py
+++ b/GraphView/graphview.py
@@ -1126,13 +1126,15 @@ class DotGenerator(object):
                 # add spouse itself
                 if spouse_handle and spouse_handle not in person_handles:
                    person_handles.append(spouse_handle)
-                # add all his spouses
+                # add all his(her) spouses
                 sp_person = self.database.get_person_from_handle(spouse_handle)
                 if sp_person:
                   for sp_family_handle in sp_person.get_family_handle_list():
                      sp_family = self.database.get_family_from_handle(sp_family_handle)
                      if sp_family.get_mother_handle() and sp_family.get_mother_handle() not in person_handles:
                        person_handles.append(sp_family.get_mother_handle())
+                     if sp_family.get_father_handle() and sp_family.get_father_handle() not in person_handles:
+                       person_handles.append(sp_family.get_father_handle())
 
     def find_ancestors(self, active_person):
         "Spider the database from the active person"

--- a/GraphView/graphview.py
+++ b/GraphView/graphview.py
@@ -1134,14 +1134,14 @@ class DotGenerator(object):
                      sp_family = self.database.get_family_from_handle(sp_family_handle)
                      if sp_family.get_mother_handle() and sp_family.get_mother_handle() not in person_handles:
                         self.add_descendant(
-                        self.database.get_person_from_handle(sp_family.get_mother_handle()),
-                        1,    # only spouse
-                        person_handles)
+                          self.database.get_person_from_handle(sp_family.get_mother_handle()),
+                          1,
+                          person_handles)
                      if sp_family.get_father_handle() and sp_family.get_father_handle() not in person_handles:
                         self.add_descendant(
-                        self.database.get_person_from_handle(sp_family.get_father_handle()),
-                        1,    # only spouse
-                        person_handles))
+                          self.database.get_person_from_handle(sp_family.get_father_handle()),
+                          1,
+                          person_handles))
 
     def find_ancestors(self, active_person):
         "Spider the database from the active person"

--- a/GraphView/graphview.py
+++ b/GraphView/graphview.py
@@ -1126,15 +1126,22 @@ class DotGenerator(object):
                 # add spouse itself
                 if spouse_handle and spouse_handle not in person_handles:
                    person_handles.append(spouse_handle)
-                # add all his(her) spouses
+                   
+                # add all his(her) spouses recursively
                 sp_person = self.database.get_person_from_handle(spouse_handle)
                 if sp_person:
                   for sp_family_handle in sp_person.get_family_handle_list():
                      sp_family = self.database.get_family_from_handle(sp_family_handle)
                      if sp_family.get_mother_handle() and sp_family.get_mother_handle() not in person_handles:
-                       person_handles.append(sp_family.get_mother_handle())
+                        self.add_descendant(
+                        self.database.get_person_from_handle(sp_family.get_mother_handle()),
+                        1,    # only spouse
+                        person_handles)
                      if sp_family.get_father_handle() and sp_family.get_father_handle() not in person_handles:
-                       person_handles.append(sp_family.get_father_handle())
+                        self.add_descendant(
+                        self.database.get_person_from_handle(sp_family.get_father_handle()),
+                        1,    # only spouse
+                        person_handles))
 
     def find_ancestors(self, active_person):
         "Spider the database from the active person"


### PR DESCRIPTION
After changes in "build_graph" definition of "self.person_handles = set()", we can't Include spouses from other marriage not selected by filter in "__add_family".
And I try to find all spouses in "add_descendant" function. I don't know if it's right but It works for me.