### PR TITLE
make.py: support several xml files (eg Form) and update Form's template.pot

### DIFF
--- a/Form/form_us.xml
+++ b/Form/form_us.xml
@@ -3107,7 +3107,7 @@
                    <_attribute>Months unemployed during census year</_attribute>
                </column>
                <column>
-                   <_attribute>(Day of the Enumerator’s visit) sick or temporarily disabled</_attribute>
+                   <_attribute>(Day of the Enumerator&apos;s visit) sick or temporarily disabled</_attribute>
                </column>
                <column>
                    <_attribute>Blind</_attribute>
@@ -6232,7 +6232,7 @@ North Dakota Census
                 <_attribute>Can Read</_attribute>
             </column>
             <column>
-                <_attribute>Can't Read</_attribute>
+                <_attribute>Can&apos;t Read</_attribute>
             </column>
             <column>
                 <_attribute>Can Write</_attribute>

--- a/make.py
+++ b/make.py
@@ -167,7 +167,8 @@ elif command == "init":
         mkdir(r("%(addon)s/po"))
         mkdir("%(addon)s/locale")
         system('''intltool-extract --type=gettext/glade "%(addon)s"/*.glade''')
-        system('''intltool-extract --type=gettext/xml "%(addon)s"/*.xml''')
+        for xml in glob.glob(r('''%(addon)s/*xml''')):
+            system('''intltool-extract --type=gettext/xml "%(xml)s"''')
         system('''xgettext --language=Python --keyword=_ --keyword=N_'''
                ''' -o "%(addon)s/po/template.pot" "%(addon)s"/*.py ''')
         system('''xgettext -j --keyword=_ --keyword=N_'''


### PR DESCRIPTION
In order to update the translation of the Form gramplet, `make.py` has to support several xml files. This is done in the first commit. Before the Form's `template.pot` can be updated, an non-ASCII character has to be substituted from the US definitions (second commit). Finally, `template.pot` is updated.

Please check carefully whether these changes make sense. I am neither a python programmer nor a regular translator.

The change of `make.py` probably has to be cherry-picked to the master branch.