### PR TITLE
fix bug 10053 PhotoTaggingGramplet exception

### DIFF
--- a/PhotoTaggingGramplet/PhotoTaggingGramplet.py
+++ b/PhotoTaggingGramplet/PhotoTaggingGramplet.py
@@ -618,7 +618,7 @@ class PhotoTaggingGramplet(Gramplet):
 
         # populate the context menu
         persons = self.all_referenced_persons()
-        if selected.person is not None:
+        if selected is not None and selected.person is not None:
             persons.remove(selected.person)
         if persons:
             self.additional_items.append(Gtk.SeparatorMenuItem())


### PR DESCRIPTION
when starting new selection with a person selected.

I have not built this for download/listing.  I also expect that our 'senior developer' will do the merges to master branch...

I also note that the PhotoTaggingGramplet source file is different than the one in the download list for Gramps master. Seems someone made changes and has not rebuilt the plugin since.

If accepted this should also be back-ported to Gramps42 branch...