### PR TITLE
Fix bug 10058 Timeline View shows infinite lifespans for some persons

### DIFF
--- a/TimelinePedigreeView/TimelinePedigreeView.py
+++ b/TimelinePedigreeView/TimelinePedigreeView.py
@@ -885,6 +885,8 @@ class TimelinePedigreeView(NavigationView):
             if death:
                 deathdate = death.get_date_object()
                 lifespan = deathdate.to_calendar("gregorian").get_year() - birthdate.to_calendar("gregorian").get_year()
+                if lifespan < 0 or lifespan > config.get('behavior.max-age-prob-alive'):
+                    lifespan = 0
 
         negWidth = 11 * lifespan
 


### PR DESCRIPTION
When one date (birth or death) is not known, the lifespan would give a huge negative or a huge positive number, leading to excessive lifespan boxes.