### PR TITLE
Fixes for Gramplet signalling issues

### DIFF
--- a/BirthdaysGramplet/BirthdaysGramplet.py
+++ b/BirthdaysGramplet/BirthdaysGramplet.py
@@ -41,14 +41,10 @@ class BirthdaysGramplet(Gramplet):
         self.set_text(_("No Family Tree loaded."))
         self.max_age = config.get('behavior.max-age-prob-alive')
 
-    def post_init(self):
-        self.disconnect("active-changed")
-
     def db_changed(self):
-        self.dbstate.db.connect('person-add', self.update)
-        self.dbstate.db.connect('person-delete', self.update)
-        self.dbstate.db.connect('person-update', self.update)
-        self.update
+        self.connect(self.dbstate.db, 'person-add', self.update)
+        self.connect(self.dbstate.db, 'person-delete', self.update)
+        self.connect(self.dbstate.db, 'person-update', self.update)
 
     def main(self):
         self.set_text(_("Processing..."))

--- a/DataEntryGramplet/DataEntryGramplet.gpr.py
+++ b/DataEntryGramplet/DataEntryGramplet.gpr.py
@@ -18,6 +18,7 @@ register(GRAMPLET,
          status=STABLE, # not yet tested with python 3
          fname="DataEntryGramplet.py",
          help_url="Data Entry Gramplet",
+         navtypes=["Person"],
          )
 
 

--- a/DataEntryGramplet/DataEntryGramplet.py
+++ b/DataEntryGramplet/DataEntryGramplet.py
@@ -997,13 +997,13 @@ class DataEntryGramplet(Gramplet):
         If person or family changes, the relatives of active person might have
         changed
         """
-        self.dbstate.db.connect('person-add', self.update)
-        self.dbstate.db.connect('person-delete', self.update)
-        self.dbstate.db.connect('person-edit', self.update)
-        self.dbstate.db.connect('family-add', self.update)
-        self.dbstate.db.connect('family-delete', self.update)
-        self.dbstate.db.connect('person-rebuild', self.update)
-        self.dbstate.db.connect('family-rebuild', self.update)
+        self.connect(self.dbstate.db, 'person-add', self.update)
+        self.connect(self.dbstate.db, 'person-delete', self.update)
+        self.connect(self.dbstate.db, 'person-update', self.update)
+        self.connect(self.dbstate.db, 'family-add', self.update)
+        self.connect(self.dbstate.db, 'family-delete', self.update)
+        self.connect(self.dbstate.db, 'person-rebuild', self.update)
+        self.connect(self.dbstate.db, 'family-rebuild', self.update)
         self._dirty = False
         self._dirty_person = None
         self.clear_data_entry(None)

--- a/DeepConnectionsGramplet/DeepConnectionsGramplet.gpr.py
+++ b/DeepConnectionsGramplet/DeepConnectionsGramplet.gpr.py
@@ -13,6 +13,7 @@ register(GRAMPLET,
          version = '1.0.26',
          gramps_target_version = "5.0",
          help_url="Deep_Connections_Gramplet",
+         navtypes=["Person"],
          )
 
 

--- a/DeepConnectionsGramplet/DeepConnectionsGramplet.py
+++ b/DeepConnectionsGramplet/DeepConnectionsGramplet.py
@@ -77,6 +77,20 @@ class DeepConnectionsGramplet(Gramplet):
         self.gui.get_container_widget().add_with_viewport(vbox)
         vbox.show_all()
 
+    def db_changed(self):
+        """
+        If person or family changes, the relatives of active person might have
+        changed
+        """
+        self.connect(self.dbstate.db, 'home-person-changed', self.update)
+        self.connect(self.dbstate.db, 'person-add', self.update)
+        self.connect(self.dbstate.db, 'person-delete', self.update)
+        self.connect(self.dbstate.db, 'person-update', self.update)
+        self.connect(self.dbstate.db, 'family-add', self.update)
+        self.connect(self.dbstate.db, 'family-delete', self.update)
+        self.connect(self.dbstate.db, 'person-rebuild', self.update)
+        self.connect(self.dbstate.db, 'family-rebuild', self.update)
+
     def get_links_from_notes(self, obj, path, relation, person_handle):
         """
         Get anyone mentioned in any note attached to this object.

--- a/DescendantCount/DescendantCount.py
+++ b/DescendantCount/DescendantCount.py
@@ -51,8 +51,8 @@ class DescendantCountGramplet(Gramplet):
                                  container=self.gui.textview)
 
     def db_changed(self):
-        self.dbstate.db.connect('person-add', self.update)
-        self.dbstate.db.connect('person-delete', self.update)
+        self.connect(self.dbstate.db, 'person-add', self.update)
+        self.connect(self.dbstate.db, 'person-delete', self.update)
 
     def active_changed(self, handle):
         self.update()

--- a/EditExifMetadata/editexifmetadata.py
+++ b/EditExifMetadata/editexifmetadata.py
@@ -246,9 +246,6 @@ class EditExifMetadata(Gramplet):
         self.gui.get_container_widget().remove(self.gui.textview)
         self.gui.get_container_widget().add_with_viewport(vbox)
 
-        self.dbstate.db.connect('media-update', self.update)
-        self.connect_signal('Media', self.update)
-
     def active_changed(self, handle):
         """
         handles when a media object has changed
@@ -259,10 +256,10 @@ class EditExifMetadata(Gramplet):
         """
         connects the media signals to self.update; which updates the display...
         """
-        self.dbstate.db.connect('media-add', self.update)
-        self.dbstate.db.connect('media-edit', self.update)
-        self.dbstate.db.connect('media-delete', self.update)
-        self.dbstate.db.connect('media-rebuild', self.update)
+        self.connect(self.dbstate.db, 'media-add', self.update)
+        self.connect(self.dbstate.db, 'media-update', self.update)
+        self.connect(self.dbstate.db, 'media-delete', self.update)
+        self.connect(self.dbstate.db, 'media-rebuild', self.update)
 
         self.connect_signal('Media', self.update)
 
@@ -1470,12 +1467,6 @@ class EditExifMetadata(Gramplet):
             else:
                 self.exif_widgets["MessageArea"].set_text(_("There was an error "
                     "in stripping the Exif metadata from this image..."))
-
-    def post_init(self):
-        """
-        disconnects the active signal upon closing
-        """
-        self.disconnect("active-changed")
 
 def string_to_rational(coordinate):
     """

--- a/ExtendedAttributes/ExtendedAttributes.py
+++ b/ExtendedAttributes/ExtendedAttributes.py
@@ -137,8 +137,7 @@ class ExtendedPersonAttributes(Attributes):
     Displays the attributes of a person.
     """
     def db_changed(self):
-        self.dbstate.db.connect('person-update', self.update)
-        self.update()
+        self.connect(self.dbstate.db, 'person-update', self.update)
 
     def active_changed(self, handle):
         self.update()
@@ -206,9 +205,8 @@ class ExtendedFamilyAttributes(Attributes):
     Displays the attributes of an event.
     """
     def db_changed(self):
-        self.dbstate.db.connect('family-update', self.update)
+        self.connect(self.dbstate.db, 'family-update', self.update)
         self.connect_signal('Family', self.update)
-        self.update()
 
     def update_has_data(self):
         active = self.get_active_object('Family')

--- a/FaceDetection/FaceDetection.py
+++ b/FaceDetection/FaceDetection.py
@@ -71,9 +71,8 @@ class FaceDetection(Gramplet):
         return self.top
 
     def db_changed(self):
-        self.dbstate.db.connect('media-update', self.update)
+        self.connect(self.dbstate.db, 'media-update', self.update)
         self.connect_signal('Media', self.update)
-        self.update()
 
     def update_has_data(self):
         active_handle = self.get_active('Media')

--- a/ImportGramplet/ImportGramplet.py
+++ b/ImportGramplet/ImportGramplet.py
@@ -202,9 +202,6 @@ class ImportGramplet(Gramplet):
         # show
         vbox.show_all()
 
-    def post_init(self):
-        self.disconnect("active-changed")
-
     def run(self, obj):
         """
         Method that is run when you click the Run button.

--- a/LastChange/LastChangeGramplet.py
+++ b/LastChange/LastChangeGramplet.py
@@ -79,9 +79,9 @@ class LastChangeGramplet(Gramplet):
 
     def db_changed(self):
         """Connect the signals that trigger an update."""
-        self.dbstate.db.connect('person-add', self.update)
-        self.dbstate.db.connect('person-delete', self.update)
-        self.dbstate.db.connect('person-update', self.update)
-        self.dbstate.db.connect('family-add', self.update)
-        self.dbstate.db.connect('family-delete', self.update)
-        self.dbstate.db.connect('family-update', self.update)
+        self.connect(self.dbstate.db, 'person-add', self.update)
+        self.connect(self.dbstate.db, 'person-delete', self.update)
+        self.connect(self.dbstate.db, 'person-update', self.update)
+        self.connect(self.dbstate.db, 'family-add', self.update)
+        self.connect(self.dbstate.db, 'family-delete', self.update)
+        self.connect(self.dbstate.db, 'family-update', self.update)

--- a/MediaBrowser/MediaBrowser.py
+++ b/MediaBrowser/MediaBrowser.py
@@ -59,8 +59,7 @@ class MediaBrowser(Gramplet):
         return top
 
     def db_changed(self):
-        self.dbstate.db.connect('person-update', self.update)
-        self.update()
+        self.connect(self.dbstate.db, 'person-update', self.update)
 
     def active_changed(self, handle):
         self.update()

--- a/NoteGramplet/NoteGramplet.gpr.py
+++ b/NoteGramplet/NoteGramplet.gpr.py
@@ -13,4 +13,5 @@ register(GRAMPLET,
          version = '1.0.24',
          gramps_target_version="5.0",
          help_url = "NoteGramplet",
+         navtypes=["Person"],
          )

--- a/NoteGramplet/NoteGramplet.py
+++ b/NoteGramplet/NoteGramplet.py
@@ -205,6 +205,8 @@ class NoteGramplet(Gramplet):
         If person or family changes, the relatives of active person might have
         changed
         """
+        self.connect(self.dbstate.db, 'person-update', self.update)
+        self.connect(self.dbstate.db, 'note-update', self.update)
         self._dirty = False
         self._dirty_person = None
         self.clear_data_entry(None)

--- a/PhotoTaggingGramplet/PhotoTaggingGramplet.py
+++ b/PhotoTaggingGramplet/PhotoTaggingGramplet.py
@@ -443,7 +443,7 @@ class PhotoTaggingGramplet(Gramplet):
     # ======================================================
 
     def db_changed(self):
-        self.dbstate.db.connect('media-update', self.update)
+        self.connect(self.dbstate.db, 'media-update', self.update)
         self.connect_signal('Media', self.update)
 
     def main(self):

--- a/PythonGramplet/PythonGramplet.py
+++ b/PythonGramplet/PythonGramplet.py
@@ -66,9 +66,6 @@ class PythonGramplet(Gramplet):
         self.set_text("Python %s\n%s " % (sys.version, self.prompt))
         self.gui.textview.connect('key-press-event', self.on_key_press)
 
-    def post_init(self):
-        self.disconnect("active-changed")
-
     def format_exception(self, max_tb_level=10):
         import traceback
         retval = ''

--- a/Query/QueryGramplet.py
+++ b/Query/QueryGramplet.py
@@ -63,9 +63,6 @@ class PythonGramplet(Gramplet):
         self.set_text("Python %s\n%s " % (sys.version, self.prompt))
         self.gui.textview.connect('key-press-event', self.on_key_press)
 
-    def post_init(self):
-        self.disconnect("active-changed")
-
     def format_exception(self, max_tb_level=10):
         import traceback
         retval = ''

--- a/RelatedRelativesGramplet/RelatedRelativesGramplet.py
+++ b/RelatedRelativesGramplet/RelatedRelativesGramplet.py
@@ -56,12 +56,12 @@ class RelatedRelativesGramplet(Gramplet):
 # Register database triggers for updates
 #
     def db_changed(self):
-        self.dbstate.db.connect('person-add', self.update)
-        self.dbstate.db.connect('person-delete', self.update)
-        self.dbstate.db.connect('family-add', self.update)
-        self.dbstate.db.connect('family-delete', self.update)
-        self.dbstate.db.connect('person-rebuild', self.update)
-        self.dbstate.db.connect('family-rebuild', self.update)
+        self.connect(self.dbstate.db, 'person-add', self.update)
+        self.connect(self.dbstate.db, 'person-delete', self.update)
+        self.connect(self.dbstate.db, 'family-add', self.update)
+        self.connect(self.dbstate.db, 'family-delete', self.update)
+        self.connect(self.dbstate.db, 'person-rebuild', self.update)
+        self.connect(self.dbstate.db, 'family-rebuild', self.update)
 
 #
 #   Function that recursively adds all descendants of a person to the

--- a/SourceReferences/SourceReferences.py
+++ b/SourceReferences/SourceReferences.py
@@ -89,7 +89,7 @@ class SourceReferences(Gramplet):
         edit_object(self.dbstate, self.uistate, objclass, handle)
 
     def db_changed(self):
-        self.dbstate.db.connect('source-update', self.update)
+        self.connect(self.dbstate.db, 'source-update', self.update)
         self.connect_signal('Source', self.update)
 
     def update_has_data(self):

--- a/WordleGramplet/WordleGramplet.py
+++ b/WordleGramplet/WordleGramplet.py
@@ -74,11 +74,11 @@ class WordleGramplet(Gramplet):
         self.set_text(_("No Family Tree loaded."))
 
     def db_changed(self):
-        self.dbstate.db.connect('person-add', self.update)
-        self.dbstate.db.connect('person-delete', self.update)
-        self.dbstate.db.connect('person-update', self.update)
-        self.dbstate.db.connect('person-rebuild', self.update)
-        self.dbstate.db.connect('family-rebuild', self.update)
+        self.connect(self.dbstate.db, 'person-add', self.update)
+        self.connect(self.dbstate.db, 'person-delete', self.update)
+        self.connect(self.dbstate.db, 'person-update', self.update)
+        self.connect(self.dbstate.db, 'person-rebuild', self.update)
+        self.connect(self.dbstate.db, 'family-rebuild', self.update)
 
     def on_load(self):
         if len(self.gui.data) > 0:

--- a/lxml/etreeGramplet.py
+++ b/lxml/etreeGramplet.py
@@ -200,10 +200,6 @@ class etreeGramplet(Gramplet):
         self.entry.set_text(os.path.join(self.__base_path, self.__file_name))
 
 
-    def post_init(self):
-        self.disconnect("active-changed")
-
-
     def build_options(self):
         from gramps.gen.plug.menu import NumberOption
         self.add_option(NumberOption(_("Number of editions back"),

--- a/lxml/lxmlGramplet.py
+++ b/lxml/lxmlGramplet.py
@@ -225,10 +225,6 @@ class lxmlGramplet(Gramplet):
         self.entry.set_text(os.path.join(self.__base_path, self.__file_name))
 
 
-    def post_init(self):
-        self.disconnect("active-changed")
-
-
     def run(self, obj):
         """
         Method that is run when you click the Run button.


### PR DESCRIPTION
This PR is intended to match the main Gramps gramps50 branch repo https://github.com/gramps-project/gramps/pull/424, that is it does the same things.

Fixes #10089, #10090
I'm pretty sure that none of these changes will hurt compatibility with gramps50 alpha2 so it should be OK to merge this before alpha3 comes out.

I discovered that doing a Family merge that also merged at least one parent, would still get HandleErrors. Root cause, a lot of Gramplets were getting connected to Person history active-changed signal, and thus were doing unnecessary updates. In this case, the Person update occured before the Family Gramplets got shifted off of the family deleted by the merge, so the Gramplets tried to show the (now deleted) family again. And got HandleErrors.

I changed the base Gramplet class to only make default connections to the Person History active-change signal when the Gramplet had a navtype of 'Person' from the .gpr file. So unless a Gramplet has navtype=['Person'] in .gpr it will not get an automatic connection to Person active-changed.

A few Addon Gramplets that should have had navtype set to 'Person', did not.

It turns out a few Gramplets knew they were getting the 'extra' Person connection, and had a 'disconnect' which now failed with the prior change. So these extra disconnects are removed.

I also noticed that on db close/open, a lot of signals were getting connected when they already were connected. This because the connection was made in a db_changed method, but never disconnected.

To prevent multiple connections after db close/open, I decided to make all connections through Gramplet class 'connect', rather than directly to db, and to implement a disconnect on db_close and on db_changed, prior to making the connections again.

In the sweep though all our Gramplets I spotted a few other smaller issues like a wrong signal connect ('person-edit', rather than 'person-update'). And a few signals were missing from some of the Gramplets.