### PR TITLE
Fix travis so it will work from other branches in PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ install:
 # The working directory is set to /home/travis/build/gramps-project/addons-source
 # by the automatic git checkout.
 
- - git clone --depth=50 --branch=$TRAVIS_BRANCH git://github.com/gramps-project/gramps.git $TRAVIS_BUILD_DIR/../gramps
+ - git clone --depth=50 --branch=maintenance/gramps50 git://github.com/gramps-project/gramps.git $TRAVIS_BUILD_DIR/../gramps
  - cd $TRAVIS_BUILD_DIR/../gramps
 
 # Build Gramps package. This seems to copy everything to


### PR DESCRIPTION
When trying to use PRs with source branches different from the base branch (maintenance/gramps50) the travis build would fail because it was using a shell variable for the source branch as the main gramps repo branch name, when it should have been using the base name.