### PR TITLE
Fix NetworkChart and TMGimporter to work with Travis (no display)

### DIFF
--- a/NetworkChart/NetworkChart.gpr.py
+++ b/NetworkChart/NetworkChart.gpr.py
@@ -47,7 +47,7 @@ if conditions_met:
         gramps_target_version = '5.0',
         include_in_listing = True,
     )
-else:
+elif uistate:  # don't start GUI if in CLI mode, just ignore
     from gramps.gen.config import config
     from gramps.gui.dialog import QuestionDialog2
     from gramps.gen.config import logging
@@ -73,7 +73,7 @@ else:
               "https://gramps-project.org/wiki/index.php?title=NetworkChart \n\n"
               "To dismiss all future NetworkChart warnings click Dismiss."),
             _(" Dismiss "),
-            _("Continue"))
+            _("Continue"), parent=uistate.window)
         prompt = yes_no.run()
         if prompt is True:
             inifile.register('networkchartwarn.MissingModules', "")

--- a/TMGimporter/importtmg.gpr.py
+++ b/TMGimporter/importtmg.gpr.py
@@ -38,7 +38,6 @@ LOG = logging.getLogger(".TMGImport")
 # Gramps modules
 #
 #------------------------------------------------------------------------
-from gramps.gui.dialog import ErrorDialog
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.sgettext
 


### PR DESCRIPTION
The .gpr files were importing Gtk, which doesn't work for Travis
because there is no display.