### PR TITLE
GraphView; some printing issues[gramps42]

### DIFF
--- a/GraphView/graphview.py
+++ b/GraphView/graphview.py
@@ -401,11 +401,13 @@ class GraphView(NavigationView):
                     self.printview(obj)
                     return
             svg = val.replace('.gv', '.svg')
+            # both dot_data and svg_data are bytes, already utf-8 encoded
+            # Just write them as binary
             try:
-                with open(val,'w') as g,\
-                     open(svg,'w') as s:
-                        g.write(self.graph_widget.dot_data.decode('utf-8'))
-                        s.write(self.graph_widget.svg_data.decode('utf-8'))
+                with open(val,'wb') as g,\
+                     open(svg,'wb') as s:
+                        g.write(self.graph_widget.dot_data)
+                        s.write(self.graph_widget.svg_data)
             except IOError as msg:
                 msg2 = _("Could not create %s") % (val + ', ' + svg)
                 ErrorDialog(msg2, str(msg), parent=dot)

--- a/GraphView/graphview.py
+++ b/GraphView/graphview.py
@@ -377,7 +377,8 @@ class GraphView(NavigationView):
             _("Select a dot file name"),
             action=Gtk.FileChooserAction.SAVE,
             buttons=(_('_Cancel'), Gtk.ResponseType.CANCEL,
-                     _('_Apply'), Gtk.ResponseType.OK))
+                     _('_Apply'), Gtk.ResponseType.OK),
+            parent=self.uistate.window)
         mpath = config.get('paths.report-directory')
         dot.set_current_folder(os.path.dirname(mpath))
         dot.set_filter(filter)
@@ -394,7 +395,7 @@ class GraphView(NavigationView):
                                      'file, or change the selected filename.'),
                                    _('_Overwrite'), None,
                                    _('_Change filename'), None,
-                                   parent=self.uistate.window)
+                                   parent=dot)
 
                 if aaa.get_response() == Gtk.ResponseType.YES:
                     dot.destroy()

--- a/GraphView/graphview.py
+++ b/GraphView/graphview.py
@@ -64,7 +64,7 @@ import gramps.gen.datehandler
 from gramps.gen.display.place import displayer as place_displayer
 from gramps.gen.constfunc import win
 from gramps.gen.config import config
-from gramps.gui.dialog import OptionDialog
+from gramps.gui.dialog import OptionDialog, ErrorDialog
 
 if win():
     DETACHED_PROCESS = 8
@@ -385,6 +385,8 @@ class GraphView(NavigationView):
         status = dot.run()
         if status == Gtk.ResponseType.OK:
             val = dot.get_filename()
+            (spath, ext) = os.path.splitext(val)
+            val = spath + ".gv" # used to avoid filename without extension
             # selected path is an existing file and we need a file
             if os.path.isfile(val):
                 aaa = OptionDialog(_('File already exists'), # parent-OK
@@ -399,11 +401,14 @@ class GraphView(NavigationView):
                     self.printview(obj)
                     return
             svg = val.replace('.gv', '.svg')
-            if val:
+            try:
                 with open(val,'w') as g,\
                      open(svg,'w') as s:
                         g.write(self.graph_widget.dot_data.decode('utf-8'))
                         s.write(self.graph_widget.svg_data.decode('utf-8'))
+            except IOError as msg:
+                msg2 = _("Could not create %s") % (val + ', ' + svg)
+                ErrorDialog(msg2, str(msg), parent=dot)
         dot.destroy()
 
 #-------------------------------------------------------------------------


### PR DESCRIPTION
* Fix GraphView for file write errors; use a message, not exception.    Fixes [#10363](https://gramps-project.org/bugs/view.php?id=10363)
* Fix GraphView; Encoding exception when printing on non utf-8 system when unicode chars are present in file.  Found on Windows system with normal cp1252 encoding.  Fixes [#10371](https://gramps-project.org/bugs/view.php?id=10371)
* Fix GraphView for bad transient parent on print file dialog and 'File already exists' dialog.  Fixes [#10372](https://gramps-project.org/bugs/view.php?id=10372)
