### PR TITLE
Fix PlaceCompletion for some issues

### DIFF
--- a/PlaceCompletion/PlaceCompletion.py
+++ b/PlaceCompletion/PlaceCompletion.py
@@ -279,8 +279,8 @@ class PlaceCompletion(Tool.Tool, ManagedWindow):
         elif group == ('zip'):
             place.set_code(val)
         else:
-            ErrorDialog(_("Error in PlaceCompletion.py"),
-                        _("Non existing group used in set"))
+            print(_("PlaceCompletion is unable to create %s %s"),
+                  group, val)
         return place
 
     def fill_combobox(self, cmb, namelistopt, default) :
@@ -401,7 +401,7 @@ class PlaceCompletion(Tool.Tool, ManagedWindow):
         if findregex :
             try:
                 #compile regex aware of locale and unicode
-                self.matchlatlon = re.compile(findregex,re.U|re.L|re.M)
+                self.matchlatlon = re.compile(findregex, re.M)
                 latlongroup = ['lat', 'lon']
                 for group in latlongroup :
                     if findregex.find(r'(?P<'+group+r'>') == -1 :
@@ -410,10 +410,10 @@ class PlaceCompletion(Tool.Tool, ManagedWindow):
                                 % {'lat' : latlongroup[0], 'lon' : latlongroup[1]},
                             self.window)
                         return
-                    #check if extra data can be extracted from file
-                    for group in possibleextrafindgroups :
-                        if findregex.find(r'(?P<'+group+r'>') != -1 :
-                            self.extrafindgroup.append(group)
+                #check if extra data can be extracted from file
+                for group in possibleextrafindgroups :
+                    if findregex.find(r'(?P<'+group+r'>') != -1 :
+                        self.extrafindgroup.append(group)
             except:
                 self.matchlatlon = None
                 WarningDialog(_('Non valid regex for match lat/lon'),
@@ -594,7 +594,8 @@ class PlaceCompletion(Tool.Tool, ManagedWindow):
     def button_press_event(self,obj,event):
         from gramps.gui.editors import EditPlace
 
-        if event.type == getattr(Gdk.EventType, "2BUTTON_PRESS") and event.button == 1:
+        if (event.type == Gdk.EventType._2BUTTON_PRESS and
+                event.button.button == 1):
             store, node = self.tree.get_selection().get_selected()
             if node:
                 #only when non empty tree view you are here
@@ -622,8 +623,8 @@ class PlaceCompletion(Tool.Tool, ManagedWindow):
                 except WindowActiveError :
                     pass
 
-        if event.type == getattr(Gdk.EventType, "KEY_PRESS") and \
-                event.keyval == Gtk.keysyms.Delete:
+        if event.type == Gdk.EventType.KEY_PRESS and \
+                event.keyval == Gdk.KEY_Delete:
             selection = self.tree.get_selection()
             store, node = selection.get_selected()
             if node :
@@ -639,8 +640,8 @@ class PlaceCompletion(Tool.Tool, ManagedWindow):
                     if row >= 0:
                         selection.select_path((row,))
 
-        if event.type == getattr(Gdk.EventType, "KEY_PRESS") and \
-                event.keyval == Gtk.keysyms.Tab:
+        if event.type == Gdk.EventType.KEY_PRESS and \
+                event.keyval == Gdk.KEY_Tab:
             #call up google maps
             self.google()
 
@@ -901,7 +902,7 @@ class PlaceCompletion(Tool.Tool, ManagedWindow):
             codes = self.county_lookup[county]
             pattern = re.sub(('COUNTY'), '(' + '|'.join(codes) + ')', pattern)
         #print 'DEBUG info: pattern for search is ' , pattern
-        regexll = re.compile(pattern,re.U|re.L|re.M)
+        regexll = re.compile(pattern, re.M)
         latlongroup = ['lat', 'lon']
         #find all occurences in the data file
         iterator = regexll.finditer(self.latlonfile_datastr)

--- a/PlaceCompletion/placecompletion.glade
+++ b/PlaceCompletion/placecompletion.glade
@@ -3,7 +3,6 @@
 <interface>
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="top">
-    <property name="visible">True</property>
     <property name="can_focus">False</property>
     <property name="default_width">450</property>
     <property name="default_height">400</property>
@@ -729,7 +728,7 @@ title format:</property>
                         <property name="xalign">1</property>
                         <property name="xpad">6</property>
                         <property name="label" translatable="yes">Available variables: city, street, locality, parish, county, state, country, postal_code</property>
-                        <property name="selectable">True</property>
+                        <property name="selectable">False</property>
                       </object>
                       <packing>
                         <property name="right_attach">2</property>
@@ -800,7 +799,7 @@ title format:</property>
                 <child>
                   <object class="GtkTreeView" id="tree1">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can_focus">True</property>
                     <property name="headers_visible">False</property>
                     <child internal-child="selection">
                       <object class="GtkTreeSelection" id="treeview-selection1"/>


### PR DESCRIPTION
Fixes  [#10409](https://gramps-project.org/bugs/view.php?id=10409)
Changed re compile options to avoid deprecated 'L' locale option.
Changed Glade file to allow correct transient parent.
Changed Glade file to allow keyboard control over result tree.
Changed Gdk event checks to correctly recognize click and keys.
Fix double change attempt for county/state.
Changed attempt to change county/state to a printed message instead of an error dialog; this doesn't do anything useful with our current enclosed places.  This avoids a click for every place during the scan when using the US state files.

I started this due to bug 10409, however as I began testing I discovered several problems.  The most concerning is that this tool is quite outdated in our current place structure.  While it works, the title change capability is of little utility for those users who use the automatic place title function.

The whole tool is useless unless the user has already manually enclosed his places.

The user can still use it for Lat/Long creation and update.

It may be time to rethink this tool and/or replace it entirely with something better, if someone is feeling ambitious.