### PR TITLE
[DescendantsLines]Centered lines are not centered and can overrun the container[gramps42]

### DIFF
--- a/DescendantsLines/DescendantsLines.py
+++ b/DescendantsLines/DescendantsLines.py
@@ -449,7 +449,7 @@ def draw_text(text, x, y, total_w, top_centered_lines=0):
         (ascent, _, height, _, _) = ctx.font_extents()
         (lx, _, width, _, _, _,) = ctx.text_extents(line)
         if ((TEXT_ALIGNMENT == 'center') or (n <= top_centered_lines)):
-            ctx.move_to(x - lx + TEXT_PAD + (total_w - width + lx) / 2, y
+            ctx.move_to(x - lx + (total_w - width + lx) / 2, y
                          + ascent + TEXT_PAD)
         elif TEXT_ALIGNMENT == 'left':
             ctx.move_to(x - lx + TEXT_PAD, y


### PR DESCRIPTION
[DescendantsLines graphical report] Centered lines are not centered and can overrun the container

Fixes: #[10398](https://gramps-project.org/bugs/view.php?id=10398)