### PR TITLE
Add View specific icons to four addons[gramps50]

### DIFF
--- a/GraphView/MANIFEST
+++ b/GraphView/MANIFEST
@@ -1,0 +1,1 @@
+GraphView/gramps-graph.svg

--- a/GraphView/gramps-graph.svg
+++ b/GraphView/gramps-graph.svg
@@ -1,0 +1,244 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="51.200001"
+   height="51.200001"
+   id="svg1771"
+   sodipodi:version="0.32"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
+   version="1.0"
+   sodipodi:docname="gramps-graph.svg"
+   inkscape:export-filename="/home/benny/programms/gramps/myicons/gramps_try4.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <title
+     id="title13529">Graphview Icon</title>
+  <defs
+     id="defs1773">
+    <inkscape:path-effect
+       effect="bspline"
+       id="path-effect12631"
+       is_visible="true"
+       weight="33.333333"
+       steps="2"
+       helper_size="0"
+       apply_no_weight="true"
+       apply_with_weight="true"
+       only_selected="false" />
+    <inkscape:path-effect
+       effect="bspline"
+       id="path-effect12627"
+       is_visible="true"
+       weight="33.333333"
+       steps="2"
+       helper_size="0"
+       apply_no_weight="true"
+       apply_with_weight="true"
+       only_selected="false" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3040">
+      <stop
+         style="stop-color:white;stop-opacity:1;"
+         offset="0"
+         id="stop3042" />
+      <stop
+         style="stop-color:white;stop-opacity:0;"
+         offset="1"
+         id="stop3044" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3040"
+       id="linearGradient1619"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25283,0,0,0.339077,34.82518,1.16907)"
+       x1="3"
+       y1="24.871992"
+       x2="70.421181"
+       y2="76.251137" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3040"
+       id="linearGradient1641"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.25283,0,0,0.339077,34.82518,25.99951)"
+       x1="3"
+       y1="24.871992"
+       x2="70.421181"
+       y2="76.251137" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="13.517279"
+     inkscape:cx="27.03502"
+     inkscape:cy="24.663191"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     inkscape:window-width="1030"
+     inkscape:window-height="878"
+     inkscape:window-x="2059"
+     inkscape:window-y="162"
+     showgrid="true"
+     units="px"
+     inkscape:snap-nodes="false"
+     inkscape:window-maximized="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid12579" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata1776">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>application</rdf:li>
+            <rdf:li>gramps</rdf:li>
+            <rdf:li>pedigree</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Paul Culley</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>Graphview Icon</dc:title>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/2.0/" />
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/2.0/">
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Reproduction" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Distribution" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/Notice" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/Attribution" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <rect
+       style="fill:none;fill-opacity:1;stroke:url(#linearGradient1619);stroke-width:0.92209893;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:11;stroke-dasharray:none;stroke-opacity:1"
+       id="rect6066"
+       width="10.156818"
+       height="5.2430906"
+       x="35.65778"
+       y="8.5638494"
+       rx="0.31386796"
+       ry="1.6276314" />
+    <rect
+       style="fill:none;fill-opacity:1;stroke:url(#linearGradient1641);stroke-width:0.92209893;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:11;stroke-dasharray:none;stroke-opacity:1"
+       id="rect6122"
+       width="10.156818"
+       height="5.2430906"
+       x="35.65778"
+       y="33.394291"
+       rx="0.31386796"
+       ry="1.6276314" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 14,14.2 c 7,9 7,9 7,9 v 0"
+       id="path12617"
+       inkscape:connector-curvature="0" />
+    <rect
+       id="rect11768"
+       width="20.938238"
+       height="6.9382391"
+       x="2.5308805"
+       y="7.7308812"
+       style="fill:#feccf0;fill-opacity:1;stroke:#861f69;stroke-width:1.06176078;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.94117647" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 36,14.2 c -7,9 -7,9 -7,9"
+       id="path12619"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="fill:#b7cee6;fill-opacity:1;stroke:#1f4986;stroke-width:1.02458441;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect12575"
+       width="20.975416"
+       height="6.9754157"
+       x="27.512293"
+       y="7.7122927" />
+    <ellipse
+       style="fill:#ffffe0;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-opacity:0.94117647"
+       id="path12577"
+       cx="25.5"
+       cy="26.200001"
+       rx="7.5"
+       ry="3.5" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 20.122393,28.562309 c -2.16889,1.33091 -4.338952,2.662539 -5.880706,4.191674 -1.541754,1.529136 -2.453673,3.254389 -3.366717,4.98177"
+       id="path12625"
+       inkscape:connector-curvature="0"
+       inkscape:path-effect="#path-effect12627"
+       inkscape:original-d="m 20.122393,28.562309 c -2.169062,1.330629 -4.339124,2.662258 -6.510186,3.994887 -0.911905,1.726118 -1.823825,3.451371 -2.737237,5.178557" />
+    <rect
+       id="rect11768-5"
+       width="13.938238"
+       height="6.9382391"
+       x="1.5308805"
+       y="37.730881"
+       style="fill:#feccf0;fill-opacity:1;stroke:#861f69;stroke-width:1.06176078;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.94117647" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 30.775425,28.784247 c 2.423833,0.692524 4.833979,1.381137 6.55959,2.897067 1.725611,1.515929 2.761606,3.85925 3.797524,6.202397"
+       id="path12629"
+       inkscape:connector-curvature="0"
+       inkscape:path-effect="#path-effect12631"
+       inkscape:original-d="m 30.775425,28.784247 c 2.417659,0.714134 4.834319,1.379948 7.249979,2.071423 1.036429,2.34104 2.072423,4.684361 3.107135,7.028041" />
+    <rect
+       id="rect11768-2"
+       width="13.938239"
+       height="6.9382391"
+       x="35.53088"
+       y="37.730881"
+       style="fill:#feccf0;fill-opacity:1;stroke:#861f69;stroke-width:1.06176078;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.94117647" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 25.5,30.200001 C 25.5,38.2 25.5,38.2 25.5,38.2"
+       id="path12621"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="fill:#b7cee6;fill-opacity:1;stroke:#1f4986;stroke-width:1.02458441;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect12575-3"
+       width="13.975415"
+       height="6.9754157"
+       x="18.512293"
+       y="37.712296" />
+  </g>
+</svg>

--- a/GraphView/graphview.gpr.py
+++ b/GraphView/graphview.gpr.py
@@ -1,3 +1,15 @@
+if locals().get('uistate'):  # don't start GUI if in CLI mode, just ignore
+    from gi.repository import Gtk, GdkPixbuf
+    import os
+    from gramps.gen.const import USER_PLUGINS
+    fname = os.path.join(USER_PLUGINS, 'GraphView',
+                        'gramps-graph.svg')
+    factory = Gtk.IconFactory()
+    pixbuf = GdkPixbuf.Pixbuf.new_from_file(fname)
+    iconset = Gtk.IconSet.new_from_pixbuf(pixbuf)
+    factory.add('gramps-graph', iconset)
+    factory.add_default()
+
 register(VIEW,
      id    = 'graphview',
      name  = _("Graph View"),
@@ -10,4 +22,5 @@ register(VIEW,
      authors = ["Gary Burton"],
      authors_email = ["gary.burton@zen.co.uk"],
      viewclass = 'GraphView',
+     stock_icon = 'gramps-graph',
 )

--- a/HtreePedigreeView/HtreePedigreeView.gpr.py
+++ b/HtreePedigreeView/HtreePedigreeView.gpr.py
@@ -28,17 +28,30 @@
 # H-tree view for Gramps
 #
 #------------------------------------------------------------------------
+if locals().get('uistate'):  # don't start GUI if in CLI mode, just ignore
+    from gi.repository import Gtk, GdkPixbuf
+    import os
+    from gramps.gen.const import USER_PLUGINS
+    fname = os.path.join(USER_PLUGINS, 'HtreePedigreeView',
+                        'gramps-htree.svg')
+    factory = Gtk.IconFactory()
+    pixbuf = GdkPixbuf.Pixbuf.new_from_file(fname)
+    iconset = Gtk.IconSet.new_from_pixbuf(pixbuf)
+    factory.add('gramps-htree', iconset)
+    factory.add_default()
 
 register(VIEW,
-id    = 'HtreePedigreeView',
-name  = _("H-Tree Pedigree"),
-category = ("Ancestry", _("Charts")),
-description =  _("The view shows a space-efficient pedigree with ancestors of the selected person"),
-version = '0.0.16',
-gramps_target_version = "5.0",
-status = STABLE,
-fname = 'HtreePedigreeView.py',
-authors = ["Pat Lefebre"],
-authors_email = [""],
-viewclass = 'HtreePedigreeView',
-  )
+    id    = 'HtreePedigreeView',
+    name  = _("H-Tree Pedigree"),
+    category = ("Ancestry", _("Charts")),
+    description =  _("The view shows a space-efficient pedigree with "
+                     "ancestors of the selected person"),
+    version = '0.0.16',
+    gramps_target_version = "5.0",
+    status = STABLE,
+    fname = 'HtreePedigreeView.py',
+    authors = ["Pat Lefebre"],
+    authors_email = [""],
+    viewclass = 'HtreePedigreeView',
+    stock_icon = 'gramps-htree',
+)

--- a/HtreePedigreeView/MANIFEST
+++ b/HtreePedigreeView/MANIFEST
@@ -1,0 +1,1 @@
+HtreePedigreeView/gramps-htree.svg

--- a/HtreePedigreeView/gramps-htree.svg
+++ b/HtreePedigreeView/gramps-htree.svg
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="38.400002pt"
+   height="38.400002pt"
+   id="svg1771"
+   sodipodi:version="0.32"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
+   version="1.0"
+   sodipodi:docname="gramps-htree.svg"
+   inkscape:export-filename="/home/benny/programms/gramps/myicons/gramps_try4.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <title
+     id="title13409">Timeline Pedigree View icon</title>
+  <defs
+     id="defs1773" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="13.517279"
+     inkscape:cx="27.03502"
+     inkscape:cy="27.440129"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     inkscape:window-width="969"
+     inkscape:window-height="934"
+     inkscape:window-x="1650"
+     inkscape:window-y="9"
+     showgrid="true"
+     inkscape:window-maximized="1"
+     inkscape:measure-start="0,0"
+     inkscape:measure-end="0,0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid12783" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata1776">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>application</rdf:li>
+            <rdf:li>gramps</rdf:li>
+            <rdf:li>pedigree</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Paul Culley</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>Timeline Pedigree View icon</dc:title>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/2.0/" />
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/2.0/">
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Reproduction" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Distribution" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/Notice" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/Attribution" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <rect
+       style="fill:#b7cee6;fill-opacity:1;stroke:#1f4986;stroke-width:1.02458417;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect12575-3"
+       width="13.975416"
+       height="9.9754152"
+       x="18.512293"
+       y="18.712292" />
+    <rect
+       id="rect11768-5"
+       width="13.938239"
+       height="9.9382391"
+       x="18.53088"
+       y="32.730881"
+       style="fill:#feccf0;fill-opacity:1;stroke:#861f69;stroke-width:1.0617609;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.94117647" />
+    <rect
+       style="fill:#b7cee6;fill-opacity:1;stroke:#1f4986;stroke-width:1.02458417;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect12575-3-1"
+       width="13.975416"
+       height="9.9754152"
+       x="1.5122921"
+       y="4.7122917" />
+    <rect
+       id="rect11768-5-7"
+       width="13.938239"
+       height="9.9382391"
+       x="35.53088"
+       y="32.730881"
+       style="fill:#feccf0;fill-opacity:1;stroke:#861f69;stroke-width:1.0617609;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.94117647" />
+    <rect
+       style="fill:#b7cee6;fill-opacity:1;stroke:#1f4986;stroke-width:1.02458417;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect12575-3-1-4"
+       width="13.975416"
+       height="9.9754152"
+       x="18.512293"
+       y="4.7122889" />
+    <rect
+       id="rect11768-5-7-4"
+       width="13.938239"
+       height="9.9382391"
+       x="35.53088"
+       y="4.7308807"
+       style="fill:#feccf0;fill-opacity:1;stroke:#861f69;stroke-width:1.0617609;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.94117647" />
+    <rect
+       style="fill:#b7cee6;fill-opacity:1;stroke:#1f4986;stroke-width:1.02458417;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect12575-3-4"
+       width="13.975416"
+       height="9.9754152"
+       x="1.5122931"
+       y="32.712296" />
+  </g>
+</svg>

--- a/QuiltView/MANIFEST
+++ b/QuiltView/MANIFEST
@@ -1,0 +1,1 @@
+QuiltView/gramps-quilt.svg

--- a/QuiltView/QuiltView.gpr.py
+++ b/QuiltView/QuiltView.gpr.py
@@ -17,17 +17,29 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #
+if locals().get('uistate'):  # don't start GUI if in CLI mode, just ignore
+    from gi.repository import Gtk, GdkPixbuf
+    import os
+    from gramps.gen.const import USER_PLUGINS
+    fname = os.path.join(USER_PLUGINS, 'QuiltView',
+                        'gramps-quilt.svg')
+    factory = Gtk.IconFactory()
+    pixbuf = GdkPixbuf.Pixbuf.new_from_file(fname)
+    iconset = Gtk.IconSet.new_from_pixbuf(pixbuf)
+    factory.add('gramps-quilt', iconset)
+    factory.add_default()
 
 register(VIEW,
-id = 'QuiltView',
-name = _('Quilt Chart'),
-category = ('Ancestry', _('Charts')),
-description =  _('The view shows a quilt chart visualisation of a family tree'),
-version = '1.0.3',
-gramps_target_version = '5.0',
-status = STABLE,
-fname = 'QuiltView.py',
-authors = ['Nick Hall', 'Serge Noiraud'],
-authors_email = ['nick__hall@hotmail.com', 'serge.noiraud@free.fr'],
-viewclass = 'QuiltView',
+    id = 'QuiltView',
+    name = _('Quilt Chart'),
+    category = ('Ancestry', _('Charts')),
+    description =  _('The view shows a quilt chart visualisation of a family tree'),
+    version = '1.0.3',
+    gramps_target_version = '5.0',
+    status = STABLE,
+    fname = 'QuiltView.py',
+    authors = ['Nick Hall', 'Serge Noiraud'],
+    authors_email = ['nick__hall@hotmail.com', 'serge.noiraud@free.fr'],
+    viewclass = 'QuiltView',
+    stock_icon = 'gramps-quilt',
 )

--- a/QuiltView/gramps-quilt.svg
+++ b/QuiltView/gramps-quilt.svg
@@ -1,0 +1,234 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="38.400002pt"
+   height="38.400002pt"
+   id="svg1771"
+   sodipodi:version="0.32"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
+   version="1.0"
+   sodipodi:docname="gramps-quilt.svg"
+   inkscape:export-filename="/home/benny/programms/gramps/myicons/gramps_try4.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <title
+     id="title13409">Timeline Pedigree View icon</title>
+  <defs
+     id="defs1773" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="13.517279"
+     inkscape:cx="27.03502"
+     inkscape:cy="27.440129"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     inkscape:window-width="969"
+     inkscape:window-height="934"
+     inkscape:window-x="1650"
+     inkscape:window-y="9"
+     showgrid="true"
+     inkscape:window-maximized="1"
+     inkscape:measure-start="0,0"
+     inkscape:measure-end="0,0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid12783" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata1776">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>application</rdf:li>
+            <rdf:li>gramps</rdf:li>
+            <rdf:li>pedigree</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Paul Culley</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>Timeline Pedigree View icon</dc:title>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/2.0/" />
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/2.0/">
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Reproduction" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Distribution" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/Notice" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/Attribution" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <rect
+       style="fill:#b7cee6;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.96078425"
+       id="rect58"
+       width="13"
+       height="6"
+       x="1.5"
+       y="1.7000018" />
+    <rect
+       style="fill:#feccf0;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.96078425"
+       id="rect868"
+       width="13"
+       height="6"
+       x="1.5"
+       y="7.7000003" />
+    <rect
+       style="fill:#cccccc;fill-opacity:1;stroke:none;stroke-width:0.99999958;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.94117647"
+       id="rect912"
+       width="4"
+       height="34"
+       x="17"
+       y="1.2000021" />
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.94117647"
+       id="rect914"
+       width="2"
+       height="2"
+       x="18"
+       y="3.200002" />
+    <rect
+       style="fill:#cccccc;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.94117647"
+       id="rect926"
+       width="4"
+       height="23.999998"
+       x="39"
+       y="17.200005" />
+    <rect
+       style="fill:#cccccc;fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.94117647"
+       id="rect928"
+       width="4"
+       height="24.000004"
+       x="45"
+       y="24.200001" />
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.94117647"
+       id="rect914-0"
+       width="2"
+       height="2"
+       x="40"
+       y="19.200003" />
+    <rect
+       style="fill:#b7cee6;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.96078425"
+       id="rect58-8"
+       width="13"
+       height="6.000001"
+       x="23.5"
+       y="17.700001" />
+    <rect
+       style="fill:#feccf0;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.96078425"
+       id="rect868-1"
+       width="13"
+       height="6.000001"
+       x="23.5"
+       y="23.700001" />
+    <rect
+       style="fill:#b7cee6;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.96078425"
+       id="rect58-5"
+       width="13"
+       height="6.000001"
+       x="23.5"
+       y="29.700001" />
+    <rect
+       style="fill:#feccf0;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.96078425"
+       id="rect868-5"
+       width="13"
+       height="6.000001"
+       x="23.5"
+       y="35.700001" />
+    <rect
+       style="fill:#b7cee6;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.96078425"
+       id="rect58-5-3"
+       width="13"
+       height="6.000001"
+       x="23.5"
+       y="41.700001" />
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.94117647"
+       id="rect914-1"
+       width="2"
+       height="2"
+       x="18"
+       y="9.2000017" />
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.94117647"
+       id="rect914-7"
+       width="2"
+       height="2"
+       x="18"
+       y="19.200003" />
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.94117647"
+       id="rect914-4"
+       width="2"
+       height="2"
+       x="18"
+       y="25.200003" />
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.94117647"
+       id="rect914-3"
+       width="2"
+       height="2"
+       x="18"
+       y="31.300001" />
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.94117647"
+       id="rect914-0-2"
+       width="2"
+       height="2"
+       x="40"
+       y="37.200001" />
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.94117647"
+       id="rect914-0-3"
+       width="2"
+       height="2"
+       x="46"
+       y="26.200003" />
+    <rect
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.94117647"
+       id="rect914-0-6"
+       width="2"
+       height="2"
+       x="46"
+       y="44.200005" />
+  </g>
+</svg>

--- a/TimelinePedigreeView/MANIFEST
+++ b/TimelinePedigreeView/MANIFEST
@@ -1,0 +1,1 @@
+TimelinePedigreeView/gramps-timelinepedigree.svg

--- a/TimelinePedigreeView/TimelinePedigreeView.gpr.py
+++ b/TimelinePedigreeView/TimelinePedigreeView.gpr.py
@@ -27,17 +27,30 @@
 # default views of Gramps
 #
 #------------------------------------------------------------------------
+if locals().get('uistate'):  # don't start GUI if in CLI mode, just ignore
+    from gi.repository import Gtk, GdkPixbuf
+    import os
+    from gramps.gen.const import USER_PLUGINS
+    fname = os.path.join(USER_PLUGINS, 'TimelinePedigreeView',
+                        'gramps-timelinepedigree.svg')
+    factory = Gtk.IconFactory()
+    pixbuf = GdkPixbuf.Pixbuf.new_from_file(fname)
+    iconset = Gtk.IconSet.new_from_pixbuf(pixbuf)
+    factory.add('gramps-timelinepedigree', iconset)
+    factory.add_default()
 
 register(VIEW,
-id    = 'TimelinePedigreeView',
-name  = _("Timeline Pedigree"),
-category = ("Ancestry", _("Ancestry")),
-description =  _("The view shows a timeline pedigree with ancestors and descendants of the selected person"),
-version = '0.1.43',
-gramps_target_version = "5.0",
-status = STABLE,
-fname = 'TimelinePedigreeView.py',
-authors = ["Felix Heß"],
-authors_email = ["xilef@nurfuerspam.de"],
-viewclass = 'TimelinePedigreeView',
-  )
+    id    = 'TimelinePedigreeView',
+    name  = _("Timeline Pedigree"),
+    category = ("Ancestry", _("Ancestry")),
+    description =  _("The view shows a timeline pedigree with ancestors and "
+                     "descendants of the selected person"),
+    version = '0.1.43',
+    gramps_target_version = "5.0",
+    status = STABLE,
+    fname = 'TimelinePedigreeView.py',
+    authors = ["Felix Heß"],
+    authors_email = ["xilef@nurfuerspam.de"],
+    viewclass = 'TimelinePedigreeView',
+    stock_icon = 'gramps-timelinepedigree',
+    )

--- a/TimelinePedigreeView/gramps-timelinepedigree.svg
+++ b/TimelinePedigreeView/gramps-timelinepedigree.svg
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="38.400002pt"
+   height="38.400002pt"
+   id="svg1771"
+   sodipodi:version="0.32"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)"
+   version="1.0"
+   sodipodi:docname="gramps-timelinepedigree.svg"
+   inkscape:export-filename="/home/benny/programms/gramps/myicons/gramps_try4.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <title
+     id="title13409">Timeline Pedigree View icon</title>
+  <defs
+     id="defs1773" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="13.517279"
+     inkscape:cx="27.03502"
+     inkscape:cy="27.440129"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     inkscape:window-width="969"
+     inkscape:window-height="934"
+     inkscape:window-x="1650"
+     inkscape:window-y="9"
+     showgrid="true"
+     inkscape:window-maximized="0"
+     inkscape:measure-start="0,0"
+     inkscape:measure-end="0,0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid12783" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata1776">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>application</rdf:li>
+            <rdf:li>gramps</rdf:li>
+            <rdf:li>pedigree</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Paul Culley</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:title>Timeline Pedigree View icon</dc:title>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/2.0/" />
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/2.0/">
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Reproduction" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/Distribution" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/Notice" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/Attribution" />
+        <cc:permits
+           rdf:resource="http://web.resource.org/cc/DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://web.resource.org/cc/ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <g
+       id="g13368">
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path5914-0"
+         d="m 19.078001,23.700004 h -2.125674 v 9 h -2.952326"
+         style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000012px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path5918-0"
+         d="m 19.077922,23.700002 h -2.125641 v -8 H 14"
+         style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000012px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+    </g>
+    <rect
+       style="fill:#b7cee6;fill-opacity:1;stroke:#1f4986;stroke-width:1.02458417;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect12575-3"
+       width="11.975415"
+       height="9.9754152"
+       x="19.512293"
+       y="18.712292" />
+    <rect
+       id="rect11768-5"
+       width="11.938239"
+       height="9.9382391"
+       x="1.5308805"
+       y="27.730883"
+       style="fill:#feccf0;fill-opacity:1;stroke:#861f69;stroke-width:1.06176078;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.94117647" />
+    <rect
+       style="fill:#b7cee6;fill-opacity:1;stroke:#1f4986;stroke-width:1.02458417;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect12575-3-1"
+       width="11.975415"
+       height="9.9754152"
+       x="1.5122921"
+       y="10.712292" />
+    <g
+       transform="matrix(-1,0,0,1,51.078001,-2.0250994e-6)"
+       id="g13368-9">
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path5914-0-1"
+         d="m 19.078001,23.700004 h -2.125674 v 9 h -2.952326"
+         style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000012px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+      <path
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc"
+         id="path5918-0-6"
+         d="m 19.077922,23.700002 h -2.125641 v -8 H 14"
+         style="fill:none;fill-opacity:0.75;fill-rule:evenodd;stroke:#000000;stroke-width:1.00000012px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+    </g>
+    <rect
+       id="rect11768-5-7"
+       width="11.938239"
+       height="9.9382391"
+       x="37.53088"
+       y="27.730883"
+       style="fill:#feccf0;fill-opacity:1;stroke:#861f69;stroke-width:1.06176078;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.94117647" />
+    <rect
+       style="fill:#b7cee6;fill-opacity:1;stroke:#1f4986;stroke-width:1.02458417;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect12575-3-1-4"
+       width="11.975415"
+       height="9.9754152"
+       x="37.512291"
+       y="10.712289" />
+  </g>
+</svg>


### PR DESCRIPTION
Sam mentioned that it would be nice if the Icons for the various addon charts were different...
Ask, and ye shall receive...

If you want this on gramps42, it is almost the same, but you have to drop the "if locals().get('uistate'):" as uistate is not available on gramps42 branch.  This means that if started in cli mode on gramp42 branch with the plugin present, you may get some (I think harmless) side effects due to the gtk imports.