### PR TITLE
Fix Clipboard Gramplet exception with data present when changing db.

### DIFF
--- a/ClipboardGramplet/ClipboardGramplet.py
+++ b/ClipboardGramplet/ClipboardGramplet.py
@@ -134,7 +134,7 @@ class ClipboardGramplet(Gramplet):
             return
         i = 0
         while i < len(self.gui.data):
-            data = unescape(self.gui.data[i])
+            data = str(unescape(self.gui.data[i]))
             i += 1
             title = unescape(self.gui.data[i])
             i += 1


### PR DESCRIPTION
Issue [#10473](https://gramps-project.org/bugs/view.php?id=10473)

This is the second part of bug10473 (first is https://github.com/gramps-project/gramps/pull/566).
This bug occurs when there is data in the clipboard Gramplet and the db is changed.  An exception occurs because the data was in bytes mode instead of str.