### PR TITLE
[CollectionsClipboardGramplet]Fix for db change and other issues[gramps50]

### DIFF
--- a/ClipboardGramplet/ClipboardGramplet.gpr.py
+++ b/ClipboardGramplet/ClipboardGramplet.gpr.py
@@ -6,7 +6,7 @@
 
 register(GRAMPLET,
          id="Clipboard Gramplet",
-         name=_("Clipboard Gramplet"),
+         name=_("Collections Clipboard Gramplet"),
          description = _("Gramplet for grouping items"),
          status = STABLE,
          version = '1.0.31',


### PR DESCRIPTION
Issue [#10475](https://gramps-project.org/bugs/view.php?id=10475)
* Clipboard Gramplet was overriding the 'refresh_objects' method of the listview, I think the original idea was to show clipboard items that were not valid for the current db.  Unfortunately, if a user tried to drag on of these invalid objects (they had a red X for icon) to a reasonable destination, it would create a corrupted db, and usually crash Gramps with HandleError.  The original Clibboard (not Gramplet) was removing these clips from the view entirely, so they could not be erroneously dropped.
* I noted that with some types of clips, the save/restore function of the Clipboard Gramplet would fail because the configure routines don't properly handle a generalized bytes element.  In particular, I saw a '%' in the bytes stream that was messing with the parsing of the .ini file.  I changed the data storage of the pickled data to a hex string to avoid this.  I also put the entire load block in a try/except to cover the remote case of loading an older versions bytes string and failing to decode it as hex.  This also covers some other possible corruptions.

* The Clipboard Gramplet was not restoring the db name and id to Text clips, which was confusing; after a Gramps restart, the text data all appeared to be coming from the current db.

There were other issues related to the original Clipboard (not Gramplet) code, these are dealt with in https://github.com/gramps-project/gramps/pull/569.  I think this stands alone, but obviously won't fix everything without the other PR.