### PR TITLE
[DynamicWeb]Fix to avoid duplicate citation link buttons on events[gramps50]

### DIFF
--- a/DynamicWeb/dynamicweb.py
+++ b/DynamicWeb/dynamicweb.py
@@ -1118,9 +1118,9 @@ class DynamicWebReport(Report):
             # Get event media
             jdata['media'] = self._data_media_reference_index(event)
             # Get event sources
-            citationlist = event.get_citation_list()
-            citationlist.extend(event_ref.get_citation_list())
-            for attr in attrlist: citationlist.extend(attr.get_citation_list())
+            citationlist = set(event.get_citation_list())
+            citationlist.update(event_ref.get_citation_list())
+            for attr in attrlist: citationlist.update(attr.get_citation_list())
             jdata['cita'] = self._data_source_citation_index_from_list(citationlist)
             # Get event participants
             result_list = list(self.database.find_backlink_handles(event.handle, include_classes=['Person', 'Family']))


### PR DESCRIPTION
Changes the report so that the individual person page doesn't get duplicate citations in the Event column of the Events tab.  From a complaint on the gramps-users mailing list https://sourceforge.net/p/gramps/mailman/message/36301205/

Should be cherry-picked to gramps42 when accepted...