### PR TITLE
Fix reports for shared event attribute and note errors

### DIFF
--- a/DescendantBooks/DetailedDescendantBookReport.py
+++ b/DescendantBooks/DetailedDescendantBookReport.py
@@ -865,7 +865,7 @@ class DetailedDescendantBookReport(Report):
 
         if self.inc_attrs:
             text = ""
-            attr_list = event.get_attribute_list()
+            attr_list = event.get_attribute_list()[:]  # we don't want to modify cached original
             attr_list.extend(event_ref.get_attribute_list())
             for attr in attr_list:
                 if text:
@@ -883,7 +883,7 @@ class DetailedDescendantBookReport(Report):
         if self.inc_notes:
             # if the event or event reference has a note attached to it,
             # get the text and format it correctly
-            notelist = event.get_note_list()
+            notelist = event.get_note_list()[:]  # we don't want to modify cached original
             notelist.extend(event_ref.get_note_list())
             for notehandle in notelist:
                 note = self.database.get_note_from_handle(notehandle)

--- a/DynamicWeb/dynamicweb.py
+++ b/DynamicWeb/dynamicweb.py
@@ -1110,9 +1110,9 @@ class DynamicWebReport(Report):
             if (evt_desc is None): evt_desc = ""
             jdata['descr'] = html_escape(evt_desc)
             # Get event notes
-            notelist = event.get_note_list()
+            notelist = event.get_note_list()[:]  # we don't want to modify cached original
             notelist.extend(event_ref.get_note_list())
-            attrlist = event.get_attribute_list()
+            attrlist = event.get_attribute_list()[:]  # we don't want to modify cached original
             attrlist.extend(event_ref.get_attribute_list())
             jdata['text'] = self.get_notes_attributes_text(notelist, attrlist)
             # Get event media
@@ -1814,7 +1814,7 @@ class DynamicWebReport(Report):
         jdata['rect'] = list(rect)
         attrlist = ref.get_attribute_list()
         jdata['note'] = self.get_notes_attributes_text(ref.get_note_list(), attrlist)
-        citationlist = ref.get_citation_list()
+        citationlist = ref.get_citation_list()[:]  # we don't want to modify cached original
         for attr in attrlist: citationlist.extend(attr.get_citation_list())
         # BUG: it seems that attribute references are given by both ref.get_citation_list and attr.get_citation_list
         jdata['cita'] = self._data_source_citation_index_from_list(citationlist)
@@ -3671,7 +3671,7 @@ class DynamicWebReport(Report):
         if (bkref_class is not None):
             self.bkref_dict[_Media][media_handle].add((bkref_class, bkref_handle, media_ref))
             # Citations for media reference, media reference attributes
-            citation_list = media_ref.get_citation_list()
+            citation_list = media_ref.get_citation_list()[:]  # we don't want to modify cached original
             for attr in media_ref.get_attribute_list():
                 citation_list.extend(attr.get_citation_list())
             for citation_handle in citation_list:
@@ -3683,7 +3683,7 @@ class DynamicWebReport(Report):
         media_name = media.get_description() or media.get_path() or ""
         self.obj_dict[_Media][media_handle] = [media_name, media.gramps_id, len(self.obj_dict[_Media])]
         # Citations for media, media attributes
-        citation_list = media.get_citation_list()
+        citation_list = media.get_citation_list()[:]  # we don't want to modify cached original
         for attr in media.get_attribute_list():
             citation_list.extend(attr.get_citation_list())
         for citation_handle in citation_list:


### PR DESCRIPTION
Fixes #10720

Since we added caching to the reports, we picked up some errors where the report writer was extending attribute and note lists from cached primary objects. This mostly did not matter, but when a primary object was referenced more than once in a report (like shared events), the extended lists would accumulate all the changes.

I looked in all the reports, searching for ".extend(" or "+=" and inspected to see if it was potentially modifying the cached primary object. If so, I made a copy of the list before using it.