### PR TITLE
[Make.py]Lets keep the *.pot files[gramps50]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ tags
 
 # Translations
 *.mo
-*.pot
 
 # Distutils
 AllNamesQuickview/locale/

--- a/AllNamesQuickview/po/template.pot
+++ b/AllNamesQuickview/po/template.pot
@@ -1,0 +1,43 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: AllNamesQuickview/AllNames.gpr.py:3 AllNamesQuickview/AllNames.py:51
+msgid "All Names of All People"
+msgstr ""
+
+#: AllNamesQuickview/AllNames.gpr.py:4
+msgid "Display all names of all people"
+msgstr ""
+
+#: AllNamesQuickview/AllNames.py:54
+msgid "Name"
+msgstr ""
+
+#: AllNamesQuickview/AllNames.py:54
+msgid "Primary Name"
+msgstr ""
+
+#: AllNamesQuickview/AllNames.py:54
+msgid "Name Type"
+msgstr ""
+
+#: AllNamesQuickview/AllNames.py:71
+#, python-format
+msgid "Total names %d"
+msgstr ""

--- a/AncestorFill/po/template.pot
+++ b/AncestorFill/po/template.pot
@@ -1,0 +1,128 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: AncestorFill/AncestorFill.gpr.py:8
+msgid "AncestorFill"
+msgstr ""
+
+#: AncestorFill/AncestorFill.gpr.py:9
+msgid "Report on the filling of the tree"
+msgstr ""
+
+#: AncestorFill/AncestorFill.py:105
+#, python-format
+msgid "Person %s is not in the Database"
+msgstr ""
+
+#: AncestorFill/AncestorFill.py:190
+#, python-format
+msgid "AncestorFill for %s"
+msgstr ""
+
+#: AncestorFill/AncestorFill.py:206
+msgid "Generation "
+msgstr ""
+
+#: AncestorFill/AncestorFill.py:207
+msgid "Number of Ancestors found "
+msgstr ""
+
+#: AncestorFill/AncestorFill.py:208
+msgid "percent of Ancestors found "
+msgstr ""
+
+#: AncestorFill/AncestorFill.py:209
+msgid "Number of single Ancestors found "
+msgstr ""
+
+#: AncestorFill/AncestorFill.py:210
+msgid "Number of theoretical Ancestors "
+msgstr ""
+
+#: AncestorFill/AncestorFill.py:211
+msgid "Pedigree Collapse "
+msgstr ""
+
+#: AncestorFill/AncestorFill.py:254
+msgid "Total Number of Ancestors found "
+msgstr ""
+
+#: AncestorFill/AncestorFill.py:256
+msgid "Total Number of single Ancestors found "
+msgstr ""
+
+#: AncestorFill/AncestorFill.py:293
+msgid "Report Options"
+msgstr ""
+
+#: AncestorFill/AncestorFill.py:295
+msgid "Center Person"
+msgstr ""
+
+#: AncestorFill/AncestorFill.py:296
+msgid "The center person for the report"
+msgstr ""
+
+#: AncestorFill/AncestorFill.py:299
+msgid "Generations"
+msgstr ""
+
+#: AncestorFill/AncestorFill.py:300
+msgid "The number of generations to include in the report"
+msgstr ""
+
+#: AncestorFill/AncestorFill.py:303
+msgid "Filled digit"
+msgstr ""
+
+#: AncestorFill/AncestorFill.py:304
+msgid ""
+"The number of digits after comma to include in the report for the percentage "
+"of ancestor found at a given generation"
+msgstr ""
+
+#: AncestorFill/AncestorFill.py:307
+msgid "Collapsed digit"
+msgstr ""
+
+#: AncestorFill/AncestorFill.py:308
+msgid ""
+"The number of digits after comma to include in the report for the pedigree "
+"Collapse"
+msgstr ""
+
+#: AncestorFill/AncestorFill.py:311
+msgid "Display theoretical"
+msgstr ""
+
+#: AncestorFill/AncestorFill.py:312
+msgid "Whether to display the theoretical number of ancestor by generation"
+msgstr ""
+
+#: AncestorFill/AncestorFill.py:360
+msgid "The style used for the title of the page."
+msgstr ""
+
+#: AncestorFill/AncestorFill.py:373
+msgid "The style used for the generation header."
+msgstr ""
+
+#: AncestorFill/AncestorFill.py:383
+msgid "The basic style used for the text display."
+msgstr ""

--- a/AssociationsTool/po/template.pot
+++ b/AssociationsTool/po/template.pot
@@ -1,0 +1,42 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: AssociationsTool/associationstool.gpr.py:35
+msgid "Check Associations data"
+msgstr ""
+
+#: AssociationsTool/associationstool.gpr.py:36
+msgid "Will check the data on Association for people."
+msgstr ""
+
+#: AssociationsTool/associationstool.py:52
+msgid "Associations state tool"
+msgstr ""
+
+#: AssociationsTool/associationstool.py:75
+msgid "Name"
+msgstr ""
+
+#: AssociationsTool/associationstool.py:76
+msgid "Type of link"
+msgstr ""
+
+#: AssociationsTool/associationstool.py:77
+msgid "Of"
+msgstr ""

--- a/AttachSourceTool/po/template.pot
+++ b/AttachSourceTool/po/template.pot
@@ -1,0 +1,101 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: AttachSourceTool/AttachSourceTool.gpr.py:25
+#: AttachSourceTool/AttachSourceTool.py:137
+#: AttachSourceTool/AttachSourceTool.py:155
+msgid "Attach Source"
+msgstr ""
+
+#: AttachSourceTool/AttachSourceTool.gpr.py:26
+msgid "Attaches a shared source to multiple objects."
+msgstr ""
+
+#: AttachSourceTool/AttachSourceTool.py:67
+#: AttachSourceTool/AttachSourceTool.py:140
+msgid "Options"
+msgstr ""
+
+#: AttachSourceTool/AttachSourceTool.py:69
+msgid "Person Filter"
+msgstr ""
+
+#: AttachSourceTool/AttachSourceTool.py:70
+msgid "Select filter to restrict people"
+msgstr ""
+
+#: AttachSourceTool/AttachSourceTool.py:74
+msgid "Filter Person"
+msgstr ""
+
+#: AttachSourceTool/AttachSourceTool.py:75
+msgid "The center person for the filter"
+msgstr ""
+
+#: AttachSourceTool/AttachSourceTool.py:81
+msgid "Source type"
+msgstr ""
+
+#: AttachSourceTool/AttachSourceTool.py:82
+msgid "New source"
+msgstr ""
+
+#: AttachSourceTool/AttachSourceTool.py:83
+msgid "Existing source"
+msgstr ""
+
+#: AttachSourceTool/AttachSourceTool.py:84
+msgid "Select the type of source to attach"
+msgstr ""
+
+#: AttachSourceTool/AttachSourceTool.py:89
+msgid "New Source Title"
+msgstr ""
+
+#: AttachSourceTool/AttachSourceTool.py:90
+msgid "Text of source to attach"
+msgstr ""
+
+#: AttachSourceTool/AttachSourceTool.py:94
+msgid "Existing Source ID"
+msgstr ""
+
+#: AttachSourceTool/AttachSourceTool.py:95
+msgid "ID of source to attach"
+msgstr ""
+
+#: AttachSourceTool/AttachSourceTool.py:156
+msgid "Results"
+msgstr ""
+
+#: AttachSourceTool/AttachSourceTool.py:157
+msgid "Processing...\n"
+msgstr ""
+
+#: AttachSourceTool/AttachSourceTool.py:174
+msgid "Attaching sources...\n"
+msgstr ""
+
+#: AttachSourceTool/AttachSourceTool.py:175
+msgid "Attaching sources..."
+msgstr ""
+
+#: AttachSourceTool/AttachSourceTool.py:197
+msgid "Done!\n"
+msgstr ""

--- a/BiographyQuickview/po/template.pot
+++ b/BiographyQuickview/po/template.pot
@@ -1,0 +1,26 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: BiographyQuickview/BiographyQuickview.gpr.py:9
+msgid "Biography"
+msgstr ""
+
+#: BiographyQuickview/BiographyQuickview.gpr.py:10
+msgid "Display a text biography"
+msgstr ""

--- a/BirthOrder/po/template.pot
+++ b/BirthOrder/po/template.pot
@@ -1,0 +1,129 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: BirthOrder/birthorder.gpr.py:9 BirthOrder/birthorder.py:62
+msgid "Sort Children in Birth order"
+msgstr ""
+
+#: BirthOrder/birthorder.gpr.py:10
+msgid ""
+"Looks through families, looking for children that are not in birth order.  "
+"User can accept individual suggestions to correct, edit the birth order "
+"manually, accept all those families that have all children with proper birth "
+"dates, or accept all."
+msgstr ""
+
+#: BirthOrder/birthorder.py:161
+msgid "No families need sorting"
+msgstr ""
+
+#: BirthOrder/birthorder.py:162
+msgid "No children were out of birth order."
+msgstr ""
+
+#: BirthOrder/birthorder.py:186
+msgid "Edit Family"
+msgstr ""
+
+#: BirthOrder/birthorder.py:203
+msgid "Processing..."
+msgstr ""
+
+#: BirthOrder/birthorder.py:204
+msgid "Edit Families"
+msgstr ""
+
+#: BirthOrder/birthorder.py:275
+msgid "Looking for children birth order"
+msgstr ""
+
+#: BirthOrder/birthorder.py:279
+msgid "Pass 1: Building preliminary lists"
+msgstr ""
+
+#: BirthOrder/birthorder.glade:56
+msgid "Select the family you wish to examine."
+msgstr ""
+
+#: BirthOrder/birthorder.glade:78
+msgid "Family ID"
+msgstr ""
+
+#: BirthOrder/birthorder.glade:93
+msgid "Father"
+msgstr ""
+
+#: BirthOrder/birthorder.glade:108
+msgid "Mother"
+msgstr ""
+
+#: BirthOrder/birthorder.glade:141
+msgid "Help"
+msgstr ""
+
+#: BirthOrder/birthorder.glade:155
+msgid "Accept All"
+msgstr ""
+
+#: BirthOrder/birthorder.glade:159
+msgid "This button will sort all of the families listed."
+msgstr ""
+
+#: BirthOrder/birthorder.glade:170
+msgid "Accept All *"
+msgstr ""
+
+#: BirthOrder/birthorder.glade:174
+msgid ""
+"This button will sort all the families with '*'.  In these families, all the "
+"children have valid dates, so the sort is unambiguous."
+msgstr ""
+
+#: BirthOrder/birthorder.glade:185
+msgid "Accept"
+msgstr ""
+
+#: BirthOrder/birthorder.glade:189
+msgid ""
+"This button will accept only the family selected and save it as shown in "
+"lower right pane."
+msgstr ""
+
+#: BirthOrder/birthorder.glade:232
+msgid "Done"
+msgstr ""
+
+#: BirthOrder/birthorder.glade:236
+msgid "This button will exit, with remaining families unchanged."
+msgstr ""
+
+#: BirthOrder/birthorder.glade:256
+msgid "Current sort"
+msgstr ""
+
+#: BirthOrder/birthorder.glade:267
+msgid "Proposed sort"
+msgstr ""
+
+#: BirthOrder/birthorder.glade:333
+msgid ""
+"When satisfied with the sort, use 'Accept' button below to accept the "
+"changes.  If you wish to adjust the order, select the child you wish to "
+"move, and use 'Up' or 'Down' buttons below to move them."
+msgstr ""

--- a/BirthdaysGramplet/po/template.pot
+++ b/BirthdaysGramplet/po/template.pot
@@ -1,0 +1,35 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: BirthdaysGramplet/BirthdaysGramplet.gpr.py:4
+#: BirthdaysGramplet/BirthdaysGramplet.gpr.py:12
+msgid "Birthdays Gramplet"
+msgstr ""
+
+#: BirthdaysGramplet/BirthdaysGramplet.gpr.py:5
+msgid "a gramplet that displays the birthdays of the living people"
+msgstr ""
+
+#: BirthdaysGramplet/BirthdaysGramplet.py:41
+msgid "No Family Tree loaded."
+msgstr ""
+
+#: BirthdaysGramplet/BirthdaysGramplet.py:50
+msgid "Processing..."
+msgstr ""

--- a/CalculateEstimatedDates/po/template.pot
+++ b/CalculateEstimatedDates/po/template.pot
@@ -1,0 +1,344 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.gpr.py:9
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:190
+msgid "Calculate Estimated Dates"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.gpr.py:10
+msgid "Calculates estimated dates for birth and death."
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:80
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:193
+msgid "Options"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:82
+msgid "Filter"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:83
+msgid "Select filter to restrict people"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:87
+msgid "Filter Person"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:88
+msgid "The center person for the filter"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:94
+msgid "Source text"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:95
+msgid "Calculated Date Estimates"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:96
+msgid "Source to remove and/or add"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:99
+msgid "Remove previously added events, notes, and source"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:100
+msgid ""
+"Remove calculated events, notes, and source; occurs immediately on Execute"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:103
+msgid "Birth"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:104
+msgid "Do not add birth events"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:105
+msgid "Add birth events without dates"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:106
+msgid "Add birth events with dates"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:107
+msgid "Add a birth events with or without estimated dates"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:110
+msgid "Death"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:111
+msgid "Do not add death events"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:112
+msgid "Add death events without dates"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:113
+msgid "Add death events with dates"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:114
+msgid "Add death events with or without estimated dates"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:118
+msgid "Maximum age"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:121
+msgid "Maximum age that one can live to"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:124
+msgid "Maximum sibling age difference"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:127
+msgid "Maximum age difference between siblings"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:130
+msgid "Average years between generations"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:133
+msgid "Average years between two generations"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:136
+msgid "Estimated Dates"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:137
+msgid "Approximate (about)"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:138
+msgid "Extremes (after and before)"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:139
+msgid "Dates on events are either about or after/before"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:170
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:187
+msgid "Help"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:172
+msgid ""
+"The Calculate Estimated Dates Tool is used to add and remove birth and death "
+"events for people that are missing these events.\n"
+"\n"
+"To use:\n"
+"1. Go to the Options tab\n"
+"2. Check the [ ] Remove option to remove previous estimates\n"
+"3. Select the Add date options to date events with or without dates\n"
+"4. Click on Execute\n"
+"5. Select the people with which to add events\n"
+"6. Click on 'Add Selected Events' button to create\n"
+"\n"
+"NOTES: if you decide to make an event permanent, remove it from the Source. "
+"Otherwise, it will get removed the next time you automatically remove these "
+"events.\n"
+"\n"
+"You may have to run the tool repeatedly (without removing previous events) "
+"to add all of the events possible."
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:199
+msgid "Select All"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:200
+msgid "Select None"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:201
+msgid "Toggle Selection"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:202
+msgid "Add Selected Events"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:208
+msgid "Remove Events, Notes, and Source and Reselect Data"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:209
+msgid ""
+"Are you sure you want to remove previous events, notes, and source and "
+"reselect data?"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:210
+msgid "Remove and Run Select Again"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:214
+msgid "Reselect Data"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:215
+msgid "Are you sure you want to reselect data?"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:216
+msgid "Run Select Again"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:225
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:234
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:401
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:415
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:420
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:425
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:436
+msgid "Select"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:234
+msgid "Person"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:234
+msgid "Action"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:235
+msgid "Birth Date"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:235
+msgid "Death Date"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:236
+msgid "Evidence"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:236
+msgid "Relative"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:237
+msgid "Processing...\n"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:255
+msgid "Removing old estimations... "
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:256
+#, python-format
+msgid "Removing '%s'..."
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:319
+msgid "done!\n"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:323
+msgid ""
+"Selecting... \n"
+"\n"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:324
+msgid "Selecting..."
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:359
+msgid "Add birth and death events"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:361
+msgid "Add birth event"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:363
+msgid "Add death event"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:398
+msgid "No events to be added."
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:439
+msgid "Selecting... "
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:440
+#, python-format
+msgid "Adding events '%s'..."
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:465
+#, python-format
+msgid "Added birth event based on %(evidence)s, from %(name)s"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:468
+#, python-format
+msgid "Added birth event based on %s"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:470
+msgid "Estimated birth date"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:480
+#, python-format
+msgid "Added death event based on %(evidence)s, from %(person)s"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:483
+#, python-format
+msgid "Added death event based on %s"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:485
+msgid "Estimated death date"
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:495
+msgid " Done! Committing..."
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:499
+#, python-format
+msgid "Added %d events."
+msgstr ""
+
+#: CalculateEstimatedDates/CalculateEstimatedDates.py:527
+msgid "Estimated date"
+msgstr ""

--- a/ChangeGivenNames/po/template.pot
+++ b/ChangeGivenNames/po/template.pot
@@ -1,0 +1,88 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ChangeGivenNames/ChangeGivenNames.gpr.py:36
+msgid "Fix Capitalization of Given Names"
+msgstr ""
+
+#: ChangeGivenNames/ChangeGivenNames.gpr.py:37
+msgid ""
+"Searches the entire database and attempts to fix capitalization of the given "
+"names."
+msgstr ""
+
+#: ChangeGivenNames/ChangeGivenNames.py:66
+msgid "manual|Fix_Capitalization_of_Given_Names..."
+msgstr ""
+
+#: ChangeGivenNames/ChangeGivenNames.py:91
+#: ChangeGivenNames/ChangeGivenNames.py:251
+msgid "Capitalization changes"
+msgstr ""
+
+#: ChangeGivenNames/ChangeGivenNames.py:105
+msgid "Checking Given Names"
+msgstr ""
+
+#: ChangeGivenNames/ChangeGivenNames.py:107
+msgid "Searching given names"
+msgstr ""
+
+#: ChangeGivenNames/ChangeGivenNames.py:123
+msgid "No modifications made"
+msgstr ""
+
+#: ChangeGivenNames/ChangeGivenNames.py:124
+msgid "No capitalization changes were detected."
+msgstr ""
+
+#: ChangeGivenNames/ChangeGivenNames.py:193
+msgid "Select"
+msgstr ""
+
+#: ChangeGivenNames/ChangeGivenNames.py:196
+msgid "Original Name"
+msgstr ""
+
+#: ChangeGivenNames/ChangeGivenNames.py:200
+msgid "Capitalization Change"
+msgstr ""
+
+#: ChangeGivenNames/ChangeGivenNames.py:204
+msgid "Affected Names"
+msgstr ""
+
+#: ChangeGivenNames/ChangeGivenNames.py:211
+msgid "Building display"
+msgstr ""
+
+#: ChangeGivenNames/changenames.glade:32
+msgid ""
+"Below is a list of the given names that \n"
+"Gramps can convert to correct capitalization. \n"
+"Select the names you wish Gramps to convert. "
+msgstr ""
+
+#: ChangeGivenNames/changenames.glade:107
+msgid "Edit selection"
+msgstr ""
+
+#: ChangeGivenNames/changenames.glade:123
+msgid "_Accept changes and close"
+msgstr ""

--- a/CheckPlaceTitles/po/template.pot
+++ b/CheckPlaceTitles/po/template.pot
@@ -1,0 +1,106 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-04 18:55-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: CheckPlaceTitles/checkplacetitles.gpr.py:28
+msgid "Check Place Titles"
+msgstr ""
+
+#: CheckPlaceTitles/checkplacetitles.gpr.py:29
+msgid "Check place titles"
+msgstr ""
+
+#: CheckPlaceTitles/checkplacetitles.py:56
+msgid "manual|Check_place_titles"
+msgstr ""
+
+#: CheckPlaceTitles/checkplacetitles.py:71
+msgid "Check Place title"
+msgstr ""
+
+#: CheckPlaceTitles/checkplacetitles.py:86
+msgid "Checking Place Titles"
+msgstr ""
+
+#: CheckPlaceTitles/checkplacetitles.py:88
+msgid "Looking for place fields"
+msgstr ""
+
+#: CheckPlaceTitles/checkplacetitles.py:107
+msgid "Differences"
+msgstr ""
+
+#: CheckPlaceTitles/checkplacetitles.py:113
+msgid "No need modifications"
+msgstr ""
+
+#: CheckPlaceTitles/checkplacetitles.py:114
+msgid "No changes need."
+msgstr ""
+
+#: CheckPlaceTitles/checkplacetitles.py:143
+msgid "Select"
+msgstr ""
+
+#: CheckPlaceTitles/checkplacetitles.py:146
+msgid "Database"
+msgstr ""
+
+#: CheckPlaceTitles/checkplacetitles.py:150
+msgid "Display"
+msgstr ""
+
+#: CheckPlaceTitles/checkplacetitles.py:160
+msgid "Building display"
+msgstr ""
+
+#: CheckPlaceTitles/checkplacetitles.py:189
+msgid "Legacy place"
+msgstr ""
+
+#: CheckPlaceTitles/checkplacetitles.py:203
+msgid "Modify Place titles"
+msgstr ""
+
+#: CheckPlaceTitles/checkplacetitles.py:226
+msgid "Place titles"
+msgstr ""
+
+#: CheckPlaceTitles/checkplacetitles.glade:56
+msgid "Remove content of place title field if it does not match"
+msgstr ""
+
+#: CheckPlaceTitles/checkplacetitles.glade:74
+msgid "Copy content of place title field to a new note."
+msgstr ""
+
+#: CheckPlaceTitles/checkplacetitles.glade:87
+msgid "Mark"
+msgstr ""
+
+#: CheckPlaceTitles/checkplacetitles.glade:91
+msgid "Attach a tag on selected places."
+msgstr ""
+
+#: CheckPlaceTitles/checkplacetitles.glade:150
+msgid "_Accept changes and close"
+msgstr ""
+
+#: CheckPlaceTitles/checkplacetitles.glade:177
+msgid "column"
+msgstr ""

--- a/CliMerge/po/template.pot
+++ b/CliMerge/po/template.pot
@@ -1,0 +1,26 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: CliMerge/CliMerge.gpr.py:8
+msgid "Command Line Merge"
+msgstr ""
+
+#: CliMerge/CliMerge.gpr.py:17
+msgid "Merge primary objects via the command line."
+msgstr ""

--- a/ClipboardGramplet/po/template.pot
+++ b/ClipboardGramplet/po/template.pot
@@ -1,0 +1,32 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ClipboardGramplet/ClipboardGramplet.gpr.py:9
+#: ClipboardGramplet/ClipboardGramplet.gpr.py:17
+msgid "Collections Clipboard"
+msgstr ""
+
+#: ClipboardGramplet/ClipboardGramplet.gpr.py:10
+msgid "Gramplet for grouping collections of items to aid in data entry."
+msgstr ""
+
+#: ClipboardGramplet/ClipboardGramplet.py:83
+#, python-format
+msgid "Clipboard Gramplet: %s"
+msgstr ""

--- a/ClockGramplet/po/template.pot
+++ b/ClockGramplet/po/template.pot
@@ -1,0 +1,30 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ClockGramplet/ClockGramplet.gpr.py:3
+msgid "Clock Gramplet"
+msgstr ""
+
+#: ClockGramplet/ClockGramplet.gpr.py:4
+msgid "Gramplet for demonstrating Cairo graphics"
+msgstr ""
+
+#: ClockGramplet/ClockGramplet.gpr.py:8
+msgid "Clock"
+msgstr ""

--- a/D3Charts/po/template.pot
+++ b/D3Charts/po/template.pot
@@ -1,0 +1,631 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: D3Charts/AncestralCollapsibleTree.gpr.py:22
+msgid "Ancestral Collapsible Tree"
+msgstr ""
+
+#: D3Charts/AncestralCollapsibleTree.gpr.py:31
+msgid ""
+"Generates a web page with a graphical representation of ancestors (SVG) "
+"represented as a Collapsible Tree Layout from the D3.js JavaScript library."
+msgstr ""
+
+#: D3Charts/AncestralCollapsibleTree.py:124 D3Charts/AncestralFanChart.py:120
+#: D3Charts/DescendantIndentedTree.py:913
+#, python-format
+msgid "Person %s is not in the Database"
+msgstr ""
+
+#: D3Charts/AncestralCollapsibleTree.py:326
+#: D3Charts/AncestralCollapsibleTree.py:768
+#: D3Charts/AncestralCollapsibleTree.py:781 D3Charts/AncestralFanChart.py:401
+#: D3Charts/AncestralFanChart.py:645 D3Charts/AncestralFanChart.py:670
+#: D3Charts/DescendantIndentedTree.py:1497
+#: D3Charts/DescendantIndentedTree.py:1557
+#: D3Charts/DescendantIndentedTree.py:1563
+#: D3Charts/DescendantIndentedTree.py:1670
+#: D3Charts/DescendantIndentedTree.py:1689
+#, python-format
+msgid "Failed writing %s: %s"
+msgstr ""
+
+#: D3Charts/AncestralCollapsibleTree.py:344 D3Charts/AncestralFanChart.py:419
+#: D3Charts/DescendantIndentedTree.py:1515
+#, python-format
+msgid "Failed to create directory structure : %s"
+msgstr ""
+
+#: D3Charts/AncestralCollapsibleTree.py:366 D3Charts/AncestralFanChart.py:441
+#: D3Charts/DescendantIndentedTree.py:1550
+#, python-format
+msgid "Failed to copy web files : %s"
+msgstr ""
+
+#: D3Charts/AncestralCollapsibleTree.py:811
+msgid "Ancestral Collapsible Tree Options"
+msgstr ""
+
+#: D3Charts/AncestralCollapsibleTree.py:813 D3Charts/AncestralFanChart.py:704
+#: D3Charts/DescendantIndentedTree.py:1778
+msgid "Center Person"
+msgstr ""
+
+#: D3Charts/AncestralCollapsibleTree.py:814 D3Charts/AncestralFanChart.py:705
+#: D3Charts/DescendantIndentedTree.py:1779
+msgid "The center person for the report"
+msgstr ""
+
+#: D3Charts/AncestralCollapsibleTree.py:828 D3Charts/AncestralFanChart.py:711
+msgid "Name format"
+msgstr ""
+
+#: D3Charts/AncestralCollapsibleTree.py:829 D3Charts/AncestralFanChart.py:712
+msgid "Default"
+msgstr ""
+
+#: D3Charts/AncestralCollapsibleTree.py:832 D3Charts/AncestralFanChart.py:715
+msgid "Select the format to display names"
+msgstr ""
+
+#: D3Charts/AncestralCollapsibleTree.py:835 D3Charts/AncestralFanChart.py:718
+#: D3Charts/DescendantIndentedTree.py:1795
+msgid "Include Generations"
+msgstr ""
+
+#: D3Charts/AncestralCollapsibleTree.py:836 D3Charts/AncestralFanChart.py:719
+#: D3Charts/DescendantIndentedTree.py:1797
+msgid "The number of generations to include in the report"
+msgstr ""
+
+#: D3Charts/AncestralCollapsibleTree.py:841
+msgid "Male Background Color"
+msgstr ""
+
+#: D3Charts/AncestralCollapsibleTree.py:842
+msgid "RGB-color for male box background."
+msgstr ""
+
+#: D3Charts/AncestralCollapsibleTree.py:845
+msgid "Male Expandable Background Color"
+msgstr ""
+
+#: D3Charts/AncestralCollapsibleTree.py:847
+msgid "RGB-color for male expandable box background."
+msgstr ""
+
+#: D3Charts/AncestralCollapsibleTree.py:850
+msgid "Female Background"
+msgstr ""
+
+#: D3Charts/AncestralCollapsibleTree.py:851
+msgid "RGB-color for female box background."
+msgstr ""
+
+#: D3Charts/AncestralCollapsibleTree.py:854
+msgid "Female Expandable Background"
+msgstr ""
+
+#: D3Charts/AncestralCollapsibleTree.py:856
+msgid "RGB-color for female expandable box background."
+msgstr ""
+
+#: D3Charts/AncestralCollapsibleTree.py:860 D3Charts/AncestralFanChart.py:732
+#: D3Charts/DescendantIndentedTree.py:1815
+msgid "Destination"
+msgstr ""
+
+#: D3Charts/AncestralCollapsibleTree.py:862 D3Charts/AncestralFanChart.py:734
+#: D3Charts/DescendantIndentedTree.py:1817
+msgid "The destination path for generated files."
+msgstr ""
+
+#: D3Charts/AncestralCollapsibleTree.py:866 D3Charts/AncestralFanChart.py:738
+#: D3Charts/DescendantIndentedTree.py:1821
+msgid "Filename"
+msgstr ""
+
+#: D3Charts/AncestralCollapsibleTree.py:867 D3Charts/AncestralFanChart.py:739
+#: D3Charts/DescendantIndentedTree.py:1822
+msgid "The destination file name for html content."
+msgstr ""
+
+#: D3Charts/AncestralFanChart.gpr.py:22
+msgid "Ancestral Fan Chart"
+msgstr ""
+
+#: D3Charts/AncestralFanChart.gpr.py:31
+msgid ""
+"Generates a web page with a graphical representation of ancestors (SVG) "
+"represented as a Fan Chart from the D3.js JavaScript library."
+msgstr ""
+
+#: D3Charts/AncestralFanChart.py:702
+msgid "Ancestral Fan Chart Options"
+msgstr ""
+
+#: D3Charts/AncestralFanChart.py:724
+msgid "Paternal Background Color"
+msgstr ""
+
+#: D3Charts/AncestralFanChart.py:725
+msgid "RGB-color for paternal box background."
+msgstr ""
+
+#: D3Charts/AncestralFanChart.py:728
+msgid "Maternal Background"
+msgstr ""
+
+#: D3Charts/AncestralFanChart.py:729
+msgid "RGB-color for maternal box background."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.gpr.py:22
+#: D3Charts/DescendantIndentedTree.py:908
+msgid "Descendant Indented Tree"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.gpr.py:31
+msgid ""
+"Generates a web page with a graphical representation of descendants (SVG) "
+"representedas a Collapsible Indented Tree Layout from the D3.js JavaScript "
+"library."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:672
+#, python-format
+msgid "See %(reference)s : %(spouse)s"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:743
+#: D3Charts/DescendantIndentedTree.py:810
+#, python-format
+msgid "%s sp."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:763
+msgid "Generating report..."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1363
+msgid "Invalid Destination Directory"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1364
+#, python-format
+msgid ""
+"Destinaton diretory %s does not exist\n"
+"Do you want to attempt to create it."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1367
+#: D3Charts/DescendantIndentedTree.py:1391
+msgid "_Yes"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1368
+#: D3Charts/DescendantIndentedTree.py:1392
+msgid "_No"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1373
+#, python-format
+msgid "Failed to create %s: %s"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1380
+msgid "Permission problem"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1381
+#, python-format
+msgid ""
+"You do not have permission to write under the directory %s\n"
+"\n"
+"Please select another directory or correct the permissions."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1387
+msgid "File already exists"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1388
+#, python-format
+msgid ""
+"Destination file %s already exists.\n"
+"Do you want to overwrite."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1443
+msgid "Default View"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1446
+msgid "Expand All"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1775
+msgid "Report Options"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1784
+msgid "Numbering system"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1786
+msgid "Simple numbering"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1787
+msgid "d'Aboville numbering"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1788
+msgid "Henry numbering"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1789
+msgid "de Villiers/Pama numbering"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1790
+msgid "Meurgey de Tupigny numbering"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1791
+msgid "Record (Modified Register) numbering"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1792
+msgid "The numbering system to be used"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1802
+msgid "Include contraction level"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1804
+msgid "The number of descendant levels to contract on initial display."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1809
+msgid "Font size"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1811
+msgid "The font size in pixels for each node."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1828
+msgid "Content"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1830
+msgid "Show marriage info"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1831
+msgid "Whether to show marriage information in the report."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1834
+msgid "Show divorce info"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1835
+msgid "Whether to show divorce information in the report."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1838
+msgid "Show duplicate trees"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1839
+msgid "Whether to show duplicate family trees in the report."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1843
+msgid "Expanded Row Background Color"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1844
+msgid "RGB-color for expanded row background."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1847
+msgid "Expandable Background Color"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1849
+msgid "RGB-color for expandable row background."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1852
+msgid "Non-Expandable Background Color"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1854
+msgid "RGB-color for non-expandable row background."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1858
+msgid "Include records marked private"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1860
+msgid "Whether to include private objects."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1863
+msgid "Living People"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1866
+msgid "Exclude"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1868
+msgid "Include Last Name Only"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1870
+msgid "Include Full Name Only"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1871
+msgid "Include"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1872
+msgid "How to handle living people."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1877
+msgid "Years from death to consider living"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1879
+msgid "Whether or not to include people who may have recently died."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1887
+msgid "Navigation"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1889
+msgid "Contraction/Expansion mechanism"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1892
+msgid "Entire node."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1893
+msgid "Arrow images at start of node."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1894
+msgid "Plus/Minus images at start of node."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1895
+#: D3Charts/DescendantIndentedTree.py:1924
+msgid "Where to click to expand/contract nodes."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1899
+msgid "Auto-generate HREF links for nodes"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1901
+msgid "Whether to auto-generate HTML links for each node on the report."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1907
+msgid "URL prefix path."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1909
+msgid "URL prefix to apply to each auto-generated HREF link."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1915
+msgid "URL file extension"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1917
+msgid "No file extension."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1918
+msgid ".html"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1919
+msgid ".htm"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1920
+msgid ".shtml"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1921
+msgid ".php"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1922
+msgid ".php3"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1923
+msgid ".cgi"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1929
+msgid "URL file name delimeter"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1931
+msgid "Remove all whitespace."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1932
+msgid "Replace whitespace with dash(-)."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1933
+msgid "Replace whitespace with underscore(_)"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1934
+msgid "What to use as file name delimiter replacing whitespace."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1939
+msgid "Generations to generate HREF links"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1941
+msgid "The number of generations to generate HREF links."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1947
+msgid "Exclude persons who died before (years)"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1950
+msgid ""
+"Whether to generate links for people who died in infancy, -1 excludes nobody."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1956
+msgid "Exclude center person"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1957
+msgid "Whether or not to generate links for center person."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1962
+msgid "Exclude Spouses"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1963
+msgid "Whether or not to generate links for spouses."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1970
+msgid "Biography Content"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1972
+msgid "Show biography tooltips"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1973
+msgid "Whether to show biography tooltips when hovering over a node."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1978
+msgid "Use callname for common name"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1979
+msgid "Whether to use the call name as the first name."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1983
+msgid "Use full dates instead of only the year"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1986
+msgid "Whether to use full dates instead of just year."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1990
+msgid "Compute death age"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1991
+msgid "Whether to compute a person's age at death."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1995
+msgid "Include Photo/Images from Gallery"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1997
+msgid "Whether to include images."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:2000
+msgid "Use complete sentences"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:2002
+msgid "Whether to use complete sentences or succinct language."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:2005
+msgid "Replace missing places with ______"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:2007
+msgid "Whether to replace missing Places with blanks."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:2011
+msgid "Replace missing dates with ______"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:2013
+msgid "Whether to replace missing Dates with blanks."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:2017
+msgid "Text Color"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:2019
+msgid "RGB-color for biography text."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:2022
+msgid "Background Color"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:2024
+msgid "RGB-color for biography tooltip."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:2027
+msgid "Header Font size"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:2029
+msgid "The font size in pixels for biography header text."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:2035
+msgid "Body Font size"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:2037
+msgid "The font size in pixels for biography body text."
+msgstr ""

--- a/DEWebConnectPack/po/template.pot
+++ b/DEWebConnectPack/po/template.pot
@@ -1,0 +1,46 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: DEWebConnectPack/DEWebPack.gpr.py:10
+msgid "DE Web Connect Pack"
+msgstr ""
+
+#: DEWebConnectPack/DEWebPack.gpr.py:11
+msgid "Collection of Web sites for the DE (requires libwebconnect)"
+msgstr ""
+
+#: DEWebConnectPack/DEWebPack.py:37
+msgid "Bielefeld Academic Search"
+msgstr ""
+
+#: DEWebConnectPack/DEWebPack.py:39
+msgid "FamilySearch.org"
+msgstr ""
+
+#: DEWebConnectPack/DEWebPack.py:42
+msgid "Google Archives"
+msgstr ""
+
+#: DEWebConnectPack/DEWebPack.py:43
+msgid "DE Google"
+msgstr ""
+
+#: DEWebConnectPack/DEWebPack.py:44
+msgid "Open Library"
+msgstr ""

--- a/DataEntryGramplet/po/template.pot
+++ b/DataEntryGramplet/po/template.pot
@@ -1,0 +1,250 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: DataEntryGramplet/DataEntryGramplet.gpr.py:8
+msgid "Data Entry Gramplet"
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.gpr.py:9
+msgid "Gramplet for quick data entry"
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.gpr.py:13
+msgid "Data Entry"
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:71
+msgid "Active person"
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:73
+msgid "Family:"
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:74
+msgid "Sources?"
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:76
+#: DataEntryGramplet/DataEntryGramplet.py:109
+msgid "Surname, Given"
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:77
+#: DataEntryGramplet/DataEntryGramplet.py:110
+msgid "Gender"
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:77
+#: DataEntryGramplet/DataEntryGramplet.py:111
+msgid "female"
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:77
+#: DataEntryGramplet/DataEntryGramplet.py:111
+msgid "male"
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:77
+#: DataEntryGramplet/DataEntryGramplet.py:111
+msgid "unknown"
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:77
+#: DataEntryGramplet/DataEntryGramplet.py:111
+msgid "other"
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:78
+#: DataEntryGramplet/DataEntryGramplet.py:80
+#: DataEntryGramplet/DataEntryGramplet.py:81
+#: DataEntryGramplet/DataEntryGramplet.py:111
+#: DataEntryGramplet/DataEntryGramplet.py:112
+#: DataEntryGramplet/DataEntryGramplet.py:113
+msgid "Source"
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:80
+#: DataEntryGramplet/DataEntryGramplet.py:112
+msgid "Birth"
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:81
+#: DataEntryGramplet/DataEntryGramplet.py:113
+msgid "Death"
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:89
+msgid "Save"
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:92
+msgid "Abandon"
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:97
+msgid "New person"
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:98
+msgid "Add relation"
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:99
+msgid "No relation to active person"
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:100
+msgid "Add as a Parent"
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:101
+msgid "Add as a Mother"
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:102
+msgid "Add as a Father"
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:103
+msgid "Add as a Spouse"
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:104
+msgid "Add as a Wife"
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:105
+msgid "Add as a Husband"
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:106
+msgid "Add as a Sibling"
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:107
+msgid "Add as a Child"
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:121
+msgid "Add"
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:124
+msgid "Copy Active Data"
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:127
+msgid "Clear"
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:167
+#: DataEntryGramplet/DataEntryGramplet.py:178
+#: DataEntryGramplet/DataEntryGramplet.py:315
+msgid "in"
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:441
+#: DataEntryGramplet/DataEntryGramplet.py:569
+#, python-format
+msgid "Gramplet Data Edit: %s"
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:515
+msgid "Please provide a name."
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:515
+msgid "Can't add new person."
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:523
+#: DataEntryGramplet/DataEntryGramplet.py:531
+#: DataEntryGramplet/DataEntryGramplet.py:536
+#: DataEntryGramplet/DataEntryGramplet.py:541
+#: DataEntryGramplet/DataEntryGramplet.py:550
+#: DataEntryGramplet/DataEntryGramplet.py:555
+#: DataEntryGramplet/DataEntryGramplet.py:560
+#: DataEntryGramplet/DataEntryGramplet.py:565
+msgid "Please set an active person."
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:523
+#: DataEntryGramplet/DataEntryGramplet.py:526
+msgid "Can't add new person as a parent."
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:526
+#: DataEntryGramplet/DataEntryGramplet.py:545
+msgid "Please set the new person's gender."
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:531
+msgid "Can't add new person as a mother."
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:536
+msgid "Can't add new person as a father."
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:541
+#: DataEntryGramplet/DataEntryGramplet.py:545
+#: DataEntryGramplet/DataEntryGramplet.py:768
+#: DataEntryGramplet/DataEntryGramplet.py:805
+#: DataEntryGramplet/DataEntryGramplet.py:838
+msgid "Can't add new person as a spouse."
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:550
+msgid "Can't add new person as a wife."
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:555
+msgid "Can't add new person as a husband."
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:560
+msgid "Can't add new person as a sibling."
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:565
+#: DataEntryGramplet/DataEntryGramplet.py:938
+msgid "Can't add new person as a child."
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:763
+msgid "Please set Active person."
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:764
+msgid "Can't add new person as a spouse to no one."
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:767
+msgid "Please set gender on Active or new person."
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:804
+#: DataEntryGramplet/DataEntryGramplet.py:837
+msgid "Same genders on Active and new person."
+msgstr ""
+
+#: DataEntryGramplet/DataEntryGramplet.py:937
+msgid "Please set gender on Active person."
+msgstr ""

--- a/DateCalculator/po/template.pot
+++ b/DateCalculator/po/template.pot
@@ -1,0 +1,73 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: DateCalculator/DateCalculator.gpr.py:21
+#: DateCalculator/DateCalculator.gpr.py:31
+msgid "Date Calculator"
+msgstr ""
+
+#: DateCalculator/DateCalculator.gpr.py:22
+msgid "Useful for date math calculations"
+msgstr ""
+
+#: DateCalculator/DateCalculator.py:63
+msgid "Expression 1"
+msgstr ""
+
+#: DateCalculator/DateCalculator.py:64
+msgid "Expression 2"
+msgstr ""
+
+#: DateCalculator/DateCalculator.py:65
+msgid "Result"
+msgstr ""
+
+#: DateCalculator/DateCalculator.py:68
+msgid "Calculate"
+msgstr ""
+
+#: DateCalculator/DateCalculator.py:71
+msgid "Clear"
+msgstr ""
+
+#: DateCalculator/DateCalculator.py:118
+msgid "Error: invalid entry for expression 1"
+msgstr ""
+
+#: DateCalculator/DateCalculator.py:128
+msgid "Error: invalid entry for expression 2"
+msgstr ""
+
+#: DateCalculator/DateCalculator.py:153 DateCalculator/DateCalculator.py:155
+#: DateCalculator/DateCalculator.py:163 DateCalculator/DateCalculator.py:165
+msgid "Error: at least one expression must be a date"
+msgstr ""
+
+#: DateCalculator/DateCalculator.py:171
+msgid ""
+"Enter an expression in the entries above and click Calculate.\n"
+"\n"
+"An expression can be:\n"
+"\n"
+"1. a valid Gramps date\n"
+"2. a positive or negative number, representing years\n"
+"3. a positive or negative tuple, representing (years, months, days)\n"
+"\n"
+"Note that at least one expression must be a date."
+msgstr ""

--- a/DeepConnectionsGramplet/po/template.pot
+++ b/DeepConnectionsGramplet/po/template.pot
@@ -1,0 +1,148 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: DeepConnectionsGramplet/DeepConnectionsGramplet.gpr.py:3
+msgid "Deep Connections Gramplet"
+msgstr ""
+
+#: DeepConnectionsGramplet/DeepConnectionsGramplet.gpr.py:4
+msgid "Gramplet showing a deep relationship between active and home people"
+msgstr ""
+
+#: DeepConnectionsGramplet/DeepConnectionsGramplet.gpr.py:10
+msgid "Deep Connections"
+msgstr ""
+
+#: DeepConnectionsGramplet/DeepConnectionsGramplet.py:59
+msgid "Double-click name for details"
+msgstr ""
+
+#: DeepConnectionsGramplet/DeepConnectionsGramplet.py:60
+msgid "No Family Tree loaded."
+msgstr ""
+
+#: DeepConnectionsGramplet/DeepConnectionsGramplet.py:65
+msgid "Pause"
+msgstr ""
+
+#: DeepConnectionsGramplet/DeepConnectionsGramplet.py:67
+msgid "Continue"
+msgstr ""
+
+#: DeepConnectionsGramplet/DeepConnectionsGramplet.py:69
+msgid "Copy"
+msgstr ""
+
+#: DeepConnectionsGramplet/DeepConnectionsGramplet.py:106
+msgid "mentioned in note"
+msgstr ""
+
+#: DeepConnectionsGramplet/DeepConnectionsGramplet.py:125
+msgid "child"
+msgstr ""
+
+#: DeepConnectionsGramplet/DeepConnectionsGramplet.py:129
+msgid "husband"
+msgstr ""
+
+#: DeepConnectionsGramplet/DeepConnectionsGramplet.py:131
+msgid "wife"
+msgstr ""
+
+#: DeepConnectionsGramplet/DeepConnectionsGramplet.py:132
+msgid "Note on Family"
+msgstr ""
+
+#: DeepConnectionsGramplet/DeepConnectionsGramplet.py:142
+msgid "sibling"
+msgstr ""
+
+#: DeepConnectionsGramplet/DeepConnectionsGramplet.py:146
+msgid "father"
+msgstr ""
+
+#: DeepConnectionsGramplet/DeepConnectionsGramplet.py:149
+msgid "mother"
+msgstr ""
+
+#: DeepConnectionsGramplet/DeepConnectionsGramplet.py:150
+msgid "Note on Parent Family"
+msgstr ""
+
+#: DeepConnectionsGramplet/DeepConnectionsGramplet.py:153
+#, python-format
+msgid "%s (association)"
+msgstr ""
+
+#: DeepConnectionsGramplet/DeepConnectionsGramplet.py:157
+msgid "Note on Person"
+msgstr ""
+
+#: DeepConnectionsGramplet/DeepConnectionsGramplet.py:187
+#, python-format
+msgid ""
+"\n"
+"   %s of "
+msgstr ""
+
+#: DeepConnectionsGramplet/DeepConnectionsGramplet.py:205
+msgid "No Home Person set."
+msgstr ""
+
+#: DeepConnectionsGramplet/DeepConnectionsGramplet.py:208
+msgid "No Active Person set."
+msgstr ""
+
+#: DeepConnectionsGramplet/DeepConnectionsGramplet.py:212
+msgid "self"
+msgstr ""
+
+#: DeepConnectionsGramplet/DeepConnectionsGramplet.py:216
+msgid "Looking for relationship between\n"
+msgstr ""
+
+#: DeepConnectionsGramplet/DeepConnectionsGramplet.py:217
+#, python-format
+msgid "  <b>%s</b> (Home Person) and\n"
+msgstr ""
+
+#: DeepConnectionsGramplet/DeepConnectionsGramplet.py:218
+#, python-format
+msgid "  <b>%s</b> (Active Person)...\n"
+msgstr ""
+
+#: DeepConnectionsGramplet/DeepConnectionsGramplet.py:228
+#, python-format
+msgid ""
+"Found relation #%d: \n"
+"   "
+msgstr ""
+
+#: DeepConnectionsGramplet/DeepConnectionsGramplet.py:238
+msgid ""
+"Paused.\n"
+"Press Continue to search for additional relations.\n"
+msgstr ""
+
+#: DeepConnectionsGramplet/DeepConnectionsGramplet.py:253
+#, python-format
+msgid ""
+"\n"
+"Search completed. %d relations found."
+msgstr ""

--- a/DenominoViso/po/template.pot
+++ b/DenominoViso/po/template.pot
@@ -1,0 +1,608 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: DenominoViso/DenominoViso.gpr.py:8
+msgid "DenominoViso"
+msgstr ""
+
+#: DenominoViso/DenominoViso.gpr.py:17
+msgid ""
+"Generates a web (XHTML) page with a graphical representation of ancestors/"
+"descendants (SVG) where details about individuals become visible upon mouse-"
+"events."
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:178
+msgid "No Source"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:207
+msgid "Ancestor"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:208
+msgid "Descendant"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:212
+msgid "Regular"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:213
+msgid "Fan"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:214
+msgid "Growth Spiral"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:215
+msgid "Mandelbrot Tree"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:216
+msgid "Pythagoras Tree"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:220
+msgid "right to left"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:221
+msgid "left to right"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:222
+msgid "top to bottom"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:223
+msgid "bottom to top"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:299 DenominoViso/DenominoViso.py:969
+#: DenominoViso/DenominoViso.py:1253 DenominoViso/DenominoViso.py:2746
+msgid "type"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:300 DenominoViso/DenominoViso.py:968
+#: DenominoViso/DenominoViso.py:1028 DenominoViso/DenominoViso.py:1253
+#: DenominoViso/DenominoViso.py:2745
+msgid "role"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:301 DenominoViso/DenominoViso.py:968
+#: DenominoViso/DenominoViso.py:1033 DenominoViso/DenominoViso.py:1253
+#: DenominoViso/DenominoViso.py:2744
+msgid "date"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:302 DenominoViso/DenominoViso.py:968
+#: DenominoViso/DenominoViso.py:1039 DenominoViso/DenominoViso.py:1254
+#: DenominoViso/DenominoViso.py:2748
+msgid "place"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:303 DenominoViso/DenominoViso.py:969
+#: DenominoViso/DenominoViso.py:1050 DenominoViso/DenominoViso.py:1254
+#: DenominoViso/DenominoViso.py:2747
+msgid "description"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:304 DenominoViso/DenominoViso.py:970
+#: DenominoViso/DenominoViso.py:1057 DenominoViso/DenominoViso.py:1255
+msgid "witnesses"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:305 DenominoViso/DenominoViso.py:322
+#: DenominoViso/DenominoViso.py:326 DenominoViso/DenominoViso.py:970
+#: DenominoViso/DenominoViso.py:1062 DenominoViso/DenominoViso.py:1255
+#: DenominoViso/DenominoViso.py:1351 DenominoViso/DenominoViso.py:1424
+msgid "source"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:388 DenominoViso/DenominoViso.py:405
+#: DenominoViso/DenominoViso.py:2498
+#, python-format
+msgid "Failure writing %s: %s"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:389
+msgid "No central person selected"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:763
+msgid "Unknown time direction"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:1139
+msgid "and"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:1275
+msgid "Events"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:1350
+msgid "Attributes"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:1423
+msgid "Addresses"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:1473
+msgid "Notes"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:1502 DenominoViso/DenominoViso.py:1556
+msgid "author"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:1507 DenominoViso/DenominoViso.py:1557
+msgid "publication_info"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:1512 DenominoViso/DenominoViso.py:1558
+msgid "abbreviation"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:1555
+msgid "Sources"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:1556 DenominoViso/DenominoViso.py:2752
+msgid "title"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:1556
+msgid "volume"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:1748
+msgid "of"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:1953
+msgid "the chart type runs out of bounds"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:1998
+msgid "Search"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:1998
+msgid "in"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2466
+msgid "Event"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2547
+msgid "DenominoViso Options"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2549
+msgid "Destination"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2551
+msgid "The destination file for the xhtml-content."
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2554
+msgid "Central Person"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2555
+msgid "The central person for the tree"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2558
+msgid "Title of the webpage"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2559
+msgid "Any string you wish."
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2562
+msgid "Display mode"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2563
+msgid "Either plot ancestor or descendants graph."
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2568
+msgid "Display type"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2569
+msgid "The type of graph to create."
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2577
+msgid "Direction of time"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2578
+msgid "Direction in which time increases."
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2583
+msgid "Generations"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2584
+msgid "The number of generations to include in the tree"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2587
+msgid "Max chart width (%)"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2588
+msgid "Width of the tree as fraction of the browser window"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2591
+msgid "Max chart height (px)"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2592
+msgid "Height of the tree in pixels."
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2595
+msgid "Closing remarks"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2596
+msgid ""
+"List of strings, free text added at the bottom, for example for a copyright "
+"notice."
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2599
+msgid "Include Options"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2602
+msgid "Include private records"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2603
+msgid "Wheater to leave out private data."
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2606
+msgid "Include Events"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2608
+msgid "Wheather to include a person's events."
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2616
+msgid "Include birth children"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2617
+msgid "Whether to include the birth of children in the list of events."
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2620
+msgid "Include death relatives"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2621
+msgid ""
+"Whether to include the death of relatives during the lifetime of person."
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2624
+msgid "Include witness note"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2625
+msgid ""
+"Whether to include the note belonging to a witness (if the event_format "
+"contains <witnesses>)"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2629
+msgid "Include Attributes"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2630
+msgid "Whether to include a person's attributes"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2633
+msgid "Include Addresses"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2634
+msgid "Whether to include a person's addresses."
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2637
+msgid "Include Note"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2638
+msgid "Whether to include a person's note."
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2641
+msgid "Include URL"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2642
+msgid "Whether to include a person's internet address."
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2645
+msgid "Include URL description"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2646
+msgid "Whether to include the description of the first URL"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2651
+msgid "Include Sources"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2652
+msgid "Whether to include a person's sources."
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2655
+msgid "Image Options"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2657
+msgid "Include Photos/Images from Gallery"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2658
+msgid "Whether to include images"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2661
+msgid "Copy Image"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2662
+msgid "Copy the images to a designated directory."
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2669
+msgid "Images with Attribute"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2670
+msgid "Determine images with which attributes to in/exclude"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2673
+msgid "Include Image source references"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2674
+msgid "Whether to include references for images"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2677
+msgid "Source reference attribute"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2678
+msgid "Image attribute that should be used as source reference"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2684
+msgid "Style Options"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2686
+msgid "Color of active person:"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2687
+msgid "RGB-color of geometric shape of the activated person."
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2690
+msgid "Color of found persons:"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2691
+msgid "RGB-color of geometric shape of the persons found."
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2694
+msgid "Color of male persons:"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2695
+msgid "RGB-color of geometric shape of the male persons."
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2698
+msgid "Colour of female persons:"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2699
+msgid "RGB-color of geometric shape of the female persons."
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2702
+msgid "Width of rectangle (hrd):"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2703
+msgid ""
+"The width of a person rectangle of the regular chart type expressed as "
+"fraction of the horizontal rectangle distance."
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2706
+msgid "Height of rectangle (hrd):"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2707
+msgid ""
+"The height of a person rectangle of the regular chart type expressed as "
+"fraction of the horizontal rectangle distance."
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2710
+msgid "Vertical distance of rectangles (hrd):"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2711
+msgid ""
+"The vertical distance of person rectangles of the regular chart type "
+"expressed as fraction of the horizontal rectangle distance."
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2714
+msgid "Extra style settings:"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2715
+msgid "Whatever css style settings are needed."
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2718
+msgid "Advanced Options"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2725
+msgid "Mouse event handler"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2727
+msgid "Mouse handler used to interact with visitor of webpage."
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2731
+msgid "Birth relationship linestyle"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2733
+msgid ""
+"List of lists where each sublist is a list with information about the dash "
+"pattern of lines connecting children to parents."
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2739
+msgid "Source confidence color"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2741
+msgid ""
+"List os lists where each sublist is a list with information on the color to "
+"use for a certain confidence level."
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2744
+msgid "Event format"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2745
+msgid "at"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2749
+msgid ""
+"List os strings with placeholders for events. Known placeholders: <type>, "
+"<role>, <date>, <place>, <description>, <witnesses>, <source> and any "
+"<attribute-value>."
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2752
+msgid "Source format"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2753
+msgid ""
+"List of strings with placeholders for sources. Known placeholders: <title>, "
+"<volume>, <author>, <publication_info> and <abbreviation>."
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2814
+msgid "restricted to:"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2854
+msgid "to directory:"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2856
+msgid "Save images in ..."
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2902
+msgid "equal to"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2906
+msgid "should be"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2948
+msgid "Name HTML-wrapper file"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2950
+msgid "Save HTML-wrapper file as ..."
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:2975
+msgid "Give a filename ..."
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:3120
+msgid "Relation type"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:3125
+msgid "Use dashed linestyle"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:3130
+msgid "Dash length"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:3134
+msgid "Inter-dash length"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:3185
+msgid "Confidence"
+msgstr ""
+
+#: DenominoViso/DenominoViso.py:3187
+msgid "Color"
+msgstr ""

--- a/DescendantBooks/po/template.pot
+++ b/DescendantBooks/po/template.pot
@@ -1,0 +1,717 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: DescendantBooks/CollectAscendants.py:178
+#, python-format
+msgid "Deep pruning ascendants from %s people..."
+msgstr ""
+
+#: DescendantBooks/CollectAscendants.py:182
+#, python-format
+msgid "Pruning ascendants from %s people..."
+msgstr ""
+
+#: DescendantBooks/CollectAscendants.py:320
+#: DescendantBooks/CollectAscendants.py:413
+#, python-format
+msgid "Getting ascendants from %s people..."
+msgstr ""
+
+#: DescendantBooks/CollectAscendants.py:331
+#, python-format
+msgid "Verifying descendants from %s people..."
+msgstr ""
+
+#: DescendantBooks/CollectAscendants.py:348
+#, python-format
+msgid "Getting missing descendants from %s people..."
+msgstr ""
+
+#: DescendantBooks/CollectAscendants.py:367
+#, python-format
+msgid "Verifying descendants from %s people after pruning..."
+msgstr ""
+
+#: DescendantBooks/CollectAscendants.py:383
+#, python-format
+msgid "Getting missing descendants from %s people ..."
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:218
+#: DescendantBooks/DescendantBookReport.py:223
+#, python-format
+msgid "sp. %(spouse)s"
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:233
+#, python-format
+msgid "sp. see  %(reference)s : %(spouse)s"
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:244
+#, python-format
+msgid "see report: %(report)s, ref: %(reference)s : %(person)s & %(spouse)s"
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:319
+#, python-format
+msgid "%s sp."
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:369
+msgid "Descendants Report"
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:374
+#: DescendantBooks/DetailedDescendantBookReport.py:167
+#, python-format
+msgid "Person %s is not in the Database"
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:418
+#: DescendantBooks/DetailedDescendantBookReport.py:409
+#, python-format
+msgid "Writing %s reports..."
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:437
+#, python-format
+msgid "%s. Descendants of %s"
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:439
+#, python-format
+msgid "Descendants of %s"
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:459
+msgid "Descendant Report"
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:465
+#: DescendantBooks/DetailedDescendantBookReport.py:591
+msgid "Table Of Contents"
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:476
+#: DescendantBooks/DetailedDescendantBookReport.py:602
+#, python-format
+msgid "%d. %s"
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:501
+#: DescendantBooks/DetailedDescendantBookReport.py:1325
+msgid "Report Options"
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:503
+#: DescendantBooks/DetailedDescendantBookReport.py:1327
+msgid "Filter"
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:505
+#: DescendantBooks/DetailedDescendantBookReport.py:1329
+msgid "Select filter to restrict people that appear in the report"
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:508
+#: DescendantBooks/DetailedDescendantBookReport.py:1332
+msgid "Center Person"
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:509
+#: DescendantBooks/DetailedDescendantBookReport.py:1333
+msgid "The center person for the report"
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:519
+#: DescendantBooks/DetailedDescendantBookReport.py:1342
+msgid "Name format"
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:520
+#: DescendantBooks/DetailedDescendantBookReport.py:1343
+msgid "Default"
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:523
+#: DescendantBooks/DetailedDescendantBookReport.py:1346
+msgid "Select the format to display names"
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:526
+#: DescendantBooks/DetailedDescendantBookReport.py:1349
+msgid "Numbering system"
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:528
+msgid "Simple numbering"
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:529
+msgid "de Villiers/Pama numbering"
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:530
+msgid "Meurgey de Tupigny numbering"
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:531
+#: DescendantBooks/DetailedDescendantBookReport.py:1355
+msgid "The numbering system to be used"
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:534
+#: DescendantBooks/DetailedDescendantBookReport.py:1358
+msgid "Generations"
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:535
+#: DescendantBooks/DetailedDescendantBookReport.py:1360
+msgid "The number of generations to include in the report"
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:538
+msgid "Show marriage info"
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:539
+msgid "Whether to show marriage information in the report."
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:542
+msgid "Show divorce info"
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:543
+msgid "Whether to show divorce information in the report."
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:546
+msgid "Show duplicate trees"
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:547
+msgid "Whether to show duplicate family trees in the report."
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:570
+#: DescendantBooks/DetailedDescendantBookReport.py:1516
+msgid "The style used for the title of the page."
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:580
+msgid "The style used for the table of contents header."
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:590
+msgid "The style used for the table of contents detail."
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:602
+#, python-format
+msgid "The style used for the level %d display."
+msgstr ""
+
+#: DescendantBooks/DescendantBookReport.py:611
+#, python-format
+msgid "The style used for the spouse level %d display."
+msgstr ""
+
+#: DescendantBooks/DescendantBooks.gpr.py:20
+msgid "Descendant Book"
+msgstr ""
+
+#: DescendantBooks/DescendantBooks.gpr.py:21
+msgid "Produces one or more descendant reports based on a supplied query."
+msgstr ""
+
+#: DescendantBooks/DescendantBooks.gpr.py:37
+msgid "Detailed Descendant Book"
+msgstr ""
+
+#: DescendantBooks/DescendantBooks.gpr.py:38
+msgid ""
+"Produces one or more detailed descendant reports based on a supplied query."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:130
+msgid "Detailed Descendants Report"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:347
+#, python-format
+msgid "Generating %s report references..."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:441
+#, python-format
+msgid "%(report_count)s. Descendant Report for %(person_name)s"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:445
+#, python-format
+msgid "Descendant Report for %(person_name)s"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:458
+#, python-format
+msgid "Generation %d"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:585
+msgid "Detailed Descendant Report"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:682
+#, python-format
+msgid "See Report : %s, Generation : %s, Person : %s"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:697
+#, python-format
+msgid "%(name)s is the same person as [%(id_str)s]."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:749
+#: DescendantBooks/DetailedDescendantBookReport.py:762
+#, python-format
+msgid "Report appearances for %s"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:793
+#, python-format
+msgid "%(event_name)s of %(name)s "
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:797
+#, python-format
+msgid "%(event_name)s of %(name)s and %(mate)s "
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:801
+#: DescendantBooks/DetailedDescendantBookReport.py:845
+#, python-format
+msgid "%(date)s, %(place)s"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:804
+#: DescendantBooks/DetailedDescendantBookReport.py:848
+#, python-format
+msgid "%(date)s"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:806
+#: DescendantBooks/DetailedDescendantBookReport.py:850
+#, python-format
+msgid "%(place)s"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:808
+#, python-format
+msgid ". Ref: %(repno)s %(gen)s %(per)s "
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:837
+#, python-format
+msgid "%(event_name)s:"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:862
+#, python-format
+msgid " %(event_text)s"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:874
+#: DescendantBooks/DetailedDescendantBookReport.py:1127
+#, python-format
+msgid "%(type)s: %(value)s%(endnotes)s"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:963
+#, python-format
+msgid "Spouse: %s"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:965
+#, python-format
+msgid "Relationship with: %s"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:980
+#, python-format
+msgid "Ref: %s. %s"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:993
+#: DescendantBooks/DetailedDescendantBookReport.py:1000
+msgid "unknown"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1015
+#, python-format
+msgid "Children of %(mother_name)s and %(father_name)s"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1073
+#, python-format
+msgid "Notes for %(mother_name)s and %(father_name)s:"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1096
+#: DescendantBooks/DetailedDescendantBookReport.py:1119
+#, python-format
+msgid "More about %(mother_name)s and %(father_name)s:"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1201
+#, python-format
+msgid "Notes for %s"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1214
+#: DescendantBooks/DetailedDescendantBookReport.py:1233
+#: DescendantBooks/DetailedDescendantBookReport.py:1247
+#: DescendantBooks/DetailedDescendantBookReport.py:1271
+#, python-format
+msgid "More about %(person_name)s:"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1221
+#, python-format
+msgid "%(name_kind)s: %(name)s%(endnotes)s"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1260
+msgid "Address: "
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1282
+#, python-format
+msgid "%(type)s:"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1287
+#, python-format
+msgid " %(value)s%(endnotes)s"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1351
+msgid "Henry numbering"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1352
+msgid "d'Aboville numbering"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1354
+msgid "Record (Modified Register) numbering"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1364
+msgid "Page break between generations"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1366
+msgid "Whether to start a new page after each generation."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1369
+msgid "Page break before end notes"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1371
+msgid "Whether to start a new page before the end notes."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1378
+msgid "Content"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1380
+msgid "Use callname for common name"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1381
+msgid "Whether to use the call name as the first name."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1384
+msgid "Use full dates instead of only the year"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1386
+msgid "Whether to use full dates instead of just year."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1389
+msgid "List children"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1390
+msgid "Whether to list children."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1393
+msgid "Compute death age"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1394
+msgid "Whether to compute a person's age at death."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1397
+msgid "Omit duplicate ancestors"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1398
+msgid "Whether to omit duplicate ancestors."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1401
+msgid "Use complete sentences"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1403
+msgid "Whether to use complete sentences or succinct language."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1406
+msgid "Add descendant reference in child list"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1409
+msgid "Whether to add descendant references in child list."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1412
+#: DescendantBooks/DetailedDescendantBookReport.py:1413
+msgid "Include"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1415
+msgid "Include notes"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1416
+msgid "Whether to include notes."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1419
+msgid "Include attributes"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1420
+msgid "Whether to include attributes."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1423
+msgid "Include Photo/Images from Gallery"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1424
+msgid "Whether to include images."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1427
+msgid "Include alternative names"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1428
+msgid "Whether to include other names."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1431
+msgid "Include events"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1432
+msgid "Whether to include events."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1435
+msgid "Include addresses"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1436
+msgid "Whether to include addresses."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1439
+msgid "Include sources"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1440
+msgid "Whether to include source references."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1443
+msgid "Include sources notes"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1444
+msgid ""
+"Whether to include source notes in the Endnotes section. Only works if "
+"Include sources is selected."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1448
+msgid "Include spouses"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1449
+msgid "Whether to include detailed spouse information."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1452
+msgid "Include spouse reference"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1453
+msgid "Whether to include reference to spouse."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1456
+msgid "Include sign of succession ('+') in child-list"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1458
+msgid ""
+"Whether to include a sign ('+') before the descendant number in the child-"
+"list to indicate a child has succession."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1463
+msgid "Include path to start-person"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1464
+msgid ""
+"Whether to include the path of descendancy from the start-person to each "
+"descendant."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1468
+msgid "Include Index of Names"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1469
+msgid "Whether to include the index of Names at the end of the report."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1473
+msgid "Include index of Dates"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1474
+msgid "Whether to include the index of Dates at the end of the report."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1478
+msgid "Include index of Places"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1479
+msgid "Whether to include the index of Places at the end of the report."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1486
+msgid "Missing information"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1488
+msgid "Replace missing places with ______"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1489
+msgid "Whether to replace missing Places with blanks."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1492
+msgid "Replace missing dates with ______"
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1493
+msgid "Whether to replace missing Dates with blanks."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1526
+msgid "The style used for the generation header."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1536
+msgid "The style used for the children list title."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1546
+msgid "The style used for the children list."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1556
+msgid "The basic style used for Note header."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1566
+msgid "The basic style used for the text display."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1573
+msgid "The style used for the first personal entry."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1583
+msgid "The style used for the More About header and for headers of mates."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1594
+msgid "The style used for additional detail data."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1604
+#: DescendantBooks/DetailedDescendantBookReport.py:1614
+msgid "The style used for note detail data."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1624
+msgid "The style used for the date in the Index of Dates."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1634
+msgid "The style used for the events in the Index of Dates."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1644
+msgid "The style used for the header in the Index of Names."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1654
+msgid "The style used for the references in the Index of Names."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1664
+msgid "The style used for the header in the Index of Places."
+msgstr ""
+
+#: DescendantBooks/DetailedDescendantBookReport.py:1675
+msgid "The style used for the references in the Index of Places."
+msgstr ""
+
+#: DescendantBooks/RunReport.py:84 DescendantBooks/RunReport.py:89
+msgid "Report could not be created"
+msgstr ""

--- a/DescendantCount/po/template.pot
+++ b/DescendantCount/po/template.pot
@@ -1,0 +1,44 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: DescendantCount/DescendantCount.gpr.py:22
+msgid "Descendant Count Gramplet"
+msgstr ""
+
+#: DescendantCount/DescendantCount.gpr.py:23
+msgid "Gramplet for showing people and descendant counts"
+msgstr ""
+
+#: DescendantCount/DescendantCount.gpr.py:31
+msgid "Descendant Count"
+msgstr ""
+
+#: DescendantCount/DescendantCount.py:87
+msgid ""
+"Click name to change active\n"
+"Double-click name to edit"
+msgstr ""
+
+#: DescendantCount/DescendantCount.py:94
+msgid "Person"
+msgstr ""
+
+#: DescendantCount/DescendantCount.py:101
+msgid "Descendants"
+msgstr ""

--- a/DescendantsLines/po/template.pot
+++ b/DescendantsLines/po/template.pot
@@ -1,0 +1,394 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: DescendantsLines/DescendantsLines.gpr.py:25
+msgid "Descendants Lines"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.gpr.py:26
+msgid "Produces descendants lines of a person"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:424
+msgid "Using SVG type for supplemental document is not supported!"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1247
+msgid "Unknown"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1438
+msgid "Report Options"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1440
+msgid "Center Person"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1441
+msgid "The center person for the report"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1444
+msgid "Output format"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1445
+msgid "PNG format"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1446
+msgid "SVG format"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1447
+msgid "PDF format"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1448
+msgid "PS format"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1449
+msgid "The output format to be used"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1453
+msgid "Destination"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1454
+msgid "The destination file for the content."
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1457
+msgid "Generations"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1458
+msgid "The number of generations to include in the chart. (0 for unlimited)"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1462
+msgid "Box around Person's block"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1463
+msgid "Draw a thin black box around each person' text block."
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1467
+msgid "Colour blocks by Generation"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1468
+msgid "Colour the background of text blocks by generation."
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1472
+msgid "Descend block colour intensity"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1473
+msgid ""
+"Intensity of backgound colour in Descendant's Block, 0=faint, 255=intense "
+"colour"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1477
+msgid "Spouse block colour intensity"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1478
+msgid ""
+"Intensity of backgound colour in Spouse's Block, 0=faint 255=intense colour"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1482
+msgid "Include an image"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1483
+msgid "Whether to include an image if one is available."
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1487
+msgid "Max Image height"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1488
+msgid "Maximum image height in pixels, 0=don't scale for height."
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1492
+msgid "Max Image width"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1493
+msgid "Maximum image width in pixels, 0=don't scale for width."
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1497
+msgid "Image Location"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1498
+msgid "Above text"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1499
+msgid "Left of text"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1500
+msgid "Position of image relative to text"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1504
+msgid "Display"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1506
+msgid "Name Display Format"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1509
+msgid ""
+"f=first & middle names, l=surname, n=nickname,\n"
+"c=commonly used given name, t=title, s=suffix, g=family nick name\n"
+"See Wiki Manual > Reports > part 2"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1516
+msgid "Use d'Aboville descendant numbering system"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1518
+msgid "Prepend name with d'Aboville descendant number in the chart."
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1521
+msgid "Colour Name by Gender"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1523
+msgid "Color the name to indicate a person's gender in the chart."
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1526
+msgid ""
+"Descendant\n"
+"Display Format"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1532
+#: DescendantsLines/DescendantsLines.py:1551
+msgid ""
+"[event, list]$e(formating)\n"
+"See Wiki Manual > Reports > part 2\n"
+"formating: dates=d(ymdMo) places=D(elcuspnoitxy) notes=n abbreviated_type=t"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1545
+msgid ""
+"Spousal\n"
+"Display Format"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1558
+msgid "Use alternate events, if Primary event is not found"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1559
+msgid ""
+"For Birth (baptism, christen)\n"
+"   Marriage (marr_lic, engagement)\n"
+"   Divorce (annulment, div_filing),\n"
+"   Death (burial, cremation, probate)."
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1565
+msgid "Sort Events by Date"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1566
+msgid "Sort events by date (else use the order of the 'Display Format' above)."
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1570
+msgid "Protect People, Images or Events that are marked Private"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1572
+msgid "The Privacy setting of only these types of Gramps objects are checked"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1576
+msgid "Privacy text"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1577
+msgid "Text to display in block, when a Person is marked private"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1581
+msgid "Text style"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1582
+msgid "Center-aligned text"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1583
+msgid "Left-aligned text"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1584
+msgid "Alignment of the text in the block for each person on the chart"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1588
+msgid "Max Note Length"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1589
+msgid ""
+"Maximum length of an event's note field in a text block, '$e(n)'\n"
+" 0=no limit "
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1594
+msgid "Replace"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1597
+msgid ""
+"Replace Display Format:\n"
+"'Replace this'/' with this'"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1599
+msgid ""
+"i.e.\n"
+"United States of America/USA"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1603
+msgid "S  &amp; F Options"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1605
+msgid "S_DOWN"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1606
+msgid "The length of the vertical edge from descendant to spouse-bar."
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1610
+msgid "S_UP"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1611
+msgid "The length of the vertical edge from spouse-bar to spouse."
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1615
+msgid "S_VPAD"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1616
+msgid "The number of ??? vpad"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1619
+msgid "SP_PAD"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1620
+#: DescendantsLines/DescendantsLines.py:1626
+#: DescendantsLines/DescendantsLines.py:1630
+#: DescendantsLines/DescendantsLines.py:1636
+#: DescendantsLines/DescendantsLines.py:1647
+msgid "The number of ??? pad"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1625
+msgid "F_PAD"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1629
+msgid "FL_PAD"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1633
+msgid "O, C &amp; Text Options"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1635
+msgid "OL_PAD"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1639
+msgid "O_DOWN"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1640
+msgid "The length of the vertical edge from spouse-bar to child-bar."
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1646
+msgid "C_PAD"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1650
+msgid "C_UP"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1652
+msgid "The length of the vertical edge from child to child-bar."
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1655
+msgid "MIN_C_WIDTH"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1656
+msgid "The number of ??? min width"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1661
+msgid "TEXT_PAD"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1662
+msgid "The number of text pad ???"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1665
+msgid "TEXT_LINE_PAD"
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1666
+msgid "The number of text line pad ??? "
+msgstr ""
+
+#: DescendantsLines/DescendantsLines.py:1680
+msgid "The default style."
+msgstr ""

--- a/DetDescendantReport-images/po/template.pot
+++ b/DetDescendantReport-images/po/template.pot
@@ -1,0 +1,458 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: DetDescendantReport-images/detdescendantreport.gpr.py:3
+msgid "Detailed Descendant Report With All Images"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreport.gpr.py:4
+msgid ""
+"Produces a detailed descendant report with all images and optional todo list."
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:175
+#, python-format
+msgid "Person %s is not in the Database"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:293
+#: DetDescendantReport-images/detdescendantreporti.py:387
+#: DetDescendantReport-images/detdescendantreporti.py:565
+#: DetDescendantReport-images/detdescendantreporti.py:599
+#: DetDescendantReport-images/detdescendantreporti.py:601
+#: DetDescendantReport-images/detdescendantreporti.py:608
+#: DetDescendantReport-images/detdescendantreporti.py:610
+#: DetDescendantReport-images/detdescendantreporti.py:636
+#: DetDescendantReport-images/detdescendantreporti.py:750
+msgid "Unknown"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:298
+#, python-format
+msgid "Descendant Report for %(person_name)s"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:311
+#, python-format
+msgid "Generation %d"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:367
+#: DetDescendantReport-images/detdescendantreporti.py:480
+msgid "; "
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:408
+#, python-format
+msgid "%(name)s is the same person as [%(id_str)s]."
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:450
+#, python-format
+msgid "%(date)s, %(place)s"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:453
+#, python-format
+msgid "%(date)s"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:455
+#, python-format
+msgid "%(place)s"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:467
+#, python-format
+msgid "%(event_name)s: %(event_text)s"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:482
+#: DetDescendantReport-images/detdescendantreporti.py:733
+#: DetDescendantReport-images/detdescendantreporti.py:862
+#, python-format
+msgid "%(type)s: %(value)s%(endnotes)s"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:568
+#, python-format
+msgid "Spouse: %s"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:570
+#, python-format
+msgid "Relationship with: %s"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:585
+#, python-format
+msgid "Ref: %(number)s. %(name)s"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:625
+#, python-format
+msgid "Children of %(mother_name)s and %(father_name)s"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:686
+#, python-format
+msgid "Notes for %(mother_name)s and %(father_name)s:"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:706
+#: DetDescendantReport-images/detdescendantreporti.py:725
+#, python-format
+msgid "More about %(mother_name)s and %(father_name)s:"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:790
+#, python-format
+msgid "Notes for %s"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:799
+#: DetDescendantReport-images/detdescendantreporti.py:818
+#: DetDescendantReport-images/detdescendantreporti.py:829
+#: DetDescendantReport-images/detdescendantreporti.py:854
+#, python-format
+msgid "More about %(person_name)s:"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:807
+#, python-format
+msgid "%(name_kind)s: %(name)s%(endnotes)s"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:842
+msgid "Address: "
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:845
+#, python-format
+msgid "%s, "
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:929
+#, python-format
+msgid "%(str1)s, %(str2)s"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:936
+#, python-format
+msgid "%(type)s: %(value)s"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:965
+msgid "Images"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:976
+msgid "Non existing media found in the Gallery"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1092
+msgid "Report Options"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1095
+msgid "Center Person"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1096
+msgid "The center person for the report"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1103
+msgid "Numbering system"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1105
+msgid "Henry numbering"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1106
+msgid "d'Aboville numbering"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1108
+msgid "Record (Modified Register) numbering"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1109
+msgid "The numbering system to be used"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1112
+msgid "Generations"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1114
+msgid "The number of generations to include in the report"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1118
+msgid "Page break between generations"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1120
+msgid "Whether to start a new page after each generation."
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1123
+msgid "Page break before end notes"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1125
+msgid "Whether to start a new page before the end notes."
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1132
+msgid "Content"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1134
+msgid "Use callname for common name"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1135
+msgid "Whether to use the call name as the first name."
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1138
+msgid "Use full dates instead of only the year"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1140
+msgid "Whether to use full dates instead of just year."
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1143
+msgid "List children"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1144
+msgid "Whether to list children."
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1147
+msgid "Compute death age"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1148
+msgid "Whether to compute a person's age at death."
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1151
+msgid "Omit duplicate ancestors"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1152
+msgid "Whether to omit duplicate ancestors."
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1155
+msgid "Use complete sentences"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1157
+msgid "Whether to use complete sentences or succinct language."
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1160
+msgid "Add descendant reference in child list"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1163
+msgid "Whether to add descendant references in child list."
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1166
+#: DetDescendantReport-images/detdescendantreporti.py:1167
+msgid "Include"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1169
+msgid "Include notes"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1170
+msgid "Whether to include notes."
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1173
+msgid "Include TODO notes"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1174
+msgid "Whether to include TODO notes."
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1177
+msgid "Include attributes"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1178
+msgid "Whether to include attributes."
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1181
+msgid "Include Photo/Images from Gallery"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1182
+msgid "Whether to include images."
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1185
+msgid "Include alternative names"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1186
+msgid "Whether to include other names."
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1189
+msgid "Include events"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1190
+msgid "Whether to include events."
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1193
+msgid "Include addresses"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1194
+msgid "Whether to include addresses."
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1197
+msgid "Include sources"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1198
+msgid "Whether to include source references."
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1201
+msgid "Include sources notes"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1202
+msgid ""
+"Whether to include source notes in the Endnotes section. Only works if "
+"Include sources is selected."
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1206
+msgid "Include spouses"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1207
+msgid "Whether to include detailed spouse information."
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1210
+msgid "Include spouse reference"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1211
+msgid "Whether to include reference to spouse."
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1214
+msgid "Include sign of succession ('+') in child-list"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1216
+msgid ""
+"Whether to include a sign ('+') before the descendant number in the child-"
+"list to indicate a child has succession."
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1221
+msgid "Include path to start-person"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1222
+msgid ""
+"Whether to include the path of descendancy from the start-person to each "
+"descendant."
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1228
+msgid "Missing information"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1230
+msgid "Replace missing places with ______"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1231
+msgid "Whether to replace missing Places with blanks."
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1234
+msgid "Replace missing dates with ______"
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1235
+msgid "Whether to replace missing Dates with blanks."
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1248
+msgid "The style used for the title of the page."
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1258
+msgid "The style used for the generation header."
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1268
+msgid "The style used for the children list title."
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1278
+msgid "The style used for the children list."
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1294
+msgid "The basic style used for the text display."
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1301
+msgid "The style used for the first personal entry."
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1311
+msgid "The style used for the More About header and for headers of mates."
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1322
+msgid "The style used for additional detail data."
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1347
+msgid "The style used for image labels."
+msgstr ""
+
+#: DetDescendantReport-images/detdescendantreporti.py:1360
+msgid "A style used for image captions."
+msgstr ""

--- a/DetId/po/template.pot
+++ b/DetId/po/template.pot
@@ -1,0 +1,35 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-04 18:55-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: DetId/DetId.gpr.py:30
+msgid "Deterministic ID"
+msgstr ""
+
+#: DetId/DetId.gpr.py:31
+msgid "Set/reset Gramps to use a Deterministic ID"
+msgstr ""
+
+#: DetId/DetId.py:74
+msgid "Deterministic ID Tool"
+msgstr ""
+
+#: DetId/DetId.py:80
+msgid ""
+"The ID and handles now start at 0x00000000, and increment by 0x100000001"
+msgstr ""

--- a/Differences/po/template.pot
+++ b/Differences/po/template.pot
@@ -1,0 +1,75 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: Differences/differences.gpr.py:4
+msgid "Database Differences Report"
+msgstr ""
+
+#: Differences/differences.gpr.py:5
+msgid "Compares an external database with the current one."
+msgstr ""
+
+#: Differences/differences.py:128
+msgid "Family Tree Differences"
+msgstr ""
+
+#: Differences/differences.py:129
+msgid "Processing..."
+msgstr ""
+
+#: Differences/differences.py:296
+msgid "Report Options"
+msgstr ""
+
+#: Differences/differences.py:298
+msgid "Family Tree file"
+msgstr ""
+
+#: Differences/differences.py:300
+msgid "Select a .gpkg or .gramps file"
+msgstr ""
+
+#: Differences/differences.py:303
+msgid "Show items that are different"
+msgstr ""
+
+#: Differences/differences.py:304
+msgid "Include items that are different"
+msgstr ""
+
+#: Differences/differences.py:307
+msgid "Show items missing from file"
+msgstr ""
+
+#: Differences/differences.py:308
+msgid "Include items not in file but in database"
+msgstr ""
+
+#: Differences/differences.py:311
+msgid "Show items added in file"
+msgstr ""
+
+#: Differences/differences.py:312
+msgid "Include items in file but not in database"
+msgstr ""
+
+#: Differences/differences.py:357 Differences/differences.py:359
+#: Differences/differences.py:362 Differences/differences.py:365
+msgid "Text"
+msgstr ""

--- a/DownloadMedia/po/template.pot
+++ b/DownloadMedia/po/template.pot
@@ -1,0 +1,55 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: DownloadMedia/DownloadMedia.gpr.py:35
+msgid "Download media files from the internet"
+msgstr ""
+
+#: DownloadMedia/DownloadMedia.gpr.py:36
+msgid "This tool downloads media files form the internet"
+msgstr ""
+
+#: DownloadMedia/DownloadMedia.py:71
+msgid "Download media"
+msgstr ""
+
+#: DownloadMedia/DownloadMedia.py:87
+msgid "Media downloaded"
+msgstr ""
+
+#: DownloadMedia/DownloadMedia.py:88
+#, python-format
+msgid "%d media files downloaded"
+msgstr ""
+
+#: DownloadMedia/DownloadMedia.py:100
+msgid "Download media tool"
+msgstr ""
+
+#: DownloadMedia/DownloadMedia.py:106
+msgid "Make sure you are connected to the internet before starting this tool."
+msgstr ""
+
+#: DownloadMedia/DownloadMedia.py:171 DownloadMedia/DownloadMedia.py:172
+msgid "Downloading files"
+msgstr ""
+
+#: DownloadMedia/DownloadMedia.py:207
+msgid "Media download errors detected"
+msgstr ""

--- a/DynamicWeb/po/template.pot
+++ b/DynamicWeb/po/template.pot
@@ -1,0 +1,1582 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: DynamicWeb/dynamicweb.gpr.py:15
+msgid "Dynamic Web Report"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.gpr.py:16
+msgid "Produces dynamic web pages for the database"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:265
+msgid "Street"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:266
+msgid "Locality"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:267
+msgid "City"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:268
+msgid "Church Parish"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:269
+msgid "County"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:270
+msgid "State/ Province"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:271
+msgid "Postal Code"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:272
+msgid "Country"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:273
+msgid "Phone"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:279
+msgid "Home Page"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:280
+msgid "SVG graphical tree"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:283
+msgid "Indexes pages"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:287 DynamicWeb/dynamicweb.py:4246
+#, python-format
+msgid "Custom page %(index)i"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:305
+msgid "Ascending tree"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:306
+msgid "Descending tree"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:307
+msgid "Descending tree with spouses"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:308
+msgid "Ascending and descending tree"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:309
+msgid "Ascending and descending tree with spouses"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:321
+msgid "Vertical (↓)"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:322
+msgid "Vertical (↑)"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:323
+msgid "Horizontal (→)"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:324
+msgid "Horizontal (←)"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:325
+msgid "Full Circle"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:326
+msgid "Half Circle"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:327
+msgid "Quadrant"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:339
+msgid "Size proportional to number of ancestors"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:340
+msgid "Homogeneous parents distribution"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:343
+msgid "Size proportional to number of descendants"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:344
+msgid "Homogeneous children distribution"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:351 DynamicWeb/dynamicweb.py:374
+msgid "Gender colors"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:352
+msgid "Generation based gradient"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:353
+msgid "Age based gradient"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:354 DynamicWeb/dynamicweb.py:373
+msgid "Single main (filter) color"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:355
+msgid "Time period based gradient"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:356 DynamicWeb/dynamicweb.py:378
+msgid "White"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:357 DynamicWeb/dynamicweb.py:376
+msgid "Color scheme classic report"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:358 DynamicWeb/dynamicweb.py:377
+msgid "Color scheme classic view"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:375
+msgid "Gradient"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:394
+msgid "Default"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:395
+msgid "Mainz"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:703
+#, python-format
+msgid "Neither %(current)s nor %(parent)s are directories"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:711 DynamicWeb/dynamicweb.py:716
+#, python-format
+msgid "Could not create the directory: %(path)s"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:742 DynamicWeb/dynamicweb.py:3380
+msgid "Dynamic Web Site Report"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:742
+msgid "Exporting family tree data ..."
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:1232 DynamicWeb/dynamicweb.py:2456
+msgid "Author"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:1233 DynamicWeb/dynamicweb.py:2446
+msgid "Abbreviation"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:1234 DynamicWeb/dynamicweb.py:2543
+msgid "Publication information"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:1304 DynamicWeb/dynamicweb.py:2474
+msgid "Date"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:1305
+msgid "Page"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:1306
+msgid "Confidence"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:1625
+#, python-format
+msgid "%(type)s: %(value)s"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:1872
+#, python-format
+msgid "Impossible to convert \"%(path)s\" to a relative path."
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2178
+msgid ""
+"The pages configuration is not valid: several pages have the same content"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2189
+msgid "Html|Home"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2190 DynamicWeb/dynamicweb.py:2203
+#: DynamicWeb/dynamicweb.py:2204 DynamicWeb/dynamicweb.py:2205
+msgid "Tree"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2191 DynamicWeb/dynamicweb.py:2206
+#: DynamicWeb/dynamicweb.py:2207 DynamicWeb/dynamicweb.py:2208
+msgid "Statistics"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2194 DynamicWeb/dynamicweb.py:2470
+msgid "Configuration"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2196 DynamicWeb/dynamicweb.py:2535
+msgid "Person"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2197
+msgid "Family"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2198 DynamicWeb/dynamicweb.py:2575
+msgid "Source"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2199 DynamicWeb/dynamicweb.py:2218
+#: DynamicWeb/dynamicweb.py:2518
+msgid "Media"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2200 DynamicWeb/dynamicweb.py:2538
+msgid "Place"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2201 DynamicWeb/dynamicweb.py:2550
+msgid "Repository"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2202
+msgid "Search results"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2213 DynamicWeb/dynamicweb.py:2214
+#: DynamicWeb/dynamicweb.py:2582
+msgid "Surnames"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2215 DynamicWeb/dynamicweb.py:2503
+msgid "Individuals"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2216 DynamicWeb/dynamicweb.py:2486
+msgid "Families"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2217 DynamicWeb/dynamicweb.py:2577
+msgid "Sources"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2219 DynamicWeb/dynamicweb.py:2540
+msgid "Places"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2220 DynamicWeb/dynamicweb.py:2448
+msgid "Addresses"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2221 DynamicWeb/dynamicweb.py:2549
+msgid "Repositories"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2272 DynamicWeb/dynamicweb.py:2502
+#: DynamicWeb/dynamicweb.py:4120
+msgid "Indexes"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2436
+#, python-format
+msgid "(b. %(birthdate)s, d. %(deathdate)s)"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2437
+#, python-format
+msgid "(b. %s)"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2438
+#, python-format
+msgid "(d. %s)"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2439
+msgid "(filtered from _MAX_ total entries)"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2440
+#, python-format
+msgid "(m. %s)"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2441
+msgid "(sort by name)"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2442
+msgid "(sort by quantity)"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2443
+msgid ": activate to sort column ascending"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2444
+msgid ": activate to sort column descending"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2445
+msgid ""
+"<p>This page provides the SVG raw code.<br>Copy the contents into a text "
+"editor and save as an SVG file.<br>Make sure that the text editor encoding "
+"is UTF-8.</p>"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2447
+msgid "Address"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2449
+msgid "Age at death"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2450
+msgid "Alternate Marriage"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2451
+msgid "Alternate Name"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2452
+msgid "Ancestors"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2453
+msgid "Associations"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2454
+msgid "Attribute"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2455
+msgid "Attributes"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2457 DynamicWeb/dynamicweb.py:4203
+msgid "Background"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2458
+msgid "Baptism"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2459
+msgid "Birth"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2460
+msgid "Burial"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2461
+msgid "Call Name"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2462
+msgid "Call Number"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2463
+msgid "Cause Of Death"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2464
+msgid "Children"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2465
+msgid "Christening"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2466
+msgid "Citation"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2467
+msgid "Citations"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2468
+msgid "Click on the map to show it full-screen"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2469
+msgid "Code"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2471
+msgid "Configure"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2472
+msgid "Count"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2473
+msgid "Cremation"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2475
+msgid "Death"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2476
+msgid "Descendants"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2477
+msgid "Description"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2478
+msgid "DynamicWeb_report#Help"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2479
+msgid "Enclosed By"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2480
+msgid "Engagement"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2481
+msgid "Event"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2482
+msgid "Events"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2483
+msgid "Examples"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2484
+msgid "F"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2485
+msgid "Families Index"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2487
+msgid "Family Nick Name"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2488
+msgid "Father"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2489
+msgid "Female"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2490
+msgid "File ready"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2491
+msgid "Gender"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2492
+msgid "Help"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2493
+msgid "ID"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2494 DynamicWeb/dynamicweb.py:4035
+msgid "Include Place map on Place Pages"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2495 DynamicWeb/dynamicweb.py:4140
+msgid "Include dates columns on the index pages"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2496 DynamicWeb/dynamicweb.py:4148
+msgid "Include a column for parents on the index pages"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2497 DynamicWeb/dynamicweb.py:4156
+msgid "Include a column for media path on the index pages"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2498 DynamicWeb/dynamicweb.py:4144
+msgid "Include a column for partners on the index pages"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2499 DynamicWeb/dynamicweb.py:4043
+msgid "Include a map in the individuals and family pages"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2500 DynamicWeb/dynamicweb.py:4090
+msgid "Include half and/ or step-siblings on the individual pages"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2501 DynamicWeb/dynamicweb.py:4160
+msgid "Include references in indexes"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2504 DynamicWeb/dynamicweb.py:4110
+msgid "Insert sources author in the sources title"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2505
+msgid "Last Modified"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2506
+msgid "Latitude"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2507
+msgid "Link"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2508
+msgid "Loading..."
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2509
+msgid "Location"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2510
+msgid "Longitude"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2511
+msgid "M"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2512
+msgid "Male"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2513
+msgid "Map"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2514
+msgid "Marriage"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2515
+msgid "Maximize"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2516
+msgid "Media Index"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2517
+msgid "Media Type"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2519
+msgid "Mother"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2520
+msgid "Name"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2521
+msgid "Nick Name"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2522
+msgid "No data available in table"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2523
+msgid "No matches found"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2524
+msgid "No matching records found"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2525
+msgid "No matching surname."
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2526
+msgid "None"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2527
+msgid "Notes"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2528
+msgid "Number"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2529
+msgid "OK"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2530
+msgid "Other participants"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2531
+msgid "Parents"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2532
+msgid "Path"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2533
+msgid "Person page"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2534
+msgid "Person to search for"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2536
+msgid "Persons Index"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2537
+msgid "Persons"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2539
+msgid "Places Index"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2541
+msgid "Preparing file ..."
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2542
+msgid "Processing..."
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2544
+msgid "References"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2545
+msgid "Relationship to Father"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2546
+msgid "Relationship to Mother"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2547
+msgid "Relationship"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2548
+msgid "Repositories Index"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2551
+msgid "Restore"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2552
+msgid "Restore default settings"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2553 DynamicWeb/dynamicweb.py:4106
+msgid "Show last modification time"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2554 DynamicWeb/dynamicweb.py:4197
+msgid "SVG tree children distribution"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2555
+msgid "SVG tree configuration"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2556 DynamicWeb/dynamicweb.py:4185
+msgid "SVG tree graph shape"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2557 DynamicWeb/dynamicweb.py:4179
+msgid "SVG tree graph type"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2558 DynamicWeb/dynamicweb.py:4191
+msgid "SVG tree parents distribution"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2559
+msgid "Save tree as file"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2560
+msgid "Search:"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2561
+msgid "Select the background color scheme"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2562
+msgid "Select the children distribution (fan charts only)"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2563
+msgid "Select the number of ascending generations"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2564
+msgid "Select the number of descending generations"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2565
+msgid "Select the parents distribution (fan charts only)"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2566
+msgid "Select the shape of graph"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2567
+msgid "Select the type of graph"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2568
+msgid "Several matches.<br>Precise your search or choose in the lists below."
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2569
+msgid "Show _MENU_ entries"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2570 DynamicWeb/dynamicweb.py:4215
+msgid "Show duplicates"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2571
+msgid "Showing 0 to 0 of 0 entries"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2572
+msgid "Showing _START_ to _END_ of _TOTAL_ entries"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2573
+msgid "Siblings"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2574
+msgid "Sort by:"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2576
+msgid "Sources Index"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2578
+msgid "Spouses"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2579 DynamicWeb/dynamicweb.py:4114
+msgid "Suppress Gramps ID"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2580
+msgid "Surname"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2581
+msgid "Surnames Index"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2583
+msgid "Title"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2584
+msgid "Type"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2585
+msgid "U"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2586
+msgid "Unknown"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2587 DynamicWeb/dynamicweb.py:4102
+msgid "Use tabbed panels instead of sections"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2588
+msgid "Use the search box above in order to find a person."
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2589
+msgid "Use a table format for the surnames index"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2590
+msgid "Use a table format for the persons index"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2591
+msgid "Use a table format for the families index"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2592
+msgid "Use a table format for the sources index"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2593
+msgid "Use a table format for the places index"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2594
+msgid "Used for family"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2595
+msgid "Used for media"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2596
+msgid "Used for person"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2597
+msgid "Used for place"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2598
+msgid "Used for source"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2599
+msgid "Value"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2600
+msgid "Web Link"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2601
+msgid "Web Links"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2602 DynamicWeb/dynamicweb.py:4216
+msgid ""
+"Whether to use a special color for the persons that appear several times in "
+"the SVG tree"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2603
+msgid "Without name"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2604
+msgid "Without surname"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2605
+msgid "Without title"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2606
+msgid "Zoom in"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2607
+msgid "Zoom out"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2608
+msgid "all"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2811
+msgid "No Home Person"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2952
+#, python-format
+msgid "Copying error: %(error)s"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2953
+#, python-format
+msgid "Impossible to copy \"%(src)s\" to \"%(dst)s\""
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2956
+msgid "Possible destination error"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2957
+msgid ""
+"You appear to have set your target directory to a directory used for data "
+"storage. This could create problems with file management. It is recommended "
+"that you consider using a different directory to store your generated web "
+"pages."
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:2984
+#, python-format
+msgid "Unable to copy web site template files from \"%(path)s\""
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3028
+#, python-format
+msgid "Keeping \"%(dst)s\" (newer than \"%(src)s\")"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3031
+#, python-format
+msgid "Copying \"%(src)s\" to \"%(dst)s\""
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3049
+msgid "Invalid file name"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3050
+msgid "The archive file must be a file, not a directory"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3060 DynamicWeb/dynamicweb.py:3078
+#, python-format
+msgid "Unable to overwrite archive file \"%(path)s\""
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3070 DynamicWeb/dynamicweb.py:3085
+#, python-format
+msgid "Unable to add file \"%(file)s\" to archive \"%(archive)s\""
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3138
+#, python-format
+msgid "DynamicWebReport ignoring link type '%(class)s'"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3381
+msgid "Constructing list of other objects..."
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3516
+#, python-format
+msgid "Family of %(husband)s and %(spouse)s"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3522
+#, python-format
+msgid "Family of %(father)s"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3526
+#, python-format
+msgid "Family of %(mother)s"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3841
+msgid ""
+"In this note, the following special words are processed:\n"
+"__SEARCH_FORM__ is replaced by a search form.\n"
+"__NB_INDIVIDUALS__ is replaced by the number of persons.\n"
+"__NB_FAMILIES__ is replaced by the number of families.\n"
+"__NB_MEDIA__ is replaced by the number of media.\n"
+"__NB_SOURCES__ is replaced by the number of sources.\n"
+"__NB_REPOSITORIES__ is replaced by the number of repositories.\n"
+"__NB_PLACES__ is replaced by the number of places.\n"
+"__MEDIA_<gid>__ is replaced by the media with Gramps ID <gid>.\n"
+"__THUMB_<gid>__ is replaced by the thumbnail of the media with Gramps ID "
+"<gid>.\n"
+"__EXPORT_DATE__ is replaced by the current date.\n"
+"__GRAMPS_VERSION__ is replaced by the Gramps version.\n"
+"__GRAMPS_HOMEPAGE__ is replaced by the Gramps homepage link.\n"
+"URL starting with \"relative://relative.<link>\" are replaced by the "
+"relative URL \"<link>\".\n"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3880
+msgid "Report"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3885
+msgid "Destination"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3887
+msgid "The destination directory for the web files"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3891
+msgid "Store web pages in archive"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3892
+msgid ""
+"Whether to create an archive file (in ZIP or TGZ format) containing the web "
+"site"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3896
+msgid "Archive file"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3898
+msgid "The archive file name (with \".zip\" or \".tgz\" extension)"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3904
+msgid "Web site title"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3904
+msgid "My Family Tree"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3905
+msgid "The title of the web site"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3908
+msgid "Filter"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3910
+msgid "Select filter to restrict people that appear on web site"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3914
+msgid "Filter Person"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3915
+msgid "The center person for the filter"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3923 DynamicWeb/dynamicweb.py:3943
+msgid "Name format (short)"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3924 DynamicWeb/dynamicweb.py:3946
+msgid "Select the format to display a shorter version of the names"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3938
+msgid "Name format"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3941
+msgid "Select the format to display names"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3949
+msgid "Web site template"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3952
+msgid "Select the template of the web site"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3955
+msgid "Copyright"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3958
+msgid "The copyright to be used for the web files"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3966
+msgid "Privacy"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3974
+msgid "Include records marked private"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3975
+msgid "Whether to include private objects"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3977
+msgid "Living People"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3978
+msgid "Exclude"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3979
+msgid "Include Last Name Only"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3980
+msgid "Include Full Name Only"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3981
+msgid "Include"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3982
+msgid "How to handle living people"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3985
+msgid "Years from death to consider living"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3986
+msgid ""
+"This allows you to restrict information on people who have not been dead for "
+"very long"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3990
+msgid "Export notes"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3991
+msgid "Whether to export notes in the web pages"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3994
+msgid "Export sources"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3995
+msgid "Whether to export sources and citations in the web pages"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3998
+msgid "Export addresses"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:3999
+msgid "Whether to export addresses in the web pages"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4004
+msgid "Options"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4007
+msgid "Include repository pages"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4008
+msgid "Whether or not to include the Repository Pages."
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4011
+msgid "Include images and media"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4012
+msgid "Whether to include images and media in the web pages"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4016
+msgid "Copy, rename files with an internal Gramps identifier"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4017
+msgid "Copy, keep file names unchanged"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4018
+msgid "Do not copy, reference existing files"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4020
+msgid "Images and media"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4023
+msgid "Whether to make a copy of the media"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4026
+msgid "Print the notes type"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4027
+msgid "Whether to print the notes type in the notes text"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4030
+msgid "Print place pages"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4031
+msgid "Whether to show pages for the places"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4037
+msgid ""
+"Whether to include a place map on the Place Pages, where Latitude/ Longitude "
+"are available."
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4045
+msgid ""
+"Whether or not to add an individual page map showing all the places on this "
+"page. This will allow you to see how your family traveled around the country."
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4053
+msgid "Google"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4054
+msgid "OpenStreetMap"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4056
+msgid "Map Service"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4059
+msgid "Choose your choice of map service for creating the Place Map Pages"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4063
+msgid "Google map API key"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4064
+msgid "The API key used for the Google map"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4071
+msgid "Advanced"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4074
+msgid "Character set encoding"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4077
+msgid "The encoding to be used for the web files"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4080
+msgid "Include family pages"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4081
+msgid "Whether or not to include family pages"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4091
+msgid ""
+"Whether to include half and/ or step-siblings with the parents and siblings"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4094
+msgid "Include GENDEX file (/gendex.txt)"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4095
+msgid "Whether to include a GENDEX file or not"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4098
+msgid "Enable page configuration"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4099
+msgid "Whether to enable page configuration"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4103
+msgid "Whether to use tabbed panels for the different sections of the pages."
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4107
+msgid "Whether to show the last modification time in the pages footer"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4111
+msgid "Whether to insert sources author in the sources title"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4115
+msgid "Whether to hide the Gramps ID"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4124
+msgid "List"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4125
+msgid "Table"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4128
+msgid "Default format for the surnames index"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4128
+msgid "The default format for the surnames index"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4129
+msgid "Default format for the persons index"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4129
+msgid "The default format for the persons index"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4130
+msgid "Default format for the families index"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4130
+msgid "The default format for the families index"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4131
+msgid "Default format for the sources index"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4131
+msgid "The default format for the sources index"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4132
+msgid "Default format for the places index"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4132
+msgid "The default format for the places index"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4141
+msgid ""
+"Whether to include dates columns (birth, death, marriage) on the index pages"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4145
+msgid "Whether to include a partners column"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4149
+msgid "Whether to include a parents column"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4152
+msgid "Generate a families index page"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4153
+msgid "Whether to generate an index page for families"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4157
+msgid "Whether to include a column showing the media path"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4161
+msgid ""
+"Whether to include the references to the items in the index pages. For "
+"example, in the media index page, the names of the individuals, families, "
+"places, sources that reference the media."
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4164
+msgid "Default number of entries in the indexes"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4167
+msgid "The default number of entries shown in one index page"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4172
+msgid "Trees"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4175
+msgid "Maximum number of generations"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4176
+msgid ""
+"The maximum number of generations to include in the ancestor and descendant "
+"trees and graphs"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4182
+msgid "Choose the default SVG tree graph type"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4188
+msgid "Choose the default SVG tree graph shape"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4194
+msgid "Choose the default SVG tree parents distribution (for fan charts only)"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4200
+msgid "Choose the default SVG tree children distribution (for fan charts only)"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4206
+msgid ""
+"Choose the background color scheme for the persons in the SVG tree graph"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4209
+msgid "Start gradient/Main color"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4212
+msgid "End gradient/2nd color"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4220
+msgid "Color for duplicates"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4225
+msgid "Pages"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4228
+msgid "HTML user header"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4229
+msgid "A note to be used as the page header"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4232
+msgid "HTML user brand name / icon"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4233
+msgid "A note to be used as the brand name or image in the menu"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4236
+msgid "HTML user footer"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4237
+msgid "A note to be used as the page footer"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4242
+msgid "Custom pages"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4246
+#, python-format
+msgid "Title for the custom page %(index)i"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4247
+#, python-format
+msgid "Name for the custom page %(index)i"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4250
+#, python-format
+msgid "Note for custom page %(index)i"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4251
+msgid "A note to be used for the custom page content.\n"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4254
+#, python-format
+msgid "Menu for the custom page %(index)i"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4255
+msgid "Whether to print a menu for the custom page"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4260
+msgid "Pages selection"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4263
+msgid "Number of pages"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4264
+msgid "Number pages in the web site menu."
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4280
+#, python-format
+msgid "Contents of page %(index)i"
+msgstr ""
+
+#: DynamicWeb/dynamicweb.py:4283
+msgid "Contents of the page"
+msgstr ""

--- a/EditExifMetadata/po/template.pot
+++ b/EditExifMetadata/po/template.pot
@@ -1,0 +1,329 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-04 18:55-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: EditExifMetadata/editexifmetadata.gpr.py:29
+#: EditExifMetadata/editexifmetadata.py:749
+#: EditExifMetadata/editexifmetadata.py:1155
+msgid "Edit Image Exif Metadata"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.gpr.py:30
+msgid "Gramplet to view, edit, and save image Exif metadata"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.gpr.py:34
+msgid "Edit Exif Metadata"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:147
+msgid "<-- Image Types -->"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:170
+msgid ""
+"Warning:  Changing this entry will update the Media object title field in "
+"Gramps not Exiv2 metadata."
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:173
+msgid "Provide a short description for this image."
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:175
+msgid ""
+"Enter the Artist/ Author of this image.  The person's name or the company "
+"who is responsible for the creation of this image."
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:178
+msgid "Enter the copyright information for this image. \n"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:180
+msgid ""
+"The original date/ time when the image was first created/ taken as in a "
+"photograph.\n"
+"Example: 1830-01-1 09:30:59"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:183
+msgid ""
+"This is the date/ time that the image was last changed/ modified.\n"
+"Example: 2011-05-24 14:30:00"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:186
+msgid ""
+"Enter the Latitude GPS coordinates for this image,\n"
+"Example: 43.722965, 43 43 22 N, 38° 38′ 03″ N, 38 38 3"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:189
+msgid ""
+"Enter the Longitude GPS coordinates for this image,\n"
+"Example: 10.396378, 10 23 46 E, 105° 6′ 6″ W, -105 6 6"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:192
+msgid ""
+"This is the measurement of Above or Below Sea Level.  It is measured in "
+"meters.Example: 200.558, -200.558"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:201
+msgid ""
+"Displays the Gramps Wiki Help page for 'Edit Image Exif Metadata' in your "
+"web browser."
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:204
+msgid ""
+"This will open up a new window to allow you to edit/ modify this image's "
+"Exif metadata.\n"
+"  It will also allow you to be able to Save the modified metadata."
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:208
+msgid "Will produce a Popup window showing a Thumbnail Viewing Area"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:210
+msgid ""
+"Select from a drop- down box the image file type that you would like to "
+"convert your non- Exiv2 compatible media object to."
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:213
+msgid ""
+"If your image is not of an image type that can have Exif metadata read/ "
+"written to/from, convert it to a type that can?"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:216
+msgid ""
+"WARNING:  This will completely erase all Exif metadata from this image!  Are "
+"you sure that you want to do this?"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:311
+msgid "Thumbnail"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:393
+msgid "Select an image to begin..."
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:415
+msgid ""
+"Image is NOT readable,\n"
+"Please choose a different image..."
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:431
+msgid ""
+"Image is NOT writable,\n"
+"You will NOT be able to save Exif metadata...."
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:443
+msgid "Please convert this image to an Exiv2- compatible image type..."
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:466
+msgid "Image Size : %04(width)d x %04(height)d pixels"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:499
+msgid "Displaying Exif metadata..."
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:666
+msgid "Click Close to close this Thumbnail View Area."
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:670
+msgid "Thumbnail View Area"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:749
+msgid ""
+"WARNING: You are about to convert this image into a .jpeg image.  Are you "
+"sure that you want to do this?"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:751
+msgid "Convert and Delete"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:751
+msgid "Convert"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:837
+msgid ""
+"Your image has been converted and the original file has been deleted, and "
+"the full path has been updated!"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:841
+msgid ""
+"There has been an error, Please check your source and destination file "
+"paths..."
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:844
+msgid ""
+"There was an error in deleting the original file.  You will need to delete "
+"it yourself!"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:861
+msgid "There was an error in converting your image file."
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:872
+msgid "Media Path Update"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:878
+msgid "There has been an error in updating the image file's path!"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:912
+msgid ""
+"Click the close button when you are finished modifying this image's Exif "
+"metadata."
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:950
+msgid "Saves a copy of the data fields into the image's Exif metadata."
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:953
+msgid "Re -display the data fields that were cleared from the Edit Area."
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:956
+msgid "This button will clear all of the data fields shown here."
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:959
+msgid ""
+"Closes this popup Edit window.\n"
+"WARNING: This action will NOT Save any changes/ modification made to this "
+"image's Exif metadata."
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:986
+msgid "Media Object Title"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:996
+msgid "media Title: "
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:1010
+msgid "General Data"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:1020
+msgid "Description: "
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:1021
+msgid "Artist: "
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:1022
+msgid "Copyright: "
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:1035
+msgid "Date/ Time"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:1049
+msgid "Original: "
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:1050
+msgid "Modified: "
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:1067
+msgid "Latitude/ Longitude/ Altitude GPS coordinates"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:1081
+msgid "Latitude :"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:1082
+msgid "Longitude :"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:1083
+msgid "Altitude :"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:1135
+msgid "Bad Date/Time"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:1143
+msgid "Invalid latitude (syntax: 18\\u00b09'"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:1144
+msgid "48.21\"S, -18.2412 or -18:9:48.21)"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:1148
+msgid "Invalid longitude (syntax: 18\\u00b09'"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:1149
+msgid "48.21\"E, -18.2412 or -18:9:48.21)"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:1155
+msgid ""
+"WARNING!  You are about to completely delete the Exif metadata from this "
+"image?"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:1318
+msgid "Media Title Update"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:1344
+msgid "Media Object Date Created"
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:1416
+msgid "Saving Exif metadata to this image..."
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:1463
+msgid "All Exif metadata has been deleted from this image..."
+msgstr ""
+
+#: EditExifMetadata/editexifmetadata.py:1468
+msgid "There was an error in stripping the Exif metadata from this image..."
+msgstr ""

--- a/ExportProlog/po/template.pot
+++ b/ExportProlog/po/template.pot
@@ -1,0 +1,26 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ExportProlog/ExportProlog.gpr.py:3
+msgid "Prolog Export"
+msgstr ""
+
+#: ExportProlog/ExportProlog.gpr.py:4
+msgid "Exports data into a Prolog fact format"
+msgstr ""

--- a/ExportRaw/po/template.pot
+++ b/ExportRaw/po/template.pot
@@ -1,0 +1,30 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ExportRaw/ExportRaw.gpr.py:3
+msgid "Raw Export"
+msgstr ""
+
+#: ExportRaw/ExportRaw.gpr.py:4
+msgid "This is a raw python object dump"
+msgstr ""
+
+#: ExportRaw/ExportRaw.gpr.py:11
+msgid "Raw options"
+msgstr ""

--- a/ExtendedAttributes/po/template.pot
+++ b/ExtendedAttributes/po/template.pot
@@ -1,0 +1,65 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ExtendedAttributes/ExtendedAttributes.gpr.py:31
+msgid "Extended Person Attributes"
+msgstr ""
+
+#: ExtendedAttributes/ExtendedAttributes.gpr.py:32
+msgid "Gramplet showing the attributes of a person"
+msgstr ""
+
+#: ExtendedAttributes/ExtendedAttributes.gpr.py:39
+#: ExtendedAttributes/ExtendedAttributes.gpr.py:53
+msgid "Extended Attributes"
+msgstr ""
+
+#: ExtendedAttributes/ExtendedAttributes.gpr.py:45
+msgid "Extended Family Attributes"
+msgstr ""
+
+#: ExtendedAttributes/ExtendedAttributes.gpr.py:46
+msgid "Gramplet showing the attributes of a family"
+msgstr ""
+
+#: ExtendedAttributes/ExtendedAttributes.py:54
+msgid ""
+"Double-click on a row to edit the object containing the selected attribute."
+msgstr ""
+
+#: ExtendedAttributes/ExtendedAttributes.py:58
+msgid "Date"
+msgstr ""
+
+#: ExtendedAttributes/ExtendedAttributes.py:60
+msgid "Key"
+msgstr ""
+
+#: ExtendedAttributes/ExtendedAttributes.py:61
+msgid "Value"
+msgstr ""
+
+#: ExtendedAttributes/ExtendedAttributes.py:156
+#, python-format
+msgid "Edit Person (%s)"
+msgstr ""
+
+#: ExtendedAttributes/ExtendedAttributes.py:220
+msgid "Edit Family"
+msgstr ""

--- a/ExtractCity/po/template.pot
+++ b/ExtractCity/po/template.pot
@@ -1,0 +1,107 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ExtractCity/extractcity.gpr.py:33
+msgid "Extract Place Data from a Place Title"
+msgstr ""
+
+#: ExtractCity/extractcity.gpr.py:34
+msgid "Attempts to extract city and state/province from a place title"
+msgstr ""
+
+#: ExtractCity/extractcity.py:68
+msgid "United States of America"
+msgstr ""
+
+#: ExtractCity/extractcity.py:68
+msgid "Canada"
+msgstr ""
+
+#: ExtractCity/extractcity.py:68
+msgid "France"
+msgstr ""
+
+#: ExtractCity/extractcity.py:68
+msgid "Sweden"
+msgstr ""
+
+#: ExtractCity/extractcity.py:391
+msgid "Place title"
+msgstr ""
+
+#: ExtractCity/extractcity.py:392
+msgid "City"
+msgstr ""
+
+#: ExtractCity/extractcity.py:393
+msgid "State"
+msgstr ""
+
+#: ExtractCity/extractcity.py:394
+msgid "ZIP/Postal Code"
+msgstr ""
+
+#: ExtractCity/extractcity.py:395
+msgid "Country"
+msgstr ""
+
+#: ExtractCity/extractcity.py:422 ExtractCity/extractcity.py:613
+msgid "Extract Place data"
+msgstr ""
+
+#: ExtractCity/extractcity.py:439
+msgid "Checking Place Titles"
+msgstr ""
+
+#: ExtractCity/extractcity.py:441
+msgid "Looking for place fields"
+msgstr ""
+
+#: ExtractCity/extractcity.py:527
+msgid "No modifications made"
+msgstr ""
+
+#: ExtractCity/extractcity.py:528
+msgid "No place information could be extracted."
+msgstr ""
+
+#: ExtractCity/extractcity.py:547
+msgid ""
+"Below is a list of Places with the possible data that can be extracted from "
+"the place title. Select the places you wish Gramps to convert."
+msgstr ""
+
+#: ExtractCity/extractcity.py:558
+msgid "Select"
+msgstr ""
+
+#: ExtractCity/extractcity.py:572
+msgid "Building display"
+msgstr ""
+
+#: ExtractCity/changenames.glade:35
+msgid ""
+"Below is a list of the family names that \n"
+"Gramps can convert to correct capitalization. \n"
+"Select the names you wish Gramps to convert. "
+msgstr ""
+
+#: ExtractCity/changenames.glade:108
+msgid "_Accept changes and close"
+msgstr ""

--- a/FRWebConnectPack/po/template.pot
+++ b/FRWebConnectPack/po/template.pot
@@ -1,0 +1,54 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: FRWebConnectPack/FRWebPack.gpr.py:10
+msgid "FR Web Connect Pack"
+msgstr ""
+
+#: FRWebConnectPack/FRWebPack.gpr.py:11
+msgid "Collection of Web sites for the FR (requires libwebconnect)"
+msgstr ""
+
+#: FRWebConnectPack/FRWebPack.py:40
+msgid "French cultural ministry"
+msgstr ""
+
+#: FRWebConnectPack/FRWebPack.py:41
+msgid "Genealogical bank"
+msgstr ""
+
+#: FRWebConnectPack/FRWebPack.py:43
+msgid "OrigineFile (Quebec)"
+msgstr ""
+
+#: FRWebConnectPack/FRWebPack.py:47
+msgid "FamilySearch.org"
+msgstr ""
+
+#: FRWebConnectPack/FRWebPack.py:48
+msgid "Cyber genealogy"
+msgstr ""
+
+#: FRWebConnectPack/FRWebPack.py:54
+msgid "Hathi Trust Digital Library"
+msgstr ""
+
+#: FRWebConnectPack/FRWebPack.py:55
+msgid "Open Library"
+msgstr ""

--- a/FaceDetection/po/template.pot
+++ b/FaceDetection/po/template.pot
@@ -1,0 +1,38 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-04 18:55-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: FaceDetection/FaceDetection.gpr.py:3
+msgid "Face Detection"
+msgstr ""
+
+#: FaceDetection/FaceDetection.gpr.py:4
+msgid "Gramplet for detecting and assigning faces"
+msgstr ""
+
+#: FaceDetection/FaceDetection.gpr.py:12
+msgid "Faces"
+msgstr ""
+
+#: FaceDetection/FaceDetection.py:63
+msgid "OpenCV-Python is not installed"
+msgstr ""
+
+#: FaceDetection/FaceDetection.py:72
+msgid "Detect New Faces"
+msgstr ""

--- a/FamilySheet/po/template.pot
+++ b/FamilySheet/po/template.pot
@@ -1,0 +1,192 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: FamilySheet/FamilySheet.gpr.py:3 FamilySheet/FamilySheet.py:126
+msgid "Family Sheet"
+msgstr ""
+
+#: FamilySheet/FamilySheet.gpr.py:4
+msgid ""
+"Produces a family sheet showing full information about a person and his/her "
+"partners and children."
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:232 FamilySheet/FamilySheet.py:275
+#, python-format
+msgid "\\u2192 %s"
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:396
+#, python-format
+msgid "Address (%(date)s): %(location)s"
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:400
+#, python-format
+msgid "Address: %(location)s"
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:451
+#, python-format
+msgid "; %(type)s: %(value)s"
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:539
+msgid "Source references:"
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:553
+#, python-format
+msgid "%s: "
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:557
+#, python-format
+msgid ", page %s"
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:570
+msgid "Notes:"
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:749
+#, python-format
+msgid "on %(ymd_date)s"
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:751
+#, python-format
+msgid "in %(ym_date)s"
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:753
+#, python-format
+msgid "in %(y_date)s"
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:757
+#, python-format
+msgid "on %(placeholder)s"
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:759
+#, python-format
+msgid "on %(placeholder)s (%(partial)s)"
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:804 FamilySheet/FamilySheet.py:806
+#, python-format
+msgid "in %(place)s"
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:841
+msgid "Report Options"
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:844
+msgid "Center person"
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:846
+msgid "The person whose partners and children are printed"
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:849
+msgid "Print sheets for"
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:851
+msgid "Center person only"
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:852
+msgid "Center person and descendants in side branches"
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:853
+msgid "Center person and all descendants"
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:854
+msgid "Whether to include descendants, and which ones."
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:857
+msgid "Use call name"
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:859
+msgid "Don't use call name"
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:860
+msgid "Replace first name with call name"
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:861
+msgid "Underline call name in first name / add call name to first name"
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:862
+msgid "Whether to include call name, and how."
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:865
+msgid "Print placeholders for missing information"
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:867
+msgid "Whether to include fields for missing information."
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:870
+msgid "Include sources"
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:871
+msgid "Whether to include source references."
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:874
+msgid "Include notes"
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:875
+msgid "Whether to include notes."
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:889
+msgid "The basic style used for the text display"
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:899
+msgid "The style used for the page key on the top"
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:908
+msgid "The style used for names"
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:918
+msgid "The style used for numbers"
+msgstr ""
+
+#: FamilySheet/FamilySheet.py:928
+msgid "The style used for footnotes (notes and source references)"
+msgstr ""

--- a/FamilyTree/po/template.pot
+++ b/FamilyTree/po/template.pot
@@ -1,0 +1,317 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: FamilyTree/FamilyTree.gpr.py:3
+msgid "Family Tree"
+msgstr ""
+
+#: FamilyTree/FamilyTree.gpr.py:4
+msgid "Produces a graphical family tree."
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:102
+#, python-format
+msgid "Family Tree for %s"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:152
+msgid "Paper too small"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:153
+msgid "Some elements may not appear or be badly rendered."
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:672 FamilyTree/FamilyTree.py:677
+msgid "Unknown"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:679
+#, python-format
+msgid "%(father)s and %(mother)s"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:686
+msgid "Anonymous"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:909
+msgid "born"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:911
+msgid "baptised"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:913
+msgid "died"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:915
+msgid "buried"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:917
+msgid "cremated"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:919
+msgid "married"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:921
+msgid "divorced"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:923
+msgid "resident"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:930
+#, python-format
+msgid "on %(ymd_date)s"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:932
+#, python-format
+msgid "in %(ym_date)s"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:934
+#, python-format
+msgid "in %(y_date)s"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:938
+#, python-format
+msgid "on %(placeholder)s"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:941
+#, python-format
+msgid "on %(placeholder)s (%(partial)s)"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:958
+#, python-format
+msgid "in %(place)s"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:969
+#, python-format
+msgid "(%(description)s)"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1039
+msgid "Tree Options"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1041
+msgid "Center Family"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1042
+msgid "The center family for the tree"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1045
+msgid "Ancestor Generations"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1046
+msgid "The number of ancestor generations to include in the tree"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1049
+msgid "Descendant Generations"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1050
+msgid "The number of descendant generations to include in the tree"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1053
+msgid "Kekule number of husband"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1054
+msgid ""
+"The Kekule number of the husband (central family). Set 0 to not show Kekule "
+"numbers"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1057
+msgid "Scale to fit on a single page"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1058
+msgid "Whether to scale to fit on a single page."
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1061
+msgid "Color"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1063
+msgid "No color"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1064
+msgid "Generations"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1065
+msgid "First generation"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1066
+msgid "Second generation"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1067
+msgid "Third generation"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1068
+msgid "Male line"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1069
+msgid "Male line and illegitimate children"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1070
+msgid "Female line"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1073
+msgid "Shuffle colors"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1074
+msgid "Whether to shuffle colors or order them in rainbow fashion."
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1077
+msgid "Content"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1079
+msgid "Use call name"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1081
+msgid "Don't use call name"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1082
+msgid "Replace first name with call name"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1083
+msgid "Underline call name in first name / add call name to first name"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1089
+msgid "Include Occupation"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1092
+msgid "Include Notes"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1095
+msgid "Include Residence"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1098
+msgid "Print event data (dead person)"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1100 FamilyTree/FamilyTree.py:1108
+msgid "None"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1101 FamilyTree/FamilyTree.py:1109
+msgid "Year only"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1102 FamilyTree/FamilyTree.py:1110
+msgid "Full date"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1103 FamilyTree/FamilyTree.py:1111
+msgid "Full date and place"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1106
+msgid "Print event data (living person)"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1114
+msgid "Fall back to baptism if birth event missing"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1117
+msgid "Fall back to burial or cremation if death event missing"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1120
+msgid "Protect private items"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1125
+msgid "Print fields for missing information"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1126
+msgid "Whether to include fields for missing information."
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1129
+msgid "Include event description"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1132
+msgid "Text Options"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1134
+msgid "Title text"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1137
+msgid "Footer text"
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1152
+msgid "The style used for the title."
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1160
+msgid "The style used for names."
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1168
+msgid "The style used for data (birth, death, marriage, divorce)."
+msgstr ""
+
+#: FamilyTree/FamilyTree.py:1178
+msgid "The style used for the footer."
+msgstr ""

--- a/Form/po/template.pot
+++ b/Form/po/template.pot
@@ -1,0 +1,8438 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: Form/editform.py:147
+#, python-format
+msgid "Form: %s"
+msgstr ""
+
+#: Form/editform.py:149
+msgid "New Form"
+msgstr ""
+
+#: Form/editform.py:156
+msgid "Edit Form"
+msgstr ""
+
+#: Form/editform.py:179
+msgid "Source:"
+msgstr ""
+
+#: Form/editform.py:191
+msgid "Reference:"
+msgstr ""
+
+#: Form/editform.py:201
+msgid "Date:"
+msgstr ""
+
+#: Form/editform.py:215
+msgid "Place:"
+msgstr ""
+
+#: Form/editform.py:250
+msgid "_Help"
+msgstr ""
+
+#: Form/editform.py:255 Form/selectform.py:97
+msgid "_Cancel"
+msgstr ""
+
+#: Form/editform.py:259 Form/selectform.py:98
+msgid "_OK"
+msgstr ""
+
+#: Form/editform.py:383
+msgid "Headings"
+msgstr ""
+
+#: Form/editform.py:404
+msgid "Key"
+msgstr ""
+
+#: Form/editform.py:410
+msgid "Value"
+msgstr ""
+
+#: Form/editform.py:485
+msgid "Details"
+msgstr ""
+
+#: Form/editform.py:685 Form/editform.py:698 Form/editform.py:904
+msgid "Select Person"
+msgstr ""
+
+#: Form/editform.py:712 Form/editform.py:714 Form/editform.py:783
+#: Form/editform.py:913 Form/editform.py:1075 Form\form_be.xml.h:1
+#: Form\form_be.xml.h:2 Form\form_be.xml.h:3 Form\form_be.xml.h:4
+#: Form\form_be.xml.h:5 Form\form_be.xml.h:6 Form\form_be.xml.h:7
+#: Form\form_ca.xml.h:10 Form\form_ca.xml.h:98 Form\form_ca.xml.h:216
+#: Form\form_ca.xml.h:308 Form\form_ca.xml.h:362 Form\form_ca.xml.h:409
+#: Form\form_ca.xml.h:464 Form\form_ca.xml.h:537 Form\form_ca.xml.h:626
+#: Form\form_ca.xml.h:675 Form\form_ca.xml.h:808 Form\form_dk.xml.h:9
+#: Form\form_dk.xml.h:26 Form\form_dk.xml.h:43 Form\form_dk.xml.h:58
+#: Form\form_dk.xml.h:75 Form\form_dk.xml.h:92 Form\form_dk.xml.h:109
+#: Form\form_dk.xml.h:128 Form\form_dk.xml.h:147 Form\form_dk.xml.h:168
+#: Form\form_dk.xml.h:191 Form\form_dk.xml.h:212 Form\form_dk.xml.h:233
+#: Form\form_dk.xml.h:257 Form\form_dk.xml.h:291 Form\form_dk.xml.h:320
+#: Form\form_dk.xml.h:344 Form\form_dk.xml.h:370 Form\form_dk.xml.h:394
+#: Form\form_dk.xml.h:414 Form\form_dk.xml.h:434 Form\form_fr.xml.h:1
+#: Form\form_fr.xml.h:9 Form\form_fr.xml.h:17 Form\form_fr.xml.h:25
+#: Form\form_fr.xml.h:33 Form\form_fr.xml.h:40 Form\form_fr.xml.h:45
+#: Form\form_fr.xml.h:50 Form\form_fr.xml.h:59 Form\form_fr.xml.h:64
+#: Form\form_fr.xml.h:69 Form\form_fr.xml.h:74 Form\form_fr.xml.h:83
+#: Form\form_fr.xml.h:89 Form\form_fr.xml.h:95 Form\form_fr.xml.h:101
+#: Form\form_fr.xml.h:109 Form\form_fr.xml.h:117 Form\form_fr.xml.h:123
+#: Form\form_fr.xml.h:130 Form\form_fr.xml.h:137 Form\form_fr.xml.h:147
+#: Form\form_fr.xml.h:155 Form\form_fr.xml.h:164 Form\form_fr.xml.h:172
+#: Form\form_fr.xml.h:181 Form\form_fr.xml.h:190 Form\form_fr.xml.h:199
+#: Form\form_fr.xml.h:208 Form\form_gb.xml.h:6 Form\form_gb.xml.h:8
+#: Form\form_gb.xml.h:10 Form\form_gb.xml.h:13 Form\form_gb.xml.h:20
+#: Form\form_gb.xml.h:26 Form\form_gb.xml.h:29 Form\form_gb.xml.h:32
+#: Form\form_gb.xml.h:39 Form\form_gb.xml.h:44 Form\form_gb.xml.h:50
+#: Form\form_gb.xml.h:59 Form\form_gb.xml.h:73 Form\form_gb.xml.h:88
+#: Form\form_gb.xml.h:103 Form\form_gb.xml.h:118 Form\form_gb.xml.h:136
+#: Form\form_gb.xml.h:147 Form\form_gb.xml.h:167 Form\form_gb.xml.h:182
+#: Form\form_gb.xml.h:202 Form\form_gb.xml.h:215 Form\form_gb.xml.h:237
+#: Form\form_gb.xml.h:248 Form\form_gb.xml.h:265 Form\form_gb.xml.h:292
+#: Form\form_gb.xml.h:320 Form\form_gb.xml.h:352 Form\form_gb.xml.h:391
+#: Form\form_gb.xml.h:418 Form\form_gb.xml.h:447 Form\form_pl.xml.h:1
+#: Form\form_pl.xml.h:20 Form\form_pl.xml.h:30 Form\form_us.xml.h:8
+#: Form\form_us.xml.h:22 Form\form_us.xml.h:43 Form\form_us.xml.h:64
+#: Form\form_us.xml.h:104 Form\form_us.xml.h:173 Form\form_us.xml.h:261
+#: Form\form_us.xml.h:337 Form\form_us.xml.h:414 Form\form_us.xml.h:436
+#: Form\form_us.xml.h:466 Form\form_us.xml.h:501 Form\form_us.xml.h:616
+#: Form\form_us.xml.h:648 Form\form_us.xml.h:672 Form\form_us.xml.h:713
+#: Form\form_us.xml.h:756 Form\form_us.xml.h:796 Form\form_us.xml.h:839
+#: Form\form_us.xml.h:887 Form\form_us.xml.h:895 Form\form_us.xml.h:914
+#: Form\form_us.xml.h:969 Form\form_us.xml.h:972 Form\form_us.xml.h:982
+#: Form\form_us.xml.h:1018 Form\form_us.xml.h:1046 Form\form_us.xml.h:1062
+#: Form\form_us.xml.h:1070 Form\form_us.xml.h:1105 Form\form_us.xml.h:1110
+#: Form\form_us.xml.h:1112 Form\form_us.xml.h:1161 Form\form_us.xml.h:1189
+#: Form\form_us.xml.h:1226 Form\form_us.xml.h:1227 Form\form_us.xml.h:1289
+#: Form\form_us.xml.h:1336 Form\form_us.xml.h:1396 Form\form_us.xml.h:1410
+#: Form\form_us.xml.h:1429 Form\form_us.xml.h:1450 Form\form_us.xml.h:1468
+#: Form\form_us.xml.h:1490 Form\form_us.xml.h:1513 Form\form_us.xml.h:1536
+#: Form\form_us.xml.h:1550 Form\form_us.xml.h:1565 Form\form_us.xml.h:1591
+#: Form\form_us.xml.h:1608 Form\form_us.xml.h:1681 Form\form_us.xml.h:1761
+#: Form\form_us.xml.h:1790 Form\form_us.xml.h:1812 Form\form_us.xml.h:1841
+#: Form\form_us.xml.h:1864 Form\form_us.xml.h:1876 Form\form_us.xml.h:1895
+#: Form\form_us.xml.h:1915 Form\form_us.xml.h:1928 Form\form_us.xml.h:1934
+#: Form\form_us.xml.h:1949 Form\form_us.xml.h:1988 Form\form_us.xml.h:2025
+#: Form\form_us.xml.h:2063 Form\form_us.xml.h:2101 Form\form_us.xml.h:2139
+#: Form\form_us.xml.h:2184 Form\form_us.xml.h:2202 Form\form_us.xml.h:2213
+#: Form\form_us.xml.h:2231 Form\form_us.xml.h:2242 Form\form_us.xml.h:2259
+#: Form\form_us.xml.h:2266 Form\form_us.xml.h:2272 Form\form_us.xml.h:2278
+#: Form\form_us.xml.h:2285 Form\form_us.xml.h:2297 Form\form_us.xml.h:2299
+#: Form\form_us.xml.h:2301 Form\form_us.xml.h:2309 Form\form_us.xml.h:2316
+#: Form\form_us.xml.h:2322 Form\form_us.xml.h:2326 Form\form_us.xml.h:2330
+#: Form\form_us.xml.h:2334 Form\form_us.xml.h:2338 Form\form_us.xml.h:2343
+#: Form\form_us.xml.h:2375 Form\form_us.xml.h:2399 Form\form_us.xml.h:2421
+#: Form\form_us.xml.h:2436 Form\form_us.xml.h:2463 Form\form_us.xml.h:2485
+#: Form\form_us.xml.h:2507
+msgid "Name"
+msgstr ""
+
+#: Form/form.py:60
+msgid "Order"
+msgstr ""
+
+#: Form/form.py:63
+msgid "Form"
+msgstr ""
+
+#: Form/form.py:66
+msgid "Groom"
+msgstr ""
+
+#: Form/form.py:67
+msgid "Bride"
+msgstr ""
+
+#: Form/formgramplet.gpr.py:30
+msgid "Form Gramplet"
+msgstr ""
+
+#: Form/formgramplet.gpr.py:31
+msgid "Gramplet interface for Forms"
+msgstr ""
+
+#: Form/formgramplet.gpr.py:42
+msgid "Forms"
+msgstr ""
+
+#: Form/formgramplet.py:108
+msgid "Source"
+msgstr ""
+
+#: Form/formgramplet.py:111
+msgid "Role"
+msgstr ""
+
+#: Form/formgramplet.py:114 Form\form_ca.xml.h:340 Form\form_ca.xml.h:388
+#: Form\form_ca.xml.h:395 Form\form_ca.xml.h:620 Form\form_us.xml.h:966
+#: Form\form_us.xml.h:2430
+msgid "Date"
+msgstr ""
+
+#: Form/formgramplet.py:117 Form\form_ca.xml.h:545 Form\form_ca.xml.h:677
+#: Form\form_dk.xml.h:166 Form\form_dk.xml.h:189 Form\form_gb.xml.h:235
+#: Form\form_us.xml.h:906
+msgid "Place"
+msgstr ""
+
+#: Form/formgramplet.py:125
+msgid "_New"
+msgstr ""
+
+#: Form/formgramplet.py:129
+msgid "_Edit"
+msgstr ""
+
+#: Form/selectform.py:71
+#, python-format
+msgid "%(title)s - Gramps"
+msgstr ""
+
+#: Form/selectform.py:71 Form/selectform.py:78
+msgid "Select Form"
+msgstr ""
+
+#: Form\form_ca.xml.h:1 Form\form_ca.xml.h:92 Form\form_ca.xml.h:210
+#: Form\form_ca.xml.h:288 Form\form_ca.xml.h:342 Form\form_ca.xml.h:390
+#: Form\form_ca.xml.h:450 Form\form_ca.xml.h:529 Form\form_ca.xml.h:615
+#: Form\form_ca.xml.h:661 Form\form_ca.xml.h:754 Form\form_ca.xml.h:794
+#: Form\form_us.xml.h:1545 Form\form_us.xml.h:1560
+msgid "Schedule"
+msgstr ""
+
+#: Form\form_ca.xml.h:2 Form\form_ca.xml.h:93 Form\form_ca.xml.h:211
+#: Form\form_ca.xml.h:798
+msgid "EnumDistrict"
+msgstr ""
+
+#: Form\form_ca.xml.h:3 Form\form_ca.xml.h:94 Form\form_ca.xml.h:212
+#: Form\form_ca.xml.h:644 Form\form_ca.xml.h:812 Form\form_us.xml.h:1162
+#: Form\form_us.xml.h:1223 Form\form_us.xml.h:1953
+msgid "Township"
+msgstr ""
+
+#: Form\form_ca.xml.h:4 Form\form_ca.xml.h:95 Form\form_dk.xml.h:1
+#: Form\form_dk.xml.h:18 Form\form_dk.xml.h:35 Form\form_dk.xml.h:50
+#: Form\form_dk.xml.h:67 Form\form_dk.xml.h:84 Form\form_dk.xml.h:101
+#: Form\form_dk.xml.h:120 Form\form_dk.xml.h:139 Form\form_dk.xml.h:158
+#: Form\form_dk.xml.h:181 Form\form_dk.xml.h:204 Form\form_dk.xml.h:225
+#: Form\form_dk.xml.h:249 Form\form_dk.xml.h:283 Form\form_dk.xml.h:312
+#: Form\form_dk.xml.h:336 Form\form_dk.xml.h:362 Form\form_dk.xml.h:386
+#: Form\form_dk.xml.h:406 Form\form_dk.xml.h:426 Form\form_gb.xml.h:413
+#: Form\form_gb.xml.h:433 Form\form_us.xml.h:853 Form\form_us.xml.h:892
+#: Form\form_us.xml.h:1222 Form\form_us.xml.h:1291 Form\form_us.xml.h:1907
+#: Form\form_us.xml.h:1927 Form\form_us.xml.h:1951 Form\form_us.xml.h:1990
+#: Form\form_us.xml.h:2027 Form\form_us.xml.h:2065 Form\form_us.xml.h:2103
+#: Form\form_us.xml.h:2138 Form\form_us.xml.h:2147 Form\form_us.xml.h:2159
+msgid "County"
+msgstr ""
+
+#: Form\form_ca.xml.h:5
+msgid "Comprising"
+msgstr ""
+
+#: Form\form_ca.xml.h:6
+msgid "OfTheSaid"
+msgstr ""
+
+#: Form\form_ca.xml.h:7 Form\form_ca.xml.h:293 Form\form_ca.xml.h:347
+#: Form\form_ca.xml.h:396 Form\form_ca.xml.h:457 Form\form_ca.xml.h:536
+#: Form\form_ca.xml.h:621 Form\form_ca.xml.h:668 Form\form_ca.xml.h:758
+#: Form\form_ca.xml.h:801
+msgid "Enumerator"
+msgstr ""
+
+#: Form\form_ca.xml.h:8 Form\form_ca.xml.h:9 Form\form_ca.xml.h:96
+#: Form\form_ca.xml.h:97 Form\form_ca.xml.h:214 Form\form_ca.xml.h:215
+#: Form\form_ca.xml.h:294 Form\form_ca.xml.h:295 Form\form_ca.xml.h:348
+#: Form\form_ca.xml.h:349 Form\form_ca.xml.h:397 Form\form_ca.xml.h:398
+#: Form\form_ca.xml.h:458 Form\form_ca.xml.h:459 Form\form_ca.xml.h:539
+#: Form\form_ca.xml.h:622 Form\form_ca.xml.h:623 Form\form_ca.xml.h:669
+#: Form\form_ca.xml.h:670 Form\form_ca.xml.h:759 Form\form_ca.xml.h:760
+#: Form\form_ca.xml.h:802 Form\form_ca.xml.h:803
+msgid "Line"
+msgstr ""
+
+#: Form\form_ca.xml.h:11 Form\form_ca.xml.h:217
+msgid "1. Names of Inmates"
+msgstr ""
+
+#: Form\form_ca.xml.h:12 Form\form_ca.xml.h:218 Form\form_ca.xml.h:322
+#: Form\form_ca.xml.h:376 Form\form_ca.xml.h:429 Form\form_ca.xml.h:492
+#: Form\form_ca.xml.h:703 Form\form_ca.xml.h:850 Form\form_dk.xml.h:16
+#: Form\form_dk.xml.h:33 Form\form_dk.xml.h:114 Form\form_dk.xml.h:133
+#: Form\form_dk.xml.h:244 Form\form_dk.xml.h:272 Form\form_dk.xml.h:307
+#: Form\form_dk.xml.h:333 Form\form_dk.xml.h:349 Form\form_dk.xml.h:381
+#: Form\form_dk.xml.h:401 Form\form_dk.xml.h:423 Form\form_dk.xml.h:443
+#: Form\form_fr.xml.h:4 Form\form_fr.xml.h:12 Form\form_fr.xml.h:20
+#: Form\form_fr.xml.h:28 Form\form_fr.xml.h:35 Form\form_fr.xml.h:53
+#: Form\form_fr.xml.h:62 Form\form_fr.xml.h:66 Form\form_fr.xml.h:72
+#: Form\form_fr.xml.h:77 Form\form_fr.xml.h:86 Form\form_fr.xml.h:92
+#: Form\form_fr.xml.h:98 Form\form_fr.xml.h:105 Form\form_fr.xml.h:113
+#: Form\form_fr.xml.h:119 Form\form_fr.xml.h:125 Form\form_fr.xml.h:132
+#: Form\form_fr.xml.h:143 Form\form_fr.xml.h:149 Form\form_fr.xml.h:158
+#: Form\form_fr.xml.h:166 Form\form_fr.xml.h:175 Form\form_fr.xml.h:184
+#: Form\form_fr.xml.h:193 Form\form_fr.xml.h:202 Form\form_fr.xml.h:213
+#: Form\form_gb.xml.h:9 Form\form_gb.xml.h:12 Form\form_gb.xml.h:24
+#: Form\form_gb.xml.h:28 Form\form_gb.xml.h:31 Form\form_gb.xml.h:42
+#: Form\form_gb.xml.h:52 Form\form_gb.xml.h:63 Form\form_gb.xml.h:77
+#: Form\form_gb.xml.h:92 Form\form_gb.xml.h:107 Form\form_gb.xml.h:122
+#: Form\form_gb.xml.h:140 Form\form_gb.xml.h:155 Form\form_gb.xml.h:172
+#: Form\form_gb.xml.h:186 Form\form_gb.xml.h:206 Form\form_gb.xml.h:223
+#: Form\form_gb.xml.h:239 Form\form_gb.xml.h:254 Form\form_gb.xml.h:275
+#: Form\form_gb.xml.h:302 Form\form_gb.xml.h:330 Form\form_gb.xml.h:362
+#: Form\form_gb.xml.h:426 Form\form_gb.xml.h:454 Form\form_us.xml.h:265
+#: Form\form_us.xml.h:341 Form\form_us.xml.h:422 Form\form_us.xml.h:440
+#: Form\form_us.xml.h:476 Form\form_us.xml.h:631 Form\form_us.xml.h:690
+#: Form\form_us.xml.h:728 Form\form_us.xml.h:777 Form\form_us.xml.h:816
+#: Form\form_us.xml.h:863 Form\form_us.xml.h:962 Form\form_us.xml.h:971
+#: Form\form_us.xml.h:990 Form\form_us.xml.h:1028 Form\form_us.xml.h:1056
+#: Form\form_us.xml.h:1069 Form\form_us.xml.h:1120 Form\form_us.xml.h:1170
+#: Form\form_us.xml.h:1202 Form\form_us.xml.h:1268 Form\form_us.xml.h:1269
+#: Form\form_us.xml.h:1295 Form\form_us.xml.h:1402 Form\form_us.xml.h:1414
+#: Form\form_us.xml.h:1436 Form\form_us.xml.h:1456 Form\form_us.xml.h:1477
+#: Form\form_us.xml.h:1499 Form\form_us.xml.h:1528 Form\form_us.xml.h:1574
+#: Form\form_us.xml.h:1605 Form\form_us.xml.h:1771 Form\form_us.xml.h:1801
+#: Form\form_us.xml.h:1825 Form\form_us.xml.h:1852 Form\form_us.xml.h:1870
+#: Form\form_us.xml.h:1884 Form\form_us.xml.h:1903 Form\form_us.xml.h:1924
+#: Form\form_us.xml.h:1963 Form\form_us.xml.h:1994 Form\form_us.xml.h:2031
+#: Form\form_us.xml.h:2069 Form\form_us.xml.h:2107 Form\form_us.xml.h:2250
+#: Form\form_us.xml.h:2271 Form\form_us.xml.h:2277 Form\form_us.xml.h:2319
+#: Form\form_us.xml.h:2324 Form\form_us.xml.h:2328 Form\form_us.xml.h:2332
+#: Form\form_us.xml.h:2336 Form\form_us.xml.h:2354 Form\form_us.xml.h:2388
+#: Form\form_us.xml.h:2403 Form\form_us.xml.h:2424 Form\form_us.xml.h:2444
+#: Form\form_us.xml.h:2491 Form\form_us.xml.h:2508
+msgid "Occupation"
+msgstr ""
+
+#: Form\form_ca.xml.h:13
+msgid "2. Profession, Trade or Occupation"
+msgstr ""
+
+#: Form\form_ca.xml.h:14 Form\form_ca.xml.h:220 Form\form_ca.xml.h:316
+#: Form\form_ca.xml.h:370 Form\form_ca.xml.h:419 Form\form_ca.xml.h:480
+#: Form\form_ca.xml.h:636 Form\form_ca.xml.h:691 Form\form_ca.xml.h:777
+#: Form\form_ca.xml.h:828
+msgid "BirthPlace"
+msgstr ""
+
+#: Form\form_ca.xml.h:15 Form\form_ca.xml.h:221
+msgid "3. Place of Birth"
+msgstr ""
+
+#: Form\form_ca.xml.h:16 Form\form_ca.xml.h:224 Form\form_ca.xml.h:318
+#: Form\form_ca.xml.h:372 Form\form_ca.xml.h:427 Form\form_ca.xml.h:490
+#: Form\form_ca.xml.h:701 Form\form_ca.xml.h:781 Form\form_ca.xml.h:830
+#: Form\form_dk.xml.h:154 Form\form_dk.xml.h:175 Form\form_dk.xml.h:198
+#: Form\form_dk.xml.h:219 Form\form_dk.xml.h:240 Form\form_dk.xml.h:268
+#: Form\form_dk.xml.h:303 Form\form_dk.xml.h:325 Form\form_fr.xml.h:80
+#: Form\form_fr.xml.h:218 Form\form_gb.xml.h:421 Form\form_gb.xml.h:450
+msgid "Religion"
+msgstr ""
+
+#: Form\form_ca.xml.h:17
+msgid "4. Religion"
+msgstr ""
+
+#: Form\form_ca.xml.h:18 Form\form_ca.xml.h:226 Form\form_gb.xml.h:16
+#: Form\form_gb.xml.h:25 Form\form_gb.xml.h:47 Form\form_us.xml.h:2267
+#: Form\form_us.xml.h:2273 Form\form_us.xml.h:2280 Form\form_us.xml.h:2298
+#: Form\form_us.xml.h:2300 Form\form_us.xml.h:2320 Form\form_us.xml.h:2325
+#: Form\form_us.xml.h:2329 Form\form_us.xml.h:2333 Form\form_us.xml.h:2337
+#: Form\form_us.xml.h:2345 Form\form_us.xml.h:2409 Form\form_us.xml.h:2420
+msgid "Residence"
+msgstr ""
+
+#: Form\form_ca.xml.h:19
+msgid "5. Residence if Outside of Limits"
+msgstr ""
+
+#: Form\form_ca.xml.h:20 Form\form_ca.xml.h:228 Form\form_ca.xml.h:312
+#: Form\form_ca.xml.h:366 Form\form_ca.xml.h:413 Form\form_ca.xml.h:478
+#: Form\form_ca.xml.h:634 Form\form_ca.xml.h:689 Form\form_ca.xml.h:775
+#: Form\form_ca.xml.h:826 Form\form_dk.xml.h:12 Form\form_dk.xml.h:29
+#: Form\form_dk.xml.h:46 Form\form_dk.xml.h:61 Form\form_dk.xml.h:78
+#: Form\form_dk.xml.h:95 Form\form_dk.xml.h:112 Form\form_dk.xml.h:131
+#: Form\form_dk.xml.h:150 Form\form_dk.xml.h:171 Form\form_dk.xml.h:194
+#: Form\form_dk.xml.h:215 Form\form_dk.xml.h:236 Form\form_fr.xml.h:34
+#: Form\form_fr.xml.h:60 Form\form_fr.xml.h:70 Form\form_fr.xml.h:75
+#: Form\form_fr.xml.h:84 Form\form_fr.xml.h:90 Form\form_fr.xml.h:96
+#: Form\form_fr.xml.h:102 Form\form_fr.xml.h:110 Form\form_fr.xml.h:118
+#: Form\form_fr.xml.h:124 Form\form_fr.xml.h:131 Form\form_fr.xml.h:141
+#: Form\form_fr.xml.h:148 Form\form_fr.xml.h:165 Form\form_fr.xml.h:209
+#: Form\form_gb.xml.h:22 Form\form_gb.xml.h:41 Form\form_gb.xml.h:51
+#: Form\form_gb.xml.h:62 Form\form_gb.xml.h:76 Form\form_gb.xml.h:91
+#: Form\form_gb.xml.h:106 Form\form_gb.xml.h:121 Form\form_gb.xml.h:139
+#: Form\form_gb.xml.h:149 Form\form_gb.xml.h:185 Form\form_gb.xml.h:205
+#: Form\form_gb.xml.h:217 Form\form_gb.xml.h:238 Form\form_gb.xml.h:253
+#: Form\form_gb.xml.h:274 Form\form_gb.xml.h:301 Form\form_gb.xml.h:329
+#: Form\form_gb.xml.h:361 Form\form_gb.xml.h:401 Form\form_gb.xml.h:424
+#: Form\form_gb.xml.h:453 Form\form_pl.xml.h:7 Form\form_pl.xml.h:35
+#: Form\form_us.xml.h:262 Form\form_us.xml.h:338 Form\form_us.xml.h:415
+#: Form\form_us.xml.h:437 Form\form_us.xml.h:469 Form\form_us.xml.h:621
+#: Form\form_us.xml.h:678 Form\form_us.xml.h:717 Form\form_us.xml.h:762
+#: Form\form_us.xml.h:804 Form\form_us.xml.h:888 Form\form_us.xml.h:985
+#: Form\form_us.xml.h:1021 Form\form_us.xml.h:1113 Form\form_us.xml.h:1166
+#: Form\form_us.xml.h:1238 Form\form_us.xml.h:1239 Form\form_us.xml.h:1290
+#: Form\form_us.xml.h:1342 Form\form_us.xml.h:1397 Form\form_us.xml.h:1411
+#: Form\form_us.xml.h:1430 Form\form_us.xml.h:1451 Form\form_us.xml.h:1472
+#: Form\form_us.xml.h:1494 Form\form_us.xml.h:1521 Form\form_us.xml.h:1537
+#: Form\form_us.xml.h:1551 Form\form_us.xml.h:1566 Form\form_us.xml.h:1596
+#: Form\form_us.xml.h:1764 Form\form_us.xml.h:1793 Form\form_us.xml.h:1815
+#: Form\form_us.xml.h:1844 Form\form_us.xml.h:1866 Form\form_us.xml.h:1880
+#: Form\form_us.xml.h:1899 Form\form_us.xml.h:1919 Form\form_us.xml.h:1962
+#: Form\form_us.xml.h:1989 Form\form_us.xml.h:2026 Form\form_us.xml.h:2064
+#: Form\form_us.xml.h:2102 Form\form_us.xml.h:2246 Form\form_us.xml.h:2269
+#: Form\form_us.xml.h:2275 Form\form_us.xml.h:2311 Form\form_us.xml.h:2317
+#: Form\form_us.xml.h:2353 Form\form_us.xml.h:2380 Form\form_us.xml.h:2401
+#: Form\form_us.xml.h:2490
+msgid "Age"
+msgstr ""
+
+#: Form\form_ca.xml.h:21
+msgid "6. Age at Next Birthday"
+msgstr ""
+
+#: Form\form_ca.xml.h:22 Form\form_ca.xml.h:230
+msgid "SexMale"
+msgstr ""
+
+#: Form\form_ca.xml.h:23
+msgid "7. Sex: Male"
+msgstr ""
+
+#: Form\form_ca.xml.h:24
+msgid "SexFemale"
+msgstr ""
+
+#: Form\form_ca.xml.h:25
+msgid "8. Sex: Female"
+msgstr ""
+
+#: Form\form_ca.xml.h:26 Form\form_ca.xml.h:234 Form\form_ca.xml.h:324
+#: Form\form_ca.xml.h:378 Form\form_ca.xml.h:415 Form\form_ca.xml.h:472
+#: Form\form_ca.xml.h:632 Form\form_ca.xml.h:683 Form\form_ca.xml.h:771
+#: Form\form_ca.xml.h:824
+msgid "MaritalStatus"
+msgstr ""
+
+#: Form\form_ca.xml.h:27
+msgid "9. Married or Single"
+msgstr ""
+
+#: Form\form_ca.xml.h:28 Form\form_ca.xml.h:240
+msgid "Coloured"
+msgstr ""
+
+#: Form\form_ca.xml.h:29
+msgid "10. Coloured Persons - Negroes"
+msgstr ""
+
+#: Form\form_ca.xml.h:30
+msgid "Indians"
+msgstr ""
+
+#: Form\form_ca.xml.h:31
+msgid "11. Indians, if any"
+msgstr ""
+
+#: Form\form_ca.xml.h:32
+msgid "ResidentsMale"
+msgstr ""
+
+#: Form\form_ca.xml.h:33
+msgid "12. Residents: Members, Male"
+msgstr ""
+
+#: Form\form_ca.xml.h:34
+msgid "ResidentsFemale"
+msgstr ""
+
+#: Form\form_ca.xml.h:35
+msgid "13. Residents: Members, Female"
+msgstr ""
+
+#: Form\form_ca.xml.h:36
+msgid "NonMembersMale"
+msgstr ""
+
+#: Form\form_ca.xml.h:37
+msgid "14. Residents: Not Members: Male"
+msgstr ""
+
+#: Form\form_ca.xml.h:38
+msgid "NonMembersFemale"
+msgstr ""
+
+#: Form\form_ca.xml.h:39
+msgid "15. Residents: Not Members: Female"
+msgstr ""
+
+#: Form\form_ca.xml.h:40
+msgid "AbsentMembersMale"
+msgstr ""
+
+#: Form\form_ca.xml.h:41
+msgid "16. Members Absent: Male"
+msgstr ""
+
+#: Form\form_ca.xml.h:42
+msgid "AbsentMembersFemale"
+msgstr ""
+
+#: Form\form_ca.xml.h:43
+msgid "17. Members Absent: Female"
+msgstr ""
+
+#: Form\form_ca.xml.h:44
+msgid "DeafDumbMale"
+msgstr ""
+
+#: Form\form_ca.xml.h:45
+msgid "18. Deaf and Dumb: Male"
+msgstr ""
+
+#: Form\form_ca.xml.h:46
+msgid "DeafDumbFemale"
+msgstr ""
+
+#: Form\form_ca.xml.h:47
+msgid "19. Deaf and Dumb: Female"
+msgstr ""
+
+#: Form\form_ca.xml.h:48
+msgid "BlindMale"
+msgstr ""
+
+#: Form\form_ca.xml.h:49
+msgid "20. Blind: Male"
+msgstr ""
+
+#: Form\form_ca.xml.h:50
+msgid "BlindFemale"
+msgstr ""
+
+#: Form\form_ca.xml.h:51
+msgid "21. Blind: Female"
+msgstr ""
+
+#: Form\form_ca.xml.h:52
+msgid "LunaticMale"
+msgstr ""
+
+#: Form\form_ca.xml.h:53
+msgid "22. Lunatics: Male"
+msgstr ""
+
+#: Form\form_ca.xml.h:54
+msgid "LunaticFemale"
+msgstr ""
+
+#: Form\form_ca.xml.h:55
+msgid "23. Lunatics: Female"
+msgstr ""
+
+#: Form\form_ca.xml.h:56 Form\form_ca.xml.h:260
+msgid "ScholarMale"
+msgstr ""
+
+#: Form\form_ca.xml.h:57
+msgid "24. Attending School: Male"
+msgstr ""
+
+#: Form\form_ca.xml.h:58 Form\form_ca.xml.h:262
+msgid "ScholarFemale"
+msgstr ""
+
+#: Form\form_ca.xml.h:59
+msgid "25. Attending School: Female"
+msgstr ""
+
+#: Form\form_ca.xml.h:60
+msgid "Birth1851Male"
+msgstr ""
+
+#: Form\form_ca.xml.h:61
+msgid "26. Births During the Year 1851: Male"
+msgstr ""
+
+#: Form\form_ca.xml.h:62
+msgid "Birth1851Female"
+msgstr ""
+
+#: Form\form_ca.xml.h:63
+msgid "27. Births During the Year 1851: Female"
+msgstr ""
+
+#: Form\form_ca.xml.h:64
+msgid "Death1851Male"
+msgstr ""
+
+#: Form\form_ca.xml.h:65
+msgid "28. Deaths During the Year 1851: Male"
+msgstr ""
+
+#: Form\form_ca.xml.h:66
+msgid "Death1851Female"
+msgstr ""
+
+#: Form\form_ca.xml.h:67
+msgid "29. Deaths During the Year 1851: Female"
+msgstr ""
+
+#: Form\form_ca.xml.h:68 Form\form_ca.xml.h:276
+msgid "DeathAgeCause"
+msgstr ""
+
+#: Form\form_ca.xml.h:69
+msgid "30. Age and Cause of Deaths"
+msgstr ""
+
+#: Form\form_ca.xml.h:70 Form\form_ca.xml.h:278
+msgid "Houses"
+msgstr ""
+
+#: Form\form_ca.xml.h:71
+msgid ""
+"31. Houses: Brick, Stone, Frame, Log, Shanty, or other kinds of residence"
+msgstr ""
+
+#: Form\form_ca.xml.h:72 Form\form_ca.xml.h:280
+msgid "HousesStories"
+msgstr ""
+
+#: Form\form_ca.xml.h:73
+msgid "32. Houses: No. of Stories"
+msgstr ""
+
+#: Form\form_ca.xml.h:74 Form\form_ca.xml.h:282
+msgid "HousesFamilies"
+msgstr ""
+
+#: Form\form_ca.xml.h:75
+msgid "33. No. of Families Occupying"
+msgstr ""
+
+#: Form\form_ca.xml.h:76 Form\form_ca.xml.h:284 Form\form_ca.xml.h:302
+#: Form\form_ca.xml.h:356 Form\form_ca.xml.h:403 Form\form_ca.xml.h:549
+msgid "HousesVacant"
+msgstr ""
+
+#: Form\form_ca.xml.h:77
+msgid "34. Houses: Vacant"
+msgstr ""
+
+#: Form\form_ca.xml.h:78
+msgid "HousesBuilding"
+msgstr ""
+
+#: Form\form_ca.xml.h:79
+msgid "35. Houses: Building"
+msgstr ""
+
+#: Form\form_ca.xml.h:80
+msgid "Shops"
+msgstr ""
+
+#: Form\form_ca.xml.h:81
+msgid "36. Shops, Stores, Inns, Taverns etc."
+msgstr ""
+
+#: Form\form_ca.xml.h:82
+msgid "PublicBuildings"
+msgstr ""
+
+#: Form\form_ca.xml.h:83
+msgid "37. Public Buildings"
+msgstr ""
+
+#: Form\form_ca.xml.h:84
+msgid "WorshipPlaces"
+msgstr ""
+
+#: Form\form_ca.xml.h:85
+msgid "38. Places of Worship"
+msgstr ""
+
+#: Form\form_ca.xml.h:86
+msgid "BuisnessInfo"
+msgstr ""
+
+#: Form\form_ca.xml.h:87
+msgid ""
+"39. Information on Mills, Factories etc., their cost, power, produce, etc."
+msgstr ""
+
+#: Form\form_ca.xml.h:88
+msgid "NumEmployees"
+msgstr ""
+
+#: Form\form_ca.xml.h:89
+msgid "40. Number of Persons Usually Employed Therein"
+msgstr ""
+
+#: Form\form_ca.xml.h:90 Form\form_ca.xml.h:208 Form\form_us.xml.h:272
+#: Form\form_us.xml.h:657 Form\form_us.xml.h:1104 Form\form_us.xml.h:1155
+#: Form\form_us.xml.h:1183 Form\form_us.xml.h:1335 Form\form_us.xml.h:2412
+#: Form\form_us.xml.h:2427 Form\form_us.xml.h:2505
+msgid "Remarks"
+msgstr ""
+
+#: Form\form_ca.xml.h:91
+msgid "41. General Remarks of the Enumerator"
+msgstr ""
+
+#: Form\form_ca.xml.h:99
+msgid "1. Name of Occupier"
+msgstr ""
+
+#: Form\form_ca.xml.h:100
+msgid "Concession"
+msgstr ""
+
+#: Form\form_ca.xml.h:101
+msgid "2. Concession or Range"
+msgstr ""
+
+#: Form\form_ca.xml.h:102
+msgid "Lot"
+msgstr ""
+
+#: Form\form_ca.xml.h:103
+msgid "3. Lot or part of Lot"
+msgstr ""
+
+#: Form\form_ca.xml.h:104
+msgid "AcresHeld"
+msgstr ""
+
+#: Form\form_ca.xml.h:105
+msgid "4. Number of Acres of Land: Held by each person or family"
+msgstr ""
+
+#: Form\form_ca.xml.h:106
+msgid "AcresCultivation"
+msgstr ""
+
+#: Form\form_ca.xml.h:107
+msgid "5. Number of Acres of Land: Under Cultivation"
+msgstr ""
+
+#: Form\form_ca.xml.h:108
+msgid "AcresCrops"
+msgstr ""
+
+#: Form\form_ca.xml.h:109
+msgid "6. Number of Acres of Land: Under Crops in 1851"
+msgstr ""
+
+#: Form\form_ca.xml.h:110
+msgid "AcresPasture"
+msgstr ""
+
+#: Form\form_ca.xml.h:111
+msgid "7. Number of Acres of Land: Under Pasture in 1851"
+msgstr ""
+
+#: Form\form_ca.xml.h:112
+msgid "AcresGardens"
+msgstr ""
+
+#: Form\form_ca.xml.h:113
+msgid "8. Number of Acres of Land: Gardens or Orchards"
+msgstr ""
+
+#: Form\form_ca.xml.h:114
+msgid "AcresWood"
+msgstr ""
+
+#: Form\form_ca.xml.h:115
+msgid "9. Number of Acres of Land: Under Wood or Wild"
+msgstr ""
+
+#: Form\form_ca.xml.h:116
+msgid "WheatAcres"
+msgstr ""
+
+#: Form\form_ca.xml.h:117
+msgid "10. Wheat: Acres"
+msgstr ""
+
+#: Form\form_ca.xml.h:118
+msgid "WheatBsh"
+msgstr ""
+
+#: Form\form_ca.xml.h:119
+msgid "11. Wheat: Produce Bsh."
+msgstr ""
+
+#: Form\form_ca.xml.h:120
+msgid "BarleyAcres"
+msgstr ""
+
+#: Form\form_ca.xml.h:121
+msgid "12. Barley: Acres"
+msgstr ""
+
+#: Form\form_ca.xml.h:122
+msgid "BarleyBsh"
+msgstr ""
+
+#: Form\form_ca.xml.h:123
+msgid "13. Barley: Produce Bsh."
+msgstr ""
+
+#: Form\form_ca.xml.h:124
+msgid "RyeAcres"
+msgstr ""
+
+#: Form\form_ca.xml.h:125
+msgid "14. Rye: Acres"
+msgstr ""
+
+#: Form\form_ca.xml.h:126
+msgid "RyeBsh"
+msgstr ""
+
+#: Form\form_ca.xml.h:127
+msgid "15. Rye: Produce Bsh."
+msgstr ""
+
+#: Form\form_ca.xml.h:128
+msgid "PeasAcres"
+msgstr ""
+
+#: Form\form_ca.xml.h:129
+msgid "16. Peas: Acres"
+msgstr ""
+
+#: Form\form_ca.xml.h:130
+msgid "PeasBush"
+msgstr ""
+
+#: Form\form_ca.xml.h:131
+msgid "17. Peas: Produce Bsh."
+msgstr ""
+
+#: Form\form_ca.xml.h:132
+msgid "OatsAcres"
+msgstr ""
+
+#: Form\form_ca.xml.h:133
+msgid "18. Oats: Acres"
+msgstr ""
+
+#: Form\form_ca.xml.h:134
+msgid "OatsBush"
+msgstr ""
+
+#: Form\form_ca.xml.h:135
+msgid "19. Oats: Produce Bsh."
+msgstr ""
+
+#: Form\form_ca.xml.h:136
+msgid "BWheatAcres"
+msgstr ""
+
+#: Form\form_ca.xml.h:137
+msgid "20. B.Wheat: Acres"
+msgstr ""
+
+#: Form\form_ca.xml.h:138
+msgid "BWheatBush"
+msgstr ""
+
+#: Form\form_ca.xml.h:139
+msgid "21. B.Wheat: Produce Bsh."
+msgstr ""
+
+#: Form\form_ca.xml.h:140
+msgid "CornAcres"
+msgstr ""
+
+#: Form\form_ca.xml.h:141
+msgid "22. Corn: Acres"
+msgstr ""
+
+#: Form\form_ca.xml.h:142
+msgid "CornBush"
+msgstr ""
+
+#: Form\form_ca.xml.h:143
+msgid "23. Corn: Produce Bsh."
+msgstr ""
+
+#: Form\form_ca.xml.h:144
+msgid "PotatoesAcres"
+msgstr ""
+
+#: Form\form_ca.xml.h:145
+msgid "24. Potatoes: Acres"
+msgstr ""
+
+#: Form\form_ca.xml.h:146
+msgid "PotatoesBush"
+msgstr ""
+
+#: Form\form_ca.xml.h:147
+msgid "25. Potatoes: Produce Bsh."
+msgstr ""
+
+#: Form\form_ca.xml.h:148
+msgid "TurnipsAcres"
+msgstr ""
+
+#: Form\form_ca.xml.h:149
+msgid "26. Turnips: Acres"
+msgstr ""
+
+#: Form\form_ca.xml.h:150
+msgid "TurnipsBush"
+msgstr ""
+
+#: Form\form_ca.xml.h:151
+msgid "27. Turnips: Produce Bsh."
+msgstr ""
+
+#: Form\form_ca.xml.h:152
+msgid "CloverBush"
+msgstr ""
+
+#: Form\form_ca.xml.h:153
+msgid "28. Clover, Timothy or other grass seed - Bsh."
+msgstr ""
+
+#: Form\form_ca.xml.h:154
+msgid "CarrotsBush"
+msgstr ""
+
+#: Form\form_ca.xml.h:155
+msgid "29. Carrots - Bsh."
+msgstr ""
+
+#: Form\form_ca.xml.h:156
+msgid "MangleWurtzel"
+msgstr ""
+
+#: Form\form_ca.xml.h:157
+msgid "30. Mangle Wurtzel"
+msgstr ""
+
+#: Form\form_ca.xml.h:158
+msgid "BeansBush"
+msgstr ""
+
+#: Form\form_ca.xml.h:159
+msgid "31. Beans Bush"
+msgstr ""
+
+#: Form\form_ca.xml.h:160
+msgid "HopsLbs"
+msgstr ""
+
+#: Form\form_ca.xml.h:161
+msgid "32. Hops Lbs."
+msgstr ""
+
+#: Form\form_ca.xml.h:162
+msgid "HayQty"
+msgstr ""
+
+#: Form\form_ca.xml.h:163
+msgid "33. Hay, Bundles or Tons"
+msgstr ""
+
+#: Form\form_ca.xml.h:164
+msgid "FlaxLbs"
+msgstr ""
+
+#: Form\form_ca.xml.h:165
+msgid "34. Flax or Hemp, Lbs."
+msgstr ""
+
+#: Form\form_ca.xml.h:166
+msgid "TobaccoLbs"
+msgstr ""
+
+#: Form\form_ca.xml.h:167
+msgid "35. Tobacco Lbs."
+msgstr ""
+
+#: Form\form_ca.xml.h:168
+msgid "WoolLbs."
+msgstr ""
+
+#: Form\form_ca.xml.h:169
+msgid "36. Wool Lbs."
+msgstr ""
+
+#: Form\form_ca.xml.h:170
+msgid "Column37"
+msgstr ""
+
+#: Form\form_ca.xml.h:171
+msgid "37."
+msgstr ""
+
+#: Form\form_ca.xml.h:172
+msgid "Column38"
+msgstr ""
+
+#: Form\form_ca.xml.h:173
+msgid "38."
+msgstr ""
+
+#: Form\form_ca.xml.h:174
+msgid "Column39"
+msgstr ""
+
+#: Form\form_ca.xml.h:175
+msgid "39."
+msgstr ""
+
+#: Form\form_ca.xml.h:176
+msgid "MapleSugarLbs"
+msgstr ""
+
+#: Form\form_ca.xml.h:177
+msgid "40. Maple Sugar Lbs."
+msgstr ""
+
+#: Form\form_ca.xml.h:178
+msgid "CiderGalls"
+msgstr ""
+
+#: Form\form_ca.xml.h:179
+msgid "41. Cider Galls."
+msgstr ""
+
+#: Form\form_ca.xml.h:180
+msgid "ClothYards"
+msgstr ""
+
+#: Form\form_ca.xml.h:181
+msgid "42. Fulled Cloth Yards"
+msgstr ""
+
+#: Form\form_ca.xml.h:182
+msgid "LinnenYards"
+msgstr ""
+
+#: Form\form_ca.xml.h:183
+msgid "43. Linnen - Yds."
+msgstr ""
+
+#: Form\form_ca.xml.h:184
+msgid "FlannelYds"
+msgstr ""
+
+#: Form\form_ca.xml.h:185
+msgid "44. Flannel - Yds."
+msgstr ""
+
+#: Form\form_ca.xml.h:186
+msgid "Bulls"
+msgstr ""
+
+#: Form\form_ca.xml.h:187
+msgid "45. Bulls, Oxen or Steers"
+msgstr ""
+
+#: Form\form_ca.xml.h:188 Form\form_us.xml.h:288 Form\form_us.xml.h:366
+msgid "Milch Cows"
+msgstr ""
+
+#: Form\form_ca.xml.h:189
+msgid "46. Milch Cows"
+msgstr ""
+
+#: Form\form_ca.xml.h:190
+msgid "Calves"
+msgstr ""
+
+#: Form\form_ca.xml.h:191
+msgid "47. Calves or Heifers"
+msgstr ""
+
+#: Form\form_ca.xml.h:192 Form\form_ca.xml.h:650 Form\form_us.xml.h:286
+#: Form\form_us.xml.h:364
+msgid "Horses"
+msgstr ""
+
+#: Form\form_ca.xml.h:193
+msgid "48. Horses of all ages"
+msgstr ""
+
+#: Form\form_ca.xml.h:194 Form\form_ca.xml.h:656 Form\form_us.xml.h:291
+#: Form\form_us.xml.h:369
+msgid "Sheep"
+msgstr ""
+
+#: Form\form_ca.xml.h:195
+msgid "49. Sheep"
+msgstr ""
+
+#: Form\form_ca.xml.h:196 Form\form_ca.xml.h:658
+msgid "Pigs"
+msgstr ""
+
+#: Form\form_ca.xml.h:197
+msgid "50. Pigs"
+msgstr ""
+
+#: Form\form_ca.xml.h:198
+msgid "ButterLbs"
+msgstr ""
+
+#: Form\form_ca.xml.h:199
+msgid "51. Butter - Lbs."
+msgstr ""
+
+#: Form\form_ca.xml.h:200
+msgid "CheeseLbs"
+msgstr ""
+
+#: Form\form_ca.xml.h:201
+msgid "52. Cheese - Lbs."
+msgstr ""
+
+#: Form\form_ca.xml.h:202
+msgid "Beef"
+msgstr ""
+
+#: Form\form_ca.xml.h:203
+msgid "53. Beef - Barrels or Cwts."
+msgstr ""
+
+#: Form\form_ca.xml.h:204
+msgid "Pork"
+msgstr ""
+
+#: Form\form_ca.xml.h:205
+msgid "54. Pork - Barrels or Cwts."
+msgstr ""
+
+#: Form\form_ca.xml.h:206
+msgid "Fish"
+msgstr ""
+
+#: Form\form_ca.xml.h:207
+msgid "55. Quantity of Fish Cured"
+msgstr ""
+
+#: Form\form_ca.xml.h:209
+msgid "56. Remarks"
+msgstr ""
+
+#: Form\form_ca.xml.h:213 Form\form_ca.xml.h:292 Form\form_ca.xml.h:346
+#: Form\form_ca.xml.h:394 Form\form_ca.xml.h:456 Form\form_ca.xml.h:535
+#: Form\form_ca.xml.h:619 Form\form_ca.xml.h:667 Form\form_ca.xml.h:757
+#: Form\form_ca.xml.h:800 Form\form_pl.xml.h:17 Form\form_us.xml.h:2283
+#: Form\form_us.xml.h:2304 Form\form_us.xml.h:2397 Form\form_us.xml.h:2484
+msgid "Page"
+msgstr ""
+
+#: Form\form_ca.xml.h:219
+msgid "2. Profession, trade or occupation"
+msgstr ""
+
+#: Form\form_ca.xml.h:222
+msgid "Married1851"
+msgstr ""
+
+#: Form\form_ca.xml.h:223
+msgid "4. Married during the year"
+msgstr ""
+
+#: Form\form_ca.xml.h:225
+msgid "5. Religion"
+msgstr ""
+
+#: Form\form_ca.xml.h:227
+msgid "6. Residence, if out of limits"
+msgstr ""
+
+#: Form\form_ca.xml.h:229
+msgid "7. Age next Birthday"
+msgstr ""
+
+#: Form\form_ca.xml.h:231
+msgid "8. Sex: Male"
+msgstr ""
+
+#: Form\form_ca.xml.h:232
+msgid "SexFemail"
+msgstr ""
+
+#: Form\form_ca.xml.h:233
+msgid "9. Sex:Female"
+msgstr ""
+
+#: Form\form_ca.xml.h:235
+msgid "10. Married or Single"
+msgstr ""
+
+#: Form\form_ca.xml.h:236
+msgid "Widowers"
+msgstr ""
+
+#: Form\form_ca.xml.h:237
+msgid "11. Widowers"
+msgstr ""
+
+#: Form\form_ca.xml.h:238
+msgid "Widows"
+msgstr ""
+
+#: Form\form_ca.xml.h:239
+msgid "12. Widows"
+msgstr ""
+
+#: Form\form_ca.xml.h:241
+msgid "13. Coloured Persons, Mulato or Indians"
+msgstr ""
+
+#: Form\form_ca.xml.h:242
+msgid "MemberMale"
+msgstr ""
+
+#: Form\form_ca.xml.h:243
+msgid "14. Members: Male"
+msgstr ""
+
+#: Form\form_ca.xml.h:244
+msgid "MemberFemale"
+msgstr ""
+
+#: Form\form_ca.xml.h:245
+msgid "15. Members: Female"
+msgstr ""
+
+#: Form\form_ca.xml.h:246
+msgid "NotMemberMale"
+msgstr ""
+
+#: Form\form_ca.xml.h:247
+msgid "16. Not Members: Male"
+msgstr ""
+
+#: Form\form_ca.xml.h:248
+msgid "NotMemberFemale"
+msgstr ""
+
+#: Form\form_ca.xml.h:249
+msgid "17. Not Members: Female"
+msgstr ""
+
+#: Form\form_ca.xml.h:250
+msgid "MemberAbsentMale"
+msgstr ""
+
+#: Form\form_ca.xml.h:251
+msgid "18. Members Absent: Male"
+msgstr ""
+
+#: Form\form_ca.xml.h:252
+msgid "MemberAbsentFemale"
+msgstr ""
+
+#: Form\form_ca.xml.h:253
+msgid "19. Members Absent: Female"
+msgstr ""
+
+#: Form\form_ca.xml.h:254 Form\form_ca.xml.h:334 Form\form_ca.xml.h:382
+#: Form\form_ca.xml.h:443 Form\form_ca.xml.h:747
+msgid "DeafDumb"
+msgstr ""
+
+#: Form\form_ca.xml.h:255 Form\form_ca.xml.h:335
+msgid "20. Deaf and Dumb"
+msgstr ""
+
+#: Form\form_ca.xml.h:256 Form\form_ca.xml.h:336 Form\form_ca.xml.h:384
+#: Form\form_ca.xml.h:445 Form\form_ca.xml.h:745 Form\form_us.xml.h:479
+#: Form\form_us.xml.h:741 Form\form_us.xml.h:993 Form\form_us.xml.h:1031
+#: Form\form_us.xml.h:1126 Form\form_us.xml.h:1328 Form\form_us.xml.h:1774
+#: Form\form_us.xml.h:1983 Form\form_us.xml.h:2017 Form\form_us.xml.h:2055
+#: Form\form_us.xml.h:2093 Form\form_us.xml.h:2131 Form\form_us.xml.h:2154
+#: Form\form_us.xml.h:2166 Form\form_us.xml.h:2178
+msgid "Blind"
+msgstr ""
+
+#: Form\form_ca.xml.h:257 Form\form_ca.xml.h:337
+msgid "21. Blind"
+msgstr ""
+
+#: Form\form_ca.xml.h:258 Form\form_ca.xml.h:338 Form\form_ca.xml.h:386
+#: Form\form_ca.xml.h:447 Form\form_ca.xml.h:749
+msgid "Lunatic"
+msgstr ""
+
+#: Form\form_ca.xml.h:259
+msgid "22. Lunatics or Idiots"
+msgstr ""
+
+#: Form\form_ca.xml.h:261
+msgid "23. Attending School within the year: Male"
+msgstr ""
+
+#: Form\form_ca.xml.h:263
+msgid "24. Attending School within the year: Female"
+msgstr ""
+
+#: Form\form_ca.xml.h:264
+msgid "CantReadMale"
+msgstr ""
+
+#: Form\form_ca.xml.h:265
+msgid "25. Persons over 20, who cannot read or write: Male"
+msgstr ""
+
+#: Form\form_ca.xml.h:266
+msgid "CantReadFemale"
+msgstr ""
+
+#: Form\form_ca.xml.h:267
+msgid "26. Persons over 20, who cannot read or write: Female"
+msgstr ""
+
+#: Form\form_ca.xml.h:268
+msgid "Birth1860Male"
+msgstr ""
+
+#: Form\form_ca.xml.h:269
+msgid "27. Births in 1860: Male"
+msgstr ""
+
+#: Form\form_ca.xml.h:270
+msgid "Birth1860Female"
+msgstr ""
+
+#: Form\form_ca.xml.h:271
+msgid "28. Births in 1860: Female"
+msgstr ""
+
+#: Form\form_ca.xml.h:272
+msgid "Death1860Male"
+msgstr ""
+
+#: Form\form_ca.xml.h:273
+msgid "29. Deaths in 1860: Male"
+msgstr ""
+
+#: Form\form_ca.xml.h:274
+msgid "Death1860Female"
+msgstr ""
+
+#: Form\form_ca.xml.h:275
+msgid "30. Deaths in 1860: Female"
+msgstr ""
+
+#: Form\form_ca.xml.h:277
+msgid "31. Age and cause of death"
+msgstr ""
+
+#: Form\form_ca.xml.h:279
+msgid "32. Houses: Brick, Stone, Frame, Log, etc."
+msgstr ""
+
+#: Form\form_ca.xml.h:281
+msgid "33. Houses: No. of Stories"
+msgstr ""
+
+#: Form\form_ca.xml.h:283
+msgid "34. Houses: No. of families living in the house"
+msgstr ""
+
+#: Form\form_ca.xml.h:285
+msgid "35. Houses: Vacant"
+msgstr ""
+
+#: Form\form_ca.xml.h:286
+msgid "HouseBeingBuilt"
+msgstr ""
+
+#: Form\form_ca.xml.h:287
+msgid "36. Houses: Being built"
+msgstr ""
+
+#: Form\form_ca.xml.h:289 Form\form_ca.xml.h:343 Form\form_ca.xml.h:391
+#: Form\form_ca.xml.h:451 Form\form_ca.xml.h:530 Form\form_ca.xml.h:616
+#: Form\form_ca.xml.h:662 Form\form_ca.xml.h:755 Form\form_ca.xml.h:795
+msgid "Province"
+msgstr ""
+
+#: Form\form_ca.xml.h:290 Form\form_ca.xml.h:344 Form\form_ca.xml.h:392
+#: Form\form_ca.xml.h:452 Form\form_ca.xml.h:531 Form\form_ca.xml.h:617
+#: Form\form_ca.xml.h:663 Form\form_ca.xml.h:796
+msgid "District"
+msgstr ""
+
+#: Form\form_ca.xml.h:291 Form\form_ca.xml.h:345 Form\form_ca.xml.h:393
+#: Form\form_ca.xml.h:453 Form\form_ca.xml.h:532 Form\form_ca.xml.h:618
+#: Form\form_ca.xml.h:664 Form\form_ca.xml.h:797
+msgid "SubDistrict"
+msgstr ""
+
+#: Form\form_ca.xml.h:296 Form\form_ca.xml.h:350 Form\form_ca.xml.h:399
+msgid "Vessels"
+msgstr ""
+
+#: Form\form_ca.xml.h:297 Form\form_ca.xml.h:351
+msgid "1. Vessels"
+msgstr ""
+
+#: Form\form_ca.xml.h:298 Form\form_ca.xml.h:352
+msgid "Shanties"
+msgstr ""
+
+#: Form\form_ca.xml.h:299 Form\form_ca.xml.h:353
+msgid "2. Shanties"
+msgstr ""
+
+#: Form\form_ca.xml.h:300 Form\form_ca.xml.h:354 Form\form_ca.xml.h:401
+msgid "HousesBeingBuilt"
+msgstr ""
+
+#: Form\form_ca.xml.h:301
+msgid "3. Dwelling houses in construction"
+msgstr ""
+
+#: Form\form_ca.xml.h:303
+msgid "4. Dwelling houses unoccupied"
+msgstr ""
+
+#: Form\form_ca.xml.h:304 Form\form_ca.xml.h:358 Form\form_ca.xml.h:405
+#: Form\form_ca.xml.h:551
+msgid "HousesInhabited"
+msgstr ""
+
+#: Form\form_ca.xml.h:305
+msgid "5. Dwelling houses inhabited"
+msgstr ""
+
+#: Form\form_ca.xml.h:306 Form\form_ca.xml.h:360 Form\form_ca.xml.h:407
+#: Form\form_ca.xml.h:557
+msgid "Families"
+msgstr ""
+
+#: Form\form_ca.xml.h:307
+msgid "6.Families"
+msgstr ""
+
+#: Form\form_ca.xml.h:309 Form\form_ca.xml.h:363
+msgid "7. Names"
+msgstr ""
+
+#: Form\form_ca.xml.h:310 Form\form_ca.xml.h:364 Form\form_ca.xml.h:411
+#: Form\form_ca.xml.h:466 Form\form_ca.xml.h:630 Form\form_ca.xml.h:679
+#: Form\form_ca.xml.h:767 Form\form_ca.xml.h:822 Form\form_gb.xml.h:7
+#: Form\form_gb.xml.h:40 Form\form_gb.xml.h:169 Form\form_gb.xml.h:425
+#: Form\form_us.xml.h:263 Form\form_us.xml.h:339 Form\form_us.xml.h:416
+#: Form\form_us.xml.h:438 Form\form_us.xml.h:468 Form\form_us.xml.h:620
+#: Form\form_us.xml.h:675 Form\form_us.xml.h:715 Form\form_us.xml.h:760
+#: Form\form_us.xml.h:802 Form\form_us.xml.h:844 Form\form_us.xml.h:984
+#: Form\form_us.xml.h:1020 Form\form_us.xml.h:1114 Form\form_us.xml.h:1167
+#: Form\form_us.xml.h:1230 Form\form_us.xml.h:1231 Form\form_us.xml.h:1319
+#: Form\form_us.xml.h:1340 Form\form_us.xml.h:1398 Form\form_us.xml.h:1412
+#: Form\form_us.xml.h:1431 Form\form_us.xml.h:1452 Form\form_us.xml.h:1473
+#: Form\form_us.xml.h:1495 Form\form_us.xml.h:1519 Form\form_us.xml.h:1538
+#: Form\form_us.xml.h:1552 Form\form_us.xml.h:1567 Form\form_us.xml.h:1595
+#: Form\form_us.xml.h:1763 Form\form_us.xml.h:1794 Form\form_us.xml.h:1816
+#: Form\form_us.xml.h:1845 Form\form_us.xml.h:1865 Form\form_us.xml.h:1879
+#: Form\form_us.xml.h:1898 Form\form_us.xml.h:1918 Form\form_us.xml.h:2009
+#: Form\form_us.xml.h:2047 Form\form_us.xml.h:2085 Form\form_us.xml.h:2123
+#: Form\form_us.xml.h:2245 Form\form_us.xml.h:2260 Form\form_us.xml.h:2288
+#: Form\form_us.xml.h:2348 Form\form_us.xml.h:2378 Form\form_us.xml.h:2402
+msgid "Sex"
+msgstr ""
+
+#: Form\form_ca.xml.h:311 Form\form_ca.xml.h:365
+msgid "8. Sex"
+msgstr ""
+
+#: Form\form_ca.xml.h:313 Form\form_ca.xml.h:367
+msgid "9. Age"
+msgstr ""
+
+#: Form\form_ca.xml.h:314
+msgid "Birth1871"
+msgstr ""
+
+#: Form\form_ca.xml.h:315 Form\form_ca.xml.h:369
+msgid "10. Born within last twelve months"
+msgstr ""
+
+#: Form\form_ca.xml.h:317 Form\form_ca.xml.h:371 Form\form_ca.xml.h:420
+msgid "11. Country or Province of Birth"
+msgstr ""
+
+#: Form\form_ca.xml.h:319 Form\form_ca.xml.h:373
+msgid "12. Religion"
+msgstr ""
+
+#: Form\form_ca.xml.h:320 Form\form_ca.xml.h:374
+msgid "Origin"
+msgstr ""
+
+#: Form\form_ca.xml.h:321 Form\form_ca.xml.h:375
+msgid "13. Origin"
+msgstr ""
+
+#: Form\form_ca.xml.h:323 Form\form_ca.xml.h:377
+msgid "14. Profession, Occupation or Trade"
+msgstr ""
+
+#: Form\form_ca.xml.h:325 Form\form_ca.xml.h:379
+msgid "15. Married or Widowed"
+msgstr ""
+
+#: Form\form_ca.xml.h:326
+msgid "Maried1871"
+msgstr ""
+
+#: Form\form_ca.xml.h:327
+msgid "16. Married within last twelve months"
+msgstr ""
+
+#: Form\form_ca.xml.h:328 Form\form_ca.xml.h:380
+msgid "Scholar"
+msgstr ""
+
+#: Form\form_ca.xml.h:329
+msgid "17. Going to school"
+msgstr ""
+
+#: Form\form_ca.xml.h:330
+msgid "CantRead"
+msgstr ""
+
+#: Form\form_ca.xml.h:331
+msgid "18. Over 20 unable to read"
+msgstr ""
+
+#: Form\form_ca.xml.h:332
+msgid "CantWrite"
+msgstr ""
+
+#: Form\form_ca.xml.h:333
+msgid "19. Over 20 unable to write"
+msgstr ""
+
+#: Form\form_ca.xml.h:339
+msgid "22. Unsound mind"
+msgstr ""
+
+#: Form\form_ca.xml.h:341
+msgid "23. Date of Operations and Remarks"
+msgstr ""
+
+#: Form\form_ca.xml.h:355
+msgid "3. Houses in construction"
+msgstr ""
+
+#: Form\form_ca.xml.h:357
+msgid "4. Houses unoccupied"
+msgstr ""
+
+#: Form\form_ca.xml.h:359
+msgid "5. Houses inhabited"
+msgstr ""
+
+#: Form\form_ca.xml.h:361
+msgid "6. Families"
+msgstr ""
+
+#: Form\form_ca.xml.h:368
+msgid "Birth1881"
+msgstr ""
+
+#: Form\form_ca.xml.h:381
+msgid "16. Going to school"
+msgstr ""
+
+#: Form\form_ca.xml.h:383
+msgid "17. Deaf and Dumb"
+msgstr ""
+
+#: Form\form_ca.xml.h:385
+msgid "18. Blind"
+msgstr ""
+
+#: Form\form_ca.xml.h:387
+msgid "19/ Unsound mind"
+msgstr ""
+
+#: Form\form_ca.xml.h:389
+msgid "20. Date of Operations and Remarks"
+msgstr ""
+
+#: Form\form_ca.xml.h:400
+msgid "1. Vessels and Shanties"
+msgstr ""
+
+#: Form\form_ca.xml.h:402
+msgid "2. Houses in construction"
+msgstr ""
+
+#: Form\form_ca.xml.h:404
+msgid "3. Houses unoccupied"
+msgstr ""
+
+#: Form\form_ca.xml.h:406
+msgid "4. Houses inhabited"
+msgstr ""
+
+#: Form\form_ca.xml.h:408
+msgid "5. Families"
+msgstr ""
+
+#: Form\form_ca.xml.h:410
+msgid "6. Names"
+msgstr ""
+
+#: Form\form_ca.xml.h:412
+msgid "7. Sex"
+msgstr ""
+
+#: Form\form_ca.xml.h:414
+msgid "8. Age"
+msgstr ""
+
+#: Form\form_ca.xml.h:416
+msgid "9. Married or Widowed"
+msgstr ""
+
+#: Form\form_ca.xml.h:417 Form\form_ca.xml.h:470 Form\form_ca.xml.h:628
+#: Form\form_ca.xml.h:681 Form\form_ca.xml.h:769 Form\form_ca.xml.h:820
+#: Form\form_dk.xml.h:14 Form\form_dk.xml.h:31 Form\form_dk.xml.h:48
+#: Form\form_dk.xml.h:65 Form\form_dk.xml.h:82 Form\form_dk.xml.h:99
+#: Form\form_dk.xml.h:118 Form\form_dk.xml.h:137 Form\form_dk.xml.h:156
+#: Form\form_dk.xml.h:177 Form\form_dk.xml.h:200 Form\form_dk.xml.h:221
+#: Form\form_dk.xml.h:242 Form\form_dk.xml.h:270 Form\form_dk.xml.h:305
+#: Form\form_dk.xml.h:331 Form\form_dk.xml.h:347 Form\form_dk.xml.h:379
+#: Form\form_dk.xml.h:399 Form\form_dk.xml.h:421 Form\form_dk.xml.h:441
+#: Form\form_fr.xml.h:5 Form\form_fr.xml.h:13 Form\form_fr.xml.h:21
+#: Form\form_fr.xml.h:29 Form\form_fr.xml.h:36 Form\form_fr.xml.h:121
+#: Form\form_fr.xml.h:128 Form\form_fr.xml.h:135 Form\form_fr.xml.h:142
+#: Form\form_fr.xml.h:152 Form\form_fr.xml.h:161 Form\form_fr.xml.h:169
+#: Form\form_fr.xml.h:178 Form\form_fr.xml.h:187 Form\form_fr.xml.h:196
+#: Form\form_fr.xml.h:205 Form\form_fr.xml.h:216 Form\form_gb.xml.h:60
+#: Form\form_gb.xml.h:74 Form\form_gb.xml.h:89 Form\form_gb.xml.h:104
+#: Form\form_gb.xml.h:119 Form\form_gb.xml.h:137 Form\form_gb.xml.h:148
+#: Form\form_gb.xml.h:183 Form\form_gb.xml.h:203 Form\form_gb.xml.h:216
+#: Form\form_gb.xml.h:271 Form\form_gb.xml.h:298 Form\form_gb.xml.h:326
+#: Form\form_gb.xml.h:358 Form\form_gb.xml.h:397 Form\form_gb.xml.h:419
+#: Form\form_gb.xml.h:448 Form\form_us.xml.h:1339 Form\form_us.xml.h:1877
+#: Form\form_us.xml.h:1896 Form\form_us.xml.h:1916
+msgid "Relation"
+msgstr ""
+
+#: Form\form_ca.xml.h:418
+msgid "10. Relationship to Head of Family"
+msgstr ""
+
+#: Form\form_ca.xml.h:421
+msgid "French"
+msgstr ""
+
+#: Form\form_ca.xml.h:422
+msgid "12. FrenchCanadian"
+msgstr ""
+
+#: Form\form_ca.xml.h:423
+msgid "BirthPlaceFather"
+msgstr ""
+
+#: Form\form_ca.xml.h:424
+msgid "13. Birth Place of Father"
+msgstr ""
+
+#: Form\form_ca.xml.h:425
+msgid "BirthPlaceMother"
+msgstr ""
+
+#: Form\form_ca.xml.h:426
+msgid "14. Birth Place of Mother"
+msgstr ""
+
+#: Form\form_ca.xml.h:428
+msgid "15. Religion"
+msgstr ""
+
+#: Form\form_ca.xml.h:430
+msgid "16. Profession, Occupation or Trade"
+msgstr ""
+
+#: Form\form_ca.xml.h:431 Form\form_ca.xml.h:496 Form\form_ca.xml.h:707
+#: Form\form_gb.xml.h:123 Form\form_gb.xml.h:187 Form\form_gb.xml.h:364
+msgid "Employer"
+msgstr ""
+
+#: Form\form_ca.xml.h:432
+msgid "17. Employers"
+msgstr ""
+
+#: Form\form_ca.xml.h:433 Form\form_ca.xml.h:498 Form\form_ca.xml.h:709
+msgid "Employee"
+msgstr ""
+
+#: Form\form_ca.xml.h:434
+msgid "18. Wage Earner"
+msgstr ""
+
+#: Form\form_ca.xml.h:435
+msgid "Unemployed"
+msgstr ""
+
+#: Form\form_ca.xml.h:436
+msgid "19. Unemployed during week preceding Census"
+msgstr ""
+
+#: Form\form_ca.xml.h:437
+msgid "Employees"
+msgstr ""
+
+#: Form\form_ca.xml.h:438
+msgid "20. Employer to state average number of hands employed during year"
+msgstr ""
+
+#: Form\form_ca.xml.h:439 Form\form_ca.xml.h:846
+msgid "CanRead"
+msgstr ""
+
+#: Form\form_ca.xml.h:440
+msgid "21. Instruction: Read"
+msgstr ""
+
+#: Form\form_ca.xml.h:441 Form\form_ca.xml.h:848
+msgid "CanWrite"
+msgstr ""
+
+#: Form\form_ca.xml.h:442
+msgid "22. Instruction: Write"
+msgstr ""
+
+#: Form\form_ca.xml.h:444
+msgid "23. Deaf and Dumb"
+msgstr ""
+
+#: Form\form_ca.xml.h:446
+msgid "24. Blind"
+msgstr ""
+
+#: Form\form_ca.xml.h:448
+msgid "25. Unsound mind"
+msgstr ""
+
+#: Form\form_ca.xml.h:449 Form\form_ca.xml.h:528 Form\form_ca.xml.h:660
+#: Form\form_ca.xml.h:753 Form\form_ca.xml.h:793
+msgid "SubTitle"
+msgstr ""
+
+#: Form\form_ca.xml.h:454 Form\form_ca.xml.h:533 Form\form_ca.xml.h:665
+msgid "PollSub"
+msgstr ""
+
+#: Form\form_ca.xml.h:455 Form\form_ca.xml.h:534 Form\form_ca.xml.h:666
+#: Form\form_ca.xml.h:756 Form\form_ca.xml.h:799
+msgid "Locality"
+msgstr ""
+
+#: Form\form_ca.xml.h:460 Form\form_ca.xml.h:671 Form\form_ca.xml.h:804
+msgid "House"
+msgstr ""
+
+#: Form\form_ca.xml.h:461 Form\form_ca.xml.h:672
+msgid "1. Dwelling house"
+msgstr ""
+
+#: Form\form_ca.xml.h:462 Form\form_ca.xml.h:624 Form\form_ca.xml.h:673
+#: Form\form_ca.xml.h:806
+msgid "Family"
+msgstr ""
+
+#: Form\form_ca.xml.h:463 Form\form_ca.xml.h:674
+msgid "2. Family or household"
+msgstr ""
+
+#: Form\form_ca.xml.h:465 Form\form_ca.xml.h:676
+msgid "3. Name of each person in family"
+msgstr ""
+
+#: Form\form_ca.xml.h:467 Form\form_ca.xml.h:631 Form\form_ca.xml.h:768
+msgid "4. Sex"
+msgstr ""
+
+#: Form\form_ca.xml.h:468
+msgid "Colour"
+msgstr ""
+
+#: Form\form_ca.xml.h:469
+msgid "5. Colour"
+msgstr ""
+
+#: Form\form_ca.xml.h:471 Form\form_ca.xml.h:682
+msgid "6. Relation to head of family"
+msgstr ""
+
+#: Form\form_ca.xml.h:473 Form\form_ca.xml.h:684
+msgid "7. Single, married, widowed, divorced or legally separated"
+msgstr ""
+
+#: Form\form_ca.xml.h:474 Form\form_ca.xml.h:685 Form\form_ca.xml.h:773
+msgid "BirthMonth"
+msgstr ""
+
+#: Form\form_ca.xml.h:475
+msgid "8. Month and Date of Birth"
+msgstr ""
+
+#: Form\form_ca.xml.h:476 Form\form_ca.xml.h:687
+msgid "BirthYear"
+msgstr ""
+
+#: Form\form_ca.xml.h:477 Form\form_ca.xml.h:688
+msgid "9. Year of birth"
+msgstr ""
+
+#: Form\form_ca.xml.h:479 Form\form_ca.xml.h:690
+msgid "10. Age at last birthday"
+msgstr ""
+
+#: Form\form_ca.xml.h:481 Form\form_ca.xml.h:692
+msgid "11. Country or place of birth"
+msgstr ""
+
+#: Form\form_ca.xml.h:482 Form\form_ca.xml.h:638 Form\form_ca.xml.h:693
+#: Form\form_ca.xml.h:832
+msgid "Immigration"
+msgstr ""
+
+#: Form\form_ca.xml.h:483 Form\form_ca.xml.h:694
+msgid "12. Year of immigration to Canada, if an immigrant"
+msgstr ""
+
+#: Form\form_ca.xml.h:484 Form\form_ca.xml.h:695 Form\form_ca.xml.h:834
+#: Form\form_us.xml.h:688
+msgid "Naturalization"
+msgstr ""
+
+#: Form\form_ca.xml.h:485 Form\form_ca.xml.h:696
+msgid "13. Year of naturalization, if formerly an alien"
+msgstr ""
+
+#: Form\form_ca.xml.h:486 Form\form_ca.xml.h:697 Form\form_ca.xml.h:779
+#: Form\form_ca.xml.h:838 Form\form_us.xml.h:891 Form\form_us.xml.h:1051
+#: Form\form_us.xml.h:1059 Form\form_us.xml.h:2270 Form\form_us.xml.h:2276
+#: Form\form_us.xml.h:2349 Form\form_us.xml.h:2379 Form\form_us.xml.h:2473
+msgid "Race"
+msgstr ""
+
+#: Form\form_ca.xml.h:487 Form\form_ca.xml.h:698
+msgid "14. Racial or tribal origin"
+msgstr ""
+
+#: Form\form_ca.xml.h:488 Form\form_ca.xml.h:699 Form\form_ca.xml.h:836
+#: Form\form_fr.xml.h:7 Form\form_fr.xml.h:15 Form\form_fr.xml.h:23
+#: Form\form_fr.xml.h:31 Form\form_fr.xml.h:79 Form\form_fr.xml.h:107
+#: Form\form_fr.xml.h:115 Form\form_fr.xml.h:127 Form\form_fr.xml.h:134
+#: Form\form_fr.xml.h:145 Form\form_fr.xml.h:151 Form\form_fr.xml.h:160
+#: Form\form_fr.xml.h:168 Form\form_fr.xml.h:177 Form\form_fr.xml.h:186
+#: Form\form_fr.xml.h:195 Form\form_fr.xml.h:204 Form\form_fr.xml.h:215
+#: Form\form_gb.xml.h:162 Form\form_gb.xml.h:230
+msgid "Nationality"
+msgstr ""
+
+#: Form\form_ca.xml.h:489 Form\form_ca.xml.h:700
+msgid "15. Nationality"
+msgstr ""
+
+#: Form\form_ca.xml.h:491 Form\form_ca.xml.h:702
+msgid "16. Religion"
+msgstr ""
+
+#: Form\form_ca.xml.h:493
+msgid "17. Profession, occupation, trade or means of living of each person"
+msgstr ""
+
+#: Form\form_ca.xml.h:494
+msgid "OwnMeans"
+msgstr ""
+
+#: Form\form_ca.xml.h:495
+msgid "18. Living on own means"
+msgstr ""
+
+#: Form\form_ca.xml.h:497 Form\form_ca.xml.h:708
+msgid "19. Employer"
+msgstr ""
+
+#: Form\form_ca.xml.h:499 Form\form_ca.xml.h:710
+msgid "20. Employee"
+msgstr ""
+
+#: Form\form_ca.xml.h:500 Form\form_ca.xml.h:711
+msgid "SelfEmployed"
+msgstr ""
+
+#: Form\form_ca.xml.h:501 Form\form_ca.xml.h:712
+msgid "21. Working on own account"
+msgstr ""
+
+#: Form\form_ca.xml.h:502 Form\form_ca.xml.h:713
+msgid "WhereEmployed"
+msgstr ""
+
+#: Form\form_ca.xml.h:503
+msgid "22. Working at trade in factory or in home"
+msgstr ""
+
+#: Form\form_ca.xml.h:504
+msgid "MonthsFactory"
+msgstr ""
+
+#: Form\form_ca.xml.h:505
+msgid "23. Months employed at trade in factory"
+msgstr ""
+
+#: Form\form_ca.xml.h:506
+msgid "MonthsHome"
+msgstr ""
+
+#: Form\form_ca.xml.h:507
+msgid "24. Months employed at trade in home"
+msgstr ""
+
+#: Form\form_ca.xml.h:508
+msgid "MonthsOther"
+msgstr ""
+
+#: Form\form_ca.xml.h:509
+msgid "25. Months employed in other occupation than trace in factory or home"
+msgstr ""
+
+#: Form\form_ca.xml.h:510 Form\form_ca.xml.h:723
+msgid "EarningsOccupation"
+msgstr ""
+
+#: Form\form_ca.xml.h:511
+msgid "26. Earnings from occupation or trade"
+msgstr ""
+
+#: Form\form_ca.xml.h:512 Form\form_ca.xml.h:725
+msgid "EarningsOther"
+msgstr ""
+
+#: Form\form_ca.xml.h:513
+msgid "27. Extra earning (From other than chief occupation or trade)"
+msgstr ""
+
+#: Form\form_ca.xml.h:514 Form\form_ca.xml.h:735 Form\form_ca.xml.h:783
+msgid "SchoolMonths"
+msgstr ""
+
+#: Form\form_ca.xml.h:515
+msgid "28. Months at school in 1910"
+msgstr ""
+
+#: Form\form_ca.xml.h:516 Form\form_ca.xml.h:737 Form\form_ca.xml.h:785
+#: Form\form_us.xml.h:1326 Form\form_us.xml.h:2015 Form\form_us.xml.h:2053
+#: Form\form_us.xml.h:2091 Form\form_us.xml.h:2129
+msgid "Read"
+msgstr ""
+
+#: Form\form_ca.xml.h:517
+msgid "29. Can read"
+msgstr ""
+
+#: Form\form_ca.xml.h:518 Form\form_ca.xml.h:739 Form\form_ca.xml.h:787
+#: Form\form_us.xml.h:1327 Form\form_us.xml.h:2016 Form\form_us.xml.h:2054
+#: Form\form_us.xml.h:2092 Form\form_us.xml.h:2130
+msgid "Write"
+msgstr ""
+
+#: Form\form_ca.xml.h:519
+msgid "30. Can write"
+msgstr ""
+
+#: Form\form_ca.xml.h:520 Form\form_ca.xml.h:840
+msgid "SpeakEnglish"
+msgstr ""
+
+#: Form\form_ca.xml.h:521
+msgid "31. Can speak English"
+msgstr ""
+
+#: Form\form_ca.xml.h:522 Form\form_ca.xml.h:842
+msgid "SpeakFrench"
+msgstr ""
+
+#: Form\form_ca.xml.h:523
+msgid "32. Can speak French"
+msgstr ""
+
+#: Form\form_ca.xml.h:524 Form\form_ca.xml.h:741 Form\form_ca.xml.h:789
+#: Form\form_gb.xml.h:193 Form\form_gb.xml.h:213 Form\form_gb.xml.h:232
+msgid "Language"
+msgstr ""
+
+#: Form\form_ca.xml.h:525
+msgid "33. Mother tongue (If spoken)"
+msgstr ""
+
+#: Form\form_ca.xml.h:526 Form\form_ca.xml.h:791
+msgid "Infirmities"
+msgstr ""
+
+#: Form\form_ca.xml.h:527
+msgid "34. Infirmities: a. Deaf and dumb; b. Blind; c. Unsound mind"
+msgstr ""
+
+#: Form\form_ca.xml.h:538
+msgid "Name from Schedule 1"
+msgstr ""
+
+#: Form\form_ca.xml.h:540
+msgid "Line on Schedule 2"
+msgstr ""
+
+#: Form\form_ca.xml.h:541
+msgid "PageRef"
+msgstr ""
+
+#: Form\form_ca.xml.h:542
+msgid "2. Page from Schedule 1"
+msgstr ""
+
+#: Form\form_ca.xml.h:543
+msgid "LineRef"
+msgstr ""
+
+#: Form\form_ca.xml.h:544
+msgid "3. Line from Schedule 1"
+msgstr ""
+
+#: Form\form_ca.xml.h:546
+msgid "3. Place of Habitation"
+msgstr ""
+
+#: Form\form_ca.xml.h:547
+msgid "HousesConst"
+msgstr ""
+
+#: Form\form_ca.xml.h:548
+msgid "4. Houses: In construction"
+msgstr ""
+
+#: Form\form_ca.xml.h:550
+msgid "5. Houses: Vacant"
+msgstr ""
+
+#: Form\form_ca.xml.h:552
+msgid "6. Houses: Inhabited"
+msgstr ""
+
+#: Form\form_ca.xml.h:553 Form\form_us.xml.h:789 Form\form_us.xml.h:832
+msgid "Institution"
+msgstr ""
+
+#: Form\form_ca.xml.h:554
+msgid "7. Institution: Special or legal name"
+msgstr ""
+
+#: Form\form_ca.xml.h:555
+msgid "Buildings"
+msgstr ""
+
+#: Form\form_ca.xml.h:556
+msgid "8. Institution: Number of buildings"
+msgstr ""
+
+#: Form\form_ca.xml.h:558
+msgid "9. Number of families in house or institution"
+msgstr ""
+
+#: Form\form_ca.xml.h:559
+msgid "Rooms"
+msgstr ""
+
+#: Form\form_ca.xml.h:560
+msgid "10. Number of rooms in house or institution for each famiy"
+msgstr ""
+
+#: Form\form_ca.xml.h:561
+msgid "Inmates"
+msgstr ""
+
+#: Form\form_ca.xml.h:562
+msgid "11. Number of inmates in institution"
+msgstr ""
+
+#: Form\form_ca.xml.h:563
+msgid "OwnedAcres"
+msgstr ""
+
+#: Form\form_ca.xml.h:564
+msgid "12. Real Estate Owned: Grand total of acres"
+msgstr ""
+
+#: Form\form_ca.xml.h:565
+msgid "OwnedLots"
+msgstr ""
+
+#: Form\form_ca.xml.h:566
+msgid "13. Real Estate Owned: Number of town or village lots"
+msgstr ""
+
+#: Form\form_ca.xml.h:567
+msgid "OwnedHouses"
+msgstr ""
+
+#: Form\form_ca.xml.h:568
+msgid "14. Real Estate Owned: Number of dwelling houses"
+msgstr ""
+
+#: Form\form_ca.xml.h:569
+msgid "OwnedStores"
+msgstr ""
+
+#: Form\form_ca.xml.h:570
+msgid "15. Real Estate Owned: Number of stores, warehouses, etc."
+msgstr ""
+
+#: Form\form_ca.xml.h:571
+msgid "OwnedBars"
+msgstr ""
+
+#: Form\form_ca.xml.h:572
+msgid "16. Real Estate Owned: Number of barns, stables and other outbuildings"
+msgstr ""
+
+#: Form\form_ca.xml.h:573
+msgid "OwnedSilos"
+msgstr ""
+
+#: Form\form_ca.xml.h:574
+msgid "17. Real Estate Owned: Number of silos and capacity in cubic feet"
+msgstr ""
+
+#: Form\form_ca.xml.h:575
+msgid "OwnedFactories"
+msgstr ""
+
+#: Form\form_ca.xml.h:576
+msgid "18. Real Estate Owned: Number of manufacturing establishments"
+msgstr ""
+
+#: Form\form_ca.xml.h:577
+msgid "LeasedAcres"
+msgstr ""
+
+#: Form\form_ca.xml.h:578
+msgid "19. Real Estate Leased: Grand total of acres"
+msgstr ""
+
+#: Form\form_ca.xml.h:579
+msgid "LeasedLots"
+msgstr ""
+
+#: Form\form_ca.xml.h:580
+msgid "20. Real Estate Leased: Number of town or village lots"
+msgstr ""
+
+#: Form\form_ca.xml.h:581
+msgid "LeasedHouses"
+msgstr ""
+
+#: Form\form_ca.xml.h:582
+msgid "21. Real Estate Leased: Number of dwelling houses"
+msgstr ""
+
+#: Form\form_ca.xml.h:583
+msgid "LeasedStores"
+msgstr ""
+
+#: Form\form_ca.xml.h:584
+msgid "22. Real Estate Leased: Number of stores, warehouses, etc."
+msgstr ""
+
+#: Form\form_ca.xml.h:585
+msgid "LeasedBarns"
+msgstr ""
+
+#: Form\form_ca.xml.h:586
+msgid "23. Real Estate Leased: Number of barns, stables and other outbuildings"
+msgstr ""
+
+#: Form\form_ca.xml.h:587
+msgid "LeasedSilos"
+msgstr ""
+
+#: Form\form_ca.xml.h:588
+msgid "24. Real Estate Leased: Number of silos and capacity in cubic feet"
+msgstr ""
+
+#: Form\form_ca.xml.h:589
+msgid "LeasedFactories"
+msgstr ""
+
+#: Form\form_ca.xml.h:590
+msgid "25. Real Estate Leased: Number of manufacturing establishments"
+msgstr ""
+
+#: Form\form_ca.xml.h:591
+msgid "Denomination"
+msgstr ""
+
+#: Form\form_ca.xml.h:592
+msgid "26. Church or place of worship: Religious denomination"
+msgstr ""
+
+#: Form\form_ca.xml.h:593
+msgid "Communicants"
+msgstr ""
+
+#: Form\form_ca.xml.h:594
+msgid "27. Church or place of worship: Number of communicants"
+msgstr ""
+
+#: Form\form_ca.xml.h:595
+msgid "Seating"
+msgstr ""
+
+#: Form\form_ca.xml.h:596
+msgid "28. Church or place of worship: Seating capacity"
+msgstr ""
+
+#: Form\form_ca.xml.h:597
+msgid "SSDenomination"
+msgstr ""
+
+#: Form\form_ca.xml.h:598
+msgid "29. Sunday School: Religious Denomination"
+msgstr ""
+
+#: Form\form_ca.xml.h:599
+msgid "SSTeachers"
+msgstr ""
+
+#: Form\form_ca.xml.h:600
+msgid "30. Sunday School: Number of officers and teachers"
+msgstr ""
+
+#: Form\form_ca.xml.h:601
+msgid "SSScholars"
+msgstr ""
+
+#: Form\form_ca.xml.h:602
+msgid "31. Sunday School: Number of Scholars"
+msgstr ""
+
+#: Form\form_ca.xml.h:603
+msgid "SchoolRooms"
+msgstr ""
+
+#: Form\form_ca.xml.h:604
+msgid "32. School: Number of rooms"
+msgstr ""
+
+#: Form\form_ca.xml.h:605
+msgid "SchoolTeachers"
+msgstr ""
+
+#: Form\form_ca.xml.h:606
+msgid "33. School: Number of teachers"
+msgstr ""
+
+#: Form\form_ca.xml.h:607
+msgid "SchoolStudents"
+msgstr ""
+
+#: Form\form_ca.xml.h:608
+msgid "34. School: Number of Scholars"
+msgstr ""
+
+#: Form\form_ca.xml.h:609
+msgid "DateVisit"
+msgstr ""
+
+#: Form\form_ca.xml.h:610
+msgid "35. Date of visit"
+msgstr ""
+
+#: Form\form_ca.xml.h:611
+msgid "Reason"
+msgstr ""
+
+#: Form\form_ca.xml.h:612
+msgid "36. The reason, if not enumerated on first visit"
+msgstr ""
+
+#: Form\form_ca.xml.h:613
+msgid "DateEnum"
+msgstr ""
+
+#: Form\form_ca.xml.h:614
+msgid "37. Date when enumerated"
+msgstr ""
+
+#: Form\form_ca.xml.h:625
+msgid "1. No. of family in order of visitation"
+msgstr ""
+
+#: Form\form_ca.xml.h:627
+msgid "2. Name of each person in the family"
+msgstr ""
+
+#: Form\form_ca.xml.h:629
+msgid "3.Relation to head of family"
+msgstr ""
+
+#: Form\form_ca.xml.h:633
+msgid "5. Married, single, widowed or divorced"
+msgstr ""
+
+#: Form\form_ca.xml.h:635
+msgid "6. Age"
+msgstr ""
+
+#: Form\form_ca.xml.h:637
+msgid "7. Country or place of birth"
+msgstr ""
+
+#: Form\form_ca.xml.h:639
+msgid "8. Year of immigration to Canada"
+msgstr ""
+
+#: Form\form_ca.xml.h:640
+msgid "PostOffice"
+msgstr ""
+
+#: Form\form_ca.xml.h:641
+msgid "9. Post office address"
+msgstr ""
+
+#: Form\form_ca.xml.h:642 Form\form_us.xml.h:1164
+msgid "Section"
+msgstr ""
+
+#: Form\form_ca.xml.h:643
+msgid "10. Location: Section"
+msgstr ""
+
+#: Form\form_ca.xml.h:645
+msgid "11. Location: Township"
+msgstr ""
+
+#: Form\form_ca.xml.h:646 Form\form_ca.xml.h:814 Form\form_us.xml.h:1163
+msgid "Range"
+msgstr ""
+
+#: Form\form_ca.xml.h:647
+msgid "12. Location: Range"
+msgstr ""
+
+#: Form\form_ca.xml.h:648 Form\form_ca.xml.h:816
+msgid "Meridian"
+msgstr ""
+
+#: Form\form_ca.xml.h:649
+msgid "13. Location: Meridian"
+msgstr ""
+
+#: Form\form_ca.xml.h:651
+msgid "14. Livestock: Horses, all ages"
+msgstr ""
+
+#: Form\form_ca.xml.h:652
+msgid "Cows"
+msgstr ""
+
+#: Form\form_ca.xml.h:653
+msgid "15. Livestock: Milch cows"
+msgstr ""
+
+#: Form\form_ca.xml.h:654
+msgid "Other"
+msgstr ""
+
+#: Form\form_ca.xml.h:655
+msgid "16. Other horned or meat cattle, all ages"
+msgstr ""
+
+#: Form\form_ca.xml.h:657
+msgid "17. Sheep and lambs, all ages"
+msgstr ""
+
+#: Form\form_ca.xml.h:659
+msgid "18. Hogs and pigs, all ages"
+msgstr ""
+
+#: Form\form_ca.xml.h:678
+msgid "4. Place of habitation"
+msgstr ""
+
+#: Form\form_ca.xml.h:680
+msgid "5. Sex"
+msgstr ""
+
+#: Form\form_ca.xml.h:686
+msgid "8. Month of birth"
+msgstr ""
+
+#: Form\form_ca.xml.h:704
+msgid "16. Chief occupation or trade"
+msgstr ""
+
+#: Form\form_ca.xml.h:705
+msgid "OtherEmployment"
+msgstr ""
+
+#: Form\form_ca.xml.h:706
+msgid "18. Employment other than at chief trade or occupation, if any"
+msgstr ""
+
+#: Form\form_ca.xml.h:714
+msgid "22. State where person employed"
+msgstr ""
+
+#: Form\form_ca.xml.h:715
+msgid "WeeksOccupation"
+msgstr ""
+
+#: Form\form_ca.xml.h:716
+msgid "23. Weeks employed in 1910 at chief occupation or trade"
+msgstr ""
+
+#: Form\form_ca.xml.h:717
+msgid "WeeksOther"
+msgstr ""
+
+#: Form\form_ca.xml.h:718
+msgid "24. Weeks employed in 1910 at other than chief occupation or trade"
+msgstr ""
+
+#: Form\form_ca.xml.h:719
+msgid "HoursOccupation"
+msgstr ""
+
+#: Form\form_ca.xml.h:720
+msgid "25. Hours of working time per week at chief occupation"
+msgstr ""
+
+#: Form\form_ca.xml.h:721
+msgid "HoursOther"
+msgstr ""
+
+#: Form\form_ca.xml.h:722
+msgid "26. Hours of working time per week at other occupation, if any"
+msgstr ""
+
+#: Form\form_ca.xml.h:724
+msgid "27. Total earnings in 1910 from chief occupation or trade"
+msgstr ""
+
+#: Form\form_ca.xml.h:726
+msgid "28. Total earnings in 1910 from other than chief occupation or trade"
+msgstr ""
+
+#: Form\form_ca.xml.h:727
+msgid "Wages"
+msgstr ""
+
+#: Form\form_ca.xml.h:728
+msgid "29. Rate of earnings per hour when employed by the hour-Cents"
+msgstr ""
+
+#: Form\form_ca.xml.h:729
+msgid "InsuranceLife"
+msgstr ""
+
+#: Form\form_ca.xml.h:730
+msgid "30. Insurance: Upon life"
+msgstr ""
+
+#: Form\form_ca.xml.h:731
+msgid "InsuranceAccident"
+msgstr ""
+
+#: Form\form_ca.xml.h:732
+msgid "31. Insurance: Against accident or illness"
+msgstr ""
+
+#: Form\form_ca.xml.h:733
+msgid "InsuranceCost"
+msgstr ""
+
+#: Form\form_ca.xml.h:734
+msgid "32. Insurance: Cost of insurance in census year"
+msgstr ""
+
+#: Form\form_ca.xml.h:736
+msgid "33. Months at school in 1910"
+msgstr ""
+
+#: Form\form_ca.xml.h:738
+msgid "34. Can Read"
+msgstr ""
+
+#: Form\form_ca.xml.h:740
+msgid "35. Can Write"
+msgstr ""
+
+#: Form\form_ca.xml.h:742
+msgid "36. Language commonly spoken"
+msgstr ""
+
+#: Form\form_ca.xml.h:743
+msgid "SchoolCost"
+msgstr ""
+
+#: Form\form_ca.xml.h:744
+msgid ""
+"37. Cost of education in 1910 for persons over 16 years of age at College, "
+"Convent or University"
+msgstr ""
+
+#: Form\form_ca.xml.h:746
+msgid "38. Blind"
+msgstr ""
+
+#: Form\form_ca.xml.h:748
+msgid "39. Deaf and dumb"
+msgstr ""
+
+#: Form\form_ca.xml.h:750
+msgid "40. Crazy or lunatic"
+msgstr ""
+
+#: Form\form_ca.xml.h:751 Form\form_us.xml.h:481 Form\form_us.xml.h:995
+#: Form\form_us.xml.h:1033 Form\form_us.xml.h:1128 Form\form_us.xml.h:1776
+#: Form\form_us.xml.h:1985
+msgid "Idiotic"
+msgstr ""
+
+#: Form\form_ca.xml.h:752
+msgid "41. Idiotic or silly"
+msgstr ""
+
+#: Form\form_ca.xml.h:761
+msgid "1. House"
+msgstr ""
+
+#: Form\form_ca.xml.h:762
+msgid "Dwelling house"
+msgstr ""
+
+#: Form\form_ca.xml.h:763
+msgid "2. Family"
+msgstr ""
+
+#: Form\form_ca.xml.h:764
+msgid "Family or household"
+msgstr ""
+
+#: Form\form_ca.xml.h:765
+msgid "3. Name"
+msgstr ""
+
+#: Form\form_ca.xml.h:766
+msgid "Name of each person in family"
+msgstr ""
+
+#: Form\form_ca.xml.h:770
+msgid "5. Relation to head of family"
+msgstr ""
+
+#: Form\form_ca.xml.h:772
+msgid "6. Single, married, widowed, divorced or legally separated"
+msgstr ""
+
+#: Form\form_ca.xml.h:774
+msgid "7. Month of birth"
+msgstr ""
+
+#: Form\form_ca.xml.h:776
+msgid "8. Age at last birthday"
+msgstr ""
+
+#: Form\form_ca.xml.h:778
+msgid "9. Country or place of birth"
+msgstr ""
+
+#: Form\form_ca.xml.h:780
+msgid "10. Racial or tribal origin"
+msgstr ""
+
+#: Form\form_ca.xml.h:782
+msgid "11. Religion"
+msgstr ""
+
+#: Form\form_ca.xml.h:784
+msgid "12. Months at school in 1910"
+msgstr ""
+
+#: Form\form_ca.xml.h:786
+msgid "13. Can Read"
+msgstr ""
+
+#: Form\form_ca.xml.h:788
+msgid "14. Can Write"
+msgstr ""
+
+#: Form\form_ca.xml.h:790
+msgid "15. Language commonly spoken"
+msgstr ""
+
+#: Form\form_ca.xml.h:792
+msgid ""
+"16. Infirmities: a. blind; b. deaf and dumb; c. idotic or silly; d. crazy or "
+"lunatic"
+msgstr ""
+
+#: Form\form_ca.xml.h:805
+msgid "1. Dwelling House"
+msgstr ""
+
+#: Form\form_ca.xml.h:807
+msgid "2. Family, Household or Institution"
+msgstr ""
+
+#: Form\form_ca.xml.h:809
+msgid "3. Name of each person in family, household or institution"
+msgstr ""
+
+#: Form\form_ca.xml.h:810
+msgid "MilitaryService"
+msgstr ""
+
+#: Form\form_ca.xml.h:811
+msgid "4. Military Service"
+msgstr ""
+
+#: Form\form_ca.xml.h:813
+msgid "5. Place of Habitation: Township"
+msgstr ""
+
+#: Form\form_ca.xml.h:815
+msgid "6. Place of Habitation: Range"
+msgstr ""
+
+#: Form\form_ca.xml.h:817
+msgid "7. Place of Habitation: Meridian"
+msgstr ""
+
+#: Form\form_ca.xml.h:818
+msgid "Municipality"
+msgstr ""
+
+#: Form\form_ca.xml.h:819
+msgid "8. Place of Habitation: Municipality"
+msgstr ""
+
+#: Form\form_ca.xml.h:821
+msgid "9. Relationship to head of family or household"
+msgstr ""
+
+#: Form\form_ca.xml.h:823
+msgid "10. Sex"
+msgstr ""
+
+#: Form\form_ca.xml.h:825
+msgid "11. Single, married, widowed, divorced or legally separated"
+msgstr ""
+
+#: Form\form_ca.xml.h:827
+msgid "12. Age at last birthday"
+msgstr ""
+
+#: Form\form_ca.xml.h:829
+msgid "13. Country or place of birth"
+msgstr ""
+
+#: Form\form_ca.xml.h:831
+msgid "14. Religion"
+msgstr ""
+
+#: Form\form_ca.xml.h:833
+msgid "15. Year of immigration to Canada"
+msgstr ""
+
+#: Form\form_ca.xml.h:835
+msgid "16. Year of naturalization"
+msgstr ""
+
+#: Form\form_ca.xml.h:837
+msgid "17. Nationality"
+msgstr ""
+
+#: Form\form_ca.xml.h:839
+msgid "18. Race or tribal origin"
+msgstr ""
+
+#: Form\form_ca.xml.h:841
+msgid "19. Can speak English"
+msgstr ""
+
+#: Form\form_ca.xml.h:843
+msgid "20. Can speak French"
+msgstr ""
+
+#: Form\form_ca.xml.h:844
+msgid "OtherLanguage"
+msgstr ""
+
+#: Form\form_ca.xml.h:845
+msgid "21. Other language spoken as mother tongue"
+msgstr ""
+
+#: Form\form_ca.xml.h:847
+msgid "22. Can Read"
+msgstr ""
+
+#: Form\form_ca.xml.h:849
+msgid "23. Can Write"
+msgstr ""
+
+#: Form\form_ca.xml.h:851
+msgid "24. Chief occupation or trade"
+msgstr ""
+
+#: Form\form_ca.xml.h:852
+msgid "Employment"
+msgstr ""
+
+#: Form\form_ca.xml.h:853
+msgid "25. Employer, \"E\", Employee, \"W\""
+msgstr ""
+
+#: Form\form_ca.xml.h:854
+msgid "EmploymentPlace"
+msgstr ""
+
+#: Form\form_ca.xml.h:855
+msgid "26. State where person is employed"
+msgstr ""
+
+#: Form\form_dk.xml.h:2 Form\form_dk.xml.h:19 Form\form_dk.xml.h:36
+#: Form\form_dk.xml.h:51 Form\form_dk.xml.h:68 Form\form_dk.xml.h:85
+#: Form\form_dk.xml.h:102 Form\form_dk.xml.h:121 Form\form_dk.xml.h:140
+#: Form\form_dk.xml.h:159 Form\form_dk.xml.h:182 Form\form_dk.xml.h:205
+#: Form\form_dk.xml.h:226 Form\form_dk.xml.h:250 Form\form_dk.xml.h:284
+#: Form\form_dk.xml.h:313 Form\form_dk.xml.h:337 Form\form_dk.xml.h:363
+#: Form\form_dk.xml.h:387 Form\form_dk.xml.h:407 Form\form_dk.xml.h:427
+msgid "Amt"
+msgstr ""
+
+#: Form\form_dk.xml.h:3 Form\form_dk.xml.h:20 Form\form_dk.xml.h:37
+#: Form\form_dk.xml.h:52 Form\form_dk.xml.h:69 Form\form_dk.xml.h:86
+#: Form\form_dk.xml.h:103 Form\form_dk.xml.h:122 Form\form_dk.xml.h:141
+#: Form\form_dk.xml.h:160 Form\form_dk.xml.h:183 Form\form_dk.xml.h:206
+#: Form\form_dk.xml.h:227 Form\form_dk.xml.h:251 Form\form_dk.xml.h:285
+#: Form\form_dk.xml.h:314 Form\form_dk.xml.h:338 Form\form_dk.xml.h:364
+#: Form\form_dk.xml.h:388 Form\form_dk.xml.h:408 Form\form_dk.xml.h:428
+msgid "Town or City"
+msgstr ""
+
+#: Form\form_dk.xml.h:4 Form\form_dk.xml.h:21 Form\form_dk.xml.h:38
+#: Form\form_dk.xml.h:53 Form\form_dk.xml.h:70 Form\form_dk.xml.h:87
+#: Form\form_dk.xml.h:104 Form\form_dk.xml.h:123 Form\form_dk.xml.h:142
+#: Form\form_dk.xml.h:161 Form\form_dk.xml.h:184 Form\form_dk.xml.h:207
+#: Form\form_dk.xml.h:228 Form\form_dk.xml.h:252 Form\form_dk.xml.h:286
+#: Form\form_dk.xml.h:315 Form\form_dk.xml.h:339 Form\form_dk.xml.h:365
+#: Form\form_dk.xml.h:389 Form\form_dk.xml.h:409 Form\form_dk.xml.h:429
+msgid "Herred eller By"
+msgstr ""
+
+#: Form\form_dk.xml.h:5 Form\form_dk.xml.h:22 Form\form_dk.xml.h:39
+#: Form\form_dk.xml.h:54 Form\form_dk.xml.h:71 Form\form_dk.xml.h:88
+#: Form\form_dk.xml.h:105 Form\form_dk.xml.h:124 Form\form_dk.xml.h:143
+#: Form\form_dk.xml.h:162 Form\form_dk.xml.h:185 Form\form_dk.xml.h:208
+#: Form\form_dk.xml.h:229 Form\form_dk.xml.h:253 Form\form_dk.xml.h:287
+#: Form\form_dk.xml.h:316 Form\form_dk.xml.h:340 Form\form_dk.xml.h:366
+#: Form\form_dk.xml.h:390 Form\form_dk.xml.h:410 Form\form_dk.xml.h:430
+#: Form\form_gb.xml.h:234 Form\form_gb.xml.h:242 Form\form_gb.xml.h:257
+#: Form\form_gb.xml.h:437
+msgid "Parish"
+msgstr ""
+
+#: Form\form_dk.xml.h:6 Form\form_dk.xml.h:23 Form\form_dk.xml.h:40
+#: Form\form_dk.xml.h:55 Form\form_dk.xml.h:72 Form\form_dk.xml.h:89
+#: Form\form_dk.xml.h:106 Form\form_dk.xml.h:125 Form\form_dk.xml.h:144
+#: Form\form_dk.xml.h:163 Form\form_dk.xml.h:186 Form\form_dk.xml.h:209
+#: Form\form_dk.xml.h:230 Form\form_dk.xml.h:254 Form\form_dk.xml.h:288
+#: Form\form_dk.xml.h:317 Form\form_dk.xml.h:341 Form\form_dk.xml.h:367
+#: Form\form_dk.xml.h:391 Form\form_dk.xml.h:411 Form\form_dk.xml.h:431
+msgid "Sogn"
+msgstr ""
+
+#: Form\form_dk.xml.h:7 Form\form_dk.xml.h:24 Form\form_dk.xml.h:41
+#: Form\form_dk.xml.h:56 Form\form_dk.xml.h:73 Form\form_dk.xml.h:90
+#: Form\form_dk.xml.h:107 Form\form_dk.xml.h:126 Form\form_dk.xml.h:145
+#: Form\form_dk.xml.h:164 Form\form_dk.xml.h:187 Form\form_dk.xml.h:210
+#: Form\form_dk.xml.h:231 Form\form_dk.xml.h:255 Form\form_dk.xml.h:289
+#: Form\form_dk.xml.h:318 Form\form_dk.xml.h:342 Form\form_dk.xml.h:368
+#: Form\form_dk.xml.h:392 Form\form_dk.xml.h:412 Form\form_dk.xml.h:432
+#: Form\form_gb.xml.h:416 Form\form_gb.xml.h:444 Form\form_us.xml.h:1337
+#: Form\form_us.xml.h:1514 Form\form_us.xml.h:1593
+msgid "Street"
+msgstr ""
+
+#: Form\form_dk.xml.h:8 Form\form_dk.xml.h:25 Form\form_dk.xml.h:42
+#: Form\form_dk.xml.h:57 Form\form_dk.xml.h:74 Form\form_dk.xml.h:91
+#: Form\form_dk.xml.h:108 Form\form_dk.xml.h:127 Form\form_dk.xml.h:146
+#: Form\form_dk.xml.h:165 Form\form_dk.xml.h:188 Form\form_dk.xml.h:211
+#: Form\form_dk.xml.h:232 Form\form_dk.xml.h:256 Form\form_dk.xml.h:290
+#: Form\form_dk.xml.h:319 Form\form_dk.xml.h:343 Form\form_dk.xml.h:369
+#: Form\form_dk.xml.h:393 Form\form_dk.xml.h:413 Form\form_dk.xml.h:433
+msgid "Gade"
+msgstr ""
+
+#: Form\form_dk.xml.h:10 Form\form_dk.xml.h:27 Form\form_dk.xml.h:44
+#: Form\form_dk.xml.h:59 Form\form_dk.xml.h:76 Form\form_dk.xml.h:93
+#: Form\form_dk.xml.h:110 Form\form_dk.xml.h:129 Form\form_dk.xml.h:148
+#: Form\form_dk.xml.h:169 Form\form_dk.xml.h:192 Form\form_dk.xml.h:213
+#: Form\form_dk.xml.h:234 Form\form_dk.xml.h:258 Form\form_dk.xml.h:293
+#: Form\form_fr.xml.h:153 Form\form_fr.xml.h:162 Form\form_fr.xml.h:170
+#: Form\form_fr.xml.h:179 Form\form_fr.xml.h:188 Form\form_fr.xml.h:197
+#: Form\form_fr.xml.h:206 Form\form_fr.xml.h:217 Form\form_gb.xml.h:23
+#: Form\form_gb.xml.h:61 Form\form_gb.xml.h:75 Form\form_gb.xml.h:90
+#: Form\form_gb.xml.h:105 Form\form_gb.xml.h:120 Form\form_gb.xml.h:138
+#: Form\form_gb.xml.h:150 Form\form_gb.xml.h:171 Form\form_gb.xml.h:184
+#: Form\form_gb.xml.h:204 Form\form_gb.xml.h:218 Form\form_gb.xml.h:252
+#: Form\form_gb.xml.h:273 Form\form_gb.xml.h:300 Form\form_gb.xml.h:328
+#: Form\form_gb.xml.h:360 Form\form_gb.xml.h:399 Form\form_gb.xml.h:427
+#: Form\form_gb.xml.h:455 Form\form_us.xml.h:1543 Form\form_us.xml.h:1557
+#: Form\form_us.xml.h:2318
+msgid "Condition"
+msgstr ""
+
+#: Form\form_dk.xml.h:11 Form\form_dk.xml.h:28 Form\form_dk.xml.h:45
+#: Form\form_dk.xml.h:60 Form\form_dk.xml.h:77 Form\form_dk.xml.h:94
+#: Form\form_dk.xml.h:111 Form\form_dk.xml.h:130 Form\form_dk.xml.h:149
+#: Form\form_dk.xml.h:170 Form\form_dk.xml.h:193 Form\form_dk.xml.h:214
+#: Form\form_dk.xml.h:235 Form\form_dk.xml.h:259 Form\form_dk.xml.h:294
+msgid "Gift"
+msgstr ""
+
+#: Form\form_dk.xml.h:13 Form\form_dk.xml.h:30 Form\form_dk.xml.h:47
+#: Form\form_dk.xml.h:62 Form\form_dk.xml.h:79 Form\form_dk.xml.h:96
+#: Form\form_dk.xml.h:113 Form\form_dk.xml.h:132 Form\form_dk.xml.h:151
+#: Form\form_dk.xml.h:172 Form\form_dk.xml.h:195 Form\form_dk.xml.h:216
+#: Form\form_dk.xml.h:237
+msgid "Alder"
+msgstr ""
+
+#: Form\form_dk.xml.h:15 Form\form_dk.xml.h:32 Form\form_dk.xml.h:49
+#: Form\form_dk.xml.h:66 Form\form_dk.xml.h:83 Form\form_dk.xml.h:100
+#: Form\form_dk.xml.h:119 Form\form_dk.xml.h:138 Form\form_dk.xml.h:157
+#: Form\form_dk.xml.h:178 Form\form_dk.xml.h:201 Form\form_dk.xml.h:222
+#: Form\form_dk.xml.h:243 Form\form_dk.xml.h:271 Form\form_dk.xml.h:306
+#: Form\form_dk.xml.h:332 Form\form_dk.xml.h:348 Form\form_dk.xml.h:380
+#: Form\form_dk.xml.h:400 Form\form_dk.xml.h:422 Form\form_dk.xml.h:442
+msgid "Stilling i familien"
+msgstr ""
+
+#: Form\form_dk.xml.h:17
+msgid "Titel, Embed, Forretning, Håndværk"
+msgstr ""
+
+#: Form\form_dk.xml.h:34
+msgid "Stilling, embede eller erhverv"
+msgstr ""
+
+#: Form\form_dk.xml.h:63 Form\form_dk.xml.h:80 Form\form_dk.xml.h:97
+#: Form\form_dk.xml.h:116 Form\form_dk.xml.h:135 Form\form_dk.xml.h:152
+#: Form\form_dk.xml.h:173 Form\form_dk.xml.h:196 Form\form_dk.xml.h:217
+#: Form\form_dk.xml.h:238 Form\form_dk.xml.h:262 Form\form_dk.xml.h:297
+#: Form\form_dk.xml.h:323 Form\form_dk.xml.h:373 Form\form_dk.xml.h:397
+#: Form\form_dk.xml.h:419 Form\form_dk.xml.h:437 Form\form_fr.xml.h:3
+#: Form\form_fr.xml.h:11 Form\form_fr.xml.h:19 Form\form_fr.xml.h:27
+#: Form\form_fr.xml.h:103 Form\form_fr.xml.h:111 Form\form_fr.xml.h:139
+#: Form\form_fr.xml.h:157 Form\form_fr.xml.h:174 Form\form_fr.xml.h:183
+#: Form\form_fr.xml.h:192 Form\form_fr.xml.h:201 Form\form_fr.xml.h:211
+#: Form\form_gb.xml.h:53 Form\form_gb.xml.h:64 Form\form_gb.xml.h:78
+#: Form\form_gb.xml.h:93 Form\form_gb.xml.h:108 Form\form_gb.xml.h:127
+#: Form\form_gb.xml.h:145 Form\form_gb.xml.h:161 Form\form_gb.xml.h:191
+#: Form\form_gb.xml.h:211 Form\form_gb.xml.h:229 Form\form_gb.xml.h:255
+#: Form\form_gb.xml.h:277 Form\form_gb.xml.h:304 Form\form_gb.xml.h:332
+#: Form\form_gb.xml.h:368 Form\form_gb.xml.h:405 Form\form_gb.xml.h:428
+#: Form\form_gb.xml.h:460
+msgid "Where Born"
+msgstr ""
+
+#: Form\form_dk.xml.h:64 Form\form_dk.xml.h:81 Form\form_dk.xml.h:98
+#: Form\form_dk.xml.h:117 Form\form_dk.xml.h:136 Form\form_dk.xml.h:153
+#: Form\form_dk.xml.h:174 Form\form_dk.xml.h:197 Form\form_dk.xml.h:218
+#: Form\form_dk.xml.h:239 Form\form_dk.xml.h:263 Form\form_dk.xml.h:298
+#: Form\form_dk.xml.h:324 Form\form_dk.xml.h:374 Form\form_dk.xml.h:398
+#: Form\form_dk.xml.h:420 Form\form_dk.xml.h:438
+msgid "Fødested"
+msgstr ""
+
+#: Form\form_dk.xml.h:115 Form\form_dk.xml.h:134
+msgid "Erhverv"
+msgstr ""
+
+#: Form\form_dk.xml.h:155 Form\form_dk.xml.h:176 Form\form_dk.xml.h:199
+#: Form\form_dk.xml.h:220 Form\form_dk.xml.h:241 Form\form_dk.xml.h:269
+#: Form\form_dk.xml.h:304 Form\form_dk.xml.h:326
+msgid "Trossamfund"
+msgstr ""
+
+#: Form\form_dk.xml.h:167 Form\form_dk.xml.h:190
+msgid "Sted"
+msgstr ""
+
+#: Form\form_dk.xml.h:179 Form\form_dk.xml.h:202 Form\form_dk.xml.h:223
+#: Form\form_dk.xml.h:247 Form\form_dk.xml.h:281 Form\form_dk.xml.h:310
+#: Form\form_dk.xml.h:352 Form\form_dk.xml.h:384 Form\form_dk.xml.h:404
+#: Form\form_fr.xml.h:8 Form\form_fr.xml.h:16 Form\form_fr.xml.h:24
+#: Form\form_fr.xml.h:32 Form\form_fr.xml.h:39 Form\form_fr.xml.h:44
+#: Form\form_fr.xml.h:49 Form\form_fr.xml.h:58 Form\form_fr.xml.h:63
+#: Form\form_fr.xml.h:68 Form\form_fr.xml.h:73 Form\form_fr.xml.h:82
+#: Form\form_fr.xml.h:88 Form\form_fr.xml.h:94 Form\form_fr.xml.h:100
+#: Form\form_fr.xml.h:108 Form\form_fr.xml.h:116 Form\form_fr.xml.h:122
+#: Form\form_fr.xml.h:129 Form\form_fr.xml.h:136 Form\form_fr.xml.h:146
+#: Form\form_fr.xml.h:154 Form\form_fr.xml.h:163 Form\form_fr.xml.h:171
+#: Form\form_fr.xml.h:180 Form\form_fr.xml.h:189 Form\form_fr.xml.h:198
+#: Form\form_fr.xml.h:207 Form\form_fr.xml.h:223
+msgid "Comments"
+msgstr ""
+
+#: Form\form_dk.xml.h:180 Form\form_dk.xml.h:203 Form\form_dk.xml.h:224
+#: Form\form_dk.xml.h:248 Form\form_dk.xml.h:282 Form\form_dk.xml.h:311
+msgid "Bemærkninger"
+msgstr ""
+
+#: Form\form_dk.xml.h:245 Form\form_dk.xml.h:273 Form\form_dk.xml.h:308
+#: Form\form_dk.xml.h:334 Form\form_dk.xml.h:350 Form\form_dk.xml.h:382
+#: Form\form_dk.xml.h:424 Form\form_dk.xml.h:444
+msgid "Place of Work"
+msgstr ""
+
+#: Form\form_dk.xml.h:246 Form\form_dk.xml.h:274 Form\form_dk.xml.h:309
+#: Form\form_dk.xml.h:335 Form\form_dk.xml.h:351 Form\form_dk.xml.h:383
+#: Form\form_dk.xml.h:425 Form\form_dk.xml.h:445
+msgid "Arbejdssted"
+msgstr ""
+
+#: Form\form_dk.xml.h:260 Form\form_dk.xml.h:295 Form\form_dk.xml.h:321
+#: Form\form_dk.xml.h:345 Form\form_dk.xml.h:371 Form\form_dk.xml.h:395
+#: Form\form_dk.xml.h:417 Form\form_dk.xml.h:435 Form\form_us.xml.h:897
+#: Form\form_us.xml.h:921 Form\form_us.xml.h:2286 Form\form_us.xml.h:2468
+msgid "Date of Birth"
+msgstr ""
+
+#: Form\form_dk.xml.h:261 Form\form_dk.xml.h:296 Form\form_dk.xml.h:322
+#: Form\form_dk.xml.h:346 Form\form_dk.xml.h:372 Form\form_dk.xml.h:396
+#: Form\form_dk.xml.h:418 Form\form_dk.xml.h:436
+msgid "Fødselsdato"
+msgstr ""
+
+#: Form\form_dk.xml.h:264 Form\form_dk.xml.h:299 Form\form_dk.xml.h:375
+msgid "Years at current residence"
+msgstr ""
+
+#: Form\form_dk.xml.h:265 Form\form_dk.xml.h:300 Form\form_dk.xml.h:376
+msgid "År tilflyttet"
+msgstr ""
+
+#: Form\form_dk.xml.h:266 Form\form_dk.xml.h:301 Form\form_dk.xml.h:377
+msgid "Previous residence"
+msgstr ""
+
+#: Form\form_dk.xml.h:267 Form\form_dk.xml.h:302 Form\form_dk.xml.h:378
+msgid "Tilflyttet fra"
+msgstr ""
+
+#: Form\form_dk.xml.h:275 Form\form_us.xml.h:2007 Form\form_us.xml.h:2045
+#: Form\form_us.xml.h:2083 Form\form_us.xml.h:2121
+msgid "Year married"
+msgstr ""
+
+#: Form\form_dk.xml.h:276
+msgid "År gift"
+msgstr ""
+
+#: Form\form_dk.xml.h:277 Form\form_gb.xml.h:153 Form\form_gb.xml.h:221
+#: Form\form_gb.xml.h:459
+msgid "Children Living"
+msgstr ""
+
+#: Form\form_dk.xml.h:278
+msgid "Levende børn"
+msgstr ""
+
+#: Form\form_dk.xml.h:279
+msgid "Children Dead"
+msgstr ""
+
+#: Form\form_dk.xml.h:280
+msgid "Døde børn"
+msgstr ""
+
+#: Form\form_dk.xml.h:292
+msgid "Køn"
+msgstr ""
+
+#: Form\form_dk.xml.h:327
+msgid "Year stayed in parish"
+msgstr ""
+
+#: Form\form_dk.xml.h:328
+msgid "Hvilket aar taget ophold i sognet"
+msgstr ""
+
+#: Form\form_dk.xml.h:329
+msgid "Previous Residence"
+msgstr ""
+
+#: Form\form_dk.xml.h:330
+msgid "Sidste bopæl inden tilflytning"
+msgstr ""
+
+#: Form\form_dk.xml.h:353 Form\form_dk.xml.h:385 Form\form_dk.xml.h:405
+msgid "Bemærkning"
+msgstr ""
+
+#: Form\form_dk.xml.h:354
+msgid "Income"
+msgstr ""
+
+#: Form\form_dk.xml.h:355
+msgid "Indkomst"
+msgstr ""
+
+#: Form\form_dk.xml.h:356
+msgid "Assets"
+msgstr ""
+
+#: Form\form_dk.xml.h:357
+msgid "Formue"
+msgstr ""
+
+#: Form\form_dk.xml.h:358
+msgid "State Tax"
+msgstr ""
+
+#: Form\form_dk.xml.h:359
+msgid "Statsskat"
+msgstr ""
+
+#: Form\form_dk.xml.h:360
+msgid "Council"
+msgstr ""
+
+#: Form\form_dk.xml.h:361
+msgid "Kommuneskat"
+msgstr ""
+
+#: Form\form_dk.xml.h:402
+msgid "Residence on 5 Nov 1924"
+msgstr ""
+
+#: Form\form_dk.xml.h:403
+msgid "Bopæl 5 nov 1924"
+msgstr ""
+
+#: Form\form_dk.xml.h:415
+msgid "Stay on 5 Nov 1929"
+msgstr ""
+
+#: Form\form_dk.xml.h:416
+msgid "Ophold 5 nov 1929"
+msgstr ""
+
+#: Form\form_dk.xml.h:439
+msgid "Date Married"
+msgstr ""
+
+#: Form\form_dk.xml.h:440
+msgid "Dato gift"
+msgstr ""
+
+#: Form\form_fr.xml.h:2 Form\form_fr.xml.h:10 Form\form_fr.xml.h:18
+#: Form\form_fr.xml.h:26 Form\form_fr.xml.h:138 Form\form_fr.xml.h:210
+#: Form\form_us.xml.h:2264 Form\form_us.xml.h:2439
+msgid "Date of birth"
+msgstr ""
+
+#: Form\form_fr.xml.h:6 Form\form_fr.xml.h:14 Form\form_fr.xml.h:22
+#: Form\form_fr.xml.h:30 Form\form_fr.xml.h:37 Form\form_fr.xml.h:43
+#: Form\form_fr.xml.h:48 Form\form_fr.xml.h:52 Form\form_fr.xml.h:61
+#: Form\form_fr.xml.h:65 Form\form_fr.xml.h:71 Form\form_fr.xml.h:76
+#: Form\form_fr.xml.h:85 Form\form_fr.xml.h:91 Form\form_fr.xml.h:97
+#: Form\form_fr.xml.h:104 Form\form_fr.xml.h:112 Form\form_fr.xml.h:140
+#: Form\form_fr.xml.h:212
+msgid "Status"
+msgstr ""
+
+#: Form\form_fr.xml.h:38 Form\form_fr.xml.h:55 Form\form_fr.xml.h:220
+msgid "Can read and write"
+msgstr ""
+
+#: Form\form_fr.xml.h:41 Form\form_fr.xml.h:46 Form\form_pl.xml.h:6
+#: Form\form_pl.xml.h:25 Form\form_pl.xml.h:34
+msgid "Gender"
+msgstr ""
+
+#: Form\form_fr.xml.h:42 Form\form_fr.xml.h:47
+msgid "Military"
+msgstr ""
+
+#: Form\form_fr.xml.h:51 Form\form_fr.xml.h:156 Form\form_fr.xml.h:173
+#: Form\form_fr.xml.h:182 Form\form_fr.xml.h:191 Form\form_fr.xml.h:200
+#: Form\form_us.xml.h:677
+msgid "Year of birth"
+msgstr ""
+
+#: Form\form_fr.xml.h:54 Form\form_fr.xml.h:78 Form\form_fr.xml.h:87
+#: Form\form_fr.xml.h:93 Form\form_fr.xml.h:99 Form\form_fr.xml.h:106
+#: Form\form_fr.xml.h:114 Form\form_fr.xml.h:120 Form\form_fr.xml.h:126
+#: Form\form_fr.xml.h:133 Form\form_fr.xml.h:150 Form\form_fr.xml.h:159
+#: Form\form_fr.xml.h:167 Form\form_fr.xml.h:176 Form\form_fr.xml.h:185
+#: Form\form_fr.xml.h:194 Form\form_fr.xml.h:203 Form\form_fr.xml.h:214
+#: Form\form_gb.xml.h:250 Form\form_gb.xml.h:267 Form\form_gb.xml.h:294
+#: Form\form_gb.xml.h:322 Form\form_gb.xml.h:354 Form\form_gb.xml.h:393
+#: Form\form_us.xml.h:1047 Form\form_us.xml.h:1063
+msgid "Address"
+msgstr ""
+
+#: Form\form_fr.xml.h:56 Form\form_fr.xml.h:221
+msgid "Taxes"
+msgstr ""
+
+#: Form\form_fr.xml.h:57 Form\form_fr.xml.h:67 Form\form_fr.xml.h:222
+msgid "Type of roof"
+msgstr ""
+
+#: Form\form_fr.xml.h:81 Form\form_fr.xml.h:219 Form\form_gb.xml.h:65
+#: Form\form_gb.xml.h:79 Form\form_gb.xml.h:94 Form\form_gb.xml.h:109
+#: Form\form_gb.xml.h:128 Form\form_gb.xml.h:146 Form\form_gb.xml.h:163
+#: Form\form_gb.xml.h:192 Form\form_gb.xml.h:212 Form\form_gb.xml.h:231
+#: Form\form_gb.xml.h:431 Form\form_gb.xml.h:463 Form\form_us.xml.h:2458
+msgid "Disability"
+msgstr ""
+
+#: Form\form_fr.xml.h:144
+msgid "Arrived since"
+msgstr ""
+
+#: Form\form_gb.xml.h:1 Form\form_gb.xml.h:17 Form\form_gb.xml.h:34
+#: Form\form_us.xml.h:2255 Form\form_us.xml.h:2313 Form\form_us.xml.h:2339
+#: Form\form_us.xml.h:2371
+msgid "Certificate Number"
+msgstr ""
+
+#: Form\form_gb.xml.h:2 Form\form_gb.xml.h:18 Form\form_gb.xml.h:35
+#: Form\form_us.xml.h:2256 Form\form_us.xml.h:2314 Form\form_us.xml.h:2340
+#: Form\form_us.xml.h:2372
+msgid "Entry Number"
+msgstr ""
+
+#: Form\form_gb.xml.h:3 Form\form_gb.xml.h:36
+msgid "Registration District"
+msgstr ""
+
+#: Form\form_gb.xml.h:4 Form\form_gb.xml.h:37 Form\form_us.xml.h:2257
+#: Form\form_us.xml.h:2341 Form\form_us.xml.h:2373
+msgid "Date Registered"
+msgstr ""
+
+#: Form\form_gb.xml.h:5 Form\form_gb.xml.h:38 Form\form_us.xml.h:2258
+#: Form\form_us.xml.h:2342 Form\form_us.xml.h:2374
+msgid "Registrar"
+msgstr ""
+
+#: Form\form_gb.xml.h:11
+msgid "Maiden Surname"
+msgstr ""
+
+#: Form\form_gb.xml.h:14 Form\form_gb.xml.h:21 Form\form_gb.xml.h:33
+#: Form\form_gb.xml.h:45 Form\form_us.xml.h:967
+msgid "Signed"
+msgstr ""
+
+#: Form\form_gb.xml.h:15 Form\form_gb.xml.h:46 Form\form_us.xml.h:2279
+msgid "Description"
+msgstr ""
+
+#: Form\form_gb.xml.h:19
+msgid "Banns/Licence"
+msgstr ""
+
+#: Form\form_gb.xml.h:27 Form\form_gb.xml.h:30
+msgid "Deceased"
+msgstr ""
+
+#: Form\form_gb.xml.h:43 Form\form_us.xml.h:2368 Form\form_us.xml.h:2408
+msgid "Cause of Death"
+msgstr ""
+
+#: Form\form_gb.xml.h:48 Form\form_gb.xml.h:56
+msgid "City or Borough"
+msgstr ""
+
+#: Form\form_gb.xml.h:49 Form\form_gb.xml.h:54 Form\form_gb.xml.h:66
+msgid "Parish or Township"
+msgstr ""
+
+#: Form\form_gb.xml.h:55 Form\form_gb.xml.h:72 Form\form_gb.xml.h:87
+msgid "Ecclesiastical District"
+msgstr ""
+
+#: Form\form_gb.xml.h:57 Form\form_gb.xml.h:70 Form\form_gb.xml.h:84
+#: Form\form_gb.xml.h:261 Form\form_gb.xml.h:289 Form\form_gb.xml.h:317
+#: Form\form_gb.xml.h:348 Form\form_gb.xml.h:387 Form\form_us.xml.h:1891
+#: Form\form_us.xml.h:1912
+msgid "Town"
+msgstr ""
+
+#: Form\form_gb.xml.h:58 Form\form_gb.xml.h:262
+msgid "Village"
+msgstr ""
+
+#: Form\form_gb.xml.h:67 Form\form_gb.xml.h:81 Form\form_gb.xml.h:96
+msgid "City or Municipal Borough"
+msgstr ""
+
+#: Form\form_gb.xml.h:68 Form\form_gb.xml.h:82 Form\form_gb.xml.h:97
+#: Form\form_gb.xml.h:112 Form\form_gb.xml.h:176
+msgid "Municipal Ward"
+msgstr ""
+
+#: Form\form_gb.xml.h:69 Form\form_gb.xml.h:83 Form\form_gb.xml.h:98
+#: Form\form_gb.xml.h:440
+msgid "Parliamentary Borough"
+msgstr ""
+
+#: Form\form_gb.xml.h:71
+msgid "Hamlet or Tything"
+msgstr ""
+
+#: Form\form_gb.xml.h:80 Form\form_gb.xml.h:95
+msgid "Civil Parish or Township"
+msgstr ""
+
+#: Form\form_gb.xml.h:85 Form\form_gb.xml.h:290 Form\form_gb.xml.h:318
+#: Form\form_gb.xml.h:349 Form\form_gb.xml.h:388
+msgid "Village or Hamlet"
+msgstr ""
+
+#: Form\form_gb.xml.h:86
+msgid "Local Board or Improvement Commissioners District"
+msgstr ""
+
+#: Form\form_gb.xml.h:99 Form\form_gb.xml.h:114 Form\form_gb.xml.h:178
+msgid "Town, Village or Hamlet"
+msgstr ""
+
+#: Form\form_gb.xml.h:100 Form\form_gb.xml.h:113 Form\form_gb.xml.h:177
+msgid "Urban Sanitary District"
+msgstr ""
+
+#: Form\form_gb.xml.h:101 Form\form_gb.xml.h:115 Form\form_gb.xml.h:179
+msgid "Rural Sanitary District"
+msgstr ""
+
+#: Form\form_gb.xml.h:102 Form\form_gb.xml.h:117 Form\form_gb.xml.h:181
+msgid "Ecclesiastical Parish or District"
+msgstr ""
+
+#: Form\form_gb.xml.h:110 Form\form_gb.xml.h:129 Form\form_gb.xml.h:174
+#: Form\form_gb.xml.h:195 Form\form_gb.xml.h:284 Form\form_gb.xml.h:311
+#: Form\form_gb.xml.h:339 Form\form_gb.xml.h:376
+msgid "Civil Parish"
+msgstr ""
+
+#: Form\form_gb.xml.h:111 Form\form_gb.xml.h:175
+msgid "Municipal Borough"
+msgstr ""
+
+#: Form\form_gb.xml.h:116 Form\form_gb.xml.h:134 Form\form_gb.xml.h:180
+#: Form\form_gb.xml.h:200
+msgid "Parliamentary Borough or Division"
+msgstr ""
+
+#: Form\form_gb.xml.h:124 Form\form_gb.xml.h:188 Form\form_gb.xml.h:365
+#: Form\form_us.xml.h:819
+msgid "Employed"
+msgstr ""
+
+#: Form\form_gb.xml.h:125 Form\form_gb.xml.h:189 Form\form_gb.xml.h:366
+msgid "Neither"
+msgstr ""
+
+#: Form\form_gb.xml.h:126 Form\form_gb.xml.h:190 Form\form_gb.xml.h:367
+msgid "Neither Employer nor Employed"
+msgstr ""
+
+#: Form\form_gb.xml.h:130 Form\form_gb.xml.h:196 Form\form_gb.xml.h:378
+msgid "Ecclesiastical Parish"
+msgstr ""
+
+#: Form\form_gb.xml.h:131 Form\form_gb.xml.h:197
+msgid "County Borough, Municipal Borough, or Urban District"
+msgstr ""
+
+#: Form\form_gb.xml.h:132 Form\form_gb.xml.h:198
+msgid "Ward of Municipal Borough or of Urban District"
+msgstr ""
+
+#: Form\form_gb.xml.h:133 Form\form_gb.xml.h:199
+msgid "Rural District"
+msgstr ""
+
+#: Form\form_gb.xml.h:135 Form\form_gb.xml.h:201
+msgid "Town or Village or Hamlet"
+msgstr ""
+
+#: Form\form_gb.xml.h:141 Form\form_gb.xml.h:157 Form\form_gb.xml.h:207
+#: Form\form_gb.xml.h:225
+msgid "Work Type"
+msgstr ""
+
+#: Form\form_gb.xml.h:142 Form\form_gb.xml.h:158 Form\form_gb.xml.h:208
+#: Form\form_gb.xml.h:226
+msgid "Employer, Worker or Own Account"
+msgstr ""
+
+#: Form\form_gb.xml.h:143 Form\form_gb.xml.h:159 Form\form_gb.xml.h:209
+#: Form\form_gb.xml.h:227
+msgid "At Home"
+msgstr ""
+
+#: Form\form_gb.xml.h:144 Form\form_gb.xml.h:160 Form\form_gb.xml.h:210
+#: Form\form_gb.xml.h:228 Form\form_gb.xml.h:404
+msgid "Working at Home"
+msgstr ""
+
+#: Form\form_gb.xml.h:151 Form\form_gb.xml.h:219 Form\form_gb.xml.h:456
+msgid "Years Married"
+msgstr ""
+
+#: Form\form_gb.xml.h:152 Form\form_gb.xml.h:220
+msgid "Children Total"
+msgstr ""
+
+#: Form\form_gb.xml.h:154 Form\form_gb.xml.h:222
+msgid "Children Died"
+msgstr ""
+
+#: Form\form_gb.xml.h:156 Form\form_gb.xml.h:224 Form\form_us.xml.h:778
+#: Form\form_us.xml.h:817 Form\form_us.xml.h:864 Form\form_us.xml.h:1529
+msgid "Industry"
+msgstr ""
+
+#: Form\form_gb.xml.h:164
+msgid "E.D. Letter Code"
+msgstr ""
+
+#: Form\form_gb.xml.h:165
+msgid "Borough, U.D. or R.D."
+msgstr ""
+
+#: Form\form_gb.xml.h:166
+msgid "Registration District and Sub-district"
+msgstr ""
+
+#: Form\form_gb.xml.h:168
+msgid "OVSPI"
+msgstr ""
+
+#: Form\form_gb.xml.h:170 Form\form_us.xml.h:2381
+msgid "Birth Date"
+msgstr ""
+
+#: Form\form_gb.xml.h:173
+msgid "Instructions"
+msgstr ""
+
+#: Form\form_gb.xml.h:194 Form\form_gb.xml.h:214 Form\form_gb.xml.h:233
+msgid "Language Spoken"
+msgstr ""
+
+#: Form\form_gb.xml.h:236 Form\form_gb.xml.h:247 Form\form_gb.xml.h:264
+#: Form\form_gb.xml.h:291 Form\form_gb.xml.h:319 Form\form_gb.xml.h:351
+#: Form\form_gb.xml.h:390
+msgid "GROS Data"
+msgstr ""
+
+#: Form\form_gb.xml.h:240
+msgid "Born in County"
+msgstr ""
+
+#: Form\form_gb.xml.h:241
+msgid "Foreigner, Born England or Ireland"
+msgstr ""
+
+#: Form\form_gb.xml.h:243 Form\form_gb.xml.h:258 Form\form_gb.xml.h:285
+#: Form\form_gb.xml.h:312 Form\form_gb.xml.h:340 Form\form_gb.xml.h:379
+msgid "Quoad Sacra Parish"
+msgstr ""
+
+#: Form\form_gb.xml.h:244 Form\form_gb.xml.h:259 Form\form_gb.xml.h:286
+#: Form\form_gb.xml.h:314 Form\form_gb.xml.h:342 Form\form_gb.xml.h:381
+msgid "Parliamentary Burgh"
+msgstr ""
+
+#: Form\form_gb.xml.h:245 Form\form_gb.xml.h:260 Form\form_gb.xml.h:287
+#: Form\form_gb.xml.h:315 Form\form_gb.xml.h:344 Form\form_gb.xml.h:383
+msgid "Royal Burgh"
+msgstr ""
+
+#: Form\form_gb.xml.h:246 Form\form_gb.xml.h:443
+msgid "Town or Village"
+msgstr ""
+
+#: Form\form_gb.xml.h:249
+msgid "House Schedule No"
+msgstr ""
+
+#: Form\form_gb.xml.h:251
+msgid "Relation to Head"
+msgstr ""
+
+#: Form\form_gb.xml.h:256
+msgid "Blind, or Deaf and Dumb"
+msgstr ""
+
+#: Form\form_gb.xml.h:263
+msgid "Enumeration District"
+msgstr ""
+
+#: Form\form_gb.xml.h:266 Form\form_gb.xml.h:293 Form\form_gb.xml.h:321
+#: Form\form_gb.xml.h:353 Form\form_gb.xml.h:392
+msgid "No. Of Schedule"
+msgstr ""
+
+#: Form\form_gb.xml.h:268 Form\form_gb.xml.h:295 Form\form_gb.xml.h:323
+#: Form\form_gb.xml.h:355 Form\form_gb.xml.h:394
+msgid "Road, Street, etc, and No. or Name of House"
+msgstr ""
+
+#: Form\form_gb.xml.h:269 Form\form_gb.xml.h:296 Form\form_gb.xml.h:324
+#: Form\form_gb.xml.h:356 Form\form_gb.xml.h:395
+msgid "House Inhabited"
+msgstr ""
+
+#: Form\form_gb.xml.h:270 Form\form_gb.xml.h:297 Form\form_gb.xml.h:325
+#: Form\form_gb.xml.h:357 Form\form_gb.xml.h:396
+msgid "House U or B"
+msgstr ""
+
+#: Form\form_gb.xml.h:272 Form\form_gb.xml.h:299 Form\form_gb.xml.h:327
+#: Form\form_gb.xml.h:359 Form\form_gb.xml.h:398 Form\form_gb.xml.h:420
+#: Form\form_gb.xml.h:449
+msgid "Relation to Head of Family"
+msgstr ""
+
+#: Form\form_gb.xml.h:276 Form\form_gb.xml.h:303 Form\form_gb.xml.h:331
+#: Form\form_gb.xml.h:363
+msgid "Rank, Profession, or Occupation"
+msgstr ""
+
+#: Form\form_gb.xml.h:278 Form\form_gb.xml.h:305 Form\form_gb.xml.h:333
+#: Form\form_gb.xml.h:370 Form\form_gb.xml.h:407 Form\form_us.xml.h:1409
+msgid "Disabled"
+msgstr ""
+
+#: Form\form_gb.xml.h:279
+msgid "Whether Blind, or Deaf and Dumb"
+msgstr ""
+
+#: Form\form_gb.xml.h:280 Form\form_gb.xml.h:307 Form\form_gb.xml.h:335
+#: Form\form_gb.xml.h:372 Form\form_gb.xml.h:409
+msgid "Children"
+msgstr ""
+
+#: Form\form_gb.xml.h:281 Form\form_gb.xml.h:308 Form\form_gb.xml.h:336
+#: Form\form_gb.xml.h:373 Form\form_gb.xml.h:410
+msgid "No. of Children from 5 to 13 attending School"
+msgstr ""
+
+#: Form\form_gb.xml.h:282 Form\form_gb.xml.h:309 Form\form_gb.xml.h:337
+#: Form\form_gb.xml.h:374 Form\form_gb.xml.h:411
+msgid "WindowRooms"
+msgstr ""
+
+#: Form\form_gb.xml.h:283 Form\form_gb.xml.h:310 Form\form_gb.xml.h:338
+#: Form\form_gb.xml.h:375 Form\form_gb.xml.h:412
+msgid "No. of Rooms with one or more Windows"
+msgstr ""
+
+#: Form\form_gb.xml.h:288 Form\form_gb.xml.h:316 Form\form_gb.xml.h:346
+#: Form\form_gb.xml.h:385
+msgid "Police Burgh"
+msgstr ""
+
+#: Form\form_gb.xml.h:306 Form\form_gb.xml.h:334 Form\form_gb.xml.h:371
+#: Form\form_gb.xml.h:408
+msgid "Whether 1. Deaf and Dumb, 2. Blind, 3. Imbecile or Idiot 4. Lunatic"
+msgstr ""
+
+#: Form\form_gb.xml.h:313
+msgid "School Board District"
+msgstr ""
+
+#: Form\form_gb.xml.h:341 Form\form_gb.xml.h:380
+msgid "School board District"
+msgstr ""
+
+#: Form\form_gb.xml.h:343 Form\form_gb.xml.h:382 Form\form_gb.xml.h:441
+msgid "Parliamentary Division"
+msgstr ""
+
+#: Form\form_gb.xml.h:345 Form\form_gb.xml.h:384
+msgid "Municipal Burgh"
+msgstr ""
+
+#: Form\form_gb.xml.h:347 Form\form_gb.xml.h:386
+msgid "Burgh Ward"
+msgstr ""
+
+#: Form\form_gb.xml.h:350 Form\form_gb.xml.h:389
+msgid "Island"
+msgstr ""
+
+#: Form\form_gb.xml.h:369 Form\form_gb.xml.h:406
+msgid "Gaellic or G. & E."
+msgstr ""
+
+#: Form\form_gb.xml.h:377
+msgid "Parish Ward"
+msgstr ""
+
+#: Form\form_gb.xml.h:400
+msgid "Condition as to Marriage"
+msgstr ""
+
+#: Form\form_gb.xml.h:402
+msgid "Profession or Occupation"
+msgstr ""
+
+#: Form\form_gb.xml.h:403
+msgid "Employer, Worker or on Own Account"
+msgstr ""
+
+#: Form\form_gb.xml.h:414 Form\form_gb.xml.h:435
+msgid "District Electoral Division"
+msgstr ""
+
+#: Form\form_gb.xml.h:415 Form\form_gb.xml.h:438
+msgid "Townland"
+msgstr ""
+
+#: Form\form_gb.xml.h:417 Form\form_gb.xml.h:446
+msgid "No. on Form B"
+msgstr ""
+
+#: Form\form_gb.xml.h:422 Form\form_gb.xml.h:451
+msgid "Education"
+msgstr ""
+
+#: Form\form_gb.xml.h:423 Form\form_gb.xml.h:452
+msgid "\"Read and Write\", \"Read\" or \"Cannot Read\""
+msgstr ""
+
+#: Form\form_gb.xml.h:429 Form\form_gb.xml.h:461
+msgid "Irish Language"
+msgstr ""
+
+#: Form\form_gb.xml.h:430 Form\form_gb.xml.h:462
+msgid ""
+"\"Irish\" or \"Irish & English\", in other cases no entry should be made"
+msgstr ""
+
+#: Form\form_gb.xml.h:432 Form\form_gb.xml.h:464
+msgid ""
+"\"Deaf and Dumb\", \"Dumb only\", \"Blind\", \"Imbecile or Idiot\", or "
+"\"Lunatic\""
+msgstr ""
+
+#: Form\form_gb.xml.h:434
+msgid "Poor Law Union"
+msgstr ""
+
+#: Form\form_gb.xml.h:436
+msgid "Barony"
+msgstr ""
+
+#: Form\form_gb.xml.h:439 Form\form_us.xml.h:1224 Form\form_us.xml.h:1958
+msgid "City"
+msgstr ""
+
+#: Form\form_gb.xml.h:442
+msgid "Urban District"
+msgstr ""
+
+#: Form\form_gb.xml.h:445
+msgid "Head of Family"
+msgstr ""
+
+#: Form\form_gb.xml.h:457
+msgid "Total Children"
+msgstr ""
+
+#: Form\form_gb.xml.h:458
+msgid "Children born alive to present Marriage"
+msgstr ""
+
+#: Form\form_pl.xml.h:2 Form\form_pl.xml.h:21 Form\form_pl.xml.h:31
+msgid "Event Type"
+msgstr ""
+
+#: Form\form_pl.xml.h:3 Form\form_pl.xml.h:22 Form\form_pl.xml.h:32
+#: Form\form_us.xml.h:2376
+msgid "Event Date"
+msgstr ""
+
+#: Form\form_pl.xml.h:4 Form\form_pl.xml.h:23 Form\form_pl.xml.h:33
+#: Form\form_us.xml.h:2377
+msgid "Event Place"
+msgstr ""
+
+#: Form\form_pl.xml.h:5
+msgid "Event Place (Original)"
+msgstr ""
+
+#: Form\form_pl.xml.h:8 Form\form_pl.xml.h:36
+msgid "Birth Year (Estimated)"
+msgstr ""
+
+#: Form\form_pl.xml.h:9 Form\form_pl.xml.h:26 Form\form_pl.xml.h:37
+#: Form\form_us.xml.h:1365 Form\form_us.xml.h:2361 Form\form_us.xml.h:2384
+#: Form\form_us.xml.h:2410
+msgid "Father's Name"
+msgstr ""
+
+#: Form\form_pl.xml.h:10 Form\form_pl.xml.h:27 Form\form_pl.xml.h:38
+#: Form\form_us.xml.h:1368 Form\form_us.xml.h:2363 Form\form_us.xml.h:2386
+#: Form\form_us.xml.h:2411
+msgid "Mother's Name"
+msgstr ""
+
+#: Form\form_pl.xml.h:11 Form\form_pl.xml.h:39 Form\form_us.xml.h:2351
+#: Form\form_us.xml.h:2391
+msgid "Spouse's Name"
+msgstr ""
+
+#: Form\form_pl.xml.h:12 Form\form_pl.xml.h:40
+msgid "Spouse's Gender"
+msgstr ""
+
+#: Form\form_pl.xml.h:13 Form\form_pl.xml.h:41
+msgid "Spouse's Age"
+msgstr ""
+
+#: Form\form_pl.xml.h:14 Form\form_pl.xml.h:42
+msgid "Spouse's Birth Year (Estimated)"
+msgstr ""
+
+#: Form\form_pl.xml.h:15 Form\form_pl.xml.h:43
+msgid "Spouse's Father's Name"
+msgstr ""
+
+#: Form\form_pl.xml.h:16 Form\form_pl.xml.h:44
+msgid "Spouse's Mother's Name"
+msgstr ""
+
+#: Form\form_pl.xml.h:18
+msgid "Record Number"
+msgstr ""
+
+#: Form\form_pl.xml.h:19
+msgid "Volume"
+msgstr ""
+
+#: Form\form_pl.xml.h:24 Form\form_us.xml.h:1338
+msgid "House Number"
+msgstr ""
+
+#: Form\form_pl.xml.h:28
+msgid "Volume Beginning Year"
+msgstr ""
+
+#: Form\form_pl.xml.h:29
+msgid "Volume Ending Year"
+msgstr ""
+
+#: Form\form_us.xml.h:1 Form\form_us.xml.h:14 Form\form_us.xml.h:35
+#: Form\form_us.xml.h:56 Form\form_us.xml.h:96 Form\form_us.xml.h:165
+#: Form\form_us.xml.h:251 Form\form_us.xml.h:273 Form\form_us.xml.h:326
+#: Form\form_us.xml.h:349 Form\form_us.xml.h:407 Form\form_us.xml.h:425
+#: Form\form_us.xml.h:454 Form\form_us.xml.h:490 Form\form_us.xml.h:602
+#: Form\form_us.xml.h:640 Form\form_us.xml.h:658 Form\form_us.xml.h:700
+#: Form\form_us.xml.h:743 Form\form_us.xml.h:781 Form\form_us.xml.h:824
+#: Form\form_us.xml.h:1004
+msgid "NARA publication"
+msgstr ""
+
+#: Form\form_us.xml.h:2 Form\form_us.xml.h:15 Form\form_us.xml.h:36
+#: Form\form_us.xml.h:57 Form\form_us.xml.h:97 Form\form_us.xml.h:166
+#: Form\form_us.xml.h:252 Form\form_us.xml.h:274 Form\form_us.xml.h:327
+#: Form\form_us.xml.h:350 Form\form_us.xml.h:408 Form\form_us.xml.h:426
+#: Form\form_us.xml.h:455 Form\form_us.xml.h:491 Form\form_us.xml.h:603
+#: Form\form_us.xml.h:641 Form\form_us.xml.h:659 Form\form_us.xml.h:701
+#: Form\form_us.xml.h:744 Form\form_us.xml.h:782 Form\form_us.xml.h:825
+#: Form\form_us.xml.h:1005
+msgid "Roll No."
+msgstr ""
+
+#: Form\form_us.xml.h:3 Form\form_us.xml.h:16 Form\form_us.xml.h:37
+#: Form\form_us.xml.h:58 Form\form_us.xml.h:98 Form\form_us.xml.h:167
+#: Form\form_us.xml.h:253 Form\form_us.xml.h:275 Form\form_us.xml.h:328
+#: Form\form_us.xml.h:351 Form\form_us.xml.h:409 Form\form_us.xml.h:427
+#: Form\form_us.xml.h:456 Form\form_us.xml.h:492 Form\form_us.xml.h:604
+#: Form\form_us.xml.h:642 Form\form_us.xml.h:664 Form\form_us.xml.h:706
+#: Form\form_us.xml.h:749 Form\form_us.xml.h:792 Form\form_us.xml.h:835
+#: Form\form_us.xml.h:893 Form\form_us.xml.h:977 Form\form_us.xml.h:1006
+#: Form\form_us.xml.h:1044 Form\form_us.xml.h:1060 Form\form_us.xml.h:1395
+#: Form\form_us.xml.h:1535 Form\form_us.xml.h:1544 Form\form_us.xml.h:1559
+#: Form\form_us.xml.h:1754 Form\form_us.xml.h:1863 Form\form_us.xml.h:1875
+#: Form\form_us.xml.h:1894 Form\form_us.xml.h:1906 Form\form_us.xml.h:2145
+#: Form\form_us.xml.h:2157 Form\form_us.xml.h:2169 Form\form_us.xml.h:2180
+#: Form\form_us.xml.h:2198 Form\form_us.xml.h:2208 Form\form_us.xml.h:2227
+#: Form\form_us.xml.h:2237 Form\form_us.xml.h:2414
+msgid "Page No."
+msgstr ""
+
+#: Form\form_us.xml.h:4 Form\form_us.xml.h:17 Form\form_us.xml.h:38
+#: Form\form_us.xml.h:59 Form\form_us.xml.h:99 Form\form_us.xml.h:168
+#: Form\form_us.xml.h:254 Form\form_us.xml.h:329 Form\form_us.xml.h:428
+#: Form\form_us.xml.h:457 Form\form_us.xml.h:493 Form\form_us.xml.h:605
+#: Form\form_us.xml.h:665 Form\form_us.xml.h:707 Form\form_us.xml.h:793
+#: Form\form_us.xml.h:836 Form\form_us.xml.h:1007 Form\form_us.xml.h:1590
+msgid "Sheet No."
+msgstr ""
+
+#: Form\form_us.xml.h:5 Form\form_us.xml.h:18 Form\form_us.xml.h:39
+#: Form\form_us.xml.h:60 Form\form_us.xml.h:100 Form\form_us.xml.h:169
+#: Form\form_us.xml.h:255 Form\form_us.xml.h:330 Form\form_us.xml.h:429
+#: Form\form_us.xml.h:460 Form\form_us.xml.h:496 Form\form_us.xml.h:608
+#: Form\form_us.xml.h:645 Form\form_us.xml.h:1010 Form\form_us.xml.h:1756
+msgid "Minor Civil Division"
+msgstr ""
+
+#: Form\form_us.xml.h:6 Form\form_us.xml.h:19 Form\form_us.xml.h:40
+#: Form\form_us.xml.h:61 Form\form_us.xml.h:101 Form\form_us.xml.h:170
+#: Form\form_us.xml.h:256 Form\form_us.xml.h:331 Form\form_us.xml.h:430
+#: Form\form_us.xml.h:461 Form\form_us.xml.h:497 Form\form_us.xml.h:609
+#: Form\form_us.xml.h:646 Form\form_us.xml.h:661 Form\form_us.xml.h:703
+#: Form\form_us.xml.h:746 Form\form_us.xml.h:784 Form\form_us.xml.h:827
+#: Form\form_us.xml.h:978 Form\form_us.xml.h:1011 Form\form_us.xml.h:1043
+#: Form\form_us.xml.h:1058 Form\form_us.xml.h:1160 Form\form_us.xml.h:1188
+#: Form\form_us.xml.h:1392 Form\form_us.xml.h:1533 Form\form_us.xml.h:1547
+#: Form\form_us.xml.h:1562 Form\form_us.xml.h:1579 Form\form_us.xml.h:1757
+#: Form\form_us.xml.h:1789 Form\form_us.xml.h:1810 Form\form_us.xml.h:1839
+#: Form\form_us.xml.h:1893 Form\form_us.xml.h:2201 Form\form_us.xml.h:2230
+msgid "County of"
+msgstr ""
+
+#: Form\form_us.xml.h:7 Form\form_us.xml.h:20 Form\form_us.xml.h:41
+#: Form\form_us.xml.h:62 Form\form_us.xml.h:102 Form\form_us.xml.h:171
+msgid "District (or Territory) of"
+msgstr ""
+
+#: Form\form_us.xml.h:9
+msgid "Free white males 16 & up"
+msgstr ""
+
+#: Form\form_us.xml.h:10
+msgid "Free white males under 16"
+msgstr ""
+
+#: Form\form_us.xml.h:11
+msgid "Free white females"
+msgstr ""
+
+#: Form\form_us.xml.h:12 Form\form_us.xml.h:33 Form\form_us.xml.h:54
+msgid "All other free persons"
+msgstr ""
+
+#: Form\form_us.xml.h:13 Form\form_us.xml.h:34 Form\form_us.xml.h:55
+msgid "Slaves"
+msgstr ""
+
+#: Form\form_us.xml.h:21 Form\form_us.xml.h:42 Form\form_us.xml.h:63
+#: Form\form_us.xml.h:103 Form\form_us.xml.h:172 Form\form_us.xml.h:258
+#: Form\form_us.xml.h:279 Form\form_us.xml.h:333 Form\form_us.xml.h:355
+#: Form\form_us.xml.h:432 Form\form_us.xml.h:463 Form\form_us.xml.h:499
+#: Form\form_us.xml.h:613 Form\form_us.xml.h:671 Form\form_us.xml.h:712
+#: Form\form_us.xml.h:754 Form\form_us.xml.h:794 Form\form_us.xml.h:837
+#: Form\form_us.xml.h:1013 Form\form_us.xml.h:1393 Form\form_us.xml.h:1548
+#: Form\form_us.xml.h:1563 Form\form_us.xml.h:1758 Form\form_us.xml.h:1811
+#: Form\form_us.xml.h:1840 Form\form_us.xml.h:2241
+msgid "Enumeration Date"
+msgstr ""
+
+#: Form\form_us.xml.h:23 Form\form_us.xml.h:44 Form\form_us.xml.h:65
+msgid "Free white males under 10"
+msgstr ""
+
+#: Form\form_us.xml.h:24 Form\form_us.xml.h:45 Form\form_us.xml.h:66
+msgid "Free white males 10-15"
+msgstr ""
+
+#: Form\form_us.xml.h:25 Form\form_us.xml.h:46 Form\form_us.xml.h:68
+msgid "Free white males 16-25"
+msgstr ""
+
+#: Form\form_us.xml.h:26 Form\form_us.xml.h:47 Form\form_us.xml.h:69
+msgid "Free white males 26-44"
+msgstr ""
+
+#: Form\form_us.xml.h:27 Form\form_us.xml.h:48 Form\form_us.xml.h:70
+msgid "Free white males 45 and over"
+msgstr ""
+
+#: Form\form_us.xml.h:28 Form\form_us.xml.h:49 Form\form_us.xml.h:71
+msgid "Free white females under 10"
+msgstr ""
+
+#: Form\form_us.xml.h:29 Form\form_us.xml.h:50 Form\form_us.xml.h:72
+msgid "Free white females 10-15"
+msgstr ""
+
+#: Form\form_us.xml.h:30 Form\form_us.xml.h:51 Form\form_us.xml.h:73
+msgid "Free white females 16-25"
+msgstr ""
+
+#: Form\form_us.xml.h:31 Form\form_us.xml.h:52 Form\form_us.xml.h:74
+msgid "Free white females 26-44"
+msgstr ""
+
+#: Form\form_us.xml.h:32 Form\form_us.xml.h:53 Form\form_us.xml.h:75
+msgid "Free white females 45 and over"
+msgstr ""
+
+#: Form\form_us.xml.h:67
+msgid "Free white males 16-18"
+msgstr ""
+
+#: Form\form_us.xml.h:76 Form\form_us.xml.h:1209
+msgid "Foreigners not naturalized"
+msgstr ""
+
+#: Form\form_us.xml.h:77
+msgid "Persons engaged in Agriculture"
+msgstr ""
+
+#: Form\form_us.xml.h:78
+msgid "Persons engaged in Commerce"
+msgstr ""
+
+#: Form\form_us.xml.h:79
+msgid "Persons engaged in Manufactures"
+msgstr ""
+
+#: Form\form_us.xml.h:80
+msgid "Slave males under 14"
+msgstr ""
+
+#: Form\form_us.xml.h:81
+msgid "Slave males 14-25"
+msgstr ""
+
+#: Form\form_us.xml.h:82
+msgid "Slave males 26-44"
+msgstr ""
+
+#: Form\form_us.xml.h:83
+msgid "Slave males 45 and over"
+msgstr ""
+
+#: Form\form_us.xml.h:84
+msgid "Slave females under 14"
+msgstr ""
+
+#: Form\form_us.xml.h:85
+msgid "Slave females 14-25"
+msgstr ""
+
+#: Form\form_us.xml.h:86
+msgid "Slave females 26-44"
+msgstr ""
+
+#: Form\form_us.xml.h:87
+msgid "Slave females 45 and over"
+msgstr ""
+
+#: Form\form_us.xml.h:88
+msgid "Free colored males under 14"
+msgstr ""
+
+#: Form\form_us.xml.h:89
+msgid "Free colored males 14-25"
+msgstr ""
+
+#: Form\form_us.xml.h:90
+msgid "Free colored males 26-44"
+msgstr ""
+
+#: Form\form_us.xml.h:91
+msgid "Free colored males 45 and over"
+msgstr ""
+
+#: Form\form_us.xml.h:92
+msgid "Free colored females under 14"
+msgstr ""
+
+#: Form\form_us.xml.h:93
+msgid "Free colored females 14-25"
+msgstr ""
+
+#: Form\form_us.xml.h:94
+msgid "Free colored females 26-44"
+msgstr ""
+
+#: Form\form_us.xml.h:95
+msgid "Free colored females 45 and over"
+msgstr ""
+
+#: Form\form_us.xml.h:105 Form\form_us.xml.h:174
+msgid "Free white males under 5"
+msgstr ""
+
+#: Form\form_us.xml.h:106 Form\form_us.xml.h:175
+msgid "Free white males 5-9"
+msgstr ""
+
+#: Form\form_us.xml.h:107 Form\form_us.xml.h:176
+msgid "Free white males 10-14"
+msgstr ""
+
+#: Form\form_us.xml.h:108 Form\form_us.xml.h:177
+msgid "Free white males 15-20"
+msgstr ""
+
+#: Form\form_us.xml.h:109 Form\form_us.xml.h:178
+msgid "Free white males 20-29"
+msgstr ""
+
+#: Form\form_us.xml.h:110 Form\form_us.xml.h:179
+msgid "Free white males 30-39"
+msgstr ""
+
+#: Form\form_us.xml.h:111 Form\form_us.xml.h:180
+msgid "Free white males 40-49"
+msgstr ""
+
+#: Form\form_us.xml.h:112 Form\form_us.xml.h:181
+msgid "Free white males 50-59"
+msgstr ""
+
+#: Form\form_us.xml.h:113 Form\form_us.xml.h:182
+msgid "Free white males 60-69"
+msgstr ""
+
+#: Form\form_us.xml.h:114 Form\form_us.xml.h:183
+msgid "Free white males 70-79"
+msgstr ""
+
+#: Form\form_us.xml.h:115 Form\form_us.xml.h:184
+msgid "Free white males 80-89"
+msgstr ""
+
+#: Form\form_us.xml.h:116 Form\form_us.xml.h:185
+msgid "Free white males 90-99"
+msgstr ""
+
+#: Form\form_us.xml.h:117 Form\form_us.xml.h:186
+msgid "Free white males 100 and over"
+msgstr ""
+
+#: Form\form_us.xml.h:118 Form\form_us.xml.h:187
+msgid "Free white females under 5"
+msgstr ""
+
+#: Form\form_us.xml.h:119 Form\form_us.xml.h:188
+msgid "Free white females 5-9"
+msgstr ""
+
+#: Form\form_us.xml.h:120 Form\form_us.xml.h:189
+msgid "Free white females 10-14"
+msgstr ""
+
+#: Form\form_us.xml.h:121 Form\form_us.xml.h:190
+msgid "Free white females 15-20"
+msgstr ""
+
+#: Form\form_us.xml.h:122 Form\form_us.xml.h:191
+msgid "Free white females 20-29"
+msgstr ""
+
+#: Form\form_us.xml.h:123 Form\form_us.xml.h:192
+msgid "Free white females 30-39"
+msgstr ""
+
+#: Form\form_us.xml.h:124 Form\form_us.xml.h:193
+msgid "Free white females 40-49"
+msgstr ""
+
+#: Form\form_us.xml.h:125 Form\form_us.xml.h:194
+msgid "Free white females 50-59"
+msgstr ""
+
+#: Form\form_us.xml.h:126 Form\form_us.xml.h:195
+msgid "Free white females 60-69"
+msgstr ""
+
+#: Form\form_us.xml.h:127 Form\form_us.xml.h:196
+msgid "Free white females 70-79"
+msgstr ""
+
+#: Form\form_us.xml.h:128 Form\form_us.xml.h:197
+msgid "Free white females 80-89"
+msgstr ""
+
+#: Form\form_us.xml.h:129 Form\form_us.xml.h:198
+msgid "Free white females 90-99"
+msgstr ""
+
+#: Form\form_us.xml.h:130 Form\form_us.xml.h:199
+msgid "Free white females 100 and over"
+msgstr ""
+
+#: Form\form_us.xml.h:131 Form\form_us.xml.h:212
+msgid "Slave males under 10"
+msgstr ""
+
+#: Form\form_us.xml.h:132 Form\form_us.xml.h:213
+msgid "Slave males 10-23"
+msgstr ""
+
+#: Form\form_us.xml.h:133 Form\form_us.xml.h:214
+msgid "Slave males 24-35"
+msgstr ""
+
+#: Form\form_us.xml.h:134 Form\form_us.xml.h:215
+msgid "Slave males 36-54"
+msgstr ""
+
+#: Form\form_us.xml.h:135 Form\form_us.xml.h:216
+msgid "Slave males 55-99"
+msgstr ""
+
+#: Form\form_us.xml.h:136 Form\form_us.xml.h:217
+msgid "Slave males 100 and over"
+msgstr ""
+
+#: Form\form_us.xml.h:137 Form\form_us.xml.h:218
+msgid "Slave females under 10"
+msgstr ""
+
+#: Form\form_us.xml.h:138 Form\form_us.xml.h:219
+msgid "Slave females 10-23"
+msgstr ""
+
+#: Form\form_us.xml.h:139 Form\form_us.xml.h:220
+msgid "Slave females 24-35"
+msgstr ""
+
+#: Form\form_us.xml.h:140 Form\form_us.xml.h:221
+msgid "Slave females 36-54"
+msgstr ""
+
+#: Form\form_us.xml.h:141 Form\form_us.xml.h:222
+msgid "Slave females 55-99"
+msgstr ""
+
+#: Form\form_us.xml.h:142 Form\form_us.xml.h:223
+msgid "Slave females 100 and over"
+msgstr ""
+
+#: Form\form_us.xml.h:143 Form\form_us.xml.h:200
+msgid "Free colored males under 10"
+msgstr ""
+
+#: Form\form_us.xml.h:144 Form\form_us.xml.h:201
+msgid "Free colored males 10-23"
+msgstr ""
+
+#: Form\form_us.xml.h:145 Form\form_us.xml.h:202
+msgid "Free colored males 24-35"
+msgstr ""
+
+#: Form\form_us.xml.h:146 Form\form_us.xml.h:203
+msgid "Free colored males 36-54"
+msgstr ""
+
+#: Form\form_us.xml.h:147 Form\form_us.xml.h:204
+msgid "Free colored males 55-99"
+msgstr ""
+
+#: Form\form_us.xml.h:148 Form\form_us.xml.h:205
+msgid "Free colored males 100 and over"
+msgstr ""
+
+#: Form\form_us.xml.h:149 Form\form_us.xml.h:206
+msgid "Free colored females under 10"
+msgstr ""
+
+#: Form\form_us.xml.h:150 Form\form_us.xml.h:207
+msgid "Free colored females 10-23"
+msgstr ""
+
+#: Form\form_us.xml.h:151 Form\form_us.xml.h:208
+msgid "Free colored females 24-35"
+msgstr ""
+
+#: Form\form_us.xml.h:152 Form\form_us.xml.h:209
+msgid "Free colored females 36-54"
+msgstr ""
+
+#: Form\form_us.xml.h:153 Form\form_us.xml.h:210
+msgid "Free colored females 55-99"
+msgstr ""
+
+#: Form\form_us.xml.h:154 Form\form_us.xml.h:211
+msgid "Free colored females 100 and over"
+msgstr ""
+
+#: Form\form_us.xml.h:155 Form\form_us.xml.h:224 Form\form_us.xml.h:1093
+#: Form\form_us.xml.h:2144
+msgid "Total"
+msgstr ""
+
+#: Form\form_us.xml.h:156 Form\form_us.xml.h:234
+msgid "White persons deaf/dumb under 14"
+msgstr ""
+
+#: Form\form_us.xml.h:157 Form\form_us.xml.h:235
+msgid "White persons deaf/dumb 14-24"
+msgstr ""
+
+#: Form\form_us.xml.h:158 Form\form_us.xml.h:236
+msgid "White persons deaf/dumb 25 and over"
+msgstr ""
+
+#: Form\form_us.xml.h:159 Form\form_us.xml.h:237
+msgid "White persons blind"
+msgstr ""
+
+#: Form\form_us.xml.h:160 Form\form_us.xml.h:1123
+msgid "Aliens"
+msgstr ""
+
+#: Form\form_us.xml.h:161
+msgid "Slaves and colored persons deaf/dumb under 14"
+msgstr ""
+
+#: Form\form_us.xml.h:162
+msgid "Slaves and colored persons deaf/dumb 14-24"
+msgstr ""
+
+#: Form\form_us.xml.h:163
+msgid "Slaves and colored persons deaf/dumb 25 and over"
+msgstr ""
+
+#: Form\form_us.xml.h:164
+msgid "Slaves and colored persons blind"
+msgstr ""
+
+#: Form\form_us.xml.h:225
+msgid "Persons employed in Mining"
+msgstr ""
+
+#: Form\form_us.xml.h:226
+msgid "Persons employed in Agriculture"
+msgstr ""
+
+#: Form\form_us.xml.h:227
+msgid "Persons employed in Commerce"
+msgstr ""
+
+#: Form\form_us.xml.h:228
+msgid "Persons employed in Manufacture and trade"
+msgstr ""
+
+#: Form\form_us.xml.h:229
+msgid "Persons employed in Navigation of the ocean"
+msgstr ""
+
+#: Form\form_us.xml.h:230
+msgid "Persons employed in Navigation of canals, lakes, rivers"
+msgstr ""
+
+#: Form\form_us.xml.h:231
+msgid "Learned professional engineers"
+msgstr ""
+
+#: Form\form_us.xml.h:232
+msgid "Names of pensioners for Revolutionary or military services"
+msgstr ""
+
+#: Form\form_us.xml.h:233
+msgid "Ages"
+msgstr ""
+
+#: Form\form_us.xml.h:238
+msgid "White persons insane and idiots at public charge"
+msgstr ""
+
+#: Form\form_us.xml.h:239
+msgid "White persons insane and idiots at private charge"
+msgstr ""
+
+#: Form\form_us.xml.h:240
+msgid "Colored persons deaf/dumb"
+msgstr ""
+
+#: Form\form_us.xml.h:241
+msgid "Colored persons blind"
+msgstr ""
+
+#: Form\form_us.xml.h:242
+msgid "Colored persons insane and idiots at private charge"
+msgstr ""
+
+#: Form\form_us.xml.h:243
+msgid "Colored persons insane and idiots at public charge"
+msgstr ""
+
+#: Form\form_us.xml.h:244
+msgid "Universities or college"
+msgstr ""
+
+#: Form\form_us.xml.h:245
+msgid "Number of students"
+msgstr ""
+
+#: Form\form_us.xml.h:246
+msgid "Academies and Grammar Schools"
+msgstr ""
+
+#: Form\form_us.xml.h:247
+msgid "No. of scholars"
+msgstr ""
+
+#: Form\form_us.xml.h:248
+msgid "Primary and Common Schools"
+msgstr ""
+
+#: Form\form_us.xml.h:249
+msgid "No. of scholars at public charge"
+msgstr ""
+
+#: Form\form_us.xml.h:250
+msgid "White persons illiterate over 20"
+msgstr ""
+
+#: Form\form_us.xml.h:257 Form\form_us.xml.h:278 Form\form_us.xml.h:332
+#: Form\form_us.xml.h:354 Form\form_us.xml.h:412 Form\form_us.xml.h:431
+#: Form\form_us.xml.h:462 Form\form_us.xml.h:498 Form\form_us.xml.h:610
+#: Form\form_us.xml.h:647 Form\form_us.xml.h:783 Form\form_us.xml.h:826
+#: Form\form_us.xml.h:979 Form\form_us.xml.h:1012 Form\form_us.xml.h:2417
+msgid "State of"
+msgstr ""
+
+#: Form\form_us.xml.h:259 Form\form_us.xml.h:280 Form\form_us.xml.h:335
+#: Form\form_us.xml.h:356 Form\form_us.xml.h:413 Form\form_us.xml.h:434
+#: Form\form_us.xml.h:464 Form\form_us.xml.h:500 Form\form_us.xml.h:614
+#: Form\form_us.xml.h:1014 Form\form_us.xml.h:1045 Form\form_us.xml.h:1061
+#: Form\form_us.xml.h:1759 Form\form_us.xml.h:2284 Form\form_us.xml.h:2306
+#: Form\form_us.xml.h:2398 Form\form_us.xml.h:2419
+msgid "Line No."
+msgstr ""
+
+#: Form\form_us.xml.h:260 Form\form_us.xml.h:336 Form\form_us.xml.h:435
+#: Form\form_us.xml.h:465 Form\form_us.xml.h:615 Form\form_us.xml.h:1017
+#: Form\form_us.xml.h:1760
+msgid "Family No."
+msgstr ""
+
+#: Form\form_us.xml.h:264 Form\form_us.xml.h:340 Form\form_us.xml.h:417
+#: Form\form_us.xml.h:439 Form\form_us.xml.h:467 Form\form_us.xml.h:619
+#: Form\form_us.xml.h:674 Form\form_us.xml.h:716 Form\form_us.xml.h:761
+#: Form\form_us.xml.h:803 Form\form_us.xml.h:983 Form\form_us.xml.h:1019
+#: Form\form_us.xml.h:1115 Form\form_us.xml.h:1168 Form\form_us.xml.h:1236
+#: Form\form_us.xml.h:1320 Form\form_us.xml.h:1399 Form\form_us.xml.h:1413
+#: Form\form_us.xml.h:1432 Form\form_us.xml.h:1453 Form\form_us.xml.h:1474
+#: Form\form_us.xml.h:1496 Form\form_us.xml.h:1520 Form\form_us.xml.h:1539
+#: Form\form_us.xml.h:1553 Form\form_us.xml.h:1568 Form\form_us.xml.h:1597
+#: Form\form_us.xml.h:1762 Form\form_us.xml.h:1795 Form\form_us.xml.h:1817
+#: Form\form_us.xml.h:1846 Form\form_us.xml.h:1867 Form\form_us.xml.h:1878
+#: Form\form_us.xml.h:1897 Form\form_us.xml.h:1917 Form\form_us.xml.h:2010
+#: Form\form_us.xml.h:2048 Form\form_us.xml.h:2086 Form\form_us.xml.h:2124
+msgid "Color"
+msgstr ""
+
+#: Form\form_us.xml.h:266 Form\form_us.xml.h:342 Form\form_us.xml.h:441
+msgid "Value of real estate"
+msgstr ""
+
+#: Form\form_us.xml.h:267 Form\form_us.xml.h:344 Form\form_us.xml.h:420
+#: Form\form_us.xml.h:443 Form\form_us.xml.h:487 Form\form_us.xml.h:625
+#: Form\form_us.xml.h:683 Form\form_us.xml.h:722 Form\form_us.xml.h:770
+#: Form\form_us.xml.h:809 Form\form_us.xml.h:850 Form\form_us.xml.h:1001
+#: Form\form_us.xml.h:1039 Form\form_us.xml.h:1119 Form\form_us.xml.h:1199
+#: Form\form_us.xml.h:1405 Form\form_us.xml.h:1417 Form\form_us.xml.h:1437
+#: Form\form_us.xml.h:1454 Form\form_us.xml.h:1475 Form\form_us.xml.h:1497
+#: Form\form_us.xml.h:1523 Form\form_us.xml.h:1569 Form\form_us.xml.h:1782
+#: Form\form_us.xml.h:2248 Form\form_us.xml.h:2265 Form\form_us.xml.h:2440
+#: Form\form_us.xml.h:2489
+msgid "Place of birth"
+msgstr ""
+
+#: Form\form_us.xml.h:268 Form\form_us.xml.h:345
+msgid "Married within the year"
+msgstr ""
+
+#: Form\form_us.xml.h:269 Form\form_us.xml.h:346 Form\form_us.xml.h:448
+#: Form\form_us.xml.h:1458 Form\form_us.xml.h:1480 Form\form_us.xml.h:1502
+msgid "Attended school within the year"
+msgstr ""
+
+#: Form\form_us.xml.h:270 Form\form_us.xml.h:347
+msgid "Illiterate and over 20"
+msgstr ""
+
+#: Form\form_us.xml.h:271 Form\form_us.xml.h:348
+msgid "Deaf, dumb, blind, insane, idiotic, pauper or convict"
+msgstr ""
+
+#: Form\form_us.xml.h:276 Form\form_us.xml.h:352
+msgid "Production of Agriculture in"
+msgstr ""
+
+#: Form\form_us.xml.h:277 Form\form_us.xml.h:353 Form\form_us.xml.h:411
+msgid "in the County of"
+msgstr ""
+
+#: Form\form_us.xml.h:281 Form\form_us.xml.h:358
+msgid "Owner, Agent, or Manager"
+msgstr ""
+
+#: Form\form_us.xml.h:282 Form\form_us.xml.h:359
+msgid "Acres Improved"
+msgstr ""
+
+#: Form\form_us.xml.h:283 Form\form_us.xml.h:360
+msgid "Acres Unimproved"
+msgstr ""
+
+#: Form\form_us.xml.h:284 Form\form_us.xml.h:361
+msgid "Cash Value of Farm"
+msgstr ""
+
+#: Form\form_us.xml.h:285 Form\form_us.xml.h:362
+msgid "Value of Farming Implements and Machinery"
+msgstr ""
+
+#: Form\form_us.xml.h:287 Form\form_us.xml.h:365
+msgid "Asses and Mules"
+msgstr ""
+
+#: Form\form_us.xml.h:289 Form\form_us.xml.h:367
+msgid "Working Oxen"
+msgstr ""
+
+#: Form\form_us.xml.h:290 Form\form_us.xml.h:368
+msgid "Other Cattle"
+msgstr ""
+
+#: Form\form_us.xml.h:292 Form\form_us.xml.h:370
+msgid "Swine"
+msgstr ""
+
+#: Form\form_us.xml.h:293 Form\form_us.xml.h:371 Form\form_us.xml.h:511
+#: Form\form_us.xml.h:1098
+msgid "Value of Live Stock"
+msgstr ""
+
+#: Form\form_us.xml.h:294
+msgid "Wheat"
+msgstr ""
+
+#: Form\form_us.xml.h:295
+msgid "Indian Corn"
+msgstr ""
+
+#: Form\form_us.xml.h:296
+msgid "Oats"
+msgstr ""
+
+#: Form\form_us.xml.h:297
+msgid "Rice"
+msgstr ""
+
+#: Form\form_us.xml.h:298
+msgid "Tobacco"
+msgstr ""
+
+#: Form\form_us.xml.h:299
+msgid "Ginned Cotton"
+msgstr ""
+
+#: Form\form_us.xml.h:300
+msgid "Wool"
+msgstr ""
+
+#: Form\form_us.xml.h:301
+msgid "Peas and Beans"
+msgstr ""
+
+#: Form\form_us.xml.h:302
+msgid "Irish Potatoes"
+msgstr ""
+
+#: Form\form_us.xml.h:303
+msgid "Sweet Potatoes"
+msgstr ""
+
+#: Form\form_us.xml.h:304
+msgid "Barley"
+msgstr ""
+
+#: Form\form_us.xml.h:305
+msgid "Buckwheat"
+msgstr ""
+
+#: Form\form_us.xml.h:306
+msgid "Value of Orchard Products"
+msgstr ""
+
+#: Form\form_us.xml.h:307
+msgid "Wine"
+msgstr ""
+
+#: Form\form_us.xml.h:308
+msgid "Value of Market Gardens"
+msgstr ""
+
+#: Form\form_us.xml.h:309
+msgid "Butter"
+msgstr ""
+
+#: Form\form_us.xml.h:310
+msgid "Cheese"
+msgstr ""
+
+#: Form\form_us.xml.h:311
+msgid "Hay"
+msgstr ""
+
+#: Form\form_us.xml.h:312
+msgid "Clover Seed"
+msgstr ""
+
+#: Form\form_us.xml.h:313
+msgid "Other Grass Seeds"
+msgstr ""
+
+#: Form\form_us.xml.h:314
+msgid "Hops"
+msgstr ""
+
+#: Form\form_us.xml.h:315
+msgid "Hemp Dew Rotted"
+msgstr ""
+
+#: Form\form_us.xml.h:316
+msgid "Hemp Water Rotted"
+msgstr ""
+
+#: Form\form_us.xml.h:317
+msgid "Flax"
+msgstr ""
+
+#: Form\form_us.xml.h:318
+msgid "Flaxseed"
+msgstr ""
+
+#: Form\form_us.xml.h:319
+msgid "Silk Cocoons"
+msgstr ""
+
+#: Form\form_us.xml.h:320
+msgid "Maple Sugar"
+msgstr ""
+
+#: Form\form_us.xml.h:321
+msgid "Cane Sugar"
+msgstr ""
+
+#: Form\form_us.xml.h:322
+msgid "Molasses"
+msgstr ""
+
+#: Form\form_us.xml.h:323
+msgid "Beeswax"
+msgstr ""
+
+#: Form\form_us.xml.h:324
+msgid "Value of Homemade Manufactures"
+msgstr ""
+
+#: Form\form_us.xml.h:325 Form\form_us.xml.h:406
+msgid "Value of Animals Slaughtered"
+msgstr ""
+
+#: Form\form_us.xml.h:334 Form\form_us.xml.h:357 Form\form_us.xml.h:433
+#: Form\form_us.xml.h:655 Form\form_us.xml.h:1292 Form\form_us.xml.h:1394
+#: Form\form_us.xml.h:1549 Form\form_us.xml.h:1564 Form\form_us.xml.h:2207
+#: Form\form_us.xml.h:2236
+msgid "Post Office"
+msgstr ""
+
+#: Form\form_us.xml.h:343 Form\form_us.xml.h:442
+msgid "Value of personal estate"
+msgstr ""
+
+#: Form\form_us.xml.h:363
+msgid "Live Stock June 1, 1860"
+msgstr ""
+
+#: Form\form_us.xml.h:372
+msgid "Produce during the year ending June 1, 1860"
+msgstr ""
+
+#: Form\form_us.xml.h:373
+msgid "Wheat, bushels of"
+msgstr ""
+
+#: Form\form_us.xml.h:374
+msgid "Rye, bushels of"
+msgstr ""
+
+#: Form\form_us.xml.h:375
+msgid "Indian Corn, bushels of"
+msgstr ""
+
+#: Form\form_us.xml.h:376
+msgid "Oats, bushels of"
+msgstr ""
+
+#: Form\form_us.xml.h:377
+msgid "Rice, pounds of"
+msgstr ""
+
+#: Form\form_us.xml.h:378
+msgid "Tobacco, pounds of"
+msgstr ""
+
+#: Form\form_us.xml.h:379
+msgid "Ginned Cotton, bales of 400 lbs."
+msgstr ""
+
+#: Form\form_us.xml.h:380
+msgid "Wool, pounds of"
+msgstr ""
+
+#: Form\form_us.xml.h:381
+msgid "Peas and Beans, bushels of"
+msgstr ""
+
+#: Form\form_us.xml.h:382
+msgid "Irish Potatoes, bushels of"
+msgstr ""
+
+#: Form\form_us.xml.h:383
+msgid "Sweet Potatoes, bushels of"
+msgstr ""
+
+#: Form\form_us.xml.h:384
+msgid "Barley, bushels of"
+msgstr ""
+
+#: Form\form_us.xml.h:385
+msgid "Buckwheat, bushels of"
+msgstr ""
+
+#: Form\form_us.xml.h:386
+msgid "Value of Orchard Products in $"
+msgstr ""
+
+#: Form\form_us.xml.h:387
+msgid "Wine, gallons of"
+msgstr ""
+
+#: Form\form_us.xml.h:388
+msgid "Value of products of market gardens"
+msgstr ""
+
+#: Form\form_us.xml.h:389
+msgid "Butter, pounds of"
+msgstr ""
+
+#: Form\form_us.xml.h:390
+msgid "Cheese, pounds of"
+msgstr ""
+
+#: Form\form_us.xml.h:391
+msgid "Hay, tons of"
+msgstr ""
+
+#: Form\form_us.xml.h:392
+msgid "Clover Seed, bushels of"
+msgstr ""
+
+#: Form\form_us.xml.h:393
+msgid "Other Grass Seeds, bushels of"
+msgstr ""
+
+#: Form\form_us.xml.h:394
+msgid "Hops, pounds of"
+msgstr ""
+
+#: Form\form_us.xml.h:395
+msgid "Hemp Dew Rotted, tons of"
+msgstr ""
+
+#: Form\form_us.xml.h:396
+msgid "Hemp Water Rotted, tons of"
+msgstr ""
+
+#: Form\form_us.xml.h:397
+msgid "Flax, pounds of"
+msgstr ""
+
+#: Form\form_us.xml.h:398
+msgid "Flaxseed, bushels of"
+msgstr ""
+
+#: Form\form_us.xml.h:399
+msgid "Silk Cocoons, pounds of"
+msgstr ""
+
+#: Form\form_us.xml.h:400
+msgid "Maple Sugar, pounds of"
+msgstr ""
+
+#: Form\form_us.xml.h:401
+msgid "Cane sugar, hogshead of 1,000 pounds"
+msgstr ""
+
+#: Form\form_us.xml.h:402
+msgid "Molasses, gallons of"
+msgstr ""
+
+#: Form\form_us.xml.h:403
+msgid "Beeswax, pounds of"
+msgstr ""
+
+#: Form\form_us.xml.h:404
+msgid "Honey, pounds of"
+msgstr ""
+
+#: Form\form_us.xml.h:405
+msgid "Value of home-made manufactures"
+msgstr ""
+
+#: Form\form_us.xml.h:410
+msgid "Persons who Died during the Year ending 1 June 1860 in"
+msgstr ""
+
+#: Form\form_us.xml.h:418
+msgid "Free or slave"
+msgstr ""
+
+#: Form\form_us.xml.h:419
+msgid "Married or widowed"
+msgstr ""
+
+#: Form\form_us.xml.h:421
+msgid "Month in which person died"
+msgstr ""
+
+#: Form\form_us.xml.h:423
+msgid "Cause of death"
+msgstr ""
+
+#: Form\form_us.xml.h:424
+msgid "Number of days ill"
+msgstr ""
+
+#: Form\form_us.xml.h:444 Form\form_us.xml.h:1555
+msgid "Father of foreign birth"
+msgstr ""
+
+#: Form\form_us.xml.h:445 Form\form_us.xml.h:1556
+msgid "Mother of foreign birth"
+msgstr ""
+
+#: Form\form_us.xml.h:446
+msgid "Month, if born within the year"
+msgstr ""
+
+#: Form\form_us.xml.h:447
+msgid "Month, if married within the year"
+msgstr ""
+
+#: Form\form_us.xml.h:449 Form\form_us.xml.h:485 Form\form_us.xml.h:1037
+#: Form\form_us.xml.h:1780
+msgid "Cannot read"
+msgstr ""
+
+#: Form\form_us.xml.h:450 Form\form_us.xml.h:486 Form\form_us.xml.h:1038
+#: Form\form_us.xml.h:1781
+msgid "Cannot write"
+msgstr ""
+
+#: Form\form_us.xml.h:451
+msgid "Deaf, dumb, blind, insane or idiotic"
+msgstr ""
+
+#: Form\form_us.xml.h:452
+msgid "Male citizen 21 and over"
+msgstr ""
+
+#: Form\form_us.xml.h:453
+msgid ""
+"Male citizen 21 and over where right to vote is denied on grounds other than "
+"rebellion or other crime"
+msgstr ""
+
+#: Form\form_us.xml.h:458 Form\form_us.xml.h:494 Form\form_us.xml.h:606
+#: Form\form_us.xml.h:662 Form\form_us.xml.h:704 Form\form_us.xml.h:747
+#: Form\form_us.xml.h:790 Form\form_us.xml.h:833 Form\form_us.xml.h:1008
+msgid "Supervisor's Dist. No."
+msgstr ""
+
+#: Form\form_us.xml.h:459 Form\form_us.xml.h:495 Form\form_us.xml.h:607
+#: Form\form_us.xml.h:663 Form\form_us.xml.h:705 Form\form_us.xml.h:748
+#: Form\form_us.xml.h:791 Form\form_us.xml.h:834 Form\form_us.xml.h:1009
+#: Form\form_us.xml.h:1755
+msgid "Enumeration Dist. No."
+msgstr ""
+
+#: Form\form_us.xml.h:470 Form\form_us.xml.h:1022 Form\form_us.xml.h:1765
+msgid "Month, if born within the census year"
+msgstr ""
+
+#: Form\form_us.xml.h:471 Form\form_us.xml.h:618 Form\form_us.xml.h:714
+#: Form\form_us.xml.h:757 Form\form_us.xml.h:797 Form\form_us.xml.h:987
+#: Form\form_us.xml.h:1023 Form\form_us.xml.h:1766 Form\form_us.xml.h:1796
+#: Form\form_us.xml.h:1818 Form\form_us.xml.h:1847 Form\form_us.xml.h:2243
+msgid "Relationship to head"
+msgstr ""
+
+#: Form\form_us.xml.h:472 Form\form_us.xml.h:1024 Form\form_us.xml.h:1434
+#: Form\form_us.xml.h:1767 Form\form_us.xml.h:1824 Form\form_us.xml.h:1851
+#: Form\form_us.xml.h:1976 Form\form_us.xml.h:2012 Form\form_us.xml.h:2050
+#: Form\form_us.xml.h:2088 Form\form_us.xml.h:2126
+msgid "Single"
+msgstr ""
+
+#: Form\form_us.xml.h:473 Form\form_us.xml.h:1025 Form\form_us.xml.h:1116
+#: Form\form_us.xml.h:1197 Form\form_us.xml.h:1433 Form\form_us.xml.h:1768
+#: Form\form_us.xml.h:1798 Form\form_us.xml.h:1822 Form\form_us.xml.h:1849
+#: Form\form_us.xml.h:1975 Form\form_us.xml.h:2011 Form\form_us.xml.h:2049
+#: Form\form_us.xml.h:2087 Form\form_us.xml.h:2125
+msgid "Married"
+msgstr ""
+
+#: Form\form_us.xml.h:474 Form\form_us.xml.h:1026 Form\form_us.xml.h:1769
+msgid "Widowed, divorced"
+msgstr ""
+
+#: Form\form_us.xml.h:475 Form\form_us.xml.h:623 Form\form_us.xml.h:1027
+#: Form\form_us.xml.h:1770
+msgid "Married during the census year"
+msgstr ""
+
+#: Form\form_us.xml.h:477 Form\form_us.xml.h:632 Form\form_us.xml.h:1029
+#: Form\form_us.xml.h:1772
+msgid "Number of months unemployed during the census year"
+msgstr ""
+
+#: Form\form_us.xml.h:478 Form\form_us.xml.h:1030 Form\form_us.xml.h:1773
+msgid "Illness on day of enumeration"
+msgstr ""
+
+#: Form\form_us.xml.h:480 Form\form_us.xml.h:742 Form\form_us.xml.h:1032
+#: Form\form_us.xml.h:1775
+msgid "Deaf and dumb"
+msgstr ""
+
+#: Form\form_us.xml.h:482 Form\form_us.xml.h:996 Form\form_us.xml.h:1034
+#: Form\form_us.xml.h:1127 Form\form_us.xml.h:1330 Form\form_us.xml.h:1777
+#: Form\form_us.xml.h:1986 Form\form_us.xml.h:2019 Form\form_us.xml.h:2057
+#: Form\form_us.xml.h:2095 Form\form_us.xml.h:2133 Form\form_us.xml.h:2155
+#: Form\form_us.xml.h:2167 Form\form_us.xml.h:2179
+msgid "Insane"
+msgstr ""
+
+#: Form\form_us.xml.h:483 Form\form_us.xml.h:1035 Form\form_us.xml.h:1778
+msgid "Maimed, crippled, bedridden, or otherwise disabled"
+msgstr ""
+
+#: Form\form_us.xml.h:484 Form\form_us.xml.h:1036 Form\form_us.xml.h:1779
+msgid "Attended school within the census year"
+msgstr ""
+
+#: Form\form_us.xml.h:488 Form\form_us.xml.h:626 Form\form_us.xml.h:684
+#: Form\form_us.xml.h:723 Form\form_us.xml.h:772 Form\form_us.xml.h:810
+#: Form\form_us.xml.h:870 Form\form_us.xml.h:1002 Form\form_us.xml.h:1040
+#: Form\form_us.xml.h:1783
+msgid "Place of birth of father"
+msgstr ""
+
+#: Form\form_us.xml.h:489 Form\form_us.xml.h:627 Form\form_us.xml.h:685
+#: Form\form_us.xml.h:724 Form\form_us.xml.h:774 Form\form_us.xml.h:811
+#: Form\form_us.xml.h:871 Form\form_us.xml.h:1003 Form\form_us.xml.h:1041
+#: Form\form_us.xml.h:1784
+msgid "Place of birth of mother"
+msgstr ""
+
+#: Form\form_us.xml.h:502
+msgid "Owner"
+msgstr ""
+
+#: Form\form_us.xml.h:503
+msgid "Rents for fixed money"
+msgstr ""
+
+#: Form\form_us.xml.h:504
+msgid "Rents for share of products"
+msgstr ""
+
+#: Form\form_us.xml.h:505
+msgid "Acres Tilled"
+msgstr ""
+
+#: Form\form_us.xml.h:506
+msgid "Acres Permanent Meadows, Pastures, Orchards, Vineyards"
+msgstr ""
+
+#: Form\form_us.xml.h:507
+msgid "Acres Woodland and forest"
+msgstr ""
+
+#: Form\form_us.xml.h:508
+msgid "Acres Other unimproved land"
+msgstr ""
+
+#: Form\form_us.xml.h:509
+msgid "Value of Farm"
+msgstr ""
+
+#: Form\form_us.xml.h:510
+msgid "Value of Implements and Machinery"
+msgstr ""
+
+#: Form\form_us.xml.h:512
+msgid "Cost of building and repairing fences in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:513
+msgid "Cost of Fertilizers purchased in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:514
+msgid "Farm Labor Hiring 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:515
+msgid "Weeks hired labor in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:516
+msgid "Estimated value of all farm productions for 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:517
+msgid "Acreage Grass Lands Mown in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:518
+msgid "Acreage Grass Lands Not Mown in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:519
+msgid "Tons Hay Harvested in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:520
+msgid "Bushels Clover Seed Harvested in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:521
+msgid "Bushels Grass Seed Harvested in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:522
+msgid "Horses on hand"
+msgstr ""
+
+#: Form\form_us.xml.h:523
+msgid "Mules and Asses on hand"
+msgstr ""
+
+#: Form\form_us.xml.h:524
+msgid "Working Oxen on hand"
+msgstr ""
+
+#: Form\form_us.xml.h:525
+msgid "Milch Cows on hand"
+msgstr ""
+
+#: Form\form_us.xml.h:526
+msgid "Other Cattle on hand"
+msgstr ""
+
+#: Form\form_us.xml.h:527
+msgid "Calves Dropped in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:528
+msgid "Cattle Purchased in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:529
+msgid "Cattle Sold living in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:530
+msgid "Cattle Slaughtered in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:531
+msgid "Cattle Died, strayed, or stolen in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:532
+msgid "Gallons Milk Sold or sent to butter or cheese factories in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:533
+msgid "Pounds Butter made on farm in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:534
+msgid "Pounds Cheese made on farm in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:535
+msgid "Sheep on hand"
+msgstr ""
+
+#: Form\form_us.xml.h:536
+msgid "Lambs Dropped in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:537
+msgid "Sheep and Lambs Purchased in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:538
+msgid "Sheep and Lambs Sold living in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:539
+msgid "Sheep and Lambs Slaughtered in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:540
+msgid "Sheep and Lambs Killed by dogs in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:541
+msgid "Sheep and Lambs Died of Disease in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:542
+msgid "Sheep and Lambs Died of stress or weather in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:543
+msgid "Number of Fleece, Spring 1880"
+msgstr ""
+
+#: Form\form_us.xml.h:544
+msgid "Pounds Wool, Spring 1880"
+msgstr ""
+
+#: Form\form_us.xml.h:545
+msgid "Swine on hand"
+msgstr ""
+
+#: Form\form_us.xml.h:546 Form\form_us.xml.h:549
+msgid "Barnyard Poultry on hand"
+msgstr ""
+
+#: Form\form_us.xml.h:547
+msgid "Other Poultry on hand"
+msgstr ""
+
+#: Form\form_us.xml.h:548
+msgid "Dozen eggs produced in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:550
+msgid "Acres Barley in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:551
+msgid "Bushels Barley in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:552
+msgid "Acres Buckwheat in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:553
+msgid "Bushels Buckwheat in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:554
+msgid "Acres Indian Corn in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:555
+msgid "Bushels Indian Corn in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:556
+msgid "Acres Oats in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:557
+msgid "Bushels Oats in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:558
+msgid "Acres Rye in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:559
+msgid "Bushels Rye in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:560
+msgid "Acres Wheat in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:561
+msgid "Bushels Wheat in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:562
+msgid "Bushels Canadian Peas in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:563
+msgid "Bushels Beans in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:564
+msgid "Acres Flax in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:565
+msgid "Bushels Flax Sued in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:566
+msgid "Tons Flax Straw in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:567
+msgid "Pounds Flax Fiber in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:568
+msgid "Acres Hemp in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:569
+msgid "Tons Hemp in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:570
+msgid "Acres Sorghum in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:571
+msgid "Pounds Sorghum Sugar in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:572
+msgid "Gallons Sorghum Molasses in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:573
+msgid "Pounds Maple Sugar in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:574
+msgid "Gallons Maple Molasses in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:575
+msgid "Acres Broom Corn in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:576
+msgid "Pounds Broom Corn in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:577
+msgid "Acres Hops in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:578
+msgid "Pounds Hops in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:579
+msgid "Acres Potatoes (Irish) in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:580
+msgid "Bushels Potatoes (Irish) in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:581
+msgid "Acres Potatoes (Sweet) in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:582
+msgid "Bushels Potatoes (Sweet) in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:583
+msgid "Acres Tobacco in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:584
+msgid "Pounds Tobacco in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:585
+msgid "Acres Apple Orchards in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:586
+msgid "Number of Bearing Apple Trees in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:587
+msgid "Bushels Apples in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:588
+msgid "Acres Peach Orchards in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:589
+msgid "Number of Bearing Peach Trees in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:590
+msgid "Bushels Peaches in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:591
+msgid "Total value of Orchard Products Sold or Consumed in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:592
+msgid "Acres Nurseries"
+msgstr ""
+
+#: Form\form_us.xml.h:593
+msgid "Value of Nursery Products Sold"
+msgstr ""
+
+#: Form\form_us.xml.h:594
+msgid "Acres Vineyards"
+msgstr ""
+
+#: Form\form_us.xml.h:595
+msgid "Grapes sold in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:596
+msgid "Wine made in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:597
+msgid "Value of Market Garden Produce Sold in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:598
+msgid "Pounds Honey in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:599
+msgid "Pounds Beeswax in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:600
+msgid "Cords of Wood cut in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:601
+msgid "Value of forest products sold or consumed in 1879"
+msgstr ""
+
+#: Form\form_us.xml.h:611
+msgid "Street and No."
+msgstr ""
+
+#: Form\form_us.xml.h:612 Form\form_us.xml.h:1156 Form\form_us.xml.h:1184
+#: Form\form_us.xml.h:1225 Form\form_us.xml.h:1294 Form\form_us.xml.h:1585
+#: Form\form_us.xml.h:1787 Form\form_us.xml.h:1957 Form\form_us.xml.h:1993
+#: Form\form_us.xml.h:2030 Form\form_us.xml.h:2068 Form\form_us.xml.h:2106
+#: Form\form_us.xml.h:2209
+msgid "Ward"
+msgstr ""
+
+#: Form\form_us.xml.h:617
+msgid "Veteran of Civil War or widow of a veteran"
+msgstr ""
+
+#: Form\form_us.xml.h:622 Form\form_us.xml.h:679 Form\form_us.xml.h:718
+#: Form\form_us.xml.h:763 Form\form_us.xml.h:988 Form\form_us.xml.h:1522
+msgid "Single, married, widowed or divorced"
+msgstr ""
+
+#: Form\form_us.xml.h:624
+msgid "Mother of how many children and number of children living"
+msgstr ""
+
+#: Form\form_us.xml.h:628 Form\form_us.xml.h:687
+msgid "Number of years in US"
+msgstr ""
+
+#: Form\form_us.xml.h:629 Form\form_us.xml.h:1350
+msgid "Naturalized"
+msgstr ""
+
+#: Form\form_us.xml.h:630 Form\form_us.xml.h:689
+msgid "Naturalization papers taken out"
+msgstr ""
+
+#: Form\form_us.xml.h:633 Form\form_us.xml.h:733 Form\form_us.xml.h:768
+#: Form\form_us.xml.h:1531
+msgid "Able to read"
+msgstr ""
+
+#: Form\form_us.xml.h:634 Form\form_us.xml.h:734 Form\form_us.xml.h:769
+#: Form\form_us.xml.h:1532
+msgid "Able to write"
+msgstr ""
+
+#: Form\form_us.xml.h:635
+msgid "Able to speak English; if not, the language spoken"
+msgstr ""
+
+#: Form\form_us.xml.h:636
+msgid "Suffering from disease"
+msgstr ""
+
+#: Form\form_us.xml.h:637
+msgid "Whether defective and name of defect"
+msgstr ""
+
+#: Form\form_us.xml.h:638
+msgid "Prisoner, convict, homeless child or pauper"
+msgstr ""
+
+#: Form\form_us.xml.h:639
+msgid "Supplemental schedule and page"
+msgstr ""
+
+#: Form\form_us.xml.h:643
+msgid "Supervisor's District No."
+msgstr ""
+
+#: Form\form_us.xml.h:644 Form\form_us.xml.h:980 Form\form_us.xml.h:1580
+msgid "Enumeration District No."
+msgstr ""
+
+#: Form\form_us.xml.h:649 Form\form_us.xml.h:925 Form\form_us.xml.h:2203
+#: Form\form_us.xml.h:2232
+msgid "Rank"
+msgstr ""
+
+#: Form\form_us.xml.h:650 Form\form_us.xml.h:1401 Form\form_us.xml.h:1446
+#: Form\form_us.xml.h:2005 Form\form_us.xml.h:2041 Form\form_us.xml.h:2079
+#: Form\form_us.xml.h:2117 Form\form_us.xml.h:2499
+msgid "Company"
+msgstr ""
+
+#: Form\form_us.xml.h:651
+msgid "Regiment/Vessel"
+msgstr ""
+
+#: Form\form_us.xml.h:652 Form\form_us.xml.h:923
+msgid "Date Enlisted"
+msgstr ""
+
+#: Form\form_us.xml.h:653
+msgid "Date Discharged"
+msgstr ""
+
+#: Form\form_us.xml.h:654
+msgid "Length of Service"
+msgstr ""
+
+#: Form\form_us.xml.h:656
+msgid "Disability Incurred"
+msgstr ""
+
+#: Form\form_us.xml.h:660 Form\form_us.xml.h:702 Form\form_us.xml.h:745
+msgid "State (or Territory) of"
+msgstr ""
+
+#: Form\form_us.xml.h:666 Form\form_us.xml.h:708 Form\form_us.xml.h:750
+#: Form\form_us.xml.h:785 Form\form_us.xml.h:828
+msgid "Division of County"
+msgstr ""
+
+#: Form\form_us.xml.h:667 Form\form_us.xml.h:709 Form\form_us.xml.h:751
+#: Form\form_us.xml.h:1914
+msgid "Name of Institution"
+msgstr ""
+
+#: Form\form_us.xml.h:668 Form\form_us.xml.h:710 Form\form_us.xml.h:752
+msgid "City, Town, Village"
+msgstr ""
+
+#: Form\form_us.xml.h:669 Form\form_us.xml.h:711 Form\form_us.xml.h:753
+#: Form\form_us.xml.h:787 Form\form_us.xml.h:830
+msgid "Ward of city"
+msgstr ""
+
+#: Form\form_us.xml.h:670 Form\form_us.xml.h:755 Form\form_us.xml.h:795
+#: Form\form_us.xml.h:838 Form\form_us.xml.h:981 Form\form_us.xml.h:2506
+msgid "Street Address"
+msgstr ""
+
+#: Form\form_us.xml.h:673 Form\form_us.xml.h:1516
+msgid "Relation to head"
+msgstr ""
+
+#: Form\form_us.xml.h:676
+msgid "Month of birth"
+msgstr ""
+
+#: Form\form_us.xml.h:680 Form\form_us.xml.h:719
+msgid "Years of present marriage"
+msgstr ""
+
+#: Form\form_us.xml.h:681 Form\form_us.xml.h:720
+msgid "Mother of how many children"
+msgstr ""
+
+#: Form\form_us.xml.h:682 Form\form_us.xml.h:721
+msgid "Number of children living"
+msgstr ""
+
+#: Form\form_us.xml.h:686 Form\form_us.xml.h:725 Form\form_us.xml.h:764
+#: Form\form_us.xml.h:813
+msgid "Year of immigration"
+msgstr ""
+
+#: Form\form_us.xml.h:691
+msgid "Months not employed"
+msgstr ""
+
+#: Form\form_us.xml.h:692 Form\form_us.xml.h:998
+msgid "Attended school"
+msgstr ""
+
+#: Form\form_us.xml.h:693 Form\form_us.xml.h:1232
+msgid "Can read"
+msgstr ""
+
+#: Form\form_us.xml.h:694 Form\form_us.xml.h:1234
+msgid "Can write"
+msgstr ""
+
+#: Form\form_us.xml.h:695
+msgid "Can speak English"
+msgstr ""
+
+#: Form\form_us.xml.h:696 Form\form_us.xml.h:736 Form\form_us.xml.h:758
+#: Form\form_us.xml.h:798 Form\form_us.xml.h:1469 Form\form_us.xml.h:1491
+#: Form\form_us.xml.h:1517
+msgid "Home owned or rented"
+msgstr ""
+
+#: Form\form_us.xml.h:697 Form\form_us.xml.h:737
+msgid "Owned free or mortgaged"
+msgstr ""
+
+#: Form\form_us.xml.h:698 Form\form_us.xml.h:738 Form\form_us.xml.h:1471
+#: Form\form_us.xml.h:1493
+msgid "Farm or house"
+msgstr ""
+
+#: Form\form_us.xml.h:699 Form\form_us.xml.h:739 Form\form_us.xml.h:780
+#: Form\form_us.xml.h:823
+msgid "Number of farm schedule"
+msgstr ""
+
+#: Form\form_us.xml.h:726 Form\form_us.xml.h:765 Form\form_us.xml.h:814
+msgid "Naturalized or alien"
+msgstr ""
+
+#: Form\form_us.xml.h:727
+msgid "Able to speak English; if not, language spoken"
+msgstr ""
+
+#: Form\form_us.xml.h:729
+msgid "Nature of industry"
+msgstr ""
+
+#: Form\form_us.xml.h:730
+msgid "Employer, employee or working on own account"
+msgstr ""
+
+#: Form\form_us.xml.h:731
+msgid "Out of work"
+msgstr ""
+
+#: Form\form_us.xml.h:732
+msgid "Weeks out of work in 1909"
+msgstr ""
+
+#: Form\form_us.xml.h:735
+msgid "Attended school since Sept. 1, 1909"
+msgstr ""
+
+#: Form\form_us.xml.h:740
+msgid "Civil War veteran"
+msgstr ""
+
+#: Form\form_us.xml.h:759
+msgid "If owned, free or mortgaged"
+msgstr ""
+
+#: Form\form_us.xml.h:766 Form\form_us.xml.h:1527
+msgid "Year of naturalization"
+msgstr ""
+
+#: Form\form_us.xml.h:767
+msgid "Attended school since Sept. 1, 1919"
+msgstr ""
+
+#: Form\form_us.xml.h:771 Form\form_us.xml.h:872
+msgid "Mother tongue"
+msgstr ""
+
+#: Form\form_us.xml.h:773
+msgid "Father mother tongue"
+msgstr ""
+
+#: Form\form_us.xml.h:775
+msgid "Mother's mother tongue"
+msgstr ""
+
+#: Form\form_us.xml.h:776 Form\form_us.xml.h:815
+msgid "Able to speak English"
+msgstr ""
+
+#: Form\form_us.xml.h:779
+msgid "Employer, worker or working on own account"
+msgstr ""
+
+#: Form\form_us.xml.h:786 Form\form_us.xml.h:829
+msgid "Incorporated place"
+msgstr ""
+
+#: Form\form_us.xml.h:788 Form\form_us.xml.h:831
+msgid "Unincorporated place"
+msgstr ""
+
+#: Form\form_us.xml.h:799
+msgid "Value of home or monthly rental"
+msgstr ""
+
+#: Form\form_us.xml.h:800
+msgid "Radio set"
+msgstr ""
+
+#: Form\form_us.xml.h:801 Form\form_us.xml.h:842
+msgid "Farm?"
+msgstr ""
+
+#: Form\form_us.xml.h:805
+msgid "Marital condition"
+msgstr ""
+
+#: Form\form_us.xml.h:806 Form\form_us.xml.h:883
+msgid "Age at first marriage"
+msgstr ""
+
+#: Form\form_us.xml.h:807
+msgid "Attended school since Sept. 1, 1929"
+msgstr ""
+
+#: Form\form_us.xml.h:808
+msgid "Able to read and write"
+msgstr ""
+
+#: Form\form_us.xml.h:812
+msgid "Language before coming to US"
+msgstr ""
+
+#: Form\form_us.xml.h:818 Form\form_us.xml.h:865
+msgid "Class of worker"
+msgstr ""
+
+#: Form\form_us.xml.h:820
+msgid "Line number for unemployed"
+msgstr ""
+
+#: Form\form_us.xml.h:821
+msgid "Veteran"
+msgstr ""
+
+#: Form\form_us.xml.h:822
+msgid "What war"
+msgstr ""
+
+#: Form\form_us.xml.h:840
+msgid "Home Owned/Rented"
+msgstr ""
+
+#: Form\form_us.xml.h:841
+msgid "Home value/monthly rental"
+msgstr ""
+
+#: Form\form_us.xml.h:843
+msgid "Relationship"
+msgstr ""
+
+#: Form\form_us.xml.h:845
+msgid "Color/Race"
+msgstr ""
+
+#: Form\form_us.xml.h:846
+msgid "Age at Last Birthday"
+msgstr ""
+
+#: Form\form_us.xml.h:847 Form\form_us.xml.h:1169 Form\form_us.xml.h:1258
+#: Form\form_us.xml.h:1321 Form\form_us.xml.h:1343 Form\form_us.xml.h:1406
+#: Form\form_us.xml.h:2247 Form\form_us.xml.h:2350 Form\form_us.xml.h:2383
+#: Form\form_us.xml.h:2404
+msgid "Marital Status"
+msgstr ""
+
+#: Form\form_us.xml.h:848
+msgid "Attended school/college since March 1, 1940"
+msgstr ""
+
+#: Form\form_us.xml.h:849
+msgid "Highest grade completed"
+msgstr ""
+
+#: Form\form_us.xml.h:851
+msgid "Citizenship if foreign born"
+msgstr ""
+
+#: Form\form_us.xml.h:852
+msgid "City (April 1, 1935)"
+msgstr ""
+
+#: Form\form_us.xml.h:854
+msgid "State (Territory/Country)"
+msgstr ""
+
+#: Form\form_us.xml.h:855
+msgid "On a Farm (Y/N)"
+msgstr ""
+
+#: Form\form_us.xml.h:856
+msgid "At Work during week March 24-30"
+msgstr ""
+
+#: Form\form_us.xml.h:857
+msgid "public Emergency Work?"
+msgstr ""
+
+#: Form\form_us.xml.h:858
+msgid "Seeking work?"
+msgstr ""
+
+#: Form\form_us.xml.h:859
+msgid "Have a Job?"
+msgstr ""
+
+#: Form\form_us.xml.h:860
+msgid "housework (H), school (S), unable to work (U) or other (Ot)"
+msgstr ""
+
+#: Form\form_us.xml.h:861
+msgid "# hours worked during week March 24-30, 1940"
+msgstr ""
+
+#: Form\form_us.xml.h:862
+msgid "Weeks unemployed up to March 30, 1940"
+msgstr ""
+
+#: Form\form_us.xml.h:866
+msgid "# weeks worked in 1939"
+msgstr ""
+
+#: Form\form_us.xml.h:867
+msgid "Amount of money, wages, salary in 1939"
+msgstr ""
+
+#: Form\form_us.xml.h:868
+msgid "Income of more than $50 from other sources?"
+msgstr ""
+
+#: Form\form_us.xml.h:869
+msgid "Number of Farm Schedule"
+msgstr ""
+
+#: Form\form_us.xml.h:873
+msgid "Veteran?"
+msgstr ""
+
+#: Form\form_us.xml.h:874
+msgid "If child, veteran-father dead?"
+msgstr ""
+
+#: Form\form_us.xml.h:875
+msgid "War/Military Service"
+msgstr ""
+
+#: Form\form_us.xml.h:876
+msgid "Have Federal SSN?"
+msgstr ""
+
+#: Form\form_us.xml.h:877
+msgid "Deductions made in 1939?"
+msgstr ""
+
+#: Form\form_us.xml.h:878
+msgid "If so, made from all, 1/2 or more, less from wages in 1939?"
+msgstr ""
+
+#: Form\form_us.xml.h:879
+msgid "Usual Occupation"
+msgstr ""
+
+#: Form\form_us.xml.h:880
+msgid "Usual Industry"
+msgstr ""
+
+#: Form\form_us.xml.h:881
+msgid "Usual Class of Work"
+msgstr ""
+
+#: Form\form_us.xml.h:882
+msgid "If woman, married more than once?"
+msgstr ""
+
+#: Form\form_us.xml.h:884
+msgid "Number of children ever born"
+msgstr ""
+
+#: Form\form_us.xml.h:885
+msgid "Census Date"
+msgstr ""
+
+#: Form\form_us.xml.h:886
+msgid "District of"
+msgstr ""
+
+#: Form\form_us.xml.h:889
+msgid "Married Y/N"
+msgstr ""
+
+#: Form\form_us.xml.h:890
+msgid "Spouses Age"
+msgstr ""
+
+#: Form\form_us.xml.h:894
+msgid "File No."
+msgstr ""
+
+#: Form\form_us.xml.h:896 Form\form_us.xml.h:915 Form\form_us.xml.h:970
+msgid "Post Office Address"
+msgstr ""
+
+#: Form\form_us.xml.h:898 Form\form_us.xml.h:920 Form\form_us.xml.h:1053
+#: Form\form_us.xml.h:1067 Form\form_us.xml.h:1364 Form\form_us.xml.h:2287
+#: Form\form_us.xml.h:2400 Form\form_us.xml.h:2425 Form\form_us.xml.h:2469
+msgid "Place of Birth"
+msgstr ""
+
+#: Form\form_us.xml.h:899
+msgid "Entered service as (rank)"
+msgstr ""
+
+#: Form\form_us.xml.h:900
+msgid "Date Entered"
+msgstr ""
+
+#: Form\form_us.xml.h:901 Form\form_us.xml.h:922
+msgid "Place of Enlistment"
+msgstr ""
+
+#: Form\form_us.xml.h:902
+msgid "Name, Letter of Co., Number of Regiment"
+msgstr ""
+
+#: Form\form_us.xml.h:903
+msgid "Continued until"
+msgstr ""
+
+#: Form\form_us.xml.h:904
+msgid "Re-enlisted as"
+msgstr ""
+
+#: Form\form_us.xml.h:905
+msgid "On date"
+msgstr ""
+
+#: Form\form_us.xml.h:907
+msgid "and continued until"
+msgstr ""
+
+#: Form\form_us.xml.h:908
+msgid "3rd enlistment"
+msgstr ""
+
+#: Form\form_us.xml.h:909
+msgid "Enlisted on"
+msgstr ""
+
+#: Form\form_us.xml.h:910
+msgid "Enlistment Place"
+msgstr ""
+
+#: Form\form_us.xml.h:911
+msgid "in the command of"
+msgstr ""
+
+#: Form\form_us.xml.h:912
+msgid "Until"
+msgstr ""
+
+#: Form\form_us.xml.h:913
+msgid "Other service, if any"
+msgstr ""
+
+#: Form\form_us.xml.h:916
+msgid "No. on pension roll"
+msgstr ""
+
+#: Form\form_us.xml.h:917
+msgid "County lived in when first placed on roll"
+msgstr ""
+
+#: Form\form_us.xml.h:918
+msgid "Other states lived in and when"
+msgstr ""
+
+#: Form\form_us.xml.h:919
+msgid "Moved to Alabama"
+msgstr ""
+
+#: Form\form_us.xml.h:924
+msgid "Branch of service"
+msgstr ""
+
+#: Form\form_us.xml.h:926
+msgid "Letter of Company"
+msgstr ""
+
+#: Form\form_us.xml.h:927
+msgid "Number of Regiment"
+msgstr ""
+
+#: Form\form_us.xml.h:928
+msgid "Was it an Alabama Regiment"
+msgstr ""
+
+#: Form\form_us.xml.h:929
+msgid "If not, give name of state"
+msgstr ""
+
+#: Form\form_us.xml.h:930
+msgid "Name of your Captain"
+msgstr ""
+
+#: Form\form_us.xml.h:931
+msgid "Name of your Colonel"
+msgstr ""
+
+#: Form\form_us.xml.h:932
+msgid "By what other name was your Company called"
+msgstr ""
+
+#: Form\form_us.xml.h:933
+msgid "By what other name was your Regiment called"
+msgstr ""
+
+#: Form\form_us.xml.h:934
+msgid "Battles in which you took part"
+msgstr ""
+
+#: Form\form_us.xml.h:935
+msgid "Ever wounded"
+msgstr ""
+
+#: Form\form_us.xml.h:936
+msgid "When wounded"
+msgstr ""
+
+#: Form\form_us.xml.h:937
+msgid "In what battles"
+msgstr ""
+
+#: Form\form_us.xml.h:938
+msgid "Were you captured"
+msgstr ""
+
+#: Form\form_us.xml.h:939
+msgid "When captured"
+msgstr ""
+
+#: Form\form_us.xml.h:940
+msgid "Where captured"
+msgstr ""
+
+#: Form\form_us.xml.h:941
+msgid "Were you imprisoned"
+msgstr ""
+
+#: Form\form_us.xml.h:942
+msgid "When imprisoned"
+msgstr ""
+
+#: Form\form_us.xml.h:943
+msgid "Were imprisoned"
+msgstr ""
+
+#: Form\form_us.xml.h:944
+msgid "How were you discharged"
+msgstr ""
+
+#: Form\form_us.xml.h:945
+msgid "Did you transfer to another Company or Command"
+msgstr ""
+
+#: Form\form_us.xml.h:946
+msgid "If so, give Company and Regiment"
+msgstr ""
+
+#: Form\form_us.xml.h:947
+msgid "What branch of service and date of transfer"
+msgstr ""
+
+#: Form\form_us.xml.h:948
+msgid "Captains name"
+msgstr ""
+
+#: Form\form_us.xml.h:949
+msgid "Colonels name"
+msgstr ""
+
+#: Form\form_us.xml.h:950
+msgid "Length of service"
+msgstr ""
+
+#: Form\form_us.xml.h:951
+msgid "Are you married"
+msgstr ""
+
+#: Form\form_us.xml.h:952
+msgid "Age of wife"
+msgstr ""
+
+#: Form\form_us.xml.h:953
+msgid "Birthplace of wife"
+msgstr ""
+
+#: Form\form_us.xml.h:954
+msgid "Date married"
+msgstr ""
+
+#: Form\form_us.xml.h:955
+msgid "Place married"
+msgstr ""
+
+#: Form\form_us.xml.h:956
+msgid "When, where and circumstances you quit the service"
+msgstr ""
+
+#: Form\form_us.xml.h:957
+msgid "Paroled at close of war"
+msgstr ""
+
+#: Form\form_us.xml.h:958
+msgid "If so, when"
+msgstr ""
+
+#: Form\form_us.xml.h:959
+msgid "and where"
+msgstr ""
+
+#: Form\form_us.xml.h:960
+msgid "Have you your parole"
+msgstr ""
+
+#: Form\form_us.xml.h:961
+msgid "Voting Precinct and County"
+msgstr ""
+
+#: Form\form_us.xml.h:963
+msgid "With whom are you living"
+msgstr ""
+
+#: Form\form_us.xml.h:964
+msgid "Regularly received your pension warrant"
+msgstr ""
+
+#: Form\form_us.xml.h:965
+msgid "If No give information regarding the same"
+msgstr ""
+
+#: Form\form_us.xml.h:968
+msgid "Witness name and P.O Address"
+msgstr ""
+
+#: Form\form_us.xml.h:973 Form\form_us.xml.h:2511
+msgid "Widow of"
+msgstr ""
+
+#: Form\form_us.xml.h:974
+msgid "Her age"
+msgstr ""
+
+#: Form\form_us.xml.h:975
+msgid "Her date of birth"
+msgstr ""
+
+#: Form\form_us.xml.h:976
+msgid "Date of marriage"
+msgstr ""
+
+#: Form\form_us.xml.h:986
+msgid "Born within census year"
+msgstr ""
+
+#: Form\form_us.xml.h:989
+msgid "Married during census year"
+msgstr ""
+
+#: Form\form_us.xml.h:991
+msgid "Months unemployed during census year"
+msgstr ""
+
+#: Form\form_us.xml.h:992
+msgid "(Day of the Enumerator's visit) sick or temporarily disabled"
+msgstr ""
+
+#: Form\form_us.xml.h:994 Form\form_us.xml.h:1125
+msgid "Deaf and Dumb"
+msgstr ""
+
+#: Form\form_us.xml.h:997
+msgid "Maimed, Crippled, Bedridden, or otherwise disabled."
+msgstr ""
+
+#: Form\form_us.xml.h:999
+msgid "Can not read"
+msgstr ""
+
+#: Form\form_us.xml.h:1000
+msgid "Can not write"
+msgstr ""
+
+#: Form\form_us.xml.h:1015
+msgid "Street Name"
+msgstr ""
+
+#: Form\form_us.xml.h:1016
+msgid "House No."
+msgstr ""
+
+#: Form\form_us.xml.h:1042 Form\form_us.xml.h:1057
+msgid "Precinct No."
+msgstr ""
+
+#: Form\form_us.xml.h:1048
+msgid "Inside or Outside City Limits"
+msgstr ""
+
+#: Form\form_us.xml.h:1049 Form\form_us.xml.h:1065
+msgid "Age Male"
+msgstr ""
+
+#: Form\form_us.xml.h:1050 Form\form_us.xml.h:1066
+msgid "Age Female"
+msgstr ""
+
+#: Form\form_us.xml.h:1052
+msgid "Relation to Family"
+msgstr ""
+
+#: Form\form_us.xml.h:1054 Form\form_us.xml.h:1068
+msgid "Degree of Education"
+msgstr ""
+
+#: Form\form_us.xml.h:1055
+msgid "Owner or Renter"
+msgstr ""
+
+#: Form\form_us.xml.h:1064
+msgid "In or Out"
+msgstr ""
+
+#: Form\form_us.xml.h:1071
+msgid "White Males Under 10"
+msgstr ""
+
+#: Form\form_us.xml.h:1072
+msgid "White Males 10 to 20"
+msgstr ""
+
+#: Form\form_us.xml.h:1073
+msgid "White Males 20 to 30"
+msgstr ""
+
+#: Form\form_us.xml.h:1074
+msgid "White Males 30 to 40"
+msgstr ""
+
+#: Form\form_us.xml.h:1075
+msgid "White Males 40 to 50"
+msgstr ""
+
+#: Form\form_us.xml.h:1076
+msgid "White Males 50 to 60"
+msgstr ""
+
+#: Form\form_us.xml.h:1077
+msgid "White Males 60 to 70"
+msgstr ""
+
+#: Form\form_us.xml.h:1078
+msgid "White Males 70 to 80"
+msgstr ""
+
+#: Form\form_us.xml.h:1079
+msgid "White Males 80 to 90"
+msgstr ""
+
+#: Form\form_us.xml.h:1080
+msgid "White Males Over 90"
+msgstr ""
+
+#: Form\form_us.xml.h:1081
+msgid "White Females Under 10"
+msgstr ""
+
+#: Form\form_us.xml.h:1082
+msgid "White Females 10 to 20"
+msgstr ""
+
+#: Form\form_us.xml.h:1083
+msgid "White Females 20 to 30"
+msgstr ""
+
+#: Form\form_us.xml.h:1084
+msgid "White Females 30 to 40"
+msgstr ""
+
+#: Form\form_us.xml.h:1085
+msgid "White Females 40 to 50"
+msgstr ""
+
+#: Form\form_us.xml.h:1086
+msgid "White Females 50 to 60"
+msgstr ""
+
+#: Form\form_us.xml.h:1087
+msgid "White Females 60 to 70"
+msgstr ""
+
+#: Form\form_us.xml.h:1088
+msgid "White Females 70 to 80"
+msgstr ""
+
+#: Form\form_us.xml.h:1089
+msgid "White Females 80 to 90"
+msgstr ""
+
+#: Form\form_us.xml.h:1090
+msgid "White Females Over 90"
+msgstr ""
+
+#: Form\form_us.xml.h:1091
+msgid "Male Negroes and Mulattoes"
+msgstr ""
+
+#: Form\form_us.xml.h:1092
+msgid "Female Negroes and Mulattoes"
+msgstr ""
+
+#: Form\form_us.xml.h:1094 Form\form_us.xml.h:1124
+msgid "Militia"
+msgstr ""
+
+#: Form\form_us.xml.h:1095
+msgid "Manufactories of All Kinds"
+msgstr ""
+
+#: Form\form_us.xml.h:1096
+msgid "Value of products of manufactories"
+msgstr ""
+
+#: Form\form_us.xml.h:1097
+msgid "Value of products of Coal Mines"
+msgstr ""
+
+#: Form\form_us.xml.h:1099
+msgid "Pounds of Wool"
+msgstr ""
+
+#: Form\form_us.xml.h:1100
+msgid "Number of Colleges"
+msgstr ""
+
+#: Form\form_us.xml.h:1101 Form\form_us.xml.h:1103
+msgid "Number of Pupils"
+msgstr ""
+
+#: Form\form_us.xml.h:1102
+msgid "Number of Common Schools"
+msgstr ""
+
+#: Form\form_us.xml.h:1106
+msgid "Males over 21 years"
+msgstr ""
+
+#: Form\form_us.xml.h:1107
+msgid "Males under 21 years"
+msgstr ""
+
+#: Form\form_us.xml.h:1108
+msgid "Females"
+msgstr ""
+
+#: Form\form_us.xml.h:1109 Form\form_us.xml.h:1111
+msgid "Total number"
+msgstr ""
+
+#: Form\form_us.xml.h:1117 Form\form_us.xml.h:1799 Form\form_us.xml.h:1823
+#: Form\form_us.xml.h:1850 Form\form_us.xml.h:1977 Form\form_us.xml.h:2013
+#: Form\form_us.xml.h:2051 Form\form_us.xml.h:2089 Form\form_us.xml.h:2127
+msgid "Widowed"
+msgstr ""
+
+#: Form\form_us.xml.h:1118
+msgid "Years resident in the state"
+msgstr ""
+
+#: Form\form_us.xml.h:1121
+msgid "Native voters"
+msgstr ""
+
+#: Form\form_us.xml.h:1122
+msgid "Naturalized voters"
+msgstr ""
+
+#: Form\form_us.xml.h:1129
+msgid "Owners of land"
+msgstr ""
+
+#: Form\form_us.xml.h:1130
+msgid "Paupers"
+msgstr ""
+
+#: Form\form_us.xml.h:1131
+msgid "Acres of improved land"
+msgstr ""
+
+#: Form\form_us.xml.h:1132
+msgid "Acres of unimproved land"
+msgstr ""
+
+#: Form\form_us.xml.h:1133
+msgid "Acres in meadow"
+msgstr ""
+
+#: Form\form_us.xml.h:1134
+msgid "Tons of hay"
+msgstr ""
+
+#: Form\form_us.xml.h:1135
+msgid "Bushels of grass seed"
+msgstr ""
+
+#: Form\form_us.xml.h:1136
+msgid "Acres of spring wheat"
+msgstr ""
+
+#: Form\form_us.xml.h:1137
+msgid "Bushels harvested (spring wheat)"
+msgstr ""
+
+#: Form\form_us.xml.h:1138
+msgid "Acres of winter wheat"
+msgstr ""
+
+#: Form\form_us.xml.h:1139
+msgid "Bushels harvested (winter wheat)"
+msgstr ""
+
+#: Form\form_us.xml.h:1140
+msgid "Acres of oats"
+msgstr ""
+
+#: Form\form_us.xml.h:1141
+msgid "Bushels harvested (oats)"
+msgstr ""
+
+#: Form\form_us.xml.h:1142
+msgid "Acres of corn"
+msgstr ""
+
+#: Form\form_us.xml.h:1143
+msgid "Bushels harvested (corn)"
+msgstr ""
+
+#: Form\form_us.xml.h:1144
+msgid "Acres of potatoes"
+msgstr ""
+
+#: Form\form_us.xml.h:1145
+msgid "Bushels harvested (potatoes)"
+msgstr ""
+
+#: Form\form_us.xml.h:1146
+msgid "Number of hogs sold"
+msgstr ""
+
+#: Form\form_us.xml.h:1147
+msgid "Value of hogs sold"
+msgstr ""
+
+#: Form\form_us.xml.h:1148
+msgid "Number of cattle sold"
+msgstr ""
+
+#: Form\form_us.xml.h:1149
+msgid "Value of cattle sold"
+msgstr ""
+
+#: Form\form_us.xml.h:1150
+msgid "Pounds of butter manufactured"
+msgstr ""
+
+#: Form\form_us.xml.h:1151
+msgid "Pounds of cheese"
+msgstr ""
+
+#: Form\form_us.xml.h:1152
+msgid "Pounds of wool"
+msgstr ""
+
+#: Form\form_us.xml.h:1153
+msgid "Value of domestic manufactures"
+msgstr ""
+
+#: Form\form_us.xml.h:1154
+msgid "Value of general manufactures"
+msgstr ""
+
+#: Form\form_us.xml.h:1157 Form\form_us.xml.h:1186 Form\form_us.xml.h:1534
+#: Form\form_us.xml.h:1785
+msgid "Town of"
+msgstr ""
+
+#: Form\form_us.xml.h:1158 Form\form_us.xml.h:1185 Form\form_us.xml.h:1786
+#: Form\form_us.xml.h:1873
+msgid "City of"
+msgstr ""
+
+#: Form\form_us.xml.h:1159 Form\form_us.xml.h:1187 Form\form_us.xml.h:1788
+msgid "Township of"
+msgstr ""
+
+#: Form\form_us.xml.h:1165
+msgid "Street and Number"
+msgstr ""
+
+#: Form\form_us.xml.h:1171
+msgid "Place of birth, county"
+msgstr ""
+
+#: Form\form_us.xml.h:1172
+msgid "Place of birth, state or territory"
+msgstr ""
+
+#: Form\form_us.xml.h:1173
+msgid "Place of birth, country"
+msgstr ""
+
+#: Form\form_us.xml.h:1174
+msgid "Father (N, Native; F, Foreign)"
+msgstr ""
+
+#: Form\form_us.xml.h:1175
+msgid "Mother (N, Native; F, Foreign)"
+msgstr ""
+
+#: Form\form_us.xml.h:1176 Form\form_us.xml.h:1204
+msgid "Subject to military duty"
+msgstr ""
+
+#: Form\form_us.xml.h:1177 Form\form_us.xml.h:1205
+msgid "Entitled to vote"
+msgstr ""
+
+#: Form\form_us.xml.h:1178
+msgid "Alien who has taken out first papers"
+msgstr ""
+
+#: Form\form_us.xml.h:1179
+msgid "Alien who has not taken out first papers"
+msgstr ""
+
+#: Form\form_us.xml.h:1180
+msgid "Over 10 and cannot read or write"
+msgstr ""
+
+#: Form\form_us.xml.h:1181
+msgid "Over 10 and can read but not write"
+msgstr ""
+
+#: Form\form_us.xml.h:1182
+msgid "Deaf and dumb, blind, insane, or idiotic"
+msgstr ""
+
+#: Form\form_us.xml.h:1190
+msgid "Age 18 or older"
+msgstr ""
+
+#: Form\form_us.xml.h:1191
+msgid "Age 5 to 18"
+msgstr ""
+
+#: Form\form_us.xml.h:1192
+msgid "Age under 5"
+msgstr ""
+
+#: Form\form_us.xml.h:1193
+msgid "White Male"
+msgstr ""
+
+#: Form\form_us.xml.h:1194
+msgid "White Female"
+msgstr ""
+
+#: Form\form_us.xml.h:1195
+msgid "Colored Male"
+msgstr ""
+
+#: Form\form_us.xml.h:1196
+msgid "Colored Female"
+msgstr ""
+
+#: Form\form_us.xml.h:1198
+msgid "Single, Widowed, or Divorced"
+msgstr ""
+
+#: Form\form_us.xml.h:1200
+msgid "Father (N,Native; F,Foreign)"
+msgstr ""
+
+#: Form\form_us.xml.h:1201
+msgid "Mother (N,Native; F,Foreign)"
+msgstr ""
+
+#: Form\form_us.xml.h:1203
+msgid "Religious belief"
+msgstr ""
+
+#: Form\form_us.xml.h:1206
+msgid "Can read but not write, over 10 years old"
+msgstr ""
+
+#: Form\form_us.xml.h:1207
+msgid "Cannot read or write, over 10 years old"
+msgstr ""
+
+#: Form\form_us.xml.h:1208
+msgid "Children over 6 and under 17 not attending school in 1894"
+msgstr ""
+
+#: Form\form_us.xml.h:1210
+msgid "Births in 1894"
+msgstr ""
+
+#: Form\form_us.xml.h:1211
+msgid "Deaths in 1894"
+msgstr ""
+
+#: Form\form_us.xml.h:1212
+msgid "Deaf and dumb not in State School for Deaf"
+msgstr ""
+
+#: Form\form_us.xml.h:1213
+msgid "Blind not in State College for Blind"
+msgstr ""
+
+#: Form\form_us.xml.h:1214
+msgid "Insane not in State Hospital for Insane"
+msgstr ""
+
+#: Form\form_us.xml.h:1215
+msgid "Company if in Civil War"
+msgstr ""
+
+#: Form\form_us.xml.h:1216
+msgid "Regiment if in Civil War"
+msgstr ""
+
+#: Form\form_us.xml.h:1217
+msgid "State if in Civil War"
+msgstr ""
+
+#: Form\form_us.xml.h:1218
+msgid "Arm of service and rank if in Civil War"
+msgstr ""
+
+#: Form\form_us.xml.h:1219
+msgid "Regiment if in Mexican War"
+msgstr ""
+
+#: Form\form_us.xml.h:1220
+msgid "State if in Mexican War"
+msgstr ""
+
+#: Form\form_us.xml.h:1221 Form\form_us.xml.h:1288 Form\form_us.xml.h:1950
+#: Form\form_us.xml.h:1987 Form\form_us.xml.h:2024 Form\form_us.xml.h:2062
+#: Form\form_us.xml.h:2100
+msgid "Card No."
+msgstr ""
+
+#: Form\form_us.xml.h:1228
+msgid "P.O. Address"
+msgstr ""
+
+#: Form\form_us.xml.h:1229
+msgid "P. O. Address"
+msgstr ""
+
+#: Form\form_us.xml.h:1233
+msgid "Can you read?"
+msgstr ""
+
+#: Form\form_us.xml.h:1235
+msgid "Can you write?"
+msgstr ""
+
+#: Form\form_us.xml.h:1237
+msgid "Color, White-Black-Yellow-Red"
+msgstr ""
+
+#: Form\form_us.xml.h:1240
+msgid "Place of Birth-Self"
+msgstr ""
+
+#: Form\form_us.xml.h:1241
+msgid "Place of birth, Self"
+msgstr ""
+
+#: Form\form_us.xml.h:1242
+msgid "Place of Birth-Mother"
+msgstr ""
+
+#: Form\form_us.xml.h:1243
+msgid "Place of birth, Mother"
+msgstr ""
+
+#: Form\form_us.xml.h:1244
+msgid "Place of Birth-Father"
+msgstr ""
+
+#: Form\form_us.xml.h:1245
+msgid "Place of birth, Father"
+msgstr ""
+
+#: Form\form_us.xml.h:1246
+msgid "Own home or farm"
+msgstr ""
+
+#: Form\form_us.xml.h:1247
+msgid "Do you own your home or farm?"
+msgstr ""
+
+#: Form\form_us.xml.h:1248
+msgid "Value of home or farm"
+msgstr ""
+
+#: Form\form_us.xml.h:1249
+msgid "Entire value of home or farm?"
+msgstr ""
+
+#: Form\form_us.xml.h:1250
+msgid "How much incumberance on home or farm"
+msgstr ""
+
+#: Form\form_us.xml.h:1251
+msgid "How much incumberance on your home or farm?"
+msgstr ""
+
+#: Form\form_us.xml.h:1252
+msgid "If foreign born, are you naturalized"
+msgstr ""
+
+#: Form\form_us.xml.h:1253
+msgid "If you are foreign born, are you naturalized?"
+msgstr ""
+
+#: Form\form_us.xml.h:1254 Form\form_us.xml.h:1255 Form\form_us.xml.h:1333
+#: Form\form_us.xml.h:2022 Form\form_us.xml.h:2060 Form\form_us.xml.h:2098
+#: Form\form_us.xml.h:2136
+msgid "Years in U.S."
+msgstr ""
+
+#: Form\form_us.xml.h:1256 Form\form_us.xml.h:1334 Form\form_us.xml.h:1352
+msgid "Years in Iowa"
+msgstr ""
+
+#: Form\form_us.xml.h:1257
+msgid "Years in Iowa>"
+msgstr ""
+
+#: Form\form_us.xml.h:1259
+msgid "Conjugal condition; Single-Married-Widowed-Divorced-Separated"
+msgstr ""
+
+#: Form\form_us.xml.h:1260
+msgid "Months in school in 1904-Public"
+msgstr ""
+
+#: Form\form_us.xml.h:1261
+msgid "Months in school in 1904; Public"
+msgstr ""
+
+#: Form\form_us.xml.h:1262
+msgid "Months in school in 1904-High"
+msgstr ""
+
+#: Form\form_us.xml.h:1263
+msgid "Months in school in 1904; High"
+msgstr ""
+
+#: Form\form_us.xml.h:1264
+msgid "Months in school in 1904-Private"
+msgstr ""
+
+#: Form\form_us.xml.h:1265
+msgid "Months in school in 1904; Private"
+msgstr ""
+
+#: Form\form_us.xml.h:1266
+msgid "Months in school in 1904-College"
+msgstr ""
+
+#: Form\form_us.xml.h:1267
+msgid "Months in school in 1904; College"
+msgstr ""
+
+#: Form\form_us.xml.h:1270 Form\form_us.xml.h:1271
+msgid "Months unemployed in 1904"
+msgstr ""
+
+#: Form\form_us.xml.h:1272
+msgid "Military-Service in which war"
+msgstr ""
+
+#: Form\form_us.xml.h:1273
+msgid "Military Service in; Civil War-Mexican War-Spanish War"
+msgstr ""
+
+#: Form\form_us.xml.h:1274
+msgid "Military-Company"
+msgstr ""
+
+#: Form\form_us.xml.h:1275
+msgid "Military Service; Company"
+msgstr ""
+
+#: Form\form_us.xml.h:1276
+msgid "Military-Regiment"
+msgstr ""
+
+#: Form\form_us.xml.h:1277
+msgid "Military Service; Regiment"
+msgstr ""
+
+#: Form\form_us.xml.h:1278
+msgid "Military-State"
+msgstr ""
+
+#: Form\form_us.xml.h:1279
+msgid "Military Service; State"
+msgstr ""
+
+#: Form\form_us.xml.h:1280
+msgid "Military-Class of service"
+msgstr ""
+
+#: Form\form_us.xml.h:1281
+msgid "Military Service; Class of service; Cavalry-Infantry-Artillery-Navy"
+msgstr ""
+
+#: Form\form_us.xml.h:1282
+msgid "Military-Date of enlistment"
+msgstr ""
+
+#: Form\form_us.xml.h:1283
+msgid "Military Service; Date of enlistment"
+msgstr ""
+
+#: Form\form_us.xml.h:1284
+msgid "Military-Date of discharge"
+msgstr ""
+
+#: Form\form_us.xml.h:1285
+msgid "Military Service; Date of discharge"
+msgstr ""
+
+#: Form\form_us.xml.h:1286
+msgid "Military-Remarks"
+msgstr ""
+
+#: Form\form_us.xml.h:1287
+msgid "Military Service; Remarks"
+msgstr ""
+
+#: Form\form_us.xml.h:1293 Form\form_us.xml.h:1992 Form\form_us.xml.h:2029
+#: Form\form_us.xml.h:2067 Form\form_us.xml.h:2105
+msgid "Town or Township"
+msgstr ""
+
+#: Form\form_us.xml.h:1296
+msgid "Months in 1914 Unemployed"
+msgstr ""
+
+#: Form\form_us.xml.h:1297
+msgid "Earnings for 1914 from occupation"
+msgstr ""
+
+#: Form\form_us.xml.h:1298
+msgid "Extent of Education Common"
+msgstr ""
+
+#: Form\form_us.xml.h:1299
+msgid "Extent of Education Grammar"
+msgstr ""
+
+#: Form\form_us.xml.h:1300
+msgid "Extent of Education High School"
+msgstr ""
+
+#: Form\form_us.xml.h:1301
+msgid "Extent of Education College"
+msgstr ""
+
+#: Form\form_us.xml.h:1302 Form\form_us.xml.h:1554 Form\form_us.xml.h:1598
+#: Form\form_us.xml.h:1964 Form\form_us.xml.h:1996 Form\form_us.xml.h:2033
+#: Form\form_us.xml.h:2071 Form\form_us.xml.h:2109 Form\form_us.xml.h:2268
+#: Form\form_us.xml.h:2274 Form\form_us.xml.h:2321 Form\form_us.xml.h:2323
+#: Form\form_us.xml.h:2327 Form\form_us.xml.h:2331 Form\form_us.xml.h:2335
+#: Form\form_us.xml.h:2360 Form\form_us.xml.h:2382
+msgid "Birthplace"
+msgstr ""
+
+#: Form\form_us.xml.h:1303
+msgid "Own house or farm"
+msgstr ""
+
+#: Form\form_us.xml.h:1304
+msgid "Incumbrance on farm or home"
+msgstr ""
+
+#: Form\form_us.xml.h:1305
+msgid "Value of farm or home"
+msgstr ""
+
+#: Form\form_us.xml.h:1306
+msgid "Military Service: Civil War"
+msgstr ""
+
+#: Form\form_us.xml.h:1307
+msgid "Military Service: Mexican"
+msgstr ""
+
+#: Form\form_us.xml.h:1308
+msgid "Military Service: Spanish"
+msgstr ""
+
+#: Form\form_us.xml.h:1309
+msgid "Military Service: Infantry"
+msgstr ""
+
+#: Form\form_us.xml.h:1310
+msgid "Military Service: Cavalry"
+msgstr ""
+
+#: Form\form_us.xml.h:1311
+msgid "Military Service: Artillery"
+msgstr ""
+
+#: Form\form_us.xml.h:1312
+msgid "Military Service: Navy"
+msgstr ""
+
+#: Form\form_us.xml.h:1313
+msgid "Military Service: State"
+msgstr ""
+
+#: Form\form_us.xml.h:1314
+msgid "Military Service: Regiment"
+msgstr ""
+
+#: Form\form_us.xml.h:1315
+msgid "Military Service: Company"
+msgstr ""
+
+#: Form\form_us.xml.h:1316
+msgid "Church Affiliation"
+msgstr ""
+
+#: Form\form_us.xml.h:1317 Form\form_us.xml.h:2362 Form\form_us.xml.h:2385
+msgid "Father's Birthplace"
+msgstr ""
+
+#: Form\form_us.xml.h:1318 Form\form_us.xml.h:2364 Form\form_us.xml.h:2387
+msgid "Mother's Birthplace"
+msgstr ""
+
+#: Form\form_us.xml.h:1322
+msgid "Months in School 1914: Public"
+msgstr ""
+
+#: Form\form_us.xml.h:1323
+msgid "Months in School 1914: High"
+msgstr ""
+
+#: Form\form_us.xml.h:1324
+msgid "Months in School 1914: Private"
+msgstr ""
+
+#: Form\form_us.xml.h:1325
+msgid "Months in School 1914: College"
+msgstr ""
+
+#: Form\form_us.xml.h:1329 Form\form_us.xml.h:1984 Form\form_us.xml.h:2018
+#: Form\form_us.xml.h:2056 Form\form_us.xml.h:2094 Form\form_us.xml.h:2132
+msgid "Deaf"
+msgstr ""
+
+#: Form\form_us.xml.h:1331 Form\form_us.xml.h:2020 Form\form_us.xml.h:2058
+#: Form\form_us.xml.h:2096 Form\form_us.xml.h:2134
+msgid "Idiot"
+msgstr ""
+
+#: Form\form_us.xml.h:1332
+msgid "Naturalized if foreign born?"
+msgstr ""
+
+#: Form\form_us.xml.h:1341 Form\form_us.xml.h:2244
+msgid "Color or Race"
+msgstr ""
+
+#: Form\form_us.xml.h:1344
+msgid "Home Owned or Rented"
+msgstr ""
+
+#: Form\form_us.xml.h:1345
+msgid "Home Owned Free or Mortgaged"
+msgstr ""
+
+#: Form\form_us.xml.h:1346
+msgid "Home Value"
+msgstr ""
+
+#: Form\form_us.xml.h:1347
+msgid "Mortgage Debt"
+msgstr ""
+
+#: Form\form_us.xml.h:1348
+msgid "Monthly Rent"
+msgstr ""
+
+#: Form\form_us.xml.h:1349
+msgid "Insurance on Home"
+msgstr ""
+
+#: Form\form_us.xml.h:1351
+msgid "Years in US"
+msgstr ""
+
+#: Form\form_us.xml.h:1353
+msgid "Attended Rural School"
+msgstr ""
+
+#: Form\form_us.xml.h:1354
+msgid "Attended Grade School"
+msgstr ""
+
+#: Form\form_us.xml.h:1355
+msgid "Attended High School"
+msgstr ""
+
+#: Form\form_us.xml.h:1356
+msgid "Attended College"
+msgstr ""
+
+#: Form\form_us.xml.h:1357
+msgid "Highest Grade Rural School"
+msgstr ""
+
+#: Form\form_us.xml.h:1358
+msgid "Highest Grade Grammar School"
+msgstr ""
+
+#: Form\form_us.xml.h:1359
+msgid "Highest Grade High School"
+msgstr ""
+
+#: Form\form_us.xml.h:1360
+msgid "No. Years College"
+msgstr ""
+
+#: Form\form_us.xml.h:1361
+msgid "Months in School 1924"
+msgstr ""
+
+#: Form\form_us.xml.h:1362
+msgid "Able to Read"
+msgstr ""
+
+#: Form\form_us.xml.h:1363
+msgid "Able to Write"
+msgstr ""
+
+#: Form\form_us.xml.h:1366
+msgid "Father's Place of Birth"
+msgstr ""
+
+#: Form\form_us.xml.h:1367
+msgid "Father's Age"
+msgstr ""
+
+#: Form\form_us.xml.h:1369
+msgid "Mother's Place of Birth"
+msgstr ""
+
+#: Form\form_us.xml.h:1370
+msgid "Mother's Age"
+msgstr ""
+
+#: Form\form_us.xml.h:1371
+msgid "Parents Place of Marriage"
+msgstr ""
+
+#: Form\form_us.xml.h:1372
+msgid "Civil War Veteran"
+msgstr ""
+
+#: Form\form_us.xml.h:1373
+msgid "Civil War Service Branch"
+msgstr ""
+
+#: Form\form_us.xml.h:1374
+msgid "Civil War State"
+msgstr ""
+
+#: Form\form_us.xml.h:1375
+msgid "Spanish-American War Veteran"
+msgstr ""
+
+#: Form\form_us.xml.h:1376
+msgid "Spanish-American War Service Branch"
+msgstr ""
+
+#: Form\form_us.xml.h:1377
+msgid "Spanish-American War State"
+msgstr ""
+
+#: Form\form_us.xml.h:1378
+msgid "World War Veteran"
+msgstr ""
+
+#: Form\form_us.xml.h:1379
+msgid "World War Service Branch"
+msgstr ""
+
+#: Form\form_us.xml.h:1380
+msgid "World War State"
+msgstr ""
+
+#: Form\form_us.xml.h:1381
+msgid "Agricultural Pursuits"
+msgstr ""
+
+#: Form\form_us.xml.h:1382
+msgid "Professional Services"
+msgstr ""
+
+#: Form\form_us.xml.h:1383
+msgid "Domestic/Personal Services"
+msgstr ""
+
+#: Form\form_us.xml.h:1384
+msgid "Trade and Transportation"
+msgstr ""
+
+#: Form\form_us.xml.h:1385
+msgid "Manufacturing and Mechanical"
+msgstr ""
+
+#: Form\form_us.xml.h:1386
+msgid "Unclassified Laborer"
+msgstr ""
+
+#: Form\form_us.xml.h:1387
+msgid "Months unemployed due to illness"
+msgstr ""
+
+#: Form\form_us.xml.h:1388
+msgid "Income lost due to illness"
+msgstr ""
+
+#: Form\form_us.xml.h:1389
+msgid "Months unemployed"
+msgstr ""
+
+#: Form\form_us.xml.h:1390
+msgid "Church"
+msgstr ""
+
+#: Form\form_us.xml.h:1391
+msgid "Free Inhabitants in"
+msgstr ""
+
+#: Form\form_us.xml.h:1400 Form\form_us.xml.h:1447 Form\form_us.xml.h:2004
+#: Form\form_us.xml.h:2042 Form\form_us.xml.h:2080 Form\form_us.xml.h:2118
+msgid "Regiment"
+msgstr ""
+
+#: Form\form_us.xml.h:1403 Form\form_us.xml.h:1415
+msgid "Real Estate"
+msgstr ""
+
+#: Form\form_us.xml.h:1404
+msgid "Personal Estate"
+msgstr ""
+
+#: Form\form_us.xml.h:1407
+msgid "Attended School"
+msgstr ""
+
+#: Form\form_us.xml.h:1408
+msgid "Illiterate"
+msgstr ""
+
+#: Form\form_us.xml.h:1416
+msgid "Personal Property"
+msgstr ""
+
+#: Form\form_us.xml.h:1418 Form\form_us.xml.h:1438
+msgid "Where From"
+msgstr ""
+
+#: Form\form_us.xml.h:1419 Form\form_us.xml.h:1440
+msgid "School"
+msgstr ""
+
+#: Form\form_us.xml.h:1420
+msgid "Cannot Read 10-15"
+msgstr ""
+
+#: Form\form_us.xml.h:1421
+msgid "Cannot Read 15-21"
+msgstr ""
+
+#: Form\form_us.xml.h:1422
+msgid "Cannot Read 21+"
+msgstr ""
+
+#: Form\form_us.xml.h:1423
+msgid "Cannot Write 10-15"
+msgstr ""
+
+#: Form\form_us.xml.h:1424
+msgid "Cannot Write 15-21"
+msgstr ""
+
+#: Form\form_us.xml.h:1425
+msgid "Cannot Write 21+"
+msgstr ""
+
+#: Form\form_us.xml.h:1426
+msgid "Cannot Read/Write 10-15"
+msgstr ""
+
+#: Form\form_us.xml.h:1427
+msgid "Cannot Read/Write 15-21"
+msgstr ""
+
+#: Form\form_us.xml.h:1428
+msgid "Cannot Read/Write 21+"
+msgstr ""
+
+#: Form\form_us.xml.h:1435
+msgid "Widow(er)"
+msgstr ""
+
+#: Form\form_us.xml.h:1439
+msgid "Learning"
+msgstr ""
+
+#: Form\form_us.xml.h:1441
+msgid "Illiteracy 10-15"
+msgstr ""
+
+#: Form\form_us.xml.h:1442
+msgid "Illiteracy 15-21"
+msgstr ""
+
+#: Form\form_us.xml.h:1443
+msgid "Illiteracy 21+"
+msgstr ""
+
+#: Form\form_us.xml.h:1444
+msgid "Honorably discharged"
+msgstr ""
+
+#: Form\form_us.xml.h:1445
+msgid "State Enlisted"
+msgstr ""
+
+#: Form\form_us.xml.h:1448
+msgid "Arm of Service"
+msgstr ""
+
+#: Form\form_us.xml.h:1449
+msgid "Prison"
+msgstr ""
+
+#: Form\form_us.xml.h:1455
+msgid "Where from Kansas"
+msgstr ""
+
+#: Form\form_us.xml.h:1457 Form\form_us.xml.h:1479 Form\form_us.xml.h:1501
+msgid "Trade or profession being learned"
+msgstr ""
+
+#: Form\form_us.xml.h:1459 Form\form_us.xml.h:1481 Form\form_us.xml.h:1503
+msgid "Illiterate and 10 to 15 years old"
+msgstr ""
+
+#: Form\form_us.xml.h:1460
+msgid "Illiterate and 16 to 21 years old"
+msgstr ""
+
+#: Form\form_us.xml.h:1461 Form\form_us.xml.h:1483 Form\form_us.xml.h:1505
+msgid "Illiterate and over 21"
+msgstr ""
+
+#: Form\form_us.xml.h:1462 Form\form_us.xml.h:1484 Form\form_us.xml.h:1507
+msgid "Honorably discharged from military service"
+msgstr ""
+
+#: Form\form_us.xml.h:1463 Form\form_us.xml.h:1485 Form\form_us.xml.h:1508
+msgid "State in which enlisted"
+msgstr ""
+
+#: Form\form_us.xml.h:1464 Form\form_us.xml.h:1486 Form\form_us.xml.h:1509
+msgid "Company or command"
+msgstr ""
+
+#: Form\form_us.xml.h:1465 Form\form_us.xml.h:1487 Form\form_us.xml.h:1510
+msgid "Regiment or other organization"
+msgstr ""
+
+#: Form\form_us.xml.h:1466 Form\form_us.xml.h:1488 Form\form_us.xml.h:1511
+msgid "Arm of service"
+msgstr ""
+
+#: Form\form_us.xml.h:1467 Form\form_us.xml.h:1489 Form\form_us.xml.h:1512
+msgid "Prison in which confined as a prisoner of war"
+msgstr ""
+
+#: Form\form_us.xml.h:1470 Form\form_us.xml.h:1492 Form\form_us.xml.h:1518
+msgid "Home owned free or mortgaged"
+msgstr ""
+
+#: Form\form_us.xml.h:1476 Form\form_us.xml.h:1498 Form\form_us.xml.h:1524
+msgid "Where from to Kansas"
+msgstr ""
+
+#: Form\form_us.xml.h:1478 Form\form_us.xml.h:1500
+msgid "Number of months unemployed"
+msgstr ""
+
+#: Form\form_us.xml.h:1482 Form\form_us.xml.h:1504
+msgid "Illiterate and 15 to 21 years old"
+msgstr ""
+
+#: Form\form_us.xml.h:1506
+msgid "Number of volumes in home library"
+msgstr ""
+
+#: Form\form_us.xml.h:1515
+msgid "Number of house"
+msgstr ""
+
+#: Form\form_us.xml.h:1525
+msgid "Year of immigration to the United States"
+msgstr ""
+
+#: Form\form_us.xml.h:1526
+msgid "Naturalized, alien or first papers"
+msgstr ""
+
+#: Form\form_us.xml.h:1530
+msgid "Attended school within year"
+msgstr ""
+
+#: Form\form_us.xml.h:1540 Form\form_us.xml.h:1881 Form\form_us.xml.h:1900
+#: Form\form_us.xml.h:1920
+msgid "Nativity"
+msgstr ""
+
+#: Form\form_us.xml.h:1541
+msgid "Father's Nativity"
+msgstr ""
+
+#: Form\form_us.xml.h:1542
+msgid "Mother's Nativity"
+msgstr ""
+
+#: Form\form_us.xml.h:1546 Form\form_us.xml.h:1561
+msgid "Inhabitants in"
+msgstr ""
+
+#: Form\form_us.xml.h:1558
+msgid "Served in Federal army during rebellion"
+msgstr ""
+
+#: Form\form_us.xml.h:1570 Form\form_us.xml.h:1601
+msgid "Residence in State - Years"
+msgstr ""
+
+#: Form\form_us.xml.h:1571 Form\form_us.xml.h:1602
+msgid "Residence in State - Months"
+msgstr ""
+
+#: Form\form_us.xml.h:1572
+msgid "Residence in District - Years"
+msgstr ""
+
+#: Form\form_us.xml.h:1573
+msgid "Residence in District - Months"
+msgstr ""
+
+#: Form\form_us.xml.h:1575 Form\form_us.xml.h:2251
+msgid "Months Employed"
+msgstr ""
+
+#: Form\form_us.xml.h:1576
+msgid "Solder/Sailor"
+msgstr ""
+
+#: Form\form_us.xml.h:1577
+msgid "Foreign father"
+msgstr ""
+
+#: Form\form_us.xml.h:1578
+msgid "Foreign mother"
+msgstr ""
+
+#: Form\form_us.xml.h:1581
+msgid "Organized Township"
+msgstr ""
+
+#: Form\form_us.xml.h:1582
+msgid "Unorganized Township"
+msgstr ""
+
+#: Form\form_us.xml.h:1583
+msgid "Name of Village"
+msgstr ""
+
+#: Form\form_us.xml.h:1584
+msgid "Name of City"
+msgstr ""
+
+#: Form\form_us.xml.h:1586
+msgid "Sub-division"
+msgstr ""
+
+#: Form\form_us.xml.h:1587
+msgid "Precincts"
+msgstr ""
+
+#: Form\form_us.xml.h:1588
+msgid "Enumerated date from"
+msgstr ""
+
+#: Form\form_us.xml.h:1589
+msgid "Enumerated date to"
+msgstr ""
+
+#: Form\form_us.xml.h:1592
+msgid "Enumeration number"
+msgstr ""
+
+#: Form\form_us.xml.h:1594
+msgid "Street Number"
+msgstr ""
+
+#: Form\form_us.xml.h:1599
+msgid "Fathers birthplace"
+msgstr ""
+
+#: Form\form_us.xml.h:1600
+msgid "Mothers birthplace"
+msgstr ""
+
+#: Form\form_us.xml.h:1603
+msgid "Residence in District - years"
+msgstr ""
+
+#: Form\form_us.xml.h:1604
+msgid "Residence in District - months"
+msgstr ""
+
+#: Form\form_us.xml.h:1606
+msgid "Army service"
+msgstr ""
+
+#: Form\form_us.xml.h:1607
+msgid "Wars"
+msgstr ""
+
+#: Form\form_us.xml.h:1609 Form\form_us.xml.h:1682
+msgid "White males under 10"
+msgstr ""
+
+#: Form\form_us.xml.h:1610 Form\form_us.xml.h:1683
+msgid "White males 10-17"
+msgstr ""
+
+#: Form\form_us.xml.h:1611 Form\form_us.xml.h:1684
+msgid "White males 18-20"
+msgstr ""
+
+#: Form\form_us.xml.h:1612 Form\form_us.xml.h:1685
+msgid "White males 21-44"
+msgstr ""
+
+#: Form\form_us.xml.h:1613 Form\form_us.xml.h:1686
+msgid "White males 45 and over"
+msgstr ""
+
+#: Form\form_us.xml.h:1614 Form\form_us.xml.h:1687
+msgid "Total White Males"
+msgstr ""
+
+#: Form\form_us.xml.h:1615 Form\form_us.xml.h:1688
+msgid "White females under 10"
+msgstr ""
+
+#: Form\form_us.xml.h:1616 Form\form_us.xml.h:1689
+msgid "White females 10-17"
+msgstr ""
+
+#: Form\form_us.xml.h:1617 Form\form_us.xml.h:1690
+msgid "White females 18-20"
+msgstr ""
+
+#: Form\form_us.xml.h:1618 Form\form_us.xml.h:1691
+msgid "White females 21-44"
+msgstr ""
+
+#: Form\form_us.xml.h:1619 Form\form_us.xml.h:1692
+msgid "White females 45 and over"
+msgstr ""
+
+#: Form\form_us.xml.h:1620 Form\form_us.xml.h:1693
+msgid "Total White Females"
+msgstr ""
+
+#: Form\form_us.xml.h:1621 Form\form_us.xml.h:1694
+msgid "Total White Population"
+msgstr ""
+
+#: Form\form_us.xml.h:1622 Form\form_us.xml.h:1695
+msgid "White persons between 6 and 18"
+msgstr ""
+
+#: Form\form_us.xml.h:1623 Form\form_us.xml.h:1696
+msgid "No. White persons who can read and write"
+msgstr ""
+
+#: Form\form_us.xml.h:1624 Form\form_us.xml.h:1697
+msgid "Colored males under 10"
+msgstr ""
+
+#: Form\form_us.xml.h:1625 Form\form_us.xml.h:1698
+msgid "Colored males 10-17"
+msgstr ""
+
+#: Form\form_us.xml.h:1626 Form\form_us.xml.h:1699
+msgid "Colored males 18-20"
+msgstr ""
+
+#: Form\form_us.xml.h:1627 Form\form_us.xml.h:1700
+msgid "Colored males 21-44"
+msgstr ""
+
+#: Form\form_us.xml.h:1628 Form\form_us.xml.h:1701
+msgid "Colored males 45 and over"
+msgstr ""
+
+#: Form\form_us.xml.h:1629 Form\form_us.xml.h:1702
+msgid "Total Colored Males"
+msgstr ""
+
+#: Form\form_us.xml.h:1630 Form\form_us.xml.h:1703
+msgid "Colored females under 10"
+msgstr ""
+
+#: Form\form_us.xml.h:1631 Form\form_us.xml.h:1704
+msgid "Colored females 10-17"
+msgstr ""
+
+#: Form\form_us.xml.h:1632 Form\form_us.xml.h:1705
+msgid "Colored females 18-20"
+msgstr ""
+
+#: Form\form_us.xml.h:1633 Form\form_us.xml.h:1706
+msgid "Colored females 21-44"
+msgstr ""
+
+#: Form\form_us.xml.h:1634 Form\form_us.xml.h:1707
+msgid "Colored females 45 and over"
+msgstr ""
+
+#: Form\form_us.xml.h:1635 Form\form_us.xml.h:1708
+msgid "Total Colored Females"
+msgstr ""
+
+#: Form\form_us.xml.h:1636 Form\form_us.xml.h:1709
+msgid "Total Colored Population"
+msgstr ""
+
+#: Form\form_us.xml.h:1637 Form\form_us.xml.h:1710
+msgid "Colored persons between 6 and 18"
+msgstr ""
+
+#: Form\form_us.xml.h:1638 Form\form_us.xml.h:1711
+msgid "No. Colored persons who can read and write"
+msgstr ""
+
+#: Form\form_us.xml.h:1639 Form\form_us.xml.h:1712
+msgid "Deaf and Dumb Males"
+msgstr ""
+
+#: Form\form_us.xml.h:1640 Form\form_us.xml.h:1713
+msgid "Deaf and Dumb Males Age"
+msgstr ""
+
+#: Form\form_us.xml.h:1641 Form\form_us.xml.h:1714
+msgid "Deaf and Dumb Females"
+msgstr ""
+
+#: Form\form_us.xml.h:1642 Form\form_us.xml.h:1715
+msgid "Deaf and Dumb Females Age"
+msgstr ""
+
+#: Form\form_us.xml.h:1643 Form\form_us.xml.h:1716
+msgid "Deaf and Dumb White"
+msgstr ""
+
+#: Form\form_us.xml.h:1644 Form\form_us.xml.h:1717
+msgid "Deaf and Dumb Colored"
+msgstr ""
+
+#: Form\form_us.xml.h:1645 Form\form_us.xml.h:1718
+msgid "No. Deaf and Dumb taught to read and write"
+msgstr ""
+
+#: Form\form_us.xml.h:1646 Form\form_us.xml.h:1719
+msgid "Blind Males"
+msgstr ""
+
+#: Form\form_us.xml.h:1647 Form\form_us.xml.h:1720
+msgid "Blind Males Age"
+msgstr ""
+
+#: Form\form_us.xml.h:1648 Form\form_us.xml.h:1721
+msgid "Blind Females"
+msgstr ""
+
+#: Form\form_us.xml.h:1649 Form\form_us.xml.h:1722
+msgid "Blind Females Age"
+msgstr ""
+
+#: Form\form_us.xml.h:1650 Form\form_us.xml.h:1723
+msgid "Blind White"
+msgstr ""
+
+#: Form\form_us.xml.h:1651 Form\form_us.xml.h:1724
+msgid "Blind Colored"
+msgstr ""
+
+#: Form\form_us.xml.h:1652 Form\form_us.xml.h:1725
+msgid "No. Blind taught to read and write"
+msgstr ""
+
+#: Form\form_us.xml.h:1653 Form\form_us.xml.h:1726
+msgid "Insane Males"
+msgstr ""
+
+#: Form\form_us.xml.h:1654 Form\form_us.xml.h:1727
+msgid "Insane Males Age"
+msgstr ""
+
+#: Form\form_us.xml.h:1655 Form\form_us.xml.h:1728
+msgid "Insane Females"
+msgstr ""
+
+#: Form\form_us.xml.h:1656 Form\form_us.xml.h:1729
+msgid "Insane Females Age"
+msgstr ""
+
+#: Form\form_us.xml.h:1657 Form\form_us.xml.h:1730
+msgid "Insane White"
+msgstr ""
+
+#: Form\form_us.xml.h:1658 Form\form_us.xml.h:1731
+msgid "Insane Colored"
+msgstr ""
+
+#: Form\form_us.xml.h:1659 Form\form_us.xml.h:1732
+msgid "No. Insane taught to read and write"
+msgstr ""
+
+#: Form\form_us.xml.h:1660 Form\form_us.xml.h:1733
+msgid "Live Stock Horses"
+msgstr ""
+
+#: Form\form_us.xml.h:1661 Form\form_us.xml.h:1734
+msgid "Live Stock Mules"
+msgstr ""
+
+#: Form\form_us.xml.h:1662 Form\form_us.xml.h:1735
+msgid "Live Stock Jacks"
+msgstr ""
+
+#: Form\form_us.xml.h:1663 Form\form_us.xml.h:1736
+msgid "Live Stock Jennies"
+msgstr ""
+
+#: Form\form_us.xml.h:1664 Form\form_us.xml.h:1737
+msgid "Live Stock Cattle"
+msgstr ""
+
+#: Form\form_us.xml.h:1665 Form\form_us.xml.h:1738
+msgid "Live Stock Sheep"
+msgstr ""
+
+#: Form\form_us.xml.h:1666 Form\form_us.xml.h:1739
+msgid "Live Stock Hogs"
+msgstr ""
+
+#: Form\form_us.xml.h:1667 Form\form_us.xml.h:1740
+msgid "Products Bushels Wheat"
+msgstr ""
+
+#: Form\form_us.xml.h:1668 Form\form_us.xml.h:1741
+msgid "Products Bushels Corn"
+msgstr ""
+
+#: Form\form_us.xml.h:1669 Form\form_us.xml.h:1742
+msgid "Products Bushels Oats"
+msgstr ""
+
+#: Form\form_us.xml.h:1670 Form\form_us.xml.h:1743
+msgid "Products Bushels Barley"
+msgstr ""
+
+#: Form\form_us.xml.h:1671 Form\form_us.xml.h:1744
+msgid "Products Bushels Rye"
+msgstr ""
+
+#: Form\form_us.xml.h:1672 Form\form_us.xml.h:1745
+msgid "Products Lbs. Tobacco"
+msgstr ""
+
+#: Form\form_us.xml.h:1673 Form\form_us.xml.h:1746
+msgid "Products Lbs. Wool"
+msgstr ""
+
+#: Form\form_us.xml.h:1674 Form\form_us.xml.h:1747
+msgid "Products Lbs. Sugar"
+msgstr ""
+
+#: Form\form_us.xml.h:1675 Form\form_us.xml.h:1748
+msgid "Products Tons Hay"
+msgstr ""
+
+#: Form\form_us.xml.h:1676 Form\form_us.xml.h:1749
+msgid "Products Tons Hemp"
+msgstr ""
+
+#: Form\form_us.xml.h:1677 Form\form_us.xml.h:1750
+msgid "Products Galls. Whiskey"
+msgstr ""
+
+#: Form\form_us.xml.h:1678 Form\form_us.xml.h:1751
+msgid "Products Galls. Wine"
+msgstr ""
+
+#: Form\form_us.xml.h:1679 Form\form_us.xml.h:1752
+msgid "Products Galls. Molasses"
+msgstr ""
+
+#: Form\form_us.xml.h:1680 Form\form_us.xml.h:1753
+msgid "Total Population"
+msgstr ""
+
+#: Form\form_us.xml.h:1791 Form\form_us.xml.h:1813 Form\form_us.xml.h:1842
+msgid "Building Material"
+msgstr ""
+
+#: Form\form_us.xml.h:1792 Form\form_us.xml.h:1814 Form\form_us.xml.h:1843
+msgid "Dwelling Value"
+msgstr ""
+
+#: Form\form_us.xml.h:1797 Form\form_us.xml.h:1819 Form\form_us.xml.h:1848
+msgid "Birthplace (NY County or other)"
+msgstr ""
+
+#: Form\form_us.xml.h:1800
+msgid "Years resident in this city or town"
+msgstr ""
+
+#: Form\form_us.xml.h:1802 Form\form_us.xml.h:1827 Form\form_us.xml.h:1854
+msgid "Native Voter"
+msgstr ""
+
+#: Form\form_us.xml.h:1803 Form\form_us.xml.h:1828 Form\form_us.xml.h:1855
+msgid "Naturalized Voter"
+msgstr ""
+
+#: Form\form_us.xml.h:1804 Form\form_us.xml.h:1829 Form\form_us.xml.h:1856
+msgid "Alien"
+msgstr ""
+
+#: Form\form_us.xml.h:1805 Form\form_us.xml.h:1830
+msgid "Persons of color not taxed"
+msgstr ""
+
+#: Form\form_us.xml.h:1806 Form\form_us.xml.h:1832 Form\form_us.xml.h:1858
+msgid "Over 21/Illiterate"
+msgstr ""
+
+#: Form\form_us.xml.h:1807 Form\form_us.xml.h:1857
+msgid "Landowner"
+msgstr ""
+
+#: Form\form_us.xml.h:1808 Form\form_us.xml.h:1833 Form\form_us.xml.h:1859
+msgid "Deaf, Dumb, Blind, Insane, Idiotic"
+msgstr ""
+
+#: Form\form_us.xml.h:1809 Form\form_us.xml.h:1838 Form\form_us.xml.h:1860
+#: Form\form_us.xml.h:2181 Form\form_us.xml.h:2210 Form\form_us.xml.h:2238
+msgid "Inhabitants in the"
+msgstr ""
+
+#: Form\form_us.xml.h:1820
+msgid "Parent of how many children"
+msgstr ""
+
+#: Form\form_us.xml.h:1821
+msgid "Number of times married"
+msgstr ""
+
+#: Form\form_us.xml.h:1826
+msgid "Place of Occupation"
+msgstr ""
+
+#: Form\form_us.xml.h:1831
+msgid "Land owner"
+msgstr ""
+
+#: Form\form_us.xml.h:1834
+msgid "Now in army"
+msgstr ""
+
+#: Form\form_us.xml.h:1835
+msgid "Now in navy"
+msgstr ""
+
+#: Form\form_us.xml.h:1836
+msgid "Formerly in army"
+msgstr ""
+
+#: Form\form_us.xml.h:1837
+msgid "Formerly in navy"
+msgstr ""
+
+#: Form\form_us.xml.h:1853
+msgid "Usual place of employment (if not same city/town)"
+msgstr ""
+
+#: Form\form_us.xml.h:1861
+msgid "Election District of the Town of"
+msgstr ""
+
+#: Form\form_us.xml.h:1862 Form\form_us.xml.h:1874 Form\form_us.xml.h:2183
+#: Form\form_us.xml.h:2212 Form\form_us.xml.h:2240
+msgid "the County of"
+msgstr ""
+
+#: Form\form_us.xml.h:1868
+msgid "Birth Country"
+msgstr ""
+
+#: Form\form_us.xml.h:1869 Form\form_us.xml.h:1883 Form\form_us.xml.h:1902
+#: Form\form_us.xml.h:1922
+msgid "Citizen or Alien"
+msgstr ""
+
+#: Form\form_us.xml.h:1871
+msgid "Inhabitants living in"
+msgstr ""
+
+#: Form\form_us.xml.h:1872
+msgid "Election District, Ward"
+msgstr ""
+
+#: Form\form_us.xml.h:1882 Form\form_us.xml.h:1901 Form\form_us.xml.h:1921
+msgid "Number of years in the US"
+msgstr ""
+
+#: Form\form_us.xml.h:1885 Form\form_us.xml.h:1904 Form\form_us.xml.h:1925
+msgid "Class"
+msgstr ""
+
+#: Form\form_us.xml.h:1886 Form\form_us.xml.h:1905 Form\form_us.xml.h:1926
+msgid "Inmate: Residence given when admitted"
+msgstr ""
+
+#: Form\form_us.xml.h:1887 Form\form_us.xml.h:1908
+msgid "Inhabitants of Block No."
+msgstr ""
+
+#: Form\form_us.xml.h:1888 Form\form_us.xml.h:1909
+msgid "Election District No."
+msgstr ""
+
+#: Form\form_us.xml.h:1889 Form\form_us.xml.h:1910
+msgid "Ward No."
+msgstr ""
+
+#: Form\form_us.xml.h:1890 Form\form_us.xml.h:1911
+msgid "City or Village"
+msgstr ""
+
+#: Form\form_us.xml.h:1892 Form\form_us.xml.h:1913
+msgid "Assembly District No."
+msgstr ""
+
+#: Form\form_us.xml.h:1923
+msgid "Where and When Naturalized"
+msgstr ""
+
+#: Form\form_us.xml.h:1929
+msgid "WM 21-60"
+msgstr ""
+
+#: Form\form_us.xml.h:1930
+msgid "WM under 21 above 60 "
+msgstr ""
+
+#: Form\form_us.xml.h:1931
+msgid "WF all ages"
+msgstr ""
+
+#: Form\form_us.xml.h:1932
+msgid "Blacks 12-50"
+msgstr ""
+
+#: Form\form_us.xml.h:1933
+msgid "Blacks under 12 above 50"
+msgstr ""
+
+#: Form\form_us.xml.h:1935
+msgid "Native White Males"
+msgstr ""
+
+#: Form\form_us.xml.h:1936
+msgid "Native White Females"
+msgstr ""
+
+#: Form\form_us.xml.h:1937
+msgid "Native Colored Males"
+msgstr ""
+
+#: Form\form_us.xml.h:1938
+msgid "Native Colored Females"
+msgstr ""
+
+#: Form\form_us.xml.h:1939
+msgid "Foreign Males"
+msgstr ""
+
+#: Form\form_us.xml.h:1940
+msgid "Foreign Females"
+msgstr ""
+
+#: Form\form_us.xml.h:1941
+msgid "Male Children 5 and Under"
+msgstr ""
+
+#: Form\form_us.xml.h:1942
+msgid "Female Children 5 and Under"
+msgstr ""
+
+#: Form\form_us.xml.h:1943
+msgid "Males 5 to 20 Years of Age"
+msgstr ""
+
+#: Form\form_us.xml.h:1944
+msgid "Females 5 to 20 Years of Age"
+msgstr ""
+
+#: Form\form_us.xml.h:1945
+msgid "Males 20 to 60 Years of Age"
+msgstr ""
+
+#: Form\form_us.xml.h:1946
+msgid "Females 20 to 60 Years of Age"
+msgstr ""
+
+#: Form\form_us.xml.h:1947
+msgid "Males Over 60 Years of Age"
+msgstr ""
+
+#: Form\form_us.xml.h:1948
+msgid "Females Over 60 Years of Age"
+msgstr ""
+
+#: Form\form_us.xml.h:1952 Form\form_us.xml.h:1991 Form\form_us.xml.h:2028
+#: Form\form_us.xml.h:2066 Form\form_us.xml.h:2104
+msgid "P.O."
+msgstr ""
+
+#: Form\form_us.xml.h:1954
+msgid "Sec."
+msgstr ""
+
+#: Form\form_us.xml.h:1955
+msgid "T."
+msgstr ""
+
+#: Form\form_us.xml.h:1956
+msgid "R."
+msgstr ""
+
+#: Form\form_us.xml.h:1959 Form\form_us.xml.h:2432
+msgid "No."
+msgstr ""
+
+#: Form\form_us.xml.h:1960
+msgid "St./Ave "
+msgstr ""
+
+#: Form\form_us.xml.h:1961
+msgid "Hotel or Institution"
+msgstr ""
+
+#: Form\form_us.xml.h:1965
+msgid "Years in South Dakota"
+msgstr ""
+
+#: Form\form_us.xml.h:1966
+msgid "Years in United States"
+msgstr ""
+
+#: Form\form_us.xml.h:1967
+msgid "Birthplace of Father"
+msgstr ""
+
+#: Form\form_us.xml.h:1968
+msgid "Birthplace of Mother"
+msgstr ""
+
+#: Form\form_us.xml.h:1969
+msgid "Male"
+msgstr ""
+
+#: Form\form_us.xml.h:1970
+msgid "Female"
+msgstr ""
+
+#: Form\form_us.xml.h:1971
+msgid "White"
+msgstr ""
+
+#: Form\form_us.xml.h:1972
+msgid "Black"
+msgstr ""
+
+#: Form\form_us.xml.h:1973
+msgid "Red"
+msgstr ""
+
+#: Form\form_us.xml.h:1974
+msgid "Yellow"
+msgstr ""
+
+#: Form\form_us.xml.h:1978 Form\form_us.xml.h:2014 Form\form_us.xml.h:2052
+#: Form\form_us.xml.h:2090 Form\form_us.xml.h:2128
+msgid "Divorced"
+msgstr ""
+
+#: Form\form_us.xml.h:1979
+msgid "Can Read"
+msgstr ""
+
+#: Form\form_us.xml.h:1980
+msgid "Can't Read"
+msgstr ""
+
+#: Form\form_us.xml.h:1981
+msgid "Can Write"
+msgstr ""
+
+#: Form\form_us.xml.h:1982
+msgid "Can't Write"
+msgstr ""
+
+#: Form\form_us.xml.h:1995 Form\form_us.xml.h:2032 Form\form_us.xml.h:2070
+#: Form\form_us.xml.h:2108
+msgid "Do you own your home or farm"
+msgstr ""
+
+#: Form\form_us.xml.h:1997 Form\form_us.xml.h:2034 Form\form_us.xml.h:2072
+#: Form\form_us.xml.h:2110
+msgid "Ancestry"
+msgstr ""
+
+#: Form\form_us.xml.h:1998 Form\form_us.xml.h:2035 Form\form_us.xml.h:2073
+#: Form\form_us.xml.h:2111
+msgid "Father's birthplace"
+msgstr ""
+
+#: Form\form_us.xml.h:1999 Form\form_us.xml.h:2036 Form\form_us.xml.h:2074
+#: Form\form_us.xml.h:2112
+msgid "Mother's birthplace"
+msgstr ""
+
+#: Form\form_us.xml.h:2000 Form\form_us.xml.h:2037 Form\form_us.xml.h:2075
+#: Form\form_us.xml.h:2113
+msgid "Extent of Education"
+msgstr ""
+
+#: Form\form_us.xml.h:2001 Form\form_us.xml.h:2038 Form\form_us.xml.h:2076
+#: Form\form_us.xml.h:2114
+msgid "Graduate of"
+msgstr ""
+
+#: Form\form_us.xml.h:2002 Form\form_us.xml.h:2039 Form\form_us.xml.h:2077
+#: Form\form_us.xml.h:2115
+msgid "Military Service"
+msgstr ""
+
+#: Form\form_us.xml.h:2003 Form\form_us.xml.h:2040 Form\form_us.xml.h:2078
+#: Form\form_us.xml.h:2116
+msgid "State"
+msgstr ""
+
+#: Form\form_us.xml.h:2006 Form\form_us.xml.h:2044 Form\form_us.xml.h:2082
+#: Form\form_us.xml.h:2120
+msgid "Maiden name of wife"
+msgstr ""
+
+#: Form\form_us.xml.h:2008 Form\form_us.xml.h:2046 Form\form_us.xml.h:2084
+#: Form\form_us.xml.h:2122
+msgid "Church affiliation"
+msgstr ""
+
+#: Form\form_us.xml.h:2021 Form\form_us.xml.h:2059 Form\form_us.xml.h:2097
+#: Form\form_us.xml.h:2135
+msgid "If Foreign Born, are you Naturalized"
+msgstr ""
+
+#: Form\form_us.xml.h:2023 Form\form_us.xml.h:2061 Form\form_us.xml.h:2099
+#: Form\form_us.xml.h:2137
+msgid "Years in S.D."
+msgstr ""
+
+#: Form\form_us.xml.h:2043 Form\form_us.xml.h:2081 Form\form_us.xml.h:2119
+msgid "Division"
+msgstr ""
+
+#: Form\form_us.xml.h:2140
+msgid "Male under 21"
+msgstr ""
+
+#: Form\form_us.xml.h:2141
+msgid "Male over 21"
+msgstr ""
+
+#: Form\form_us.xml.h:2142
+msgid "Female under 21"
+msgstr ""
+
+#: Form\form_us.xml.h:2143
+msgid "Female over 21"
+msgstr ""
+
+#: Form\form_us.xml.h:2146 Form\form_us.xml.h:2158
+msgid "Town/City"
+msgstr ""
+
+#: Form\form_us.xml.h:2148 Form\form_us.xml.h:2160 Form\form_us.xml.h:2172
+msgid "Heads of Families"
+msgstr ""
+
+#: Form\form_us.xml.h:2149 Form\form_us.xml.h:2161 Form\form_us.xml.h:2173
+#: Form\form_us.xml.h:2185 Form\form_us.xml.h:2214
+msgid "White males"
+msgstr ""
+
+#: Form\form_us.xml.h:2150 Form\form_us.xml.h:2162 Form\form_us.xml.h:2174
+#: Form\form_us.xml.h:2186 Form\form_us.xml.h:2215
+msgid "White females"
+msgstr ""
+
+#: Form\form_us.xml.h:2151 Form\form_us.xml.h:2163 Form\form_us.xml.h:2175
+#: Form\form_us.xml.h:2187 Form\form_us.xml.h:2216
+msgid "Colored males"
+msgstr ""
+
+#: Form\form_us.xml.h:2152 Form\form_us.xml.h:2164 Form\form_us.xml.h:2176
+#: Form\form_us.xml.h:2188 Form\form_us.xml.h:2217
+msgid "Colored females"
+msgstr ""
+
+#: Form\form_us.xml.h:2153 Form\form_us.xml.h:2165 Form\form_us.xml.h:2177
+msgid "Deaf & Dumb"
+msgstr ""
+
+#: Form\form_us.xml.h:2156 Form\form_us.xml.h:2168
+msgid "Foreign Birth"
+msgstr ""
+
+#: Form\form_us.xml.h:2170
+msgid "Inhabitants of"
+msgstr ""
+
+#: Form\form_us.xml.h:2171
+msgid "in"
+msgstr ""
+
+#: Form\form_us.xml.h:2182 Form\form_us.xml.h:2200 Form\form_us.xml.h:2211
+#: Form\form_us.xml.h:2229 Form\form_us.xml.h:2239
+msgid "of"
+msgstr ""
+
+#: Form\form_us.xml.h:2189 Form\form_us.xml.h:2218
+msgid "Nativity - United States"
+msgstr ""
+
+#: Form\form_us.xml.h:2190 Form\form_us.xml.h:2219
+msgid "Nativity - Germany"
+msgstr ""
+
+#: Form\form_us.xml.h:2191 Form\form_us.xml.h:2220
+msgid "Nativity - Great Britain"
+msgstr ""
+
+#: Form\form_us.xml.h:2192 Form\form_us.xml.h:2221
+msgid "Nativity - Ireland"
+msgstr ""
+
+#: Form\form_us.xml.h:2193 Form\form_us.xml.h:2222
+msgid "Nativity - France"
+msgstr ""
+
+#: Form\form_us.xml.h:2194 Form\form_us.xml.h:2223
+msgid "Nativity - British America"
+msgstr ""
+
+#: Form\form_us.xml.h:2195 Form\form_us.xml.h:2224
+msgid "Nativity - Scandinavian"
+msgstr ""
+
+#: Form\form_us.xml.h:2196 Form\form_us.xml.h:2225
+msgid "Nativity - Holland"
+msgstr ""
+
+#: Form\form_us.xml.h:2197 Form\form_us.xml.h:2226
+msgid "Nativity - All other countries"
+msgstr ""
+
+#: Form\form_us.xml.h:2199 Form\form_us.xml.h:2228
+msgid "Residing in the"
+msgstr ""
+
+#: Form\form_us.xml.h:2204 Form\form_us.xml.h:2233
+msgid "Co."
+msgstr ""
+
+#: Form\form_us.xml.h:2205 Form\form_us.xml.h:2234
+msgid "Reg't."
+msgstr ""
+
+#: Form\form_us.xml.h:2206 Form\form_us.xml.h:2235
+msgid "State or Vessel"
+msgstr ""
+
+#: Form\form_us.xml.h:2249
+msgid "Parents place of birth"
+msgstr ""
+
+#: Form\form_us.xml.h:2252
+msgid "Owned/Rented"
+msgstr ""
+
+#: Form\form_us.xml.h:2253
+msgid "Free/Mortgaged"
+msgstr ""
+
+#: Form\form_us.xml.h:2254
+msgid "Farm/House"
+msgstr ""
+
+#: Form\form_us.xml.h:2261
+msgid "Twin, triplet or other"
+msgstr ""
+
+#: Form\form_us.xml.h:2262
+msgid "No. in order of birth"
+msgstr ""
+
+#: Form\form_us.xml.h:2263
+msgid "Legitimate"
+msgstr ""
+
+#: Form\form_us.xml.h:2281 Form\form_us.xml.h:2302 Form\form_us.xml.h:2395
+#: Form\form_us.xml.h:2482
+msgid "Place of Record"
+msgstr ""
+
+#: Form\form_us.xml.h:2282 Form\form_us.xml.h:2303 Form\form_us.xml.h:2396
+#: Form\form_us.xml.h:2483
+msgid "Book/Volume"
+msgstr ""
+
+#: Form\form_us.xml.h:2289 Form\form_us.xml.h:2405
+msgid "Race/Color"
+msgstr ""
+
+#: Form\form_us.xml.h:2290
+msgid "Illegitimate"
+msgstr ""
+
+#: Form\form_us.xml.h:2291
+msgid "Father"
+msgstr ""
+
+#: Form\form_us.xml.h:2292
+msgid ""
+"STOP! If you want this record to be attached to the Parents move to Father."
+msgstr ""
+
+#: Form\form_us.xml.h:2293
+msgid "Mother (Maiden Name)"
+msgstr ""
+
+#: Form\form_us.xml.h:2294
+msgid "Residence of Parents"
+msgstr ""
+
+#: Form\form_us.xml.h:2295
+msgid "By Whom Reported"
+msgstr ""
+
+#: Form\form_us.xml.h:2296 Form\form_us.xml.h:2413
+msgid "Date Recorded"
+msgstr ""
+
+#: Form\form_us.xml.h:2305
+msgid "License No."
+msgstr ""
+
+#: Form\form_us.xml.h:2307
+msgid "Date of Marriage"
+msgstr ""
+
+#: Form\form_us.xml.h:2308
+msgid "Married by"
+msgstr ""
+
+#: Form\form_us.xml.h:2310
+msgid "Place of Marriage"
+msgstr ""
+
+#: Form\form_us.xml.h:2312
+msgid "Consent given by"
+msgstr ""
+
+#: Form\form_us.xml.h:2315
+msgid "Bond/Licence"
+msgstr ""
+
+#: Form\form_us.xml.h:2344 Form\form_us.xml.h:2407
+msgid "Place of Death"
+msgstr ""
+
+#: Form\form_us.xml.h:2346
+msgid "Length of Residence"
+msgstr ""
+
+#: Form\form_us.xml.h:2347
+msgid "Served in U.S. Military"
+msgstr ""
+
+#: Form\form_us.xml.h:2352
+msgid "Birth date of deceased"
+msgstr ""
+
+#: Form\form_us.xml.h:2355
+msgid "Industry or Business"
+msgstr ""
+
+#: Form\form_us.xml.h:2356
+msgid "Name of employer"
+msgstr ""
+
+#: Form\form_us.xml.h:2357
+msgid "Date last worked"
+msgstr ""
+
+#: Form\form_us.xml.h:2358
+msgid "Years in this occupation"
+msgstr ""
+
+#: Form\form_us.xml.h:2359
+msgid "Education Level"
+msgstr ""
+
+#: Form\form_us.xml.h:2365
+msgid "Social Security No."
+msgstr ""
+
+#: Form\form_us.xml.h:2366
+msgid "Informant"
+msgstr ""
+
+#: Form\form_us.xml.h:2367 Form\form_us.xml.h:2406
+msgid "Date of Death"
+msgstr ""
+
+#: Form\form_us.xml.h:2369
+msgid "Place of Burial"
+msgstr ""
+
+#: Form\form_us.xml.h:2370
+msgid "Date of Burial"
+msgstr ""
+
+#: Form\form_us.xml.h:2389
+msgid "Social Security Number"
+msgstr ""
+
+#: Form\form_us.xml.h:2390
+msgid "Residence Place"
+msgstr ""
+
+#: Form\form_us.xml.h:2392
+msgid "Burial Date"
+msgstr ""
+
+#: Form\form_us.xml.h:2393
+msgid "Burial Place"
+msgstr ""
+
+#: Form\form_us.xml.h:2394
+msgid "Cemetery"
+msgstr ""
+
+#: Form\form_us.xml.h:2415
+msgid "Congressional District"
+msgstr ""
+
+#: Form\form_us.xml.h:2416
+msgid "in the Counties of"
+msgstr ""
+
+#: Form\form_us.xml.h:2418
+msgid "in the month of"
+msgstr ""
+
+#: Form\form_us.xml.h:2422
+msgid "Age 1 July 1863"
+msgstr ""
+
+#: Form\form_us.xml.h:2423
+msgid "White or Colored"
+msgstr ""
+
+#: Form\form_us.xml.h:2426
+msgid "Former Military Service"
+msgstr ""
+
+#: Form\form_us.xml.h:2428
+msgid "Station Headquarters"
+msgstr ""
+
+#: Form\form_us.xml.h:2429
+msgid "Congr. Dist. of"
+msgstr ""
+
+#: Form\form_us.xml.h:2431
+msgid "Card (A, B, or C)"
+msgstr ""
+
+#: Form\form_us.xml.h:2433
+msgid "Serial No."
+msgstr ""
+
+#: Form\form_us.xml.h:2434
+msgid "Registration No."
+msgstr ""
+
+#: Form\form_us.xml.h:2435
+msgid "Order No."
+msgstr ""
+
+#: Form\form_us.xml.h:2437
+msgid "Age in yrs."
+msgstr ""
+
+#: Form\form_us.xml.h:2438
+msgid "Home Address"
+msgstr ""
+
+#: Form\form_us.xml.h:2441
+msgid "Citizenship"
+msgstr ""
+
+#: Form\form_us.xml.h:2442
+msgid "Natural-born, Naturalized Citizen, Alien, Noncitizen or citizen Indian"
+msgstr ""
+
+#: Form\form_us.xml.h:2443
+msgid "If not a citizen, of what nation are you a citizen or subject?"
+msgstr ""
+
+#: Form\form_us.xml.h:2445 Form\form_us.xml.h:2471
+msgid "Employer's Name & address"
+msgstr ""
+
+#: Form\form_us.xml.h:2446
+msgid "Nearest Relative"
+msgstr ""
+
+#: Form\form_us.xml.h:2447
+msgid "Dependants & Address"
+msgstr ""
+
+#: Form\form_us.xml.h:2448
+msgid ""
+"Have you a father, mother, wife, child under 12, or a sister or brother "
+"under 12, solely dependent on your support (specify which)?"
+msgstr ""
+
+#: Form\form_us.xml.h:2449
+msgid "Marital status"
+msgstr ""
+
+#: Form\form_us.xml.h:2450
+msgid "What military service have you had? (Branch, Years, Nation or State)"
+msgstr ""
+
+#: Form\form_us.xml.h:2451
+msgid "Do you claim exemption from draft (specify grounds)"
+msgstr ""
+
+#: Form\form_us.xml.h:2452
+msgid "Race "
+msgstr ""
+
+#: Form\form_us.xml.h:2453 Form\form_us.xml.h:2474 Form\form_us.xml.h:2495
+msgid "Height"
+msgstr ""
+
+#: Form\form_us.xml.h:2454
+msgid "Build / Weight"
+msgstr ""
+
+#: Form\form_us.xml.h:2455
+msgid "Eye Color"
+msgstr ""
+
+#: Form\form_us.xml.h:2456
+msgid "Hair Color"
+msgstr ""
+
+#: Form\form_us.xml.h:2457
+msgid "Bald"
+msgstr ""
+
+#: Form\form_us.xml.h:2459 Form\form_us.xml.h:2481
+msgid "Place of Registration"
+msgstr ""
+
+#: Form\form_us.xml.h:2460 Form\form_us.xml.h:2480
+msgid "Date of Registration"
+msgstr ""
+
+#: Form\form_us.xml.h:2461
+msgid "Serial Number"
+msgstr ""
+
+#: Form\form_us.xml.h:2462
+msgid "Order Number"
+msgstr ""
+
+#: Form\form_us.xml.h:2464
+msgid "Place of Residence"
+msgstr ""
+
+#: Form\form_us.xml.h:2465
+msgid "Mailing Address"
+msgstr ""
+
+#: Form\form_us.xml.h:2466
+msgid "Telephone"
+msgstr ""
+
+#: Form\form_us.xml.h:2467
+msgid "Age in years"
+msgstr ""
+
+#: Form\form_us.xml.h:2470
+msgid "Who will always know your address (Name & Address)"
+msgstr ""
+
+#: Form\form_us.xml.h:2472
+msgid "Place of employment or business"
+msgstr ""
+
+#: Form\form_us.xml.h:2475
+msgid "Weight"
+msgstr ""
+
+#: Form\form_us.xml.h:2476 Form\form_us.xml.h:2494
+msgid "Complexion"
+msgstr ""
+
+#: Form\form_us.xml.h:2477
+msgid "Eyes"
+msgstr ""
+
+#: Form\form_us.xml.h:2478
+msgid "Hair"
+msgstr ""
+
+#: Form\form_us.xml.h:2479
+msgid "Other characteristics"
+msgstr ""
+
+#: Form\form_us.xml.h:2486
+msgid "Date entered"
+msgstr ""
+
+#: Form\form_us.xml.h:2487
+msgid "Place entered"
+msgstr ""
+
+#: Form\form_us.xml.h:2488
+msgid "Term of enlistment"
+msgstr ""
+
+#: Form\form_us.xml.h:2492
+msgid "Eye color"
+msgstr ""
+
+#: Form\form_us.xml.h:2493
+msgid "Hair color"
+msgstr ""
+
+#: Form\form_us.xml.h:2496
+msgid "Rank in"
+msgstr ""
+
+#: Form\form_us.xml.h:2497
+msgid "Branch"
+msgstr ""
+
+#: Form\form_us.xml.h:2498
+msgid "Regiment/Unit/Ship"
+msgstr ""
+
+#: Form\form_us.xml.h:2500
+msgid "Service Number"
+msgstr ""
+
+#: Form\form_us.xml.h:2501
+msgid "No. of enlistment"
+msgstr ""
+
+#: Form\form_us.xml.h:2502
+msgid "Date discharged"
+msgstr ""
+
+#: Form\form_us.xml.h:2503
+msgid "Place discharged"
+msgstr ""
+
+#: Form\form_us.xml.h:2504
+msgid "Rank out"
+msgstr ""
+
+#: Form\form_us.xml.h:2509
+msgid "Industry/Employer"
+msgstr ""
+
+#: Form\form_us.xml.h:2510
+msgid "Spouse"
+msgstr ""
+
+#: Form\form_us.xml.h:2512
+msgid "Residents Status"
+msgstr ""

--- a/GedcomExtensions/po/template.pot
+++ b/GedcomExtensions/po/template.pot
@@ -1,0 +1,51 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: GedcomExtensions/GedcomExtensions.gpr.py:31
+msgid "Export GEDCOM Extensions (GED2)"
+msgstr ""
+
+#: GedcomExtensions/GedcomExtensions.gpr.py:32
+msgid "GEDCOM Extensions (GED2)"
+msgstr ""
+
+#: GedcomExtensions/GedcomExtensions.gpr.py:33
+msgid "Extensions to the common GEDCOM format."
+msgstr ""
+
+#: GedcomExtensions/GedcomExtensions.gpr.py:40
+msgid "GEDCOM Extensions options"
+msgstr ""
+
+#: GedcomExtensions/GedcomExtensions.py:121
+msgid "Include witnesses"
+msgstr ""
+
+#: GedcomExtensions/GedcomExtensions.py:122
+msgid "Include media"
+msgstr ""
+
+#: GedcomExtensions/GedcomExtensions.py:151
+#, python-format
+msgid "Could not create %s"
+msgstr ""
+
+#: GedcomExtensions/GedcomExtensions.py:154
+msgid "Export failed"
+msgstr ""

--- a/GenealogyTree/po/template.pot
+++ b/GenealogyTree/po/template.pot
@@ -1,0 +1,142 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: GenealogyTree/gt_ancestor.py:83 GenealogyTree/gt_descendant.py:83
+#: GenealogyTree/gt_sandclock.py:91
+#, python-format
+msgid "Person %s is not in the Database"
+msgstr ""
+
+#: GenealogyTree/gt_ancestor.py:148 GenealogyTree/gt_descendant.py:156
+#: GenealogyTree/gt_grandparent.py:205 GenealogyTree/gt_sandclock.py:215
+msgid "Report Options"
+msgstr ""
+
+#: GenealogyTree/gt_ancestor.py:150 GenealogyTree/gt_descendant.py:158
+#: GenealogyTree/gt_grandparent.py:207 GenealogyTree/gt_sandclock.py:218
+msgid "Center Person"
+msgstr ""
+
+#: GenealogyTree/gt_ancestor.py:151 GenealogyTree/gt_descendant.py:159
+#: GenealogyTree/gt_grandparent.py:208 GenealogyTree/gt_sandclock.py:219
+msgid "The center person for the report"
+msgstr ""
+
+#: GenealogyTree/gt_ancestor.py:154 GenealogyTree/gt_descendant.py:162
+#: GenealogyTree/gt_grandparent.py:211
+msgid "Generations"
+msgstr ""
+
+#: GenealogyTree/gt_ancestor.py:155 GenealogyTree/gt_descendant.py:163
+#: GenealogyTree/gt_grandparent.py:212 GenealogyTree/gt_sandclock.py:227
+#: GenealogyTree/gt_sandclock.py:231
+msgid "The number of generations to include in the tree"
+msgstr ""
+
+#: GenealogyTree/gt_ancestor.py:158 GenealogyTree/gt_descendant.py:166
+#: GenealogyTree/gt_grandparent.py:219 GenealogyTree/gt_sandclock.py:238
+msgid "Include images"
+msgstr ""
+
+#: GenealogyTree/gt_ancestor.py:159 GenealogyTree/gt_descendant.py:167
+#: GenealogyTree/gt_grandparent.py:220 GenealogyTree/gt_sandclock.py:239
+msgid "Include images of people in the nodes."
+msgstr ""
+
+#: GenealogyTree/gt_grandparent.py:107
+#, python-format
+msgid "Person %s does not have both a paternal and a maternal grandparent"
+msgstr ""
+
+#: GenealogyTree/gt_grandparent.py:215
+msgid "Grandparent family spacing"
+msgstr ""
+
+#: GenealogyTree/gt_grandparent.py:216
+msgid "Extra spacing of grandparent families (mm)"
+msgstr ""
+
+#: GenealogyTree/gt_sandclock.py:96
+#, python-format
+msgid "Family %s is not in the Database"
+msgstr ""
+
+#: GenealogyTree/gt_sandclock.py:222
+msgid "Center Family"
+msgstr ""
+
+#: GenealogyTree/gt_sandclock.py:223
+msgid "The center family for the report"
+msgstr ""
+
+#: GenealogyTree/gt_sandclock.py:226
+msgid "Generations up"
+msgstr ""
+
+#: GenealogyTree/gt_sandclock.py:230
+msgid "Generations down"
+msgstr ""
+
+#: GenealogyTree/gt_sandclock.py:234
+msgid "Include siblings"
+msgstr ""
+
+#: GenealogyTree/gt_sandclock.py:235
+msgid "Include siblings of ancestors."
+msgstr ""
+
+#: GenealogyTree/treeplugins.gpr.py:29
+msgid "Ancestor Tree"
+msgstr ""
+
+#: GenealogyTree/treeplugins.gpr.py:30
+msgid "Ancestor tree using LaTeX genealogytree"
+msgstr ""
+
+#: GenealogyTree/treeplugins.gpr.py:51
+msgid "Descendant Tree"
+msgstr ""
+
+#: GenealogyTree/treeplugins.gpr.py:52
+msgid "Descendant tree using LaTeX genealogytree"
+msgstr ""
+
+#: GenealogyTree/treeplugins.gpr.py:73
+msgid "Grandparent Tree"
+msgstr ""
+
+#: GenealogyTree/treeplugins.gpr.py:74
+msgid "Grandparent tree using LaTeX genealogytree"
+msgstr ""
+
+#: GenealogyTree/treeplugins.gpr.py:95
+msgid "Sandclock Tree"
+msgstr ""
+
+#: GenealogyTree/treeplugins.gpr.py:96
+msgid "Sandclock tree using LaTeX genealogytree"
+msgstr ""
+
+#: GenealogyTree/treeplugins.gpr.py:117
+msgid "Sandclock Tree for a Family"
+msgstr ""
+
+#: GenealogyTree/treeplugins.gpr.py:118
+msgid "Sandclock tree for a family using LaTeX genealogytree"
+msgstr ""

--- a/GetGOV/po/template.pot
+++ b/GetGOV/po/template.pot
@@ -1,0 +1,54 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: GetGOV/getgov.gpr.py:30 GetGOV/getgov.gpr.py:41
+msgid "GetGOV"
+msgstr ""
+
+#: GetGOV/getgov.gpr.py:31
+msgid "Gramplet to get places from the GOV database"
+msgstr ""
+
+#: GetGOV/getgov.py:301
+msgid "Enter GOV-id:"
+msgstr ""
+
+#: GetGOV/getgov.py:309
+msgid "Get Place"
+msgstr ""
+
+#: GetGOV/getgov.py:353
+#, python-format
+msgid "Add GOV-id place %s"
+msgstr ""
+
+#: GetGOV/getgov.py:502
+#, python-format
+msgid "from %s to %s"
+msgstr ""
+
+#: GetGOV/getgov.py:504
+#, python-format
+msgid "after %s"
+msgstr ""
+
+#: GetGOV/getgov.py:506
+#, python-format
+msgid "before %s"
+msgstr ""

--- a/GoogleEarthWriteKML/po/template.pot
+++ b/GoogleEarthWriteKML/po/template.pot
@@ -1,0 +1,71 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: GoogleEarthWriteKML/GoogleEarthWriteKML.gpr.py:30
+msgid "GoogleEarth"
+msgstr ""
+
+#: GoogleEarthWriteKML/GoogleEarthWriteKML.gpr.py:35
+msgid "Creates data file for GoogleEarth and opens it"
+msgstr ""
+
+#: GoogleEarthWriteKML/GoogleEarthWriteKML.py:119
+msgid "No place description"
+msgstr ""
+
+#: GoogleEarthWriteKML/GoogleEarthWriteKML.py:152
+msgid "GoogleEarth not installed!"
+msgstr ""
+
+#: GoogleEarthWriteKML/GoogleEarthWriteKML.py:153
+#, python-format
+msgid ""
+"Create kmz/kml file ''%s''\n"
+"in user directory ''%s''?"
+msgstr ""
+
+#: GoogleEarthWriteKML/GoogleEarthWriteKML.py:156
+#: GoogleEarthWriteKML/GoogleEarthWriteKML.py:177
+msgid "Yes"
+msgstr ""
+
+#: GoogleEarthWriteKML/GoogleEarthWriteKML.py:157
+#: GoogleEarthWriteKML/GoogleEarthWriteKML.py:178
+msgid "No"
+msgstr ""
+
+#: GoogleEarthWriteKML/GoogleEarthWriteKML.py:163
+#, python-format
+msgid "Failure writing to %s"
+msgstr ""
+
+#: GoogleEarthWriteKML/GoogleEarthWriteKML.py:164
+msgid "Directory does not exist"
+msgstr ""
+
+#: GoogleEarthWriteKML/GoogleEarthWriteKML.py:173
+msgid "GoogleEarth file exists!"
+msgstr ""
+
+#: GoogleEarthWriteKML/GoogleEarthWriteKML.py:174
+#, python-format
+msgid ""
+"Overwrite kmz/kml file ''%s''\n"
+"in user home directory ''%s''?"
+msgstr ""

--- a/GraphView/po/template.pot
+++ b/GraphView/po/template.pot
@@ -1,0 +1,310 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: GraphView/graphview.gpr.py:36 GraphView/graphview.py:134
+msgid "Graph View"
+msgstr ""
+
+#: GraphView/graphview.gpr.py:37
+msgid "Charts"
+msgstr ""
+
+#: GraphView/graphview.gpr.py:38
+msgid "Dynamic and interactive graph of relations"
+msgstr ""
+
+#: GraphView/graphview.gpr.py:51
+msgid ""
+"Graphview Warning:  Goocanvas 2 (https://wiki.gnome.org/action/show/Projects/"
+"GooCanvas) is required for this view to work"
+msgstr ""
+
+#: GraphView/graphview.gpr.py:56
+msgid ""
+"Graphview Warning:  GraphViz (http://www.graphviz.org) is required for this "
+"view to work"
+msgstr ""
+
+#: GraphView/graphview.gpr.py:65
+msgid "Graphview Failed to Load"
+msgstr ""
+
+#: GraphView/graphview.gpr.py:66
+#, python-format
+msgid ""
+"\n"
+"\n"
+"Graphview is missing python modules or programs.\n"
+"%smust be installed.\n"
+"\n"
+"For now, it may be possible to install the files manually. See\n"
+"<a href=\"https://gramps-project.org/wiki/index.php?title=Graph_View\" title="
+"\"https://gramps-project.org/wiki/index.php?title=Graph_View\">https://"
+"gramps-project.org/wiki/index.php?title=Graph_View</a> \n"
+"\n"
+"To dismiss all future Graphview warnings click Dismiss."
+msgstr ""
+
+#: GraphView/graphview.gpr.py:82
+msgid " Dismiss "
+msgstr ""
+
+#: GraphView/graphview.gpr.py:83
+msgid "Continue"
+msgstr ""
+
+#: GraphView/graphview.py:169
+msgid "_Print..."
+msgstr ""
+
+#: GraphView/graphview.py:171
+msgid ""
+"Save the dot file for a later print.\n"
+"This will save a .gv file and a svg file.\n"
+"You must select a .gv file"
+msgstr ""
+
+#: GraphView/graphview.py:434 GraphView/graphview.py:1037
+msgid "Show images"
+msgstr ""
+
+#: GraphView/graphview.py:436 GraphView/graphview.py:1045
+msgid "Highlight the home person"
+msgstr ""
+
+#: GraphView/graphview.py:439 GraphView/graphview.py:1053
+msgid "Show full dates"
+msgstr ""
+
+#: GraphView/graphview.py:442 GraphView/graphview.py:1061
+msgid "Show places"
+msgstr ""
+
+#: GraphView/graphview.py:444 GraphView/graphview.py:1069
+msgid "Show tags"
+msgstr ""
+
+#: GraphView/graphview.py:446
+msgid "Layout"
+msgstr ""
+
+#: GraphView/graphview.py:459
+msgid "Path color to home person"
+msgstr ""
+
+#: GraphView/graphview.py:462
+msgid "Colors"
+msgstr ""
+
+#: GraphView/graphview.py:475 GraphView/graphview.py:1079
+msgid "Show animation"
+msgstr ""
+
+#: GraphView/graphview.py:479
+msgid "Animation speed (1..5 and 5 is the slower)"
+msgstr ""
+
+#: GraphView/graphview.py:483
+msgid "Animation count (0..8 use 0 to turn off)"
+msgstr ""
+
+#: GraphView/graphview.py:492
+msgid "Animation"
+msgstr ""
+
+#: GraphView/graphview.py:508
+msgid "Select a dot file name"
+msgstr ""
+
+#: GraphView/graphview.py:510
+msgid "_Cancel"
+msgstr ""
+
+#: GraphView/graphview.py:511
+msgid "_Apply"
+msgstr ""
+
+#: GraphView/graphview.py:525
+msgid "File already exists"
+msgstr ""
+
+#: GraphView/graphview.py:526
+msgid ""
+"You can choose to either overwrite the file, or change the selected filename."
+msgstr ""
+
+#: GraphView/graphview.py:528
+msgid "_Overwrite"
+msgstr ""
+
+#: GraphView/graphview.py:529
+msgid "_Change filename"
+msgstr ""
+
+#: GraphView/graphview.py:544
+#, python-format
+msgid "Could not create %s"
+msgstr ""
+
+#: GraphView/graphview.py:596
+msgid "Zoom in"
+msgstr ""
+
+#: GraphView/graphview.py:603
+msgid "Zoom out"
+msgstr ""
+
+#: GraphView/graphview.py:610
+msgid "Zoom to original"
+msgstr ""
+
+#: GraphView/graphview.py:617
+msgid "Zoom to best fit"
+msgstr ""
+
+#: GraphView/graphview.py:624
+msgid "Go to active person"
+msgstr ""
+
+#: GraphView/graphview.py:634
+msgid "Go to bookmark"
+msgstr ""
+
+#: GraphView/graphview.py:642
+msgid "Ancestor generations"
+msgstr ""
+
+#: GraphView/graphview.py:651
+msgid "Descendant generations"
+msgstr ""
+
+#: GraphView/graphview.py:760
+#, python-format
+msgid ""
+"Person <b><i>%s</i></b> is not in the current view.\n"
+"Do you want to set it active and rebuild view?"
+msgstr ""
+
+#: GraphView/graphview.py:763
+msgid "Change active person?"
+msgstr ""
+
+#: GraphView/graphview.py:764
+msgid "Yes"
+msgstr ""
+
+#: GraphView/graphview.py:764
+msgid "No"
+msgstr ""
+
+#: GraphView/graphview.py:1088
+msgid "Lines type"
+msgstr ""
+
+#: GraphView/graphview.py:1094
+msgid "Direct"
+msgstr ""
+
+#: GraphView/graphview.py:1102
+msgid "Curves"
+msgstr ""
+
+#: GraphView/graphview.py:1110
+msgid "Ortho"
+msgstr ""
+
+#: GraphView/graphview.py:1141
+msgid "About Graph View"
+msgstr ""
+
+#: GraphView/graphview.py:1156 GraphView/graphview.py:1352
+msgid "Edit"
+msgstr ""
+
+#: GraphView/graphview.py:1159 GraphView/graphview.py:1355
+msgid "Edit tags"
+msgstr ""
+
+#: GraphView/graphview.py:1162
+msgid "_Copy"
+msgstr ""
+
+#: GraphView/graphview.py:1172
+msgid "Spouses"
+msgstr ""
+
+#: GraphView/graphview.py:1177 GraphView/graphview.py:1305
+msgid "Add"
+msgstr ""
+
+#: GraphView/graphview.py:1202
+msgid "Siblings"
+msgstr ""
+
+#: GraphView/graphview.py:1271
+msgid "Parents"
+msgstr ""
+
+#: GraphView/graphview.py:1311
+msgid "Related"
+msgstr ""
+
+#: GraphView/graphview.py:1343
+msgid "Set as home person"
+msgstr ""
+
+#: GraphView/graphview.py:1373
+msgid "Children"
+msgstr ""
+
+#: GraphView/graphview.py:1386
+msgid "Add child to family"
+msgstr ""
+
+#: GraphView/graphview.py:1465
+msgid "Add Child to Family"
+msgstr ""
+
+#: GraphView/graphview.py:1548
+msgid "Adding Tags"
+msgstr ""
+
+#: GraphView/graphview.py:1554
+#, python-format
+msgid "Adding Tags to person (%s)"
+msgstr ""
+
+#: GraphView/graphview.py:1559
+#, python-format
+msgid "Adding Tags to family (%s)"
+msgstr ""
+
+#: GraphView/graphview.py:2631
+#, python-format
+msgid "b. %s"
+msgstr ""
+
+#: GraphView/graphview.py:2636
+#, python-format
+msgid "d. %s"
+msgstr ""
+
+#: GraphView/graphview.py:2815
+msgid "<b>Tags:</b>"
+msgstr ""

--- a/HeadlineNewsGramplet/po/template.pot
+++ b/HeadlineNewsGramplet/po/template.pot
@@ -1,0 +1,38 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: HeadlineNewsGramplet/HeadlineNewsGramplet.gpr.py:3
+msgid "Headline News Gramplet"
+msgstr ""
+
+#: HeadlineNewsGramplet/HeadlineNewsGramplet.gpr.py:4
+msgid "Gramplet that shows the latest Gramps news"
+msgstr ""
+
+#: HeadlineNewsGramplet/HeadlineNewsGramplet.gpr.py:10
+msgid "Headline News"
+msgstr ""
+
+#: HeadlineNewsGramplet/HeadlineNewsGramplet.py:107
+msgid "Read Gramps headline news"
+msgstr ""
+
+#: HeadlineNewsGramplet/HeadlineNewsGramplet.py:111
+msgid "No Family Tree loaded."
+msgstr ""

--- a/HouseTimelineGramplet/po/template.pot
+++ b/HouseTimelineGramplet/po/template.pot
@@ -1,0 +1,90 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: HouseTimelineGramplet/housetimeline.gpr.py:3
+#: HouseTimelineGramplet/housetimeline.gpr.py:14
+msgid "House Timeline"
+msgstr ""
+
+#: HouseTimelineGramplet/housetimeline.gpr.py:4
+msgid "Lists the Residents of an Address by Timeline"
+msgstr ""
+
+#: HouseTimelineGramplet/housetimeline.py:25
+msgid "Double-click name for details"
+msgstr ""
+
+#: HouseTimelineGramplet/housetimeline.py:42
+#: HouseTimelineGramplet/housetimeline.py:49
+msgid "House Icon Style"
+msgstr ""
+
+#: HouseTimelineGramplet/housetimeline.py:50
+msgid "Standard"
+msgstr ""
+
+#: HouseTimelineGramplet/housetimeline.py:51
+msgid "Small"
+msgstr ""
+
+#: HouseTimelineGramplet/housetimeline.py:52
+msgid "Unicode"
+msgstr ""
+
+#: HouseTimelineGramplet/housetimeline.py:53
+msgid "None"
+msgstr ""
+
+#: HouseTimelineGramplet/housetimeline.py:59
+msgid "Processing..."
+msgstr ""
+
+#: HouseTimelineGramplet/housetimeline.py:82
+msgid ""
+"There are no individuals with Address data. Please add Address data to "
+"people."
+msgstr ""
+
+#: HouseTimelineGramplet/housetimeline.py:117
+msgid "Location"
+msgstr ""
+
+#: HouseTimelineGramplet/housetimeline.py:118
+msgid "Time In Family"
+msgstr ""
+
+#: HouseTimelineGramplet/housetimeline.py:119
+msgid "First Resident"
+msgstr ""
+
+#: HouseTimelineGramplet/housetimeline.py:120
+msgid "Last Resident"
+msgstr ""
+
+#: HouseTimelineGramplet/housetimeline.py:121
+msgid "Timeline"
+msgstr ""
+
+#: HouseTimelineGramplet/housetimeline.py:122
+msgid "Unknown"
+msgstr ""
+
+#: HouseTimelineGramplet/housetimeline.py:123
+msgid "Total Known Residents"
+msgstr ""

--- a/HtmlView/po/template.pot
+++ b/HtmlView/po/template.pot
@@ -1,0 +1,70 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-04 18:55-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: HtmlView/htmlview.gpr.py:30
+msgid "Html View"
+msgstr ""
+
+#: HtmlView/htmlview.gpr.py:31
+msgid "A view showing html pages embedded in Gramps"
+msgstr ""
+
+#: HtmlView/htmlview.gpr.py:39
+msgid "Web"
+msgstr ""
+
+#: HtmlView/htmlview.py:318
+msgid "HtmlView"
+msgstr ""
+
+#: HtmlView/htmlview.py:484
+msgid "_Back"
+msgstr ""
+
+#: HtmlView/htmlview.py:485
+msgid "Go to the previous page in the history"
+msgstr ""
+
+#: HtmlView/htmlview.py:492
+msgid "_Forward"
+msgstr ""
+
+#: HtmlView/htmlview.py:493
+msgid "Go to the next page in the history"
+msgstr ""
+
+#: HtmlView/htmlview.py:498
+msgid "_Refresh"
+msgstr ""
+
+#: HtmlView/htmlview.py:501
+msgid "Stop and reload the page."
+msgstr ""
+
+#: HtmlView/htmlview.py:545
+msgid "Start page for the Html View"
+msgstr ""
+
+#: HtmlView/htmlview.py:546
+msgid ""
+"Type a webpage address at the top, and hit the execute button to load a "
+"webpage in this page\n"
+"<br>\n"
+"For example: "
+msgstr ""

--- a/HtreePedigreeView/po/template.pot
+++ b/HtreePedigreeView/po/template.pot
@@ -1,0 +1,154 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: HtreePedigreeView/HtreePedigreeView.gpr.py:45
+msgid "H-Tree Pedigree"
+msgstr ""
+
+#: HtreePedigreeView/HtreePedigreeView.gpr.py:46
+msgid "Charts"
+msgstr ""
+
+#: HtreePedigreeView/HtreePedigreeView.gpr.py:47
+msgid ""
+"The view shows a space-efficient pedigree with ancestors of the selected "
+"person"
+msgstr ""
+
+#: HtreePedigreeView/HtreePedigreeView.py:83
+msgid "short for born|b."
+msgstr ""
+
+#: HtreePedigreeView/HtreePedigreeView.py:84
+msgid "short for died|d."
+msgstr ""
+
+#: HtreePedigreeView/HtreePedigreeView.py:85
+msgid "short for baptized|bap."
+msgstr ""
+
+#: HtreePedigreeView/HtreePedigreeView.py:86
+msgid "short for christened|chr."
+msgstr ""
+
+#: HtreePedigreeView/HtreePedigreeView.py:87
+msgid "short for buried|bur."
+msgstr ""
+
+#: HtreePedigreeView/HtreePedigreeView.py:88
+msgid "short for cremated|crem."
+msgstr ""
+
+#: HtreePedigreeView/HtreePedigreeView.py:533
+msgid "H-tree Pedigree View"
+msgstr ""
+
+#: HtreePedigreeView/HtreePedigreeView.py:699
+msgid "Person Filter Editor"
+msgstr ""
+
+#: HtreePedigreeView/HtreePedigreeView.py:1542
+msgid "Relationship loop detected"
+msgstr ""
+
+#: HtreePedigreeView/HtreePedigreeView.py:1543
+msgid "A person was found to be his/her own ancestor."
+msgstr ""
+
+#: HtreePedigreeView/HtreePedigreeView.py:1587
+msgid "Pre_vious"
+msgstr ""
+
+#: HtreePedigreeView/HtreePedigreeView.py:1588
+msgid "_Next"
+msgstr ""
+
+#: HtreePedigreeView/HtreePedigreeView.py:1589
+msgid "_Home"
+msgstr ""
+
+#: HtreePedigreeView/HtreePedigreeView.py:1611
+msgid "Mouse scroll direction"
+msgstr ""
+
+#: HtreePedigreeView/HtreePedigreeView.py:1615
+msgid "Top <-> Bottom"
+msgstr ""
+
+#: HtreePedigreeView/HtreePedigreeView.py:1622
+msgid "Left <-> Right"
+msgstr ""
+
+#: HtreePedigreeView/HtreePedigreeView.py:1640
+msgid "About H-Tree"
+msgstr ""
+
+#: HtreePedigreeView/HtreePedigreeView.py:1651
+msgid "_Add"
+msgstr ""
+
+#: HtreePedigreeView/HtreePedigreeView.py:1686
+#: HtreePedigreeView/HtreePedigreeView.py:1914
+msgid "_Edit"
+msgstr ""
+
+#: HtreePedigreeView/HtreePedigreeView.py:1691
+#: HtreePedigreeView/HtreePedigreeView.py:1919
+msgid "_Copy"
+msgstr ""
+
+#: HtreePedigreeView/HtreePedigreeView.py:1701
+msgid "Spouses"
+msgstr ""
+
+#: HtreePedigreeView/HtreePedigreeView.py:1735
+msgid "Siblings"
+msgstr ""
+
+#: HtreePedigreeView/HtreePedigreeView.py:1777
+msgid "Children"
+msgstr ""
+
+#: HtreePedigreeView/HtreePedigreeView.py:1814
+msgid "Parents"
+msgstr ""
+
+#: HtreePedigreeView/HtreePedigreeView.py:1851
+msgid "Add New Parents..."
+msgstr ""
+
+#: HtreePedigreeView/HtreePedigreeView.py:1862
+msgid "Related"
+msgstr ""
+
+#: HtreePedigreeView/HtreePedigreeView.py:2046
+msgid "Show images"
+msgstr ""
+
+#: HtreePedigreeView/HtreePedigreeView.py:2055
+msgid "Show tags"
+msgstr ""
+
+#: HtreePedigreeView/HtreePedigreeView.py:2072
+msgid "Tree size"
+msgstr ""
+
+#: HtreePedigreeView/HtreePedigreeView.py:2076
+msgid "Layout"
+msgstr ""

--- a/ImportGramplet/po/template.pot
+++ b/ImportGramplet/po/template.pot
@@ -1,0 +1,81 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ImportGramplet/ImportGramplet.gpr.py:9
+msgid "Import Gramplet"
+msgstr ""
+
+#: ImportGramplet/ImportGramplet.gpr.py:10
+msgid "Gramplet for importing text"
+msgstr ""
+
+#: ImportGramplet/ImportGramplet.gpr.py:17
+msgid "Import"
+msgstr ""
+
+#: ImportGramplet/ImportGramplet.py:71
+msgid "CSV import"
+msgstr ""
+
+#: ImportGramplet/ImportGramplet.py:94
+msgid "VCard import"
+msgstr ""
+
+#: ImportGramplet/ImportGramplet.py:116
+msgid "Gramps XML import"
+msgstr ""
+
+#: ImportGramplet/ImportGramplet.py:143
+msgid "Could not change media path"
+msgstr ""
+
+#: ImportGramplet/ImportGramplet.py:144
+#, python-format
+msgid ""
+"The opened file has media path %s, which conflicts with the media path of "
+"the family tree you import into. The original media path has been retained. "
+"Copy the files to a correct directory or change the media path in the "
+"Preferences."
+msgstr ""
+
+#: ImportGramplet/ImportGramplet.py:172
+msgid ""
+"Enter text to import and then click\n"
+"the Import button at bottom"
+msgstr ""
+
+#: ImportGramplet/ImportGramplet.py:198
+msgid "_Import"
+msgstr ""
+
+#: ImportGramplet/ImportGramplet.py:218
+msgid "Import done"
+msgstr ""
+
+#: ImportGramplet/ImportGramplet.py:228
+msgid "Importing Text..."
+msgstr ""
+
+#: ImportGramplet/ImportGramplet.py:259
+msgid "Can't determine type of import"
+msgstr ""
+
+#: ImportGramplet/ImportGramplet.py:260
+msgid "Import failed"
+msgstr ""

--- a/ImportMerge/po/template.pot
+++ b/ImportMerge/po/template.pot
@@ -1,0 +1,366 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ImportMerge/importmerge.gpr.py:30 ImportMerge/importmerge.py:311
+#: ImportMerge/importmerge.py:690
+msgid "Import and Merge tool"
+msgstr ""
+
+#: ImportMerge/importmerge.gpr.py:31
+msgid ""
+"Compares a Gramps XML database with the current one, and allows merging of "
+"the differences."
+msgstr ""
+
+#: ImportMerge/importmerge.py:80
+msgid "Import and merge a Gramps XML"
+msgstr ""
+
+#: ImportMerge/importmerge.py:89
+msgid "Missing"
+msgstr ""
+
+#: ImportMerge/importmerge.py:91
+msgid "Added"
+msgstr ""
+
+#: ImportMerge/importmerge.py:93
+msgid "Different"
+msgstr ""
+
+#: ImportMerge/importmerge.py:108
+msgid "Delete original"
+msgstr ""
+
+#: ImportMerge/importmerge.py:109 ImportMerge/importmerge.glade:332
+msgid "Ignore"
+msgstr ""
+
+#: ImportMerge/importmerge.py:110
+msgid "Add Import"
+msgstr ""
+
+#: ImportMerge/importmerge.py:111
+msgid "Merge into original"
+msgstr ""
+
+#: ImportMerge/importmerge.py:112
+msgid "Merge into import"
+msgstr ""
+
+#: ImportMerge/importmerge.py:113
+msgid "Replace with import"
+msgstr ""
+
+#: ImportMerge/importmerge.py:114
+msgid "Keep original"
+msgstr ""
+
+#: ImportMerge/importmerge.py:115 ImportMerge/importmerge.glade:291
+msgid ""
+"Use buttons below to set the 'Action' for each difference.  No changes will "
+"be made to your tree until you press 'Done' and confirm."
+msgstr ""
+
+#: ImportMerge/importmerge.py:118
+msgid ""
+"This item will be deleted from your tree.  Any referenced items were also "
+"marked for deletion."
+msgstr ""
+
+#: ImportMerge/importmerge.py:120
+msgid ""
+"This item will not be changed in your tree.  Any referenced items were also "
+"marked for Ignore."
+msgstr ""
+
+#: ImportMerge/importmerge.py:122
+msgid ""
+"This item will be added to your tree.  Any referenced items were also marked "
+"for adding."
+msgstr ""
+
+#: ImportMerge/importmerge.py:124
+msgid ""
+"This item will be merged, saving data from your tree.  Any referenced items "
+"were also marked for merging or adding."
+msgstr ""
+
+#: ImportMerge/importmerge.py:126
+msgid ""
+"This item will be merged, using data from the import.  Any referenced items "
+"were also marked for merging or adding."
+msgstr ""
+
+#: ImportMerge/importmerge.py:128
+msgid ""
+"The import data will entirely replace the data in your tree.  Any referenced "
+"items were also marked for replacement or removal."
+msgstr ""
+
+#: ImportMerge/importmerge.py:130
+msgid ""
+"This item will not be changed in your tree.  Any referenced items were also "
+"marked to keep."
+msgstr ""
+
+#: ImportMerge/importmerge.py:145
+msgid "Family"
+msgstr ""
+
+#: ImportMerge/importmerge.py:145
+msgid "Person"
+msgstr ""
+
+#: ImportMerge/importmerge.py:145
+msgid "Citation"
+msgstr ""
+
+#: ImportMerge/importmerge.py:145
+msgid "Event"
+msgstr ""
+
+#: ImportMerge/importmerge.py:145
+msgid "Media"
+msgstr ""
+
+#: ImportMerge/importmerge.py:146
+msgid "Note"
+msgstr ""
+
+#: ImportMerge/importmerge.py:146
+msgid "Place"
+msgstr ""
+
+#: ImportMerge/importmerge.py:146
+msgid "Repository"
+msgstr ""
+
+#: ImportMerge/importmerge.py:146
+msgid "Source"
+msgstr ""
+
+#: ImportMerge/importmerge.py:146
+msgid "Tag"
+msgstr ""
+
+#: ImportMerge/importmerge.py:312
+msgid "Importing data..."
+msgstr ""
+
+#: ImportMerge/importmerge.py:321
+msgid "Import Failure"
+msgstr ""
+
+#: ImportMerge/importmerge.py:325
+msgid "Searching..."
+msgstr ""
+
+#: ImportMerge/importmerge.py:389
+msgid "Your Tree and import are the same."
+msgstr ""
+
+#: ImportMerge/importmerge.py:421
+msgid "Last changed"
+msgstr ""
+
+#: ImportMerge/importmerge.py:434 ImportMerge/importmerge.py:443
+#: ImportMerge/importmerge.py:451 ImportMerge/importmerge.py:459
+msgid "your tree "
+msgstr ""
+
+#: ImportMerge/importmerge.py:441 ImportMerge/importmerge.py:449
+#: ImportMerge/importmerge.py:457
+msgid "imported "
+msgstr ""
+
+#: ImportMerge/importmerge.py:464 ImportMerge/importmerge.py:943
+#: ImportMerge/importmerge.py:964
+msgid "Original"
+msgstr ""
+
+#: ImportMerge/importmerge.py:465 ImportMerge/importmerge.py:944
+#: ImportMerge/importmerge.py:965
+msgid "Imported"
+msgstr ""
+
+#: ImportMerge/importmerge.py:467 ImportMerge/importmerge.py:946
+#: ImportMerge/importmerge.py:967
+msgid "Result  "
+msgstr ""
+
+#: ImportMerge/importmerge.py:692
+msgid "Processing..."
+msgstr ""
+
+#: ImportMerge/importmerge.py:693
+msgid "Import and Merge"
+msgstr ""
+
+#: ImportMerge/importmerge.py:893 ImportMerge/importmerge.glade:405
+msgid "Replace"
+msgstr ""
+
+#: ImportMerge/importmerge.py:898
+msgid "Add"
+msgstr ""
+
+#: ImportMerge/importmerge.py:903
+msgid "Delete"
+msgstr ""
+
+#: ImportMerge/importmerge.glade:8
+msgid ""
+"A '*' indicates that the action was automarked, a '?' indicates a conflict "
+"between automarks."
+msgstr ""
+
+#: ImportMerge/importmerge.glade:9
+msgid "Action"
+msgstr ""
+
+#: ImportMerge/importmerge.glade:38
+msgid "Import file"
+msgstr ""
+
+#: ImportMerge/importmerge.glade:122
+msgid "Select the difference you wish to examine."
+msgstr ""
+
+#: ImportMerge/importmerge.glade:132
+msgid "Status"
+msgstr ""
+
+#: ImportMerge/importmerge.glade:147
+msgid "Object"
+msgstr ""
+
+#: ImportMerge/importmerge.glade:162
+msgid "ID"
+msgstr ""
+
+#: ImportMerge/importmerge.glade:178
+msgid "Object Name/Description"
+msgstr ""
+
+#: ImportMerge/importmerge.glade:225
+msgid ""
+"Data item details, showing the current treeitem, imported tree item, and "
+"result (when chosen)."
+msgstr ""
+
+#: ImportMerge/importmerge.glade:246
+msgid "Object and item"
+msgstr ""
+
+#: ImportMerge/importmerge.glade:262
+msgid "Differences"
+msgstr ""
+
+#: ImportMerge/importmerge.glade:318
+msgid "Help"
+msgstr ""
+
+#: ImportMerge/importmerge.glade:336
+msgid "This button will ignore the difference, no changes to your tree."
+msgstr ""
+
+#: ImportMerge/importmerge.glade:347
+msgid "Unmark"
+msgstr ""
+
+#: ImportMerge/importmerge.glade:351
+msgid "This button will add the imported data as a new object to your tree."
+msgstr ""
+
+#: ImportMerge/importmerge.glade:362
+msgid "Done"
+msgstr ""
+
+#: ImportMerge/importmerge.glade:366
+msgid ""
+"This button will bring up a dialog allowing you to finalize your changes, or "
+"abandon them."
+msgstr ""
+
+#: ImportMerge/importmerge.glade:390
+msgid "Merge Original"
+msgstr ""
+
+#: ImportMerge/importmerge.glade:394
+msgid ""
+"This button will merge the imported data into your tree with your tree data "
+"as a base."
+msgstr ""
+
+#: ImportMerge/importmerge.glade:409
+msgid "This button will replace your tree data with the imported data."
+msgstr ""
+
+#: ImportMerge/importmerge.glade:420
+msgid "Merge Import"
+msgstr ""
+
+#: ImportMerge/importmerge.glade:424
+msgid ""
+"This button will merge the imported data into your tree with the imported "
+"data as a base."
+msgstr ""
+
+#: ImportMerge/importmerge.glade:435
+msgid "Edit Import"
+msgstr ""
+
+#: ImportMerge/importmerge.glade:439
+msgid ""
+"This button will edit the imported data.  The data will still need to be "
+"merged, added or replaced."
+msgstr ""
+
+#: ImportMerge/importmerge.glade:462
+msgid "Show more details"
+msgstr ""
+
+#: ImportMerge/importmerge.glade:479
+msgid "Automark Families"
+msgstr ""
+
+#: ImportMerge/importmerge.glade:496
+msgid "Automark Parent Families"
+msgstr ""
+
+#: ImportMerge/importmerge.glade:549
+msgid "Close _without saving"
+msgstr ""
+
+#: ImportMerge/importmerge.glade:564
+msgid "_Cancel"
+msgstr ""
+
+#: ImportMerge/importmerge.glade:580
+msgid "_Save"
+msgstr ""
+
+#: ImportMerge/importmerge.glade:611
+msgid "Save Changes?"
+msgstr ""
+
+#: ImportMerge/importmerge.glade:642
+msgid "If you close without saving, the changes you have made will be lost"
+msgstr ""

--- a/JSON/po/template.pot
+++ b/JSON/po/template.pot
@@ -1,0 +1,47 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: JSON/JSON.gpr.py:3
+msgid "JSON Export"
+msgstr ""
+
+#: JSON/JSON.gpr.py:4
+msgid "This is a JSON export"
+msgstr ""
+
+#: JSON/JSON.gpr.py:11
+msgid "JSON options"
+msgstr ""
+
+#: JSON/JSON.gpr.py:17
+msgid "JSON Import"
+msgstr ""
+
+#: JSON/JSON.gpr.py:18
+msgid "This is a JSON import"
+msgstr ""
+
+#: JSON/JSONImport.py:56
+msgid "JSON import"
+msgstr ""
+
+#: JSON/JSONImport.py:85
+#, python-format
+msgid "%s could not be opened\n"
+msgstr ""

--- a/LastChange/po/template.pot
+++ b/LastChange/po/template.pot
@@ -1,0 +1,195 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: LastChange/LastChange.gpr.py:24
+msgid "Last Change Gramplet"
+msgstr ""
+
+#: LastChange/LastChange.gpr.py:25
+msgid "List the last ten person records that have been changed"
+msgstr ""
+
+#: LastChange/LastChange.gpr.py:34
+msgid "Latest Changes"
+msgstr ""
+
+#: LastChange/LastChange.gpr.py:40 LastChange/LastChangeReport.py:74
+#: LastChange/LastChangeReport.py:113
+msgid "Last Change Report"
+msgstr ""
+
+#: LastChange/LastChange.gpr.py:41
+msgid "Report of the last records that have been changed"
+msgstr ""
+
+#: LastChange/LastChangeGramplet.py:55
+msgid "Double-click name for details"
+msgstr ""
+
+#: LastChange/LastChangeGramplet.py:56
+msgid "No Family Tree loaded."
+msgstr ""
+
+#: LastChange/LastChangeGramplet.py:60
+msgid "Processing..."
+msgstr ""
+
+#: LastChange/LastChangeGramplet.py:82
+msgid "changed on"
+msgstr ""
+
+#: LastChange/LastChangeReport.py:53
+msgid "<Unknown>"
+msgstr ""
+
+#: LastChange/LastChangeReport.py:75
+msgid "You must select at least one type of record."
+msgstr ""
+
+#: LastChange/LastChangeReport.py:116 LastChange/LastChangeReport.py:345
+msgid "People"
+msgstr ""
+
+#: LastChange/LastChangeReport.py:118 LastChange/LastChangeReport.py:346
+msgid "Families"
+msgstr ""
+
+#: LastChange/LastChangeReport.py:120 LastChange/LastChangeReport.py:348
+msgid "Events"
+msgstr ""
+
+#: LastChange/LastChangeReport.py:122 LastChange/LastChangeReport.py:347
+msgid "Places"
+msgstr ""
+
+#: LastChange/LastChangeReport.py:124 LastChange/LastChangeReport.py:349
+msgid "Media"
+msgstr ""
+
+#: LastChange/LastChangeReport.py:126 LastChange/LastChangeReport.py:350
+msgid "Sources"
+msgstr ""
+
+#: LastChange/LastChangeReport.py:128 LastChange/LastChangeReport.py:351
+msgid "Notes"
+msgstr ""
+
+#: LastChange/LastChangeReport.py:130 LastChange/LastChangeReport.py:352
+msgid "Citations"
+msgstr ""
+
+#: LastChange/LastChangeReport.py:180
+msgid "People Changed"
+msgstr ""
+
+#: LastChange/LastChangeReport.py:181 LastChange/LastChangeReport.py:198
+#: LastChange/LastChangeReport.py:229 LastChange/LastChangeReport.py:252
+#: LastChange/LastChangeReport.py:270 LastChange/LastChangeReport.py:288
+#: LastChange/LastChangeReport.py:305 LastChange/LastChangeReport.py:322
+msgid "ID"
+msgstr ""
+
+#: LastChange/LastChangeReport.py:181
+msgid "Person"
+msgstr ""
+
+#: LastChange/LastChangeReport.py:181 LastChange/LastChangeReport.py:198
+#: LastChange/LastChangeReport.py:229 LastChange/LastChangeReport.py:252
+#: LastChange/LastChangeReport.py:270 LastChange/LastChangeReport.py:288
+#: LastChange/LastChangeReport.py:305 LastChange/LastChangeReport.py:322
+msgid "Changed On"
+msgstr ""
+
+#: LastChange/LastChangeReport.py:197
+msgid "Families Changed"
+msgstr ""
+
+#: LastChange/LastChangeReport.py:198
+msgid "Family Surname"
+msgstr ""
+
+#: LastChange/LastChangeReport.py:215
+#, python-format
+msgid "%s and %s"
+msgstr ""
+
+#: LastChange/LastChangeReport.py:228
+msgid "Events Changed"
+msgstr ""
+
+#: LastChange/LastChangeReport.py:229
+msgid "Event"
+msgstr ""
+
+#: LastChange/LastChangeReport.py:251
+msgid "Places Changed"
+msgstr ""
+
+#: LastChange/LastChangeReport.py:252
+msgid "Place"
+msgstr ""
+
+#: LastChange/LastChangeReport.py:269
+msgid "Media Changed"
+msgstr ""
+
+#: LastChange/LastChangeReport.py:270
+msgid "Path"
+msgstr ""
+
+#: LastChange/LastChangeReport.py:287
+msgid "Sources Changed"
+msgstr ""
+
+#: LastChange/LastChangeReport.py:288 LastChange/LastChangeReport.py:305
+#: LastChange/LastChangeReport.py:322
+msgid "Title"
+msgstr ""
+
+#: LastChange/LastChangeReport.py:304
+msgid "Notes Changed"
+msgstr ""
+
+#: LastChange/LastChangeReport.py:321
+msgid "Citations Changed"
+msgstr ""
+
+#: LastChange/LastChangeReport.py:343
+msgid "Report Options"
+msgstr ""
+
+#: LastChange/LastChangeReport.py:344
+msgid "Select From"
+msgstr ""
+
+#: LastChange/LastChangeReport.py:378
+msgid "The style used for the title of the page."
+msgstr ""
+
+#: LastChange/LastChangeReport.py:393
+msgid "The style used for the section headers."
+msgstr ""
+
+#: LastChange/LastChangeReport.py:403
+msgid "The style used for normal text"
+msgstr ""
+
+#: LastChange/LastChangeReport.py:415
+msgid "The basic style used for table headings."
+msgstr ""

--- a/LinesOfDescendency/po/template.pot
+++ b/LinesOfDescendency/po/template.pot
@@ -1,0 +1,70 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: LinesOfDescendency/lines-of-descendency.gpr.py:30
+msgid "Lines of Descendency Report"
+msgstr ""
+
+#: LinesOfDescendency/lines-of-descendency.gpr.py:31
+msgid ""
+"Prints out all descendency lines from a given ancestor to a given descendent "
+"in text."
+msgstr ""
+
+#: LinesOfDescendency/lines-of-descendency.py:53
+msgid "People"
+msgstr ""
+
+#: LinesOfDescendency/lines-of-descendency.py:55
+msgid "Ancestor"
+msgstr ""
+
+#: LinesOfDescendency/lines-of-descendency.py:56
+msgid "The ancestor from which to start the line"
+msgstr ""
+
+#: LinesOfDescendency/lines-of-descendency.py:59
+msgid "Descendent"
+msgstr ""
+
+#: LinesOfDescendency/lines-of-descendency.py:60
+msgid "The descendent to which to build the line"
+msgstr ""
+
+#: LinesOfDescendency/lines-of-descendency.py:72
+msgid "The style used for the title of the page."
+msgstr ""
+
+#: LinesOfDescendency/lines-of-descendency.py:82
+msgid "The style used for the title of a line."
+msgstr ""
+
+#: LinesOfDescendency/lines-of-descendency.py:89
+msgid "The basic style used for the text display."
+msgstr ""
+
+#: LinesOfDescendency/lines-of-descendency.py:103
+#, python-format
+msgid "Person %s is not in the Database"
+msgstr ""
+
+#: LinesOfDescendency/lines-of-descendency.py:176
+#, python-format
+msgid "Lines of Descendency from %(ancestor)s to %(descendent)s"
+msgstr ""

--- a/ListeEclair/po/template.pot
+++ b/ListeEclair/po/template.pot
@@ -1,0 +1,87 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ListeEclair/ListeEclair.gpr.py:3 ListeEclair/ListeEclair.py:97
+#: ListeEclair/ListeEclair.py:104
+msgid "Liste Eclair"
+msgstr ""
+
+#: ListeEclair/ListeEclair.gpr.py:4
+msgid "Produit une liste eclair"
+msgstr ""
+
+#: ListeEclair/ListeEclair.py:97
+msgid "Generating report"
+msgstr ""
+
+#: ListeEclair/ListeEclair.py:253
+msgid "Report Options"
+msgstr ""
+
+#: ListeEclair/ListeEclair.py:260
+msgid "Select using filter"
+msgstr ""
+
+#: ListeEclair/ListeEclair.py:261
+msgid "Select places using a filter"
+msgstr ""
+
+#: ListeEclair/ListeEclair.py:266
+msgid "Entire Database"
+msgstr ""
+
+#: ListeEclair/ListeEclair.py:273
+msgid "Select places individually"
+msgstr ""
+
+#: ListeEclair/ListeEclair.py:274
+msgid "List of places to report on"
+msgstr ""
+
+#: ListeEclair/ListeEclair.py:277
+msgid "Type de Liste"
+msgstr ""
+
+#: ListeEclair/ListeEclair.py:279
+msgid "Tiny Tafel"
+msgstr ""
+
+#: ListeEclair/ListeEclair.py:280
+msgid "cousingenweb"
+msgstr ""
+
+#: ListeEclair/ListeEclair.py:281
+msgid "Type de liste"
+msgstr ""
+
+#: ListeEclair/ListeEclair.py:284
+msgid "Include private data"
+msgstr ""
+
+#: ListeEclair/ListeEclair.py:285
+msgid "Whether to include private data"
+msgstr ""
+
+#: ListeEclair/ListeEclair.py:301
+msgid "The style used for the liste eclair."
+msgstr ""
+
+#: ListeEclair/ListeEclair.py:314
+msgid "The style used for place title."
+msgstr ""

--- a/MediaBrowser/po/template.pot
+++ b/MediaBrowser/po/template.pot
@@ -1,0 +1,34 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: MediaBrowser/MediaBrowser.gpr.py:30
+msgid "Media Browser"
+msgstr ""
+
+#: MediaBrowser/MediaBrowser.gpr.py:31
+msgid "Gramplet showing details of a person"
+msgstr ""
+
+#: MediaBrowser/MediaBrowser.gpr.py:38
+msgid "Browser"
+msgstr ""
+
+#: MediaBrowser/MediaBrowser.py:53
+msgid "Object"
+msgstr ""

--- a/MediaMerge/po/template.pot
+++ b/MediaMerge/po/template.pot
@@ -1,0 +1,52 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: MediaMerge/mediamerge.gpr.py:32
+msgid "Merge Media"
+msgstr ""
+
+#: MediaMerge/mediamerge.gpr.py:33
+msgid ""
+"Searches the entire database, looking for media that have the same path and "
+"merges them."
+msgstr ""
+
+#: MediaMerge/mediamerge.py:95
+msgid "Media Merge"
+msgstr ""
+
+#: MediaMerge/mediamerge.py:140
+#, python-brace-format
+msgid "{number_of} media merged"
+msgid_plural "{number_of} media merged"
+msgstr[0] ""
+msgstr[1] ""
+
+#: MediaMerge/mediamerge.py:144
+msgid "Number of merges done"
+msgstr ""
+
+#: MediaMerge/mediamerge.py:147
+msgid "No modifications made"
+msgstr ""
+
+#: MediaMerge/mediamerge.py:148
+msgid "No media items merged."
+msgstr ""

--- a/MediaVerify/po/template.pot
+++ b/MediaVerify/po/template.pot
@@ -1,0 +1,141 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: MediaVerify/MediaVerify.gpr.py:30
+msgid "Media Verify"
+msgstr ""
+
+#: MediaVerify/MediaVerify.gpr.py:31
+msgid "Verify that media is present in the correct path"
+msgstr ""
+
+#: MediaVerify/MediaVerify.py:78
+msgid "Media Verify Tool"
+msgstr ""
+
+#: MediaVerify/MediaVerify.py:83
+msgid "Moved/Renamed Files"
+msgstr ""
+
+#: MediaVerify/MediaVerify.py:83
+msgid "Missing Files"
+msgstr ""
+
+#: MediaVerify/MediaVerify.py:84
+msgid "Duplicate Files"
+msgstr ""
+
+#: MediaVerify/MediaVerify.py:84
+msgid "Extra Files"
+msgstr ""
+
+#: MediaVerify/MediaVerify.py:85
+msgid "No md5 Generated"
+msgstr ""
+
+#: MediaVerify/MediaVerify.py:85
+msgid "Errors"
+msgstr ""
+
+#: MediaVerify/MediaVerify.py:100
+msgid "Close"
+msgstr ""
+
+#: MediaVerify/MediaVerify.py:101
+msgid "Close the Media Verify Tool"
+msgstr ""
+
+#: MediaVerify/MediaVerify.py:103
+msgid "Generate"
+msgstr ""
+
+#: MediaVerify/MediaVerify.py:104
+msgid "Generate md5 hashes for media objects"
+msgstr ""
+
+#: MediaVerify/MediaVerify.py:106
+msgid "Verify"
+msgstr ""
+
+#: MediaVerify/MediaVerify.py:107
+msgid "Check media paths and report missing, duplicate and extra files"
+msgstr ""
+
+#: MediaVerify/MediaVerify.py:110
+msgid "Export"
+msgstr ""
+
+#: MediaVerify/MediaVerify.py:111
+msgid "Export the results to a text file"
+msgstr ""
+
+#: MediaVerify/MediaVerify.py:113
+msgid "Fix"
+msgstr ""
+
+#: MediaVerify/MediaVerify.py:114
+msgid "Fix media paths of moved and renamed files"
+msgstr ""
+
+#: MediaVerify/MediaVerify.py:132
+msgid "Verify Gramps media using md5 hashes"
+msgstr ""
+
+#: MediaVerify/MediaVerify.py:143
+msgid "Files"
+msgstr ""
+
+#: MediaVerify/MediaVerify.py:195
+msgid "Export results to a text file"
+msgstr ""
+
+#: MediaVerify/MediaVerify.py:218
+#, python-format
+msgid "Error when writing the report: %s"
+msgstr ""
+
+#: MediaVerify/MediaVerify.py:259
+msgid "Generating media hashes"
+msgstr ""
+
+#: MediaVerify/MediaVerify.py:261
+msgid "Set media hashes"
+msgstr ""
+
+#: MediaVerify/MediaVerify.py:296
+msgid ""
+"Media path not set.  You must set the \"Base path for relative media paths\" "
+"in the Preferences."
+msgstr ""
+
+#: MediaVerify/MediaVerify.py:307
+msgid "Finding files"
+msgstr ""
+
+#: MediaVerify/MediaVerify.py:335
+msgid "Checking paths"
+msgstr ""
+
+#: MediaVerify/MediaVerify.py:388
+msgid "Fixing file paths"
+msgstr ""
+
+#: MediaVerify/MediaVerify.py:390
+msgid "Fix media paths"
+msgstr ""

--- a/MongoDB/po/template.pot
+++ b/MongoDB/po/template.pot
@@ -1,0 +1,34 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-04 18:55-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: MongoDB/mongodb.gpr.py:22
+msgid "MongoDB"
+msgstr ""
+
+#: MongoDB/mongodb.gpr.py:23
+msgid "_MongoDB Database"
+msgstr ""
+
+#: MongoDB/mongodb.gpr.py:24
+msgid "MongoDB Database"
+msgstr ""
+
+#: MongoDB/mongodb.py:84
+msgid "Database version"
+msgstr ""

--- a/NetworkChart/po/template.pot
+++ b/NetworkChart/po/template.pot
@@ -1,0 +1,607 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: NetworkChart/NetworkChart.gpr.py:31
+msgid "Network Chart"
+msgstr ""
+
+#: NetworkChart/NetworkChart.gpr.py:41
+msgid "Generates a family network chart."
+msgstr ""
+
+#: NetworkChart/NetworkChart.gpr.py:51
+msgid "NetworkChart Warning:  Python networkx module not found."
+msgstr ""
+
+#: NetworkChart/NetworkChart.gpr.py:54
+msgid ""
+"NetworkChart Warning:  NetworkChart needs one of the following to work: \n"
+"     Python module  pydotplus            OR\n"
+"     Python module  pygraphviz           OR\n"
+msgstr ""
+
+#: NetworkChart/NetworkChart.gpr.py:62
+msgid "NetworkChart Failed to Load"
+msgstr ""
+
+#: NetworkChart/NetworkChart.gpr.py:63
+msgid ""
+"\n"
+"\n"
+"NetworkChart is missing python modules or programs.  Networkx AND at\n"
+"least one of (pydotplus OR pygraphviz) must be\n"
+"installed.  For now, it may be possible to install the files manually. See\n"
+"\n"
+"https://gramps-project.org/wiki/index.php?title=NetworkChart \n"
+"\n"
+"To dismiss all future NetworkChart warnings click Dismiss."
+msgstr ""
+
+#: NetworkChart/NetworkChart.gpr.py:68
+msgid " Dismiss "
+msgstr ""
+
+#: NetworkChart/NetworkChart.gpr.py:69
+msgid "Continue"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:133
+msgid "birth abbreviation|b."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:134
+msgid "death abbreviation|d."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:135
+msgid "marriage abbreviation|m."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:136
+msgid "Unknown"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:856
+msgid "File exists. Overwrite?"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:858
+msgid "Cancel"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:859
+msgid "Yes"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:903
+msgid "created"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:904 NetworkChart/NetworkChart.py:907
+msgid "last_written"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:917
+msgid "Main"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:919
+msgid "Graph Style"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:921
+msgid "Orthogonal (right angles in connectors)"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:922
+msgid "Straight (no right angles in connectors)"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:923
+msgid "Curved (curved and straight connectors)"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:925
+msgid "Default (Orthogonal)"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:930
+msgid "Select the graph line connector format."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:933
+msgid "Graph Direction"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:935
+msgid "Top to Bottom"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:935
+msgid "Left to Right"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:936
+msgid "Bottom to Top"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:936
+msgid "Right to Left"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:938
+msgid "Default (Top to Bottom)"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:941
+msgid "Select the graph direction."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:944
+msgid "URL Style"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:946
+msgid "Include URLs from database."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:947
+msgid "Dynamic URL = Prefix + GrampID + Suffix"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:948
+msgid "Static URL = Prefix"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:949
+msgid "Don't include URLs"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:950
+msgid "Default (include)"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:953
+msgid "Select URL style."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:956
+msgid "URL Prefix,Suffix"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:957
+msgid ""
+"Enter the Prefix,Suffix (use comma)\n"
+"for dynamically generated URLs.\n"
+"URL = Prefix + GrampsID + Suffix."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:962
+msgid "Enter Font Name"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:964
+msgid ""
+"Enter the primary font style for the chart.\n"
+"Must already be installed.\n"
+"White Rabbit can be obtained from\n"
+"https://www.fontsquirrel.com/fonts/white-rabbit"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:969
+msgid "Spacing (inch)"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:970
+msgid ""
+"Enter the seperation distance between \"Generations\" in inches (0.1-5.0)."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:974
+msgid "Enter Chart Title"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:976
+msgid "Set the title of the chart."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:980
+msgid "Folder"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:982
+msgid "The destination folder for generated files."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:986 NetworkChart/NetworkChart.py:1284
+#: NetworkChart/NetworkChart.py:1292
+msgid "network"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:989
+msgid "Filename"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:991
+msgid "The filename for the generated svg network chart."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:998
+msgid "Different node shapes/edges for gender."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:999
+msgid "Node differences for gender."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1002
+msgid "Color"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1004
+msgid "Male Background"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1005
+msgid "RGB-color for male box background."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1008
+msgid "Male Background Alpha"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1010
+msgid "Alpha for Male box background (transparent=0, solid=255)."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1014
+msgid "Male Box Edge"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1015
+msgid "RGB-color for Male box edge."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1018
+msgid "Female Background"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1019 NetworkChart/NetworkChart.py:1030
+msgid "RGB-color for Female box background."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1024
+msgid "Alpha for Female box background (transparent=0, solid=255)."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1029
+msgid "Female Box Edge"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1033
+msgid "Other Background"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1034
+msgid "RGB-color for other box background."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1037
+msgid "Other Background Alpha"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1039
+msgid "Alpha for Other box background (transparent=0, solid=255)."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1043
+msgid "Family Connector Line"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1044
+msgid "RGB-color for family connector line."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1047
+msgid "Marriage Connector Line"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1048
+msgid "RGB-color for marriage connector line."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1051
+msgid "Highlight Connector Line"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1052
+msgid ""
+"RGB-color for the highlighted path between two individuals.  If the graph."
+"inverts, reverse the order to change."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1057
+msgid "Trim Box Edge"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1058
+msgid "RGB-color for box edge that has been trimmed."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1062
+msgid "Remove color background on all nodes."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1064
+msgid "Removes color background for individuals (nodes) on chart."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1067
+msgid "Privacy"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1069
+msgid ""
+"Enter year to start\n"
+"rounding birthday\n"
+"to year only"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1072
+msgid ""
+"Birthdays after this year are represented by the year only.  Invalid entries "
+"will be ignored."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1076
+msgid "Round birthday to year after year entered (above)."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1078
+msgid "Represent birthday by year only."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1082
+msgid ""
+"Enter year to start\n"
+"rounding marriage\n"
+"date to year only"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1083
+msgid ""
+"Marriages after this year are represented bythe year only. Invalid entries "
+"will be ignored."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1088
+msgid "Round marriage to year after year entered (above)."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1090
+msgid "Represent marriage by year only."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1095
+msgid ""
+"Attempts to remove middle names.  Only works for entries with birth year in "
+"the record."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1103
+msgid "Remove middle names."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1108
+msgid "Allow inclusion of private records in chart."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1113
+msgid "Trim"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1115
+msgid "Trim descendants"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1117
+msgid "All descendants (children) of selected individuals will not be shown."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1123
+msgid "Enable trimming of descendants."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1125
+msgid ""
+"You must enter valid person(s) before \n"
+"enabling trimming of descendants from tree."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1130
+msgid "Trim ancestors"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1131
+msgid "All ancestors (parents) of selected individuals will not be shown."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1137
+msgid "Enable trimming of ancestors."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1139
+msgid "Enable trimming of ancestors from tree."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1143
+msgid "Enable trim groups."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1145
+msgid ""
+"Remove groups less than Min Group Size.  Automatic\n"
+"for databases with more than 1500 individuals."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1150
+msgid "Min Group Size"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1152
+msgid ""
+"Enter the minimum size group to display.\n"
+"Value may be 2 or greater."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1157
+msgid "Highlight"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1160
+msgid ""
+"Select Start and\n"
+"End Individuals in\n"
+"displayed path(s).\n"
+"Select two"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1163
+msgid ""
+"Starting and ending person for displayed path(s).\n"
+"Select two people"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1167
+msgid "Highlight path(s)"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1171
+msgid "Default (None)"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1176
+msgid ""
+"None - Don't highlight paths.\n"
+"Direct - Highlight direct descendant/ancestor paths.\n"
+"Any - Highlight any path(s) including direct or indirect."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1181
+msgid "Show only path(s)"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1183
+msgid "None"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1183
+msgid "Direct"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1183
+msgid "Any"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1184
+msgid "Default (none)"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1188
+msgid ""
+"None - Don't show paths only.\n"
+"Direct - Show only direct descendant/ancestor paths.\n"
+"Any - Show only path(s) direct or indirect."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1193
+msgid "Center Person"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1195
+msgid "Select person at center of selection radius in graph."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1198
+msgid ""
+"Max connections\n"
+"from center"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1201
+msgid ""
+"Enter the maximum number of connections allowed from\n"
+"the center person.  Value may be 1 or greater."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1206
+msgid "Limit graph to max connections from center."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1208
+msgid "Display up to max connections from central person."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1212
+msgid "Highlight central person in graph."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1214
+msgid "Add yellow color background to central person."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1218
+msgid "Config"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1222
+msgid "Database"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1228
+msgid "File Type"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1230
+msgid "Default (svg)"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1233
+msgid ""
+"svg - Scalable Vector Graphics file.\n"
+"pdf - Adobe Portable Document Format.\n"
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1238
+msgid "Use database handle instead of GrampID id in URLs."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1240
+msgid ""
+"Use database handle instead of the gramps id for URLs.\n"
+"The handle should never change whereas gramps ids can."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1244
+msgid "Confirm overwrite file."
+msgstr ""
+
+#: NetworkChart/NetworkChart.py:1247
+msgid "Enable/disable confirmation of file overwrite."
+msgstr ""

--- a/NoteCleanup/po/template.pot
+++ b/NoteCleanup/po/template.pot
@@ -1,0 +1,148 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: NoteCleanup/NoteCleanup.gpr.py:30 NoteCleanup/NoteCleanup.py:395
+msgid "Note Cleanup"
+msgstr ""
+
+#: NoteCleanup/NoteCleanup.gpr.py:31
+msgid "Clean up Notes that contain HTML markup"
+msgstr ""
+
+#: NoteCleanup/NoteCleanup.py:90
+msgid "Note Cleanup Tool"
+msgstr ""
+
+#: NoteCleanup/NoteCleanup.py:96
+msgid "Cleaned Notes"
+msgstr ""
+
+#: NoteCleanup/NoteCleanup.py:96
+msgid "Links Only"
+msgstr ""
+
+#: NoteCleanup/NoteCleanup.py:97
+msgid "Issues"
+msgstr ""
+
+#: NoteCleanup/NoteCleanup.py:119
+msgid "Close"
+msgstr ""
+
+#: NoteCleanup/NoteCleanup.py:120
+msgid "Close the Note Cleanup Tool"
+msgstr ""
+
+#: NoteCleanup/NoteCleanup.py:122
+msgid "Save All"
+msgstr ""
+
+#: NoteCleanup/NoteCleanup.py:123
+msgid "Save All Changes"
+msgstr ""
+
+#: NoteCleanup/NoteCleanup.py:125
+msgid "Search"
+msgstr ""
+
+#: NoteCleanup/NoteCleanup.py:126
+msgid "Search for Untidy Notes"
+msgstr ""
+
+#: NoteCleanup/NoteCleanup.py:128
+msgid "Generate Test Notes"
+msgstr ""
+
+#: NoteCleanup/NoteCleanup.py:130
+msgid ""
+"Generate Test notes in range N99996-N99999.\n"
+"These are added to your database, so you may want to work with a test "
+"database or delete them later."
+msgstr ""
+
+#: NoteCleanup/NoteCleanup.py:134
+msgid "Export"
+msgstr ""
+
+#: NoteCleanup/NoteCleanup.py:135
+msgid "Export the results to a text file"
+msgstr ""
+
+#: NoteCleanup/NoteCleanup.py:172
+msgid ""
+"Please back up your database before running this tool.\n"
+"\n"
+"Start the tool by pressing the 'Search' button, then review the results.\n"
+"When satisifed press the 'Save All' button to save your work.\n"
+"You may export a summary list of the notes that were found using the "
+"'Export' button."
+msgstr ""
+
+#: NoteCleanup/NoteCleanup.py:182
+msgid "Clean up Notes"
+msgstr ""
+
+#: NoteCleanup/NoteCleanup.py:193
+msgid "Notes"
+msgstr ""
+
+#: NoteCleanup/NoteCleanup.py:277
+msgid "Cleanup Test Notes"
+msgstr ""
+
+#: NoteCleanup/NoteCleanup.py:299 NoteCleanup/NoteCleanup.py:304
+msgid "Add Test Note"
+msgstr ""
+
+#: NoteCleanup/NoteCleanup.py:313
+msgid "Export results to a text file"
+msgstr ""
+
+#: NoteCleanup/NoteCleanup.py:336
+#, python-format
+msgid "Error when writing the report: %s"
+msgstr ""
+
+#: NoteCleanup/NoteCleanup.py:370
+msgid ""
+"\n"
+"\n"
+"Notes selected on the left pane are shown Before cleanup in this box."
+msgstr ""
+
+#: NoteCleanup/NoteCleanup.py:373
+msgid ""
+"\n"
+"\n"
+"Notes selected on the left pane are shown After cleanup in this box.\n"
+"If you wish to make changes, you can make them here and use the style "
+"controls in the toolbar above."
+msgstr ""
+
+#: NoteCleanup/NoteCleanup.py:388
+msgid "Saving Notes"
+msgstr ""
+
+#: NoteCleanup/NoteCleanup.py:390
+msgid "Saving Cleaned Notes"
+msgstr ""
+
+#: NoteCleanup/NoteCleanup.py:415
+msgid "Scanning Notes"
+msgstr ""

--- a/NoteGramplet/po/template.pot
+++ b/NoteGramplet/po/template.pot
@@ -1,0 +1,54 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: NoteGramplet/NoteGramplet.gpr.py:3
+msgid "Note Gramplet"
+msgstr ""
+
+#: NoteGramplet/NoteGramplet.gpr.py:4
+msgid "Gramplet for editing active person's notes"
+msgstr ""
+
+#: NoteGramplet/NoteGramplet.gpr.py:10
+msgid "Note"
+msgstr ""
+
+#: NoteGramplet/NoteGramplet.py:65
+msgid "Active person"
+msgstr ""
+
+#: NoteGramplet/NoteGramplet.py:89
+msgid "Family"
+msgstr ""
+
+#: NoteGramplet/NoteGramplet.py:111
+msgid "Save"
+msgstr ""
+
+#: NoteGramplet/NoteGramplet.py:114
+msgid "Abandon"
+msgstr ""
+
+#: NoteGramplet/NoteGramplet.py:173 NoteGramplet/NoteGramplet.py:256
+msgid "Person Note"
+msgstr ""
+
+#: NoteGramplet/NoteGramplet.py:254
+msgid "Save Note"
+msgstr ""

--- a/NumberOfDescendantsQuickview/po/template.pot
+++ b/NumberOfDescendantsQuickview/po/template.pot
@@ -1,0 +1,66 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.gpr.py:3
+msgid "Number of descendants"
+msgstr ""
+
+#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.gpr.py:4
+msgid "Shows the number of descendants of the current person"
+msgstr ""
+
+#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:62
+#, python-format
+msgid "Number of %s's descendants"
+msgstr ""
+
+#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:87
+#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:94
+msgid "Generation"
+msgstr ""
+
+#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:88
+#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:95
+#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:111
+#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:115
+msgid "Total"
+msgstr ""
+
+#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:89
+msgid "Seen"
+msgstr ""
+
+#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:90
+msgid "Outlived"
+msgstr ""
+
+#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:91
+#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:96
+msgid "Now alive"
+msgstr ""
+
+#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:122
+#, python-format
+msgid "Seen = number of descendants whose birth %s has lived to see"
+msgstr ""
+
+#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:124
+#, python-format
+msgid "Outlived = number of descendants who died while %s was still alive"
+msgstr ""

--- a/Overview/po/template.pot
+++ b/Overview/po/template.pot
@@ -1,0 +1,70 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: Overview/Overview.gpr.py:28
+msgid "Person Overview"
+msgstr ""
+
+#: Overview/Overview.gpr.py:29
+msgid "Gramplet showing an overview of events for a person"
+msgstr ""
+
+#: Overview/Overview.gpr.py:36 Overview/Overview.gpr.py:50
+msgid "Overview"
+msgstr ""
+
+#: Overview/Overview.gpr.py:42
+msgid "Family Overview"
+msgstr ""
+
+#: Overview/Overview.gpr.py:43
+msgid "Gramplet showing an overview of events for a family"
+msgstr ""
+
+#: Overview/Overview.py:70
+msgid "Double-click on a row to edit the selected event."
+msgstr ""
+
+#: Overview/Overview.py:74
+msgid "Type"
+msgstr ""
+
+#: Overview/Overview.py:75
+msgid "Date"
+msgstr ""
+
+#: Overview/Overview.py:77
+msgid "Age"
+msgstr ""
+
+#: Overview/Overview.py:78 Overview/Overview.py:112
+msgid "Where Born"
+msgstr ""
+
+#: Overview/Overview.py:79 Overview/Overview.py:114
+msgid "Condition"
+msgstr ""
+
+#: Overview/Overview.py:80 Overview/Overview.py:116
+msgid "Occupation"
+msgstr ""
+
+#: Overview/Overview.py:81 Overview/Overview.py:118
+msgid "Residence"
+msgstr ""

--- a/Participants/po/template.pot
+++ b/Participants/po/template.pot
@@ -1,0 +1,46 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: Participants/Participants.gpr.py:30 Participants/Participants.gpr.py:38
+msgid "Participants"
+msgstr ""
+
+#: Participants/Participants.gpr.py:31
+msgid "Gramplet showing the participants in an event"
+msgstr ""
+
+#: Participants/Participants.py:75
+msgid "Double-click on a row to edit the selected participant."
+msgstr ""
+
+#: Participants/Participants.py:79
+msgid "Name"
+msgstr ""
+
+#: Participants/Participants.py:80
+msgid "Role"
+msgstr ""
+
+#: Participants/Participants.py:81
+msgid "Birth Date"
+msgstr ""
+
+#: Participants/Participants.py:83
+msgid "Spouses"
+msgstr ""

--- a/PedigreeChart/po/template.pot
+++ b/PedigreeChart/po/template.pot
@@ -1,0 +1,89 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: PedigreeChart/PedigreeChart.gpr.py:24
+msgid "Pedigree Chart"
+msgstr ""
+
+#: PedigreeChart/PedigreeChart.gpr.py:25
+msgid "Alternate version of the traditional pedigree chart."
+msgstr ""
+
+#: PedigreeChart/PedigreeChart.py:372
+#, python-format
+msgid "Person %s is not in the Database"
+msgstr ""
+
+#: PedigreeChart/PedigreeChart.py:375 PedigreeChart/PedigreeChart.py:523
+msgid "Mother"
+msgstr ""
+
+#: PedigreeChart/PedigreeChart.py:379
+#, python-format
+msgid "Pedigree Chart for %s"
+msgstr ""
+
+#: PedigreeChart/PedigreeChart.py:526
+msgid "Father"
+msgstr ""
+
+#: PedigreeChart/PedigreeChart.py:528
+#, python-format
+msgid "Page %d"
+msgstr ""
+
+#: PedigreeChart/PedigreeChart.py:630
+msgid "Tree Options"
+msgstr ""
+
+#: PedigreeChart/PedigreeChart.py:632
+msgid "Center Person"
+msgstr ""
+
+#: PedigreeChart/PedigreeChart.py:633
+msgid "The center person for the tree"
+msgstr ""
+
+#: PedigreeChart/PedigreeChart.py:636
+msgid "Generations"
+msgstr ""
+
+#: PedigreeChart/PedigreeChart.py:637
+msgid "The number of generations to include in the tree"
+msgstr ""
+
+#: PedigreeChart/PedigreeChart.py:640
+msgid "Show Mother/Father captions"
+msgstr ""
+
+#: PedigreeChart/PedigreeChart.py:641
+msgid "Show the title of mother or father beside each ancestor's box."
+msgstr ""
+
+#: PedigreeChart/PedigreeChart.py:653
+msgid "The basic style used for the text display."
+msgstr ""
+
+#: PedigreeChart/PedigreeChart.py:662
+msgid "The basic style used for the title display."
+msgstr ""
+
+#: PedigreeChart/PedigreeChart.py:671
+msgid "Style used for labels and captions"
+msgstr ""

--- a/PersonEverything/po/template.pot
+++ b/PersonEverything/po/template.pot
@@ -1,0 +1,347 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: PersonEverything/PersonEverything.gpr.py:31
+msgid "PersonEverything Report"
+msgstr ""
+
+#: PersonEverything/PersonEverything.gpr.py:32
+msgid "Produces a report containing everything about the active person"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:109
+#, python-format
+msgid "Person %s is not in the Database"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:131
+#, python-format
+msgid "All information about %s"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:140
+msgid "Person Events"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:146
+msgid "Families"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:152
+msgid "Endnotes"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:168
+msgid "Gender"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:171
+msgid "Primary name"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:172
+#: PersonEverything/PersonEverything.py:179
+#: PersonEverything/PersonEverything.py:299
+#: PersonEverything/PersonEverything.py:593
+#: PersonEverything/PersonEverything.py:718
+msgid "Type"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:178
+msgid "Alternate name"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:198
+msgid "Event reference"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:199
+msgid "Role"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:206
+msgid "Family"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:212
+msgid "Child"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:218
+msgid "Relationship to Father"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:223
+msgid "Relationship to Mother"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:236
+msgid "Parent Family"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:247
+msgid "Relationship"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:257
+msgid "Father"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:268
+msgid "Mother"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:290
+#: PersonEverything/PersonEverything.py:960
+#: PersonEverything/PersonEverything.py:976
+msgid "Private"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:314
+msgid "Address"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:324
+msgid "Attribute"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:352
+msgid "Confidence"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:355
+msgid "Unknown"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:367
+msgid "Date"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:376
+msgid "Description"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:385
+msgid "Event"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:386
+msgid "Event type"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:401
+msgid "Temple and status"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:412
+msgid "LDS Ordinance family"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:416
+msgid "LDS "
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:417
+msgid "Ordinance"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:432
+msgid "Street, City, County, State, Postal Code, Country, Phone number"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:446
+msgid "Media Reference"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:453
+#: PersonEverything/PersonEverything.py:726
+msgid "Description and Path"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:472
+msgid "Could not add photo to page"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:473
+msgid "File does not exist"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:482
+msgid "Referenced Region"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:500
+msgid "unknown"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:501
+msgid "Media Object"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:503
+msgid "Mime type"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:514
+msgid ""
+"Given name(s): Title, Given, Suffix, Call Name, Nick Name, Family Nick Name"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:539
+msgid "Note"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:540
+msgid "Note type"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:551
+msgid "Parent Place"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:566
+#: PersonEverything/PersonEverything.py:570
+msgid "Alternate Location"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:567
+msgid "Parish"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:583
+msgid "Place"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:584
+msgid "Place Title"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:589
+msgid "Name"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:597
+msgid "Code"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:605
+msgid "Alternative Name"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:613
+msgid "Latitude, Longitude"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:634
+msgid "Call number"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:641
+msgid "Repository"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:642
+msgid "Repository type"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:664
+msgid "Repository reference"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:665
+msgid "Media type"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:672
+#: PersonEverything/PersonEverything.py:676
+msgid "Surname"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:673
+msgid "Origin type"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:680
+msgid "Prefix, surname, connector"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:685
+msgid "{This is the primary surname}"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:698
+msgid "Tag name"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:709
+msgid "Tag colour and priority"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:717
+msgid "URL"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:900
+msgid "Source"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:906
+msgid "Citation"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:954
+msgid "No source information found"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:995
+msgid "Report Options"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:997
+msgid "Center Person"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:998
+msgid "The center person for the report"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:1004
+msgid "Name format"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:1005
+msgid "Default"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:1008
+msgid "Select the format to display names"
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:1022
+msgid "The style used for the title of the page."
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:1033
+#, python-format
+msgid "The style used for the level %d display."
+msgstr ""
+
+#: PersonEverything/PersonEverything.py:1054
+msgid "The basic style used for the endnotes source display."
+msgstr ""

--- a/PhotoTaggingGramplet/po/template.pot
+++ b/PhotoTaggingGramplet/po/template.pot
@@ -1,0 +1,154 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.gpr.py:3
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.gpr.py:11
+msgid "Photo Tagging"
+msgstr ""
+
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.gpr.py:4
+msgid "Gramplet for tagging people in photos"
+msgstr ""
+
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:118
+msgid "Selection"
+msgstr ""
+
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:120
+msgid "Replace existing references to the person being assigned without asking"
+msgstr ""
+
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:127
+msgid "Face detection"
+msgstr ""
+
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:130
+msgid "Minimum face width (px)"
+msgstr ""
+
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:132
+msgid "Minimum face height (px)"
+msgstr ""
+
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:135
+msgid "Detect faces inside existing boxes"
+msgstr ""
+
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:137
+msgid "Sensitivity (1 min .. 20 max)"
+msgstr ""
+
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:271
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:734
+msgid "Select Person"
+msgstr ""
+
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:272
+msgid "Add Person"
+msgstr ""
+
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:273
+msgid "Clear Reference"
+msgstr ""
+
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:274
+msgid "Remove Selection"
+msgstr ""
+
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:275
+msgid "Edit referenced Person"
+msgstr ""
+
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:276
+msgid "Zoom In"
+msgstr ""
+
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:277
+msgid "Zoom Out"
+msgstr ""
+
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:280
+msgid "Detect faces"
+msgstr ""
+
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:282
+msgid "Detect faces (OpenCV module required)"
+msgstr ""
+
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:285
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:796
+msgid "Settings"
+msgstr ""
+
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:333
+msgid "Preview"
+msgstr ""
+
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:334
+msgid "Person"
+msgstr ""
+
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:450
+msgid "Set as active person"
+msgstr ""
+
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:453
+msgid "_Select"
+msgstr ""
+
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:456
+msgid "_Add"
+msgstr ""
+
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:459
+msgid "_Clear"
+msgstr ""
+
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:462
+msgid "_Remove"
+msgstr ""
+
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:609
+#, python-format
+msgid "Edit Person (%s)"
+msgstr ""
+
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:665
+#, python-brace-format
+msgid "Replace to {0}"
+msgstr ""
+
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:766
+msgid "Detecting faces..."
+msgstr ""
+
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:791
+msgid "Detection finished"
+msgstr ""
+
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:841
+#, python-brace-format
+msgid "Another region of this image is associated with {name}. Remove it?"
+msgstr ""
+
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:844
+#, python-brace-format
+msgid ""
+"{count} other regions of this image are associated with {name}. Remove them?"
+msgstr ""

--- a/PhpGedView/po/template.pot
+++ b/PhpGedView/po/template.pot
@@ -1,0 +1,103 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-04 18:55-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: PhpGedView/phpgedview.gpr.py:23
+msgid "PhpGedView"
+msgstr ""
+
+#: PhpGedView/phpgedview.gpr.py:24
+msgid "Download a GEDCOM file from a phpGedView server."
+msgstr ""
+
+#: PhpGedView/phpgedviewconnector.py:204 PhpGedView/phpgedviewconnector.py:215
+msgid "Fetching index list..."
+msgstr ""
+
+#: PhpGedView/phpgedviewconnector.py:218 PhpGedView/phpgedviewconnector.py:222
+msgid "Fetching records..."
+msgstr ""
+
+#: PhpGedView/phpgedviewconnector.py:327
+msgid "Logging in..."
+msgstr ""
+
+#: PhpGedView/phpgedviewconnector.py:330
+msgid "Fetching GEDCOM..."
+msgstr ""
+
+#: PhpGedView/phpgedviewconnector.py:334
+msgid "Importing GEDCOM..."
+msgstr ""
+
+#: PhpGedView/phpgedviewconnector.py:341
+msgid "Error: login failed"
+msgstr ""
+
+#: PhpGedView/phpgedviewconnector.py:342 PhpGedView/phpgedviewconnector.py:367
+msgid "done."
+msgstr ""
+
+#: PhpGedView/phpgedviewconnector.py:347
+msgid "Connecting..."
+msgstr ""
+
+#: PhpGedView/phpgedviewconnector.py:349
+msgid "Get version..."
+msgstr ""
+
+#: PhpGedView/phpgedviewconnector.py:352
+#, python-format
+msgid "Version %s"
+msgstr ""
+
+#: PhpGedView/phpgedviewconnector.py:353
+msgid "Reading file list..."
+msgstr ""
+
+#: PhpGedView/phpgedviewconnector.py:366
+msgid "Error: Invalid URL"
+msgstr ""
+
+#: PhpGedView/phpgedview.glade:12
+msgid "- default -"
+msgstr ""
+
+#: PhpGedView/phpgedview.glade:19 PhpGedView/phpgedview.glade:85
+msgid "phpGedView import"
+msgstr ""
+
+#: PhpGedView/phpgedview.glade:103
+msgid "http://"
+msgstr ""
+
+#: PhpGedView/phpgedview.glade:158
+msgid "File:"
+msgstr ""
+
+#: PhpGedView/phpgedview.glade:170
+msgid "Username:"
+msgstr ""
+
+#: PhpGedView/phpgedview.glade:182
+msgid "Password:"
+msgstr ""
+
+#: PhpGedView/phpgedview.glade:206
+msgid "URL:"
+msgstr ""

--- a/PlaceCleanup/po/template.pot
+++ b/PlaceCleanup/po/template.pot
@@ -1,0 +1,454 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: PlaceCleanup/placecleanup.gpr.py:28 PlaceCleanup/placecleanup.gpr.py:44
+msgid "Place Cleanup"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.gpr.py:29
+msgid ""
+"Place Cleanup Gramplet assists in merging places, as well as completing "
+"places from the GeoNames web database"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.py:266 PlaceCleanup/placecleanup.glade:1020
+msgid ""
+"No\n"
+"Matches"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.py:267 PlaceCleanup/placecleanup.glade:827
+msgid "Find"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.py:293
+#, python-format
+msgid ""
+"%s\n"
+"Local\n"
+"Matches"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.py:295
+msgid "Find GeoNames"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.py:303
+msgid "Need to set GeoNames ID"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.py:304
+msgid "Use the Help button for more information"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.py:336
+msgid "No matches were found"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.py:337
+msgid ""
+"Try changing the Title, or use the \"Edit\" button to finish this level of "
+"the place manually."
+msgstr ""
+
+#: PlaceCleanup/placecleanup.py:347
+#, python-format
+msgid ""
+"%s\n"
+"GeoNames\n"
+"Matches"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.py:353
+#, python-format
+msgid "%s matches were found"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.py:354
+msgid ""
+"Only 10 matches are shown.\n"
+"To see additional results, press the search button again.\n"
+"Or try changing the Title with more detail, such as a country."
+msgstr ""
+
+#: PlaceCleanup/placecleanup.py:396 PlaceCleanup/placecleanup.py:398
+#: PlaceCleanup/placecleanup.py:787
+msgid ", "
+msgstr ""
+
+#: PlaceCleanup/placecleanup.py:418 PlaceCleanup/placecleanup.py:423
+msgid "Problem getting data from web"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.py:424
+msgid "Web request Timeout, you can try again..."
+msgstr ""
+
+#: PlaceCleanup/placecleanup.py:432
+msgid "Problem getting data from GeoNames"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.py:477 PlaceCleanup/placecleanup.py:748
+msgid "Place cycle detected"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.py:478
+msgid ""
+"One of the places you are merging encloses the other!\n"
+"Please choose another place."
+msgstr ""
+
+#: PlaceCleanup/placecleanup.py:740
+#, python-format
+msgid "Add Place (%s)"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.py:749
+msgid ""
+"The place you chose is enclosed in the place you are workin on!\n"
+"Please cancel and choose another place."
+msgstr ""
+
+#: PlaceCleanup/placecleanup.py:772
+#, python-format
+msgid "Add Citation (%s)"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.py:777
+#, python-format
+msgid "Edit Place (%s)"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.py:935
+msgid "GeoNames web site"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.py:940
+msgid "GeoNames author"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.py:945
+msgid "GeoNames was founded by Marc Wick. You can reach him at "
+msgstr ""
+
+#: PlaceCleanup/placecleanup.py:948
+msgid ""
+"GeoNames is a project of Unxos GmbH, Weingartenstrasse 8, 8708 Männedorf, "
+"Switzerland.\n"
+"This work is licensed under a "
+msgstr ""
+
+#: PlaceCleanup/placecleanup.py:951
+msgid "Creative Commons Attribution 3.0 License"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.py:963
+#, python-format
+msgid "Add Souce/Repo/Note (%s)"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.py:1064
+msgid "This Place is not used!"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.py:1065
+msgid ""
+"You should delete it, or, if it contains useful notes or other data, use the "
+"Find to merge it into a valid place."
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:27
+msgid "City, County, State, Country"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:48
+msgid "Primary Name"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:63
+msgid "Postal Code"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:77 PlaceCleanup/placecleanup.glade:987
+msgid "Type"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:88
+msgid "The current Primary name."
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:102
+msgid "The postal code for the place, if any."
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:115
+msgid "What type of place this is. Eg 'Country', 'City', ... ."
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:132 PlaceCleanup/placecleanup.glade:150
+#: PlaceCleanup/placecleanup.glade:281
+msgid "Orig"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:136
+msgid "Check this box if you want to keep the original Postal code."
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:154
+msgid "Check this box if you want to keep the original Place Type."
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:196
+msgid "Longitude"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:222
+msgid "Latitude"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:232
+msgid "Keep Original"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:236
+msgid "Check this box if you want to keep the original Latitude and Longitude."
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:254
+msgid "The Gramps ID.."
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:272
+msgid "ID"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:285
+msgid "Check this box if you want to keep the original Gramps ID."
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:315
+msgid ""
+"Alterative Names\n"
+"Select one or more rows and press 'Keep' button to toggle the 'include into "
+"place' status ."
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:330
+msgid "Inc"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:350
+msgid "Name"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:370
+msgid "Lang"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:389
+msgid "Date"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:440
+msgid "Keep"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:444
+msgid ""
+"Select one or more rows and use this button to keep the alternative names."
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:456
+msgid "Primary"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:460
+msgid "Select one row and use this button to make the row the primary name."
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:472
+msgid "Discard"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:476
+msgid ""
+"Select one or more rows and use this button to discard the alternative names."
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:504
+msgid "Cancel the operation, no changes are made to your Place."
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:520
+msgid "Store the values in your Place."
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:566
+msgid "Ok"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:581
+msgid "Help"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:605
+msgid "Keep Web Links"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:609
+msgid "Puts web links (typically wikipedia) into your place."
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:622
+msgid "Add citation and source to Place"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:626
+msgid "This Adds a Citation to your place, citing GeoNames."
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:641
+msgid "GeoNames User ID"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:653
+msgid "Enter you Geonames user ID here."
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:665
+msgid "Alternative Names Languages to keep"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:677
+msgid ""
+"Enter the two or three letter codes for the languages you wish to keep, "
+"seperated by spaces.\n"
+"For example \"en fr ru\".\n"
+"These languages will initially be checked off on the Names result display.\n"
+"If you often see an un-checked name in a specific language you want, add the "
+"language code here."
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:693
+msgid "Currently Enclosed Places"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:705
+msgid ""
+"When cleaning a place that is already enclosed, this affects what is done.\n"
+"If '<b>Keep current Enclosure</b>' is selected, no changes to the enclosing "
+"place is made.\n"
+"If '<b>Replace with GeoNames Enclosure</b>' is selected, the enclosed place "
+"is changed to the next level GeoNames place.  This may result in some unused "
+"places remaining in your database."
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:710
+msgid "Keep current Enclosure"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:726
+msgid "Replace with GeoNames Enclosure"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:771
+msgid "Title"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:782
+msgid ""
+"Current Place title.\n"
+"You can edit this to help find other places, particularly to reduce the "
+"number of results."
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:831
+msgid "Search your local places and GeoNames for a match."
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:843
+msgid "Select"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:847
+msgid ""
+"Continue to merge (for local places), or to complete a place (for GeoNames)."
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:860
+msgid "Edit"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:864
+msgid ""
+"Split up Title, Edit manually, and enclose with next level of hierarchy.  "
+"For use when the initial component of the Title is too detailed to be found "
+"in the gazetteer."
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:890
+msgid "Next Place"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:894
+msgid "Find an incomplete place."
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:917
+msgid "Set preferences"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:940
+msgid "Select one of these places to continue the cleanup process."
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:967
+msgid "Search result places"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:1034
+msgid ""
+"Checking the 'Populated' checkbox causes the GeoNames search to include "
+"'Populted places', places where people live and work."
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:1053
+msgid "Populated"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:1065
+msgid ""
+"Checking the 'Admin' checkbox cause the GeoNames search to include "
+"adminstrative subdivisions in the search (countries, states, counties etc.)."
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:1084
+msgid ""
+"Checking the 'Spot' checkbox cause the GeoNames search to include a wide "
+"variety of other places in the search (churches, burial grounds, buildings "
+"etc.)."
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:1101
+msgid "Admin"
+msgstr ""
+
+#: PlaceCleanup/placecleanup.glade:1112
+msgid "Spot"
+msgstr ""

--- a/PlaceCompletion/po/template.pot
+++ b/PlaceCompletion/po/template.pot
@@ -1,0 +1,351 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: PlaceCompletion/PlaceCompletion.gpr.py:25
+msgid "PlaceCompletion"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.gpr.py:26
+msgid ""
+"Provides a browsable list of selected places, with possibility to complete/"
+"parse/set the attribute fields."
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:95
+msgid ""
+"Place Completion by parsing, file lookup and batch setting of place "
+"attributes"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:258
+msgid "Error in PlaceCompletion.py"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:259
+msgid "Non existing group used in get"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:282
+#, python-format
+msgid "PlaceCompletion is unable to create %s %s"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:340
+msgid "Places tool"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:408
+msgid "Missing regex groups in match lat/lon"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:409
+#, python-format
+msgid ""
+"Regex groups %(lat)s and %(lon)s must be present in lat/lon match. Quiting"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:419
+msgid "Non valid regex for match lat/lon"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:420
+msgid "Non valid regular expression given to find lat/lon. Quiting."
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:479
+msgid "Finding Places and appropriate changes"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:481
+msgid "Filtering"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:491
+msgid "Loading lat/lon file in Memory..."
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:497
+msgid "Examining places"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:520
+msgid "City"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:523
+msgid "State"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:526
+msgid "Country"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:685
+msgid "Set Tag"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:687
+msgid "Doing Place changes"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:731
+msgid "No place record was modified."
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:733
+msgid "1 place record was modified."
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:735
+#, python-format
+msgid "%d place records were modified."
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:736
+msgid "Change places"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:808
+#: PlaceCompletion/PlaceCompletion.py:814
+#: PlaceCompletion/PlaceCompletion.py:819
+#: PlaceCompletion/PlaceCompletion.py:825
+msgid "Cannot open file"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:809
+msgid "The selected file is a directory, not a file."
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:815
+msgid "You do not have read access to the selected file."
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:820
+msgid "The file you want to access is not a regular file."
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:826
+msgid "The file does not exist."
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:858
+msgid "Problem reading file"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:970
+#: PlaceCompletion/PlaceCompletion.py:982
+#, python-format
+msgid "invalid lat or lon value, %(lat)s, %(lon)s"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:1135
+msgid "No lat/lon conversion"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:1136
+msgid "All in degree notation"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:1137
+msgid "All in decimal notation"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:1138
+msgid "Correct -50° in 50°S"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:1142
+msgid "No changes"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:1143
+msgid "City[, State]"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:1145
+msgid "City,PostalCode,Country"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:1147
+msgid "City[(Street;Locality;Parish)],PostalCode,Country"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:1149
+msgid "TitleStart [, City] [, State]"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:1151
+msgid "TitleStart [, City] [, County] [, State] [, Country]"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:1153
+msgid "TitleStart [, City] [, Zip] [, County] [, State] [, Country]"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:1177
+msgid "Don't search"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:1180
+msgid "GeoNames country file, city search"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:1185
+msgid "GeoNames country file, city localized variants search"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:1190
+msgid "GeoNames country file, county/city search"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:1202
+msgid "GeoNames country file, title begin, general search"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:1207
+msgid "GeoNames USA state file, city search"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:1221
+msgid "GNS Geonet country file, city search"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:1228
+msgid "GNS Geonet country file, county/city search"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:1236
+msgid "GNS Geonet country file, title begin, general search"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:1244
+msgid "Wikipedia CSV Dump"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:1332
+msgid "All Places"
+msgstr ""
+
+#: PlaceCompletion/PlaceCompletion.py:1335
+msgid "No Latitude/Longitude given"
+msgstr ""
+
+#: PlaceCompletion/placecompletion.glade:85
+msgid "_Google Maps"
+msgstr ""
+
+#: PlaceCompletion/placecompletion.glade:112
+msgid "Apply all suggested changes"
+msgstr ""
+
+#: PlaceCompletion/placecompletion.glade:148
+msgid "Selection of the Places you want to complete:"
+msgstr ""
+
+#: PlaceCompletion/placecompletion.glade:178
+msgid "C_ity:"
+msgstr ""
+
+#: PlaceCompletion/placecompletion.glade:195
+msgid "Parish:"
+msgstr ""
+
+#: PlaceCompletion/placecompletion.glade:240
+msgid "County:"
+msgstr ""
+
+#: PlaceCompletion/placecompletion.glade:271
+msgid "Place _filter:"
+msgstr ""
+
+#: PlaceCompletion/placecompletion.glade:321
+msgid "State:"
+msgstr ""
+
+#: PlaceCompletion/placecompletion.glade:336
+msgid "Count_ry:"
+msgstr ""
+
+#: PlaceCompletion/placecompletion.glade:366
+msgid "C_enter latitude:"
+msgstr ""
+
+#: PlaceCompletion/placecompletion.glade:383
+msgid "Center longitude:"
+msgstr ""
+
+#: PlaceCompletion/placecompletion.glade:430
+msgid "Places in a rectangle:"
+msgstr ""
+
+#: PlaceCompletion/placecompletion.glade:443
+msgid "Width:"
+msgstr ""
+
+#: PlaceCompletion/placecompletion.glade:460
+msgid "Height:"
+msgstr ""
+
+#: PlaceCompletion/placecompletion.glade:527
+msgid "1. Look up latitude and longitude:"
+msgstr ""
+
+#: PlaceCompletion/placecompletion.glade:554
+msgid "Search in:"
+msgstr ""
+
+#: PlaceCompletion/placecompletion.glade:566
+msgid "Select A File"
+msgstr ""
+
+#: PlaceCompletion/placecompletion.glade:579
+msgid "Parse as:"
+msgstr ""
+
+#: PlaceCompletion/placecompletion.glade:619
+msgid "2. Conversion of existing title or position:"
+msgstr ""
+
+#: PlaceCompletion/placecompletion.glade:649
+msgid "Change title into:"
+msgstr ""
+
+#: PlaceCompletion/placecompletion.glade:664
+msgid "Convert lat/lon as:"
+msgstr ""
+
+#: PlaceCompletion/placecompletion.glade:701
+msgid ""
+"Or define a simple\n"
+"title format:"
+msgstr ""
+
+#: PlaceCompletion/placecompletion.glade:730
+msgid ""
+"Available variables: city, street, locality, parish, county, state, country, "
+"postal_code"
+msgstr ""
+
+#: PlaceCompletion/placecompletion.glade:820
+msgid ""
+"Delete to delete a row, Double-click on the row to edit place with changes "
+"pre-entered, \n"
+"Press Tab on a row or Google Maps button to see place on a map. Press Apply "
+"to do all changes automatically"
+msgstr ""

--- a/PluginManager/po/template.pot
+++ b/PluginManager/po/template.pot
@@ -1,0 +1,245 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: PluginManager/PluginManager.gpr.py:29
+msgid "Plugin Manager Enhanced"
+msgstr ""
+
+#: PluginManager/PluginManager.gpr.py:30
+msgid "An Addon/Plugin Manager with several additional capabilities"
+msgstr ""
+
+#: PluginManager/PluginManager.py:87
+msgid "Plugin Manager - Enhanced"
+msgstr ""
+
+#: PluginManager/PluginManager.py:144
+msgid "_Help"
+msgstr ""
+
+#: PluginManager/PluginManager.py:151
+msgid ""
+"Enter search words to filter the addons.\n"
+"All the words must be present somewhere in the row or\n"
+"the addon filename to be included in the search.\n"
+"Word case and order is ignored."
+msgstr ""
+
+#: PluginManager/PluginManager.py:155
+msgid "Search..."
+msgstr ""
+
+#: PluginManager/PluginManager.py:161
+msgid "Check for updated addons now"
+msgstr ""
+
+#: PluginManager/PluginManager.py:168
+msgid "Reload"
+msgstr ""
+
+#: PluginManager/PluginManager.py:174 PluginManager/PluginManager.py:735
+msgid "_Close"
+msgstr ""
+
+#: PluginManager/PluginManager.py:207
+msgid "Restart..."
+msgstr ""
+
+#: PluginManager/PluginManager.py:208
+msgid ""
+"Please Restart Gramps so that your addon changes can be safely completed."
+msgstr ""
+
+#: PluginManager/PluginManager.py:284
+msgid "Id"
+msgstr ""
+
+#: PluginManager/PluginManager.py:285
+msgid "Plugin name"
+msgstr ""
+
+#: PluginManager/PluginManager.py:286 PluginManager/PluginManager.py:457
+msgid "Description"
+msgstr ""
+
+#: PluginManager/PluginManager.py:287
+msgid "Version"
+msgstr ""
+
+#: PluginManager/PluginManager.py:288
+msgid "Authors"
+msgstr ""
+
+#: PluginManager/PluginManager.py:289
+msgid "Email"
+msgstr ""
+
+#: PluginManager/PluginManager.py:290
+msgid "Filename"
+msgstr ""
+
+#: PluginManager/PluginManager.py:291
+msgid "Location"
+msgstr ""
+
+#: PluginManager/PluginManager.py:296
+msgid "Loaded"
+msgstr ""
+
+#: PluginManager/PluginManager.py:299
+msgid "Hidden"
+msgstr ""
+
+#: PluginManager/PluginManager.py:304 PluginManager/PluginManager.py:699
+msgid "Failed"
+msgstr ""
+
+#: PluginManager/PluginManager.py:377
+msgid "Installation Errors"
+msgstr ""
+
+#: PluginManager/PluginManager.py:378
+msgid "The following addons had errors: "
+msgstr ""
+
+#: PluginManager/PluginManager.py:400
+msgid "Error"
+msgstr ""
+
+#: PluginManager/PluginManager.py:401
+#, python-format
+msgid "Error removing the '%s' directory, The uninstall may have failed"
+msgstr ""
+
+#: PluginManager/PluginManager.py:429
+msgid "Type"
+msgstr ""
+
+#: PluginManager/PluginManager.py:438
+msgid "Status"
+msgstr ""
+
+#: PluginManager/PluginManager.py:441
+msgid ""
+"'*' items are supplied by 3rd party authors,\n"
+"<s>strikeout</s> items are hidden"
+msgstr ""
+
+#: PluginManager/PluginManager.py:449
+msgid "Name"
+msgstr ""
+
+#: PluginManager/PluginManager.py:472
+msgid "Info"
+msgstr ""
+
+#: PluginManager/PluginManager.py:475 PluginManager/PluginManager.py:586
+msgid "Hide"
+msgstr ""
+
+#: PluginManager/PluginManager.py:478 PluginManager/PluginManager.py:600
+msgid "Install"
+msgstr ""
+
+#: PluginManager/PluginManager.py:481
+msgid "Edit"
+msgstr ""
+
+#: PluginManager/PluginManager.py:483
+msgid "Load"
+msgstr ""
+
+#: PluginManager/PluginManager.py:494
+msgid "Show hidden items"
+msgstr ""
+
+#: PluginManager/PluginManager.py:502
+msgid "Show Built-in items"
+msgstr ""
+
+#: PluginManager/PluginManager.py:509
+msgid "* indicates 3rd party addon"
+msgstr ""
+
+#: PluginManager/PluginManager.py:514
+msgid "Plugins"
+msgstr ""
+
+#: PluginManager/PluginManager.py:584
+msgid "Unhide"
+msgstr ""
+
+#: PluginManager/PluginManager.py:603
+msgid "Uninstall"
+msgstr ""
+
+#: PluginManager/PluginManager.py:613
+msgid "Checking Addons Failed"
+msgstr ""
+
+#: PluginManager/PluginManager.py:614
+msgid "The addon repository appears to be unavailable. Please try again later."
+msgstr ""
+
+#: PluginManager/PluginManager.py:628
+msgid ""
+"3rd party addons are not shown until the addons update list is downloaded.  "
+"Would you like to check for updated addons now?"
+msgstr ""
+
+#: PluginManager/PluginManager.py:631
+msgid "Yes"
+msgstr ""
+
+#: PluginManager/PluginManager.py:631
+msgid "No"
+msgstr ""
+
+#: PluginManager/PluginManager.py:674
+msgid "*Available"
+msgstr ""
+
+#: PluginManager/PluginManager.py:688
+msgid "Built-in"
+msgstr ""
+
+#: PluginManager/PluginManager.py:693
+msgid "*Installed"
+msgstr ""
+
+#: PluginManager/PluginManager.py:702
+msgid "Update Available"
+msgstr ""
+
+#: PluginManager/PluginManager.py:729
+#, python-format
+msgid "%(str1)s: %(str2)s"
+msgstr ""
+
+#: PluginManager/PluginManager.py:729
+msgid "Detailed Info"
+msgstr ""
+
+#: PluginManager/PluginManager.py:828
+msgid "Updated"
+msgstr ""
+
+#: PluginManager/PluginManager.py:839
+msgid "updates|New"
+msgstr ""

--- a/PostgreSQL/po/template.pot
+++ b/PostgreSQL/po/template.pot
@@ -1,0 +1,66 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: PostgreSQL/postgresql.gpr.py:26
+msgid "PostgreSQL"
+msgstr ""
+
+#: PostgreSQL/postgresql.gpr.py:27
+msgid "_PostgreSQL Database"
+msgstr ""
+
+#: PostgreSQL/postgresql.gpr.py:28
+msgid "PostgreSQL Database"
+msgstr ""
+
+#: PostgreSQL/postgresql.gpr.py:42
+msgid "PostgreSQL Warning:  Python psycopg2 module not found."
+msgstr ""
+
+#: PostgreSQL/postgresql.gpr.py:48
+msgid "PostgreSQL Failed to Load"
+msgstr ""
+
+#: PostgreSQL/postgresql.gpr.py:49
+msgid ""
+"\n"
+"\n"
+"PostgreSQL is missing the psycopg2 python module.\n"
+"For now, it may be possible to install the files manually. See\n"
+"\n"
+"https://gramps-project.org/wiki/index.php?title=PostgreSQL \n"
+"\n"
+"To dismiss all future PostgreSQL warnings click Dismiss."
+msgstr ""
+
+#: PostgreSQL/postgresql.gpr.py:53
+msgid " Dismiss "
+msgstr ""
+
+#: PostgreSQL/postgresql.gpr.py:54
+msgid "Continue"
+msgstr ""
+
+#: PostgreSQL/postgresql.py:68
+msgid "Database version"
+msgstr ""
+
+#: PostgreSQL/postgresql.py:69
+msgid "Database module location"
+msgstr ""

--- a/PrerequisitesCheckerGramplet/po/template.pot
+++ b/PrerequisitesCheckerGramplet/po/template.pot
@@ -1,0 +1,27 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: PrerequisitesCheckerGramplet/PrerequisitesCheckerGramplet.gpr.py:28
+#: PrerequisitesCheckerGramplet/PrerequisitesCheckerGramplet.gpr.py:36
+msgid "Prerequisites Checker"
+msgstr ""
+
+#: PrerequisitesCheckerGramplet/PrerequisitesCheckerGramplet.gpr.py:29
+msgid "Prerequisites Checker Gramplet"
+msgstr ""

--- a/PythonGramplet/po/template.pot
+++ b/PythonGramplet/po/template.pot
@@ -1,0 +1,34 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: PythonGramplet/PythonGramplet.gpr.py:3
+msgid "Python Gramplet"
+msgstr ""
+
+#: PythonGramplet/PythonGramplet.gpr.py:4
+msgid "Interactive Python interpreter"
+msgstr ""
+
+#: PythonGramplet/PythonGramplet.gpr.py:9
+msgid "Python Shell"
+msgstr ""
+
+#: PythonGramplet/PythonGramplet.py:55
+msgid "Enter Python expressions"
+msgstr ""

--- a/Query/po/template.pot
+++ b/Query/po/template.pot
@@ -1,0 +1,59 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-04 18:55-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: Query/Query.gpr.py:9
+msgid "Query Gramplet"
+msgstr ""
+
+#: Query/Query.gpr.py:10
+msgid "Gramplet for running SQL-like queries"
+msgstr ""
+
+#: Query/Query.gpr.py:18
+msgid "Query"
+msgstr ""
+
+#: Query/Query.gpr.py:31
+msgid "Query Quickview"
+msgstr ""
+
+#: Query/Query.gpr.py:32
+msgid "Quick view for SQL-like running queries"
+msgstr ""
+
+#: Query/QueryGramplet.py:52
+msgid "Enter Python expressions"
+msgstr ""
+
+#: Query/QueryGramplet.py:176
+msgid "Enter SQL query"
+msgstr ""
+
+#: Query/QueryQuickview.py:347 Query/QueryQuickview.py:367
+#, python-format
+msgid "%d rows processed in %s seconds.\n"
+msgstr ""
+
+#: Query/QueryQuickview.py:425
+msgid "Date"
+msgstr ""
+
+#: Query/QueryQuickview.py:426
+msgid "Today"
+msgstr ""

--- a/QuiltView/po/template.pot
+++ b/QuiltView/po/template.pot
@@ -1,0 +1,188 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: QuiltView/QuiltView.gpr.py:34
+msgid "Quilt Chart"
+msgstr ""
+
+#: QuiltView/QuiltView.gpr.py:35
+msgid "Charts"
+msgstr ""
+
+#: QuiltView/QuiltView.gpr.py:36
+msgid "The view shows a quilt chart visualisation of a family tree"
+msgstr ""
+
+#: QuiltView/QuiltView.py:214
+msgid "Quilt chart"
+msgstr ""
+
+#: QuiltView/QuiltView.py:291
+msgid "Select the name for which you want to see."
+msgstr ""
+
+#: QuiltView/QuiltView.py:296
+msgid "Clear"
+msgstr ""
+
+#: QuiltView/QuiltView.py:298
+msgid "Clear the entry field in the name selection box."
+msgstr ""
+
+#: QuiltView/QuiltView.py:303
+msgid "Nothing is selected"
+msgstr ""
+
+#: QuiltView/QuiltView.py:361
+msgid "Person Filter Editor"
+msgstr ""
+
+#: QuiltView/QuiltView.py:363
+msgid "Print the entire tree"
+msgstr ""
+
+#: QuiltView/QuiltView.py:438
+#, python-format
+msgid ""
+"You have %(filter)d filtered people, %(count)d people shown on the tree and "
+"%(total)d people in your database."
+msgstr ""
+
+#: QuiltView/QuiltView.py:467
+msgid "Could Not Set a Bookmark"
+msgstr ""
+
+#: QuiltView/QuiltView.py:468
+msgid "A bookmark could not be set because no one was selected."
+msgstr ""
+
+#: QuiltView/QuiltView.py:528
+msgid "Loading individuals"
+msgstr ""
+
+#: QuiltView/QuiltView.py:529
+msgid "Loading the data"
+msgstr ""
+
+#: QuiltView/QuiltView.py:905
+msgid "About Quilt View"
+msgstr ""
+
+#: QuiltView/QuiltView.py:975
+#, python-format
+msgid "Family of %(husband)s and %(spouse)s"
+msgstr ""
+
+#: QuiltView/QuiltView.py:981 QuiltView/QuiltView.py:985
+#, python-format
+msgid "Family of %s"
+msgstr ""
+
+#: QuiltView/QuiltView.py:1040 QuiltView/QuiltView.py:1169
+msgid "Edit"
+msgstr ""
+
+#: QuiltView/QuiltView.py:1043 QuiltView/QuiltView.py:1172
+msgid "Edit tags"
+msgstr ""
+
+#: QuiltView/QuiltView.py:1059 QuiltView/QuiltView.py:1384
+msgid "Children"
+msgstr ""
+
+#: QuiltView/QuiltView.py:1072 QuiltView/QuiltView.py:1397
+msgid "Add child to family"
+msgstr ""
+
+#: QuiltView/QuiltView.py:1142
+msgid "Add Child to Family"
+msgstr ""
+
+#: QuiltView/QuiltView.py:1175
+msgid "_Copy"
+msgstr ""
+
+#: QuiltView/QuiltView.py:1185
+msgid "Spouses"
+msgstr ""
+
+#: QuiltView/QuiltView.py:1190 QuiltView/QuiltView.py:1315
+msgid "Add"
+msgstr ""
+
+#: QuiltView/QuiltView.py:1214
+msgid "Siblings"
+msgstr ""
+
+#: QuiltView/QuiltView.py:1282
+msgid "Parents"
+msgstr ""
+
+#: QuiltView/QuiltView.py:1321
+msgid "Related"
+msgstr ""
+
+#: QuiltView/QuiltView.py:1352
+msgid "Set as home person"
+msgstr ""
+
+#: QuiltView/QuiltView.py:1502
+msgid "Adding Tags"
+msgstr ""
+
+#: QuiltView/QuiltView.py:1508
+#, python-format
+msgid "Adding Tags to person (%s)"
+msgstr ""
+
+#: QuiltView/QuiltView.py:1513
+#, python-format
+msgid "Adding Tags to family (%s)"
+msgstr ""
+
+#: QuiltView/QuiltView.py:1713
+msgid "Printing the tree"
+msgstr ""
+
+#: QuiltView/QuiltView.py:1717
+#, python-format
+msgid "Need to print %(pages)s pages (%(format)s format)"
+msgstr ""
+
+#: QuiltView/QuiltView.py:1769
+msgid ""
+"Center on the selected person.\n"
+"The new position of the person will be near the top left corner."
+msgstr ""
+
+#: QuiltView/QuiltView.py:1774
+msgid "The path color"
+msgstr ""
+
+#: QuiltView/QuiltView.py:1779
+msgid "The selected person color"
+msgstr ""
+
+#: QuiltView/QuiltView.py:1784
+msgid "The path transparency"
+msgstr ""
+
+#: QuiltView/QuiltView.py:1787
+msgid "General options"
+msgstr ""

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Once you use the comands below the version number will be incremented and the re
 files will be in the second addon repository to be commited.
 
 Examples:
-* Creates the initial addon-source directories for the addon.
+* Creates the initial addon-source directories and .pot file for the addon.
 ```
 python3 make.py gramps50 init AddonDirectory
 ```
@@ -48,9 +48,9 @@ python3 make.py gramps50 listing AddonDirectory
 Valid command summary
 =====================
 
-* **clean** - Removes unnecessary files(template.pot/ locale etc) from the addon
+* **clean** - Removes unnecessary files(locale etc) from the addon
 
-* **init** - Get all of the strings from the addon and create template.po
+* **init** [subcomand: **all**] - Get all of the strings from the addon and create template.po
 
 * **update** - Updates the template.po file
 

--- a/RebuildTypes/po/template.pot
+++ b/RebuildTypes/po/template.pot
@@ -1,0 +1,35 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-04 18:55-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: RebuildTypes/RebuildTypes.gpr.py:25
+msgid "Rebuild Gramps Types"
+msgstr ""
+
+#: RebuildTypes/RebuildTypes.gpr.py:26
+msgid "Rebuilds Gramps Types"
+msgstr ""
+
+#: RebuildTypes/RebuildTypes.py:75
+msgid "Gramps Types rebuilt"
+msgstr ""
+
+#: RebuildTypes/RebuildTypes.py:76
+#, python-format
+msgid "Found %d custom event types"
+msgstr ""

--- a/RelID/po/template.pot
+++ b/RelID/po/template.pot
@@ -1,0 +1,107 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-04 18:55-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: RelID/relation_tab.gpr.py:35
+msgid "Display relations and distances with the home person"
+msgstr ""
+
+#: RelID/relation_tab.gpr.py:36
+msgid "Will display relational informations with the home person"
+msgstr ""
+
+#: RelID/relation_tab.py:75
+msgid "Relation and distances with root"
+msgstr ""
+
+#: RelID/relation_tab.py:92
+msgid "Folder Chooser"
+msgstr ""
+
+#: RelID/relation_tab.py:95
+msgid "_Cancel"
+msgstr ""
+
+#: RelID/relation_tab.py:97
+msgid "_Select"
+msgstr ""
+
+#: RelID/relation_tab.py:99
+msgid "Please, select a folder"
+msgstr ""
+
+#: RelID/relation_tab.py:110
+msgid "Rel_id"
+msgstr ""
+
+#: RelID/relation_tab.py:111
+msgid "Relation"
+msgstr ""
+
+#: RelID/relation_tab.py:112
+msgid "Name"
+msgstr ""
+
+#: RelID/relation_tab.py:113
+msgid "up"
+msgstr ""
+
+#: RelID/relation_tab.py:114
+msgid "down"
+msgstr ""
+
+#: RelID/relation_tab.py:115
+msgid "Common MRA"
+msgstr ""
+
+#: RelID/relation_tab.py:116
+msgid "Rank"
+msgstr ""
+
+#: RelID/relation_tab.py:117
+msgid "Period"
+msgstr ""
+
+#: RelID/relation_tab.py:126
+msgid "Save"
+msgstr ""
+
+#: RelID/relation_tab.py:164
+msgid "Please wait, filtering..."
+msgstr ""
+
+#: RelID/relation_tab.py:169
+msgid "No default_person"
+msgstr ""
+
+#: RelID/relation_tab.py:174
+msgid "Generating relation map..."
+msgstr ""
+
+#: RelID/relation_tab.py:190
+#, python-format
+msgid ""
+"%d/%d \n"
+" %d/%d seconds \n"
+" %d/%d \n"
+"%f|\t%f"
+msgstr ""
+
+#: RelID/relation_tab.py:308
+msgid "You do not have write rights on this folder"
+msgstr ""

--- a/RelatedRelativesGramplet/po/template.pot
+++ b/RelatedRelativesGramplet/po/template.pot
@@ -1,0 +1,58 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: RelatedRelativesGramplet/RelatedRelativesGramplet.gpr.py:3
+msgid "Related Relatives Gramplet"
+msgstr ""
+
+#: RelatedRelativesGramplet/RelatedRelativesGramplet.gpr.py:4
+msgid "Gramplet showing relatives in a relation"
+msgstr ""
+
+#: RelatedRelativesGramplet/RelatedRelativesGramplet.gpr.py:10
+msgid "Related Relatives"
+msgstr ""
+
+#: RelatedRelativesGramplet/RelatedRelativesGramplet.py:52
+msgid "No Family Tree loaded."
+msgstr ""
+
+#: RelatedRelativesGramplet/RelatedRelativesGramplet.py:93
+msgid "Relations of related people in your database:"
+msgstr ""
+
+#: RelatedRelativesGramplet/RelatedRelativesGramplet.py:216
+msgid "and"
+msgstr ""
+
+#: RelatedRelativesGramplet/RelatedRelativesGramplet.py:219
+msgid "are partners and"
+msgstr ""
+
+#: RelatedRelativesGramplet/RelatedRelativesGramplet.py:242
+msgid "Common ancestor"
+msgstr ""
+
+#: RelatedRelativesGramplet/RelatedRelativesGramplet.py:253
+msgid "No relatives in a relation found"
+msgstr ""
+
+#: RelatedRelativesGramplet/RelatedRelativesGramplet.py:254
+msgid "END"
+msgstr ""

--- a/RepositoriesReport/po/template.pot
+++ b/RepositoriesReport/po/template.pot
@@ -1,0 +1,201 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: RepositoriesReport/RepositoriesReport.gpr.py:25
+msgid "Repositories Report Options"
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReport.gpr.py:26
+#: RepositoriesReport/RepositoriesReport.gpr.py:43
+msgid "Produces a textual repositories report"
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReport.gpr.py:42
+#: RepositoriesReport/RepositoriesReport.py:80
+#: RepositoriesReport/RepositoriesReportAlt.py:139
+msgid "Repositories Report"
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReport.py:151
+#: RepositoriesReport/RepositoriesReportAlt.py:409
+msgid "Report Options"
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReport.py:175
+#: RepositoriesReport/RepositoriesReportAlt.py:503
+msgid "The style used for the title of the report."
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReport.py:189
+#: RepositoriesReport/RepositoriesReportAlt.py:517
+msgid "The style used for repository title."
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReport.py:203
+#: RepositoriesReport/RepositoriesReportAlt.py:532
+msgid "The style used for each section."
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:202
+msgid "Address:"
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:263
+msgid "Author:"
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:268
+msgid "Abbreviation:"
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:273
+msgid "Publication information:"
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:278
+msgid "Data:"
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:360
+msgid "Confidence level:"
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:365
+msgid "Citation:"
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:371
+msgid "Date:"
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:377
+msgid "Page:"
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:410
+msgid "Repositories"
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:411
+msgid "Sources"
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:417
+msgid "Select using filter"
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:418
+msgid "Selection with a filter"
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:430
+msgid "Include repository's urls"
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:431
+msgid "Whether to include urls on repository."
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:434
+msgid "Include repository's address"
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:435
+msgid "Whether to include addresses on repository."
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:438
+msgid "Include source's author"
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:439
+msgid "Whether to include author."
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:442
+msgid "Include source's abbreviation"
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:443
+msgid "Whether to include abbreviation."
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:446
+msgid "Include source's publication information"
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:447
+msgid "Whether to include publication information."
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:450
+msgid "Include source's data"
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:451
+msgid "Whether to include keys and values."
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:454
+msgid "Include notes"
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:455
+msgid "Whether to include notes on repositories and sources."
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:458
+msgid "Include media"
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:459
+msgid "Whether to include media."
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:462
+msgid "Include citations"
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:463
+msgid "Whether to include citations on sources."
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:466
+msgid "Include private records"
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:467
+msgid "Whether to include repositories and sources marked as private."
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:470
+msgid "Display empty values"
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:471
+msgid "Whether to include key records with empty values."
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:547
+msgid "The style used for child section."
+msgstr ""
+
+#: RepositoriesReport/RepositoriesReportAlt.py:559
+msgid "The basic style used for the note display."
+msgstr ""

--- a/RestoreHist/po/template.pot
+++ b/RestoreHist/po/template.pot
@@ -1,0 +1,29 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: RestoreHist/restorehist.gpr.py:29
+msgid "Restart where you were last working"
+msgstr ""
+
+#: RestoreHist/restorehist.gpr.py:30
+msgid ""
+"This addon causes Gramps to restart on the same view and object where Gramps "
+"was previously closed.  It adds no new menus or Gramplets, but allows the "
+"last six objects visited to be found via the 'Go' menu."
+msgstr ""

--- a/SetAttributeTool/po/template.pot
+++ b/SetAttributeTool/po/template.pot
@@ -1,0 +1,121 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: SetAttributeTool/SetAttributeTool.gpr.py:25
+#: SetAttributeTool/SetAttributeTool.py:121
+#: SetAttributeTool/SetAttributeTool.py:129
+msgid "Set Attribute"
+msgstr ""
+
+#: SetAttributeTool/SetAttributeTool.gpr.py:26
+msgid "Set an attribute to a given value."
+msgstr ""
+
+#: SetAttributeTool/SetAttributeTool.py:68
+#: SetAttributeTool/SetAttributeTool.py:124
+msgid "Options"
+msgstr ""
+
+#: SetAttributeTool/SetAttributeTool.py:70
+msgid "Person Filter"
+msgstr ""
+
+#: SetAttributeTool/SetAttributeTool.py:71
+msgid "Select filter to restrict people"
+msgstr ""
+
+#: SetAttributeTool/SetAttributeTool.py:75
+msgid "Filter Person"
+msgstr ""
+
+#: SetAttributeTool/SetAttributeTool.py:76
+msgid "The center person for the filter"
+msgstr ""
+
+#: SetAttributeTool/SetAttributeTool.py:80
+msgid "Attribute"
+msgstr ""
+
+#: SetAttributeTool/SetAttributeTool.py:81
+msgid "Value"
+msgstr ""
+
+#: SetAttributeTool/SetAttributeTool.py:83
+msgid "Attribute type to add or edit"
+msgstr ""
+
+#: SetAttributeTool/SetAttributeTool.py:84
+msgid "Attribute value to add or edit"
+msgstr ""
+
+#: SetAttributeTool/SetAttributeTool.py:91
+msgid "Remove"
+msgstr ""
+
+#: SetAttributeTool/SetAttributeTool.py:92
+msgid "Remove attribute type and value set"
+msgstr ""
+
+#: SetAttributeTool/SetAttributeTool.py:130
+#: SetAttributeTool/SetAttributeTool.py:189
+msgid "Results"
+msgstr ""
+
+#: SetAttributeTool/SetAttributeTool.py:131
+#: SetAttributeTool/SetAttributeTool.py:190
+msgid "Processing...\n"
+msgstr ""
+
+#: SetAttributeTool/SetAttributeTool.py:146
+msgid "Setting attributes..."
+msgstr ""
+
+#: SetAttributeTool/SetAttributeTool.py:153
+#, python-format
+msgid ""
+"Setting '%s' attributes to '%s'...\n"
+"\n"
+msgstr ""
+
+#: SetAttributeTool/SetAttributeTool.py:184
+#, python-format
+msgid ""
+"\n"
+"Set %d '%s' attributes to '%s'\n"
+msgstr ""
+
+#: SetAttributeTool/SetAttributeTool.py:186
+#: SetAttributeTool/SetAttributeTool.py:235
+msgid "Done!\n"
+msgstr ""
+
+#: SetAttributeTool/SetAttributeTool.py:188
+msgid "Remove Attribute"
+msgstr ""
+
+#: SetAttributeTool/SetAttributeTool.py:205
+msgid "Removing attributes..."
+msgstr ""
+
+#: SetAttributeTool/SetAttributeTool.py:230
+#, python-format
+msgid ""
+"\n"
+"Removing %d '%s' attributes to '%s'\n"
+msgstr ""

--- a/SourceIndex/po/template.pot
+++ b/SourceIndex/po/template.pot
@@ -1,0 +1,632 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-04 18:55-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: SourceIndex/birth.py:126 SourceIndex/census.py:82 SourceIndex/death.py:87
+#: SourceIndex/index.py:92 SourceIndex/marriage.py:87 SourceIndex/witness.py:64
+msgid "Sources Index"
+msgstr ""
+
+#: SourceIndex/index.py:407
+msgid "*** Error: Must install either ElementTree or lxml."
+msgstr ""
+
+#: SourceIndex/index.py:409
+msgid "must install either ElementTree or lxml"
+msgstr ""
+
+#: SourceIndex/SourceIndex.gpr.py:23
+msgid "BirthIndex"
+msgstr ""
+
+#: SourceIndex/SourceIndex.gpr.py:38
+msgid "MarriageIndex"
+msgstr ""
+
+#: SourceIndex/SourceIndex.gpr.py:53
+msgid "DeathIndex"
+msgstr ""
+
+#: SourceIndex/SourceIndex.gpr.py:68
+msgid "CensusIndex"
+msgstr ""
+
+#: SourceIndex/SourceIndex.gpr.py:83
+msgid "Witness"
+msgstr ""
+
+#: SourceIndex/SourceIndex.gpr.py:98
+msgid "SourceIndex"
+msgstr ""
+
+#: SourceIndex/birth.glade:7 SourceIndex/index.glade:585
+msgid "birth"
+msgstr ""
+
+#: SourceIndex/birth.glade:47 SourceIndex/birth.glade:316
+#: SourceIndex/birth.glade:852 SourceIndex/census.glade:745
+#: SourceIndex/death.glade:78 SourceIndex/death.glade:484
+#: SourceIndex/marriage.glade:266
+msgid "Date:"
+msgstr ""
+
+#: SourceIndex/birth.glade:65 SourceIndex/census.glade:728
+#: SourceIndex/death.glade:97 SourceIndex/marriage.glade:64
+msgid "Info:"
+msgstr ""
+
+#: SourceIndex/birth.glade:99
+msgid "Birth act:"
+msgstr ""
+
+#: SourceIndex/birth.glade:113 SourceIndex/census.glade:873
+#: SourceIndex/death.glade:182 SourceIndex/marriage.glade:1263
+msgid "Reference:"
+msgstr ""
+
+#: SourceIndex/birth.glade:129
+msgid ""
+"Volume\n"
+"    Page:"
+msgstr ""
+
+#: SourceIndex/birth.glade:149
+msgid "The source title"
+msgstr ""
+
+#: SourceIndex/birth.glade:164
+msgid "The volume or page of this source"
+msgstr ""
+
+#: SourceIndex/birth.glade:195 SourceIndex/birth.glade:297
+#: SourceIndex/birth.glade:644 SourceIndex/witness.glade:73
+msgid "Names:"
+msgstr ""
+
+#: SourceIndex/birth.glade:214
+msgid "select the gender/sex"
+msgstr ""
+
+#: SourceIndex/birth.glade:230 SourceIndex/census.glade:254
+#: SourceIndex/death.glade:386
+msgid "Gender:"
+msgstr ""
+
+#: SourceIndex/birth.glade:247
+msgid "The names of the main person written into the source"
+msgstr ""
+
+#: SourceIndex/birth.glade:262
+msgid "The first names of the main person written into the source"
+msgstr ""
+
+#: SourceIndex/birth.glade:278 SourceIndex/birth.glade:511
+#: SourceIndex/birth.glade:729 SourceIndex/witness.glade:90
+msgid "First names:"
+msgstr ""
+
+#: SourceIndex/birth.glade:334 SourceIndex/birth.glade:493
+msgid "Other:"
+msgstr ""
+
+#: SourceIndex/birth.glade:351
+msgid "Repository title"
+msgstr ""
+
+#: SourceIndex/birth.glade:388 SourceIndex/census.glade:973
+#: SourceIndex/death.glade:589 SourceIndex/marriage.glade:234
+msgid "<b>Image</b>"
+msgstr ""
+
+#: SourceIndex/birth.glade:406
+msgid "<b><i>Repository</i></b>"
+msgstr ""
+
+#: SourceIndex/birth.glade:421
+msgid ""
+"Spouse\n"
+"names:"
+msgstr ""
+
+#: SourceIndex/birth.glade:441
+msgid ""
+"Marriage\n"
+"date:"
+msgstr ""
+
+#: SourceIndex/birth.glade:460
+msgid ""
+"Death\n"
+"date:"
+msgstr ""
+
+#: SourceIndex/birth.glade:544 SourceIndex/birth.glade:762
+#: SourceIndex/census.glade:286 SourceIndex/death.glade:521
+#: SourceIndex/death.glade:669 SourceIndex/death.glade:939
+#: SourceIndex/marriage.glade:467 SourceIndex/marriage.glade:789
+#: SourceIndex/marriage.glade:808 SourceIndex/marriage.glade:827
+#: SourceIndex/marriage.glade:1562 SourceIndex/marriage.glade:1621
+#: SourceIndex/witness.glade:107
+msgid "Age:"
+msgstr ""
+
+#: SourceIndex/birth.glade:578 SourceIndex/birth.glade:677
+#: SourceIndex/census.glade:543 SourceIndex/death.glade:722
+#: SourceIndex/death.glade:821 SourceIndex/marriage.glade:529
+#: SourceIndex/marriage.glade:903 SourceIndex/marriage.glade:922
+#: SourceIndex/marriage.glade:941 SourceIndex/marriage.glade:1361
+#: SourceIndex/marriage.glade:1474 SourceIndex/witness.glade:141
+msgid "Occupation:"
+msgstr ""
+
+#: SourceIndex/birth.glade:597 SourceIndex/birth.glade:710
+#: SourceIndex/death.glade:741 SourceIndex/death.glade:854
+#: SourceIndex/marriage.glade:560 SourceIndex/marriage.glade:960
+#: SourceIndex/marriage.glade:979 SourceIndex/marriage.glade:998
+#: SourceIndex/marriage.glade:1408 SourceIndex/marriage.glade:1455
+#: SourceIndex/witness.glade:158
+msgid "Live:"
+msgstr ""
+
+#: SourceIndex/birth.glade:833
+msgid ""
+"<b>Witness\n"
+"Godfather\n"
+"Godmother:</b>"
+msgstr ""
+
+#: SourceIndex/birth.glade:870
+msgid "Call number:"
+msgstr ""
+
+#: SourceIndex/birth.glade:887
+msgid "The call number into the repository"
+msgstr ""
+
+#: SourceIndex/birth.glade:925
+msgid "<b><i>Data person</i></b>"
+msgstr ""
+
+#: SourceIndex/birth.glade:949
+msgid "<b><i>Data margin</i></b>"
+msgstr ""
+
+#: SourceIndex/birth.glade:973
+msgid "<b><i>Data father</i></b>"
+msgstr ""
+
+#: SourceIndex/birth.glade:985
+msgid "<b><i>Data mother</i></b>"
+msgstr ""
+
+#: SourceIndex/birth.glade:1021
+msgid ""
+"witness1, name, given, age, occupation;\n"
+"witness2, name, given, age, occupation;\n"
+"godfather, name, given, age, occupation;\n"
+"etc ..."
+msgstr ""
+
+#: SourceIndex/birth.glade:1365 SourceIndex/census.glade:63
+#: SourceIndex/death.glade:1452 SourceIndex/marriage.glade:1976
+#: SourceIndex/witness.glade:360
+msgid "Cancel"
+msgstr ""
+
+#: SourceIndex/birth.glade:1420 SourceIndex/census.glade:117
+#: SourceIndex/death.glade:1507 SourceIndex/marriage.glade:2031
+#: SourceIndex/witness.glade:415
+msgid "OK"
+msgstr ""
+
+#: SourceIndex/birth.glade:1549
+msgid ""
+"Marriage\n"
+"place:"
+msgstr ""
+
+#: SourceIndex/birth.glade:1568
+msgid ""
+"Death\n"
+"place:"
+msgstr ""
+
+#: SourceIndex/birth.glade:1588
+msgid ""
+"Birth\n"
+"place:"
+msgstr ""
+
+#: SourceIndex/birth.glade:1892 SourceIndex/birth.glade:1911
+msgid "Origine:"
+msgstr ""
+
+#: SourceIndex/birth.glade:2272
+msgid "<b><i>Citation</i></b>"
+msgstr ""
+
+#: SourceIndex/birth.glade:2287
+msgid "<b><i>Source</i></b>"
+msgstr ""
+
+#: SourceIndex/census.glade:7 SourceIndex/index.glade:768
+msgid "census"
+msgstr ""
+
+#: SourceIndex/census.glade:160
+msgid "<b>Census</b>"
+msgstr ""
+
+#: SourceIndex/census.glade:176 SourceIndex/death.glade:607
+#: SourceIndex/marriage.glade:185
+msgid "<b>Repository</b>"
+msgstr ""
+
+#: SourceIndex/census.glade:190 SourceIndex/death.glade:353
+#: SourceIndex/death.glade:465 SourceIndex/death.glade:788
+#: SourceIndex/marriage.glade:405 SourceIndex/marriage.glade:591
+#: SourceIndex/marriage.glade:610 SourceIndex/marriage.glade:629
+#: SourceIndex/marriage.glade:1330 SourceIndex/marriage.glade:1493
+msgid "Name:"
+msgstr ""
+
+#: SourceIndex/census.glade:221 SourceIndex/death.glade:432
+#: SourceIndex/death.glade:636 SourceIndex/death.glade:873
+#: SourceIndex/marriage.glade:450 SourceIndex/marriage.glade:732
+#: SourceIndex/marriage.glade:751 SourceIndex/marriage.glade:770
+#: SourceIndex/marriage.glade:1543 SourceIndex/marriage.glade:1701
+msgid "First name:"
+msgstr ""
+
+#: SourceIndex/census.glade:319 SourceIndex/death.glade:1003
+msgid "Birth date:"
+msgstr ""
+
+#: SourceIndex/census.glade:364
+msgid "Death date:"
+msgstr ""
+
+#: SourceIndex/census.glade:381 SourceIndex/death.glade:1035
+msgid "Birth place:"
+msgstr ""
+
+#: SourceIndex/census.glade:414
+msgid "Death place:"
+msgstr ""
+
+#: SourceIndex/census.glade:447
+msgid "Family status:"
+msgstr ""
+
+#: SourceIndex/census.glade:466 SourceIndex/death.glade:1099
+msgid "Spouse name:"
+msgstr ""
+
+#: SourceIndex/census.glade:510 SourceIndex/death.glade:703
+#: SourceIndex/death.glade:892 SourceIndex/marriage.glade:498
+#: SourceIndex/marriage.glade:846 SourceIndex/marriage.glade:865
+#: SourceIndex/marriage.glade:884 SourceIndex/marriage.glade:1526
+#: SourceIndex/marriage.glade:1654 SourceIndex/witness.glade:124
+msgid "Origin:"
+msgstr ""
+
+#: SourceIndex/census.glade:671 SourceIndex/death.glade:1067
+msgid "Note:"
+msgstr ""
+
+#: SourceIndex/census.glade:712 SourceIndex/death.glade:621
+msgid "<b>Data person</b>"
+msgstr ""
+
+#: SourceIndex/census.glade:777 SourceIndex/census.glade:841
+#: SourceIndex/death.glade:131 SourceIndex/death.glade:201
+#: SourceIndex/marriage.glade:284 SourceIndex/marriage.glade:1233
+msgid "ID:"
+msgstr ""
+
+#: SourceIndex/census.glade:811
+msgid "Address:"
+msgstr ""
+
+#: SourceIndex/census.glade:904 SourceIndex/death.glade:217
+#: SourceIndex/marriage.glade:1296
+msgid "Volume:"
+msgstr ""
+
+#: SourceIndex/census.glade:1046
+msgid "order, person, surname, given, age, status, occupation, etc ..."
+msgstr ""
+
+#: SourceIndex/census.glade:1090
+msgid "Note"
+msgstr ""
+
+#: SourceIndex/death.glade:7 SourceIndex/index.glade:707
+msgid "death"
+msgstr ""
+
+#: SourceIndex/death.glade:165
+msgid "Death act:"
+msgstr ""
+
+#: SourceIndex/death.glade:282
+msgid "<b>Death act</b>"
+msgstr ""
+
+#: SourceIndex/death.glade:503
+msgid "Place:"
+msgstr ""
+
+#: SourceIndex/death.glade:986 SourceIndex/marriage.glade:1720
+msgid "<b>Witness:</b>"
+msgstr ""
+
+#: SourceIndex/death.glade:1131
+msgid "Marriage date:"
+msgstr ""
+
+#: SourceIndex/death.glade:1163
+msgid "Marriage place:"
+msgstr ""
+
+#: SourceIndex/death.glade:1195
+msgid "<b>Data mother</b>"
+msgstr ""
+
+#: SourceIndex/death.glade:1210
+msgid "<b>Data father</b>"
+msgstr ""
+
+#: SourceIndex/death.glade:1225
+msgid "<b>Spouse</b> "
+msgstr ""
+
+#: SourceIndex/death.glade:1274 SourceIndex/death.glade:1293
+#: SourceIndex/death.glade:1312 SourceIndex/marriage.glade:1819
+#: SourceIndex/marriage.glade:1836 SourceIndex/marriage.glade:1855
+#: SourceIndex/marriage.glade:1874
+msgid "alive"
+msgstr ""
+
+#: SourceIndex/death.glade:1394 SourceIndex/marriage.glade:1773
+msgid ""
+"witness1, name, given, age, occupation; witness2, name, given, age, "
+"occupation, etc ..."
+msgstr ""
+
+#: SourceIndex/index.glade:7
+msgid "index"
+msgstr ""
+
+#: SourceIndex/index.glade:50
+msgid "_File"
+msgstr ""
+
+#: SourceIndex/index.glade:79
+msgid "Import CSV"
+msgstr ""
+
+#: SourceIndex/index.glade:141
+msgid "_Edit"
+msgstr ""
+
+#: SourceIndex/index.glade:199
+msgid "_View"
+msgstr ""
+
+#: SourceIndex/index.glade:209
+msgid "Display all"
+msgstr ""
+
+#: SourceIndex/index.glade:210
+msgid "All"
+msgstr ""
+
+#: SourceIndex/index.glade:220
+msgid "Display only births"
+msgstr ""
+
+#: SourceIndex/index.glade:221
+msgid "Births/Baptisms"
+msgstr ""
+
+#: SourceIndex/index.glade:231
+msgid "Display only marriages"
+msgstr ""
+
+#: SourceIndex/index.glade:232
+msgid "Marriages/Families"
+msgstr ""
+
+#: SourceIndex/index.glade:242
+msgid "Display only deaths"
+msgstr ""
+
+#: SourceIndex/index.glade:243
+msgid "Deaths/Burials"
+msgstr ""
+
+#: SourceIndex/index.glade:253
+msgid "Display only censuses"
+msgstr ""
+
+#: SourceIndex/index.glade:254
+msgid "Censuses"
+msgstr ""
+
+#: SourceIndex/index.glade:268
+msgid "_Help"
+msgstr ""
+
+#: SourceIndex/index.glade:278
+msgid "About this utility."
+msgstr ""
+
+#: SourceIndex/index.glade:279
+msgid "About dialog"
+msgstr ""
+
+#: SourceIndex/index.glade:312
+msgid "New birth or baptism"
+msgstr ""
+
+#: SourceIndex/index.glade:341
+msgid "add birth act"
+msgstr ""
+
+#: SourceIndex/index.glade:373
+msgid "New marriage"
+msgstr ""
+
+#: SourceIndex/index.glade:402
+msgid "add marriage act"
+msgstr ""
+
+#: SourceIndex/index.glade:434
+msgid "New death or burial"
+msgstr ""
+
+#: SourceIndex/index.glade:463
+msgid "add death act"
+msgstr ""
+
+#: SourceIndex/index.glade:495
+msgid "New census"
+msgstr ""
+
+#: SourceIndex/index.glade:524
+msgid "add census"
+msgstr ""
+
+#: SourceIndex/index.glade:556
+msgid "Select a birth source"
+msgstr ""
+
+#: SourceIndex/index.glade:617
+msgid "Select a marriage source"
+msgstr ""
+
+#: SourceIndex/index.glade:646 SourceIndex/marriage.glade:7
+msgid "marriage"
+msgstr ""
+
+#: SourceIndex/index.glade:678
+msgid "Select a death source"
+msgstr ""
+
+#: SourceIndex/index.glade:739
+msgid "Select a census source"
+msgstr ""
+
+#: SourceIndex/index.glade:800
+msgid "Select a repository storing a source"
+msgstr ""
+
+#: SourceIndex/index.glade:829
+msgid "repositories"
+msgstr ""
+
+#: SourceIndex/index.glade:869
+msgid "Selected view"
+msgstr ""
+
+#: SourceIndex/index.glade:889
+msgid ""
+"Records transcriptions ... births/deaths/marriages/censuses with common "
+"fields: id, repository, person name, birth date and place, parents."
+msgstr ""
+
+#: SourceIndex/marriage.glade:49
+msgid "Marriage act:"
+msgstr ""
+
+#: SourceIndex/marriage.glade:81
+msgid "m. date:"
+msgstr ""
+
+#: SourceIndex/marriage.glade:97
+msgid "m. place:"
+msgstr ""
+
+#: SourceIndex/marriage.glade:113
+msgid "d.contract:"
+msgstr ""
+
+#: SourceIndex/marriage.glade:131
+msgid "dates banns:"
+msgstr ""
+
+#: SourceIndex/marriage.glade:149
+msgid "p.contract:"
+msgstr ""
+
+#: SourceIndex/marriage.glade:167
+msgid "places banns:"
+msgstr ""
+
+#: SourceIndex/marriage.glade:198
+msgid "<b>Data union</b>"
+msgstr ""
+
+#: SourceIndex/marriage.glade:318
+msgid "<b>Marriage act</b>"
+msgstr ""
+
+#: SourceIndex/marriage.glade:333
+msgid ""
+"<b>Data father\n"
+"spouse1</b>"
+msgstr ""
+
+#: SourceIndex/marriage.glade:351
+msgid ""
+"<b>Data mother\n"
+"spouse1</b>"
+msgstr ""
+
+#: SourceIndex/marriage.glade:369
+msgid ""
+"<b>Data mother\n"
+"spouse2</b>"
+msgstr ""
+
+#: SourceIndex/marriage.glade:387
+msgid ""
+"<b>Data father\n"
+"spouse2</b>"
+msgstr ""
+
+#: SourceIndex/marriage.glade:1185
+msgid "<b>Data spouse1</b>"
+msgstr ""
+
+#: SourceIndex/marriage.glade:1202
+msgid "<b>Data spouse2</b>"
+msgstr ""
+
+#: SourceIndex/witness.glade:7
+msgid "witness"
+msgstr ""
+
+#: SourceIndex/witness.glade:60
+msgid "<b>Witness</b>"
+msgstr ""
+
+#: SourceIndex/witness.glade:175
+msgid "Relationship:"
+msgstr ""

--- a/SourceReferences/po/template.pot
+++ b/SourceReferences/po/template.pot
@@ -1,0 +1,53 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-04 18:55-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: SourceReferences/SourceReferences.gpr.py:31
+msgid "Source References"
+msgstr ""
+
+#: SourceReferences/SourceReferences.gpr.py:32
+msgid "Gramplet showing the references for a source"
+msgstr ""
+
+#: SourceReferences/SourceReferences.gpr.py:40
+msgid "References"
+msgstr ""
+
+#: SourceReferences/SourceReferences.py:50
+msgid "Type"
+msgstr ""
+
+#: SourceReferences/SourceReferences.py:51
+msgid "Name"
+msgstr ""
+
+#: SourceReferences/SourceReferences.py:141
+msgid ""
+"Cannot open new citation editor at this time. Either the citation is already "
+"being edited, or the associated source is already being edited, and opening "
+"a citation editor (which also allows the source to be edited), would create "
+"ambiguity by opening two editors on the same source. \n"
+"\n"
+"To edit the citation, close the source editor and open an editor for the "
+"citation alone"
+msgstr ""
+
+#: SourceReferences/SourceReferences.py:154
+msgid "Cannot open new citation editor"
+msgstr ""

--- a/SourcesCitationsReport/po/template.pot
+++ b/SourcesCitationsReport/po/template.pot
@@ -1,0 +1,192 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: SourcesCitationsReport/SourcesCitationsReport.gpr.py:10
+msgid "Sources and Citations Report"
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.gpr.py:11
+msgid "Provides a source and Citations Report with notes"
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:267
+#, python-format
+msgid "   key: %s"
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:277
+#, python-format
+msgid "%d"
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:279
+#, python-format
+msgid "  %s"
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:285
+#, python-format
+msgid " - %s "
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:291
+#, python-format
+msgid "   Type: %s"
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:293
+#, python-format
+msgid "   N-ID: %s"
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:301
+#, python-format
+msgid "   %s"
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:315
+#: SourcesCitationsReport/SourcesCitationsReport.py:336
+#: SourcesCitationsReport/SourcesCitationsReport.py:363
+#: SourcesCitationsReport/SourcesCitationsReport.py:369
+#: SourcesCitationsReport/SourcesCitationsReport.py:375
+#, python-format
+msgid "%s"
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:317
+#: SourcesCitationsReport/SourcesCitationsReport.py:338
+#, python-format
+msgid "   ( %s )"
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:324
+msgid "   Eheleute: "
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:326
+#, python-format
+msgid "%s "
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:329
+#, python-format
+msgid "and %s "
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:340
+#, python-format
+msgid " %s"
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:348
+msgid "Person"
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:348
+msgid "ID"
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:349
+msgid "Role"
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:404
+msgid "Report Options"
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:406
+msgid "Report Title"
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:406
+msgid "Title of the Report"
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:407
+msgid "Title string for the report."
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:410
+msgid "Subtitle"
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:410
+msgid "Subtitle of the Report"
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:411
+msgid "Subtitle string for the report."
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:418
+#, python-format
+msgid "Copyright %(year)d %(name)s"
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:420
+msgid "Footer"
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:421
+msgid "Footer string for the page."
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:428
+msgid "Select using filter"
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:429
+msgid "Select sources using a filter"
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:436
+msgid "Show persons"
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:437
+msgid "Whether to show events and persons mentioned in the note"
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:470
+msgid "The style used for the title of the report."
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:485
+msgid "The style used for source title."
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:500
+msgid "The style used for citation title."
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:512
+msgid "The style used for Source details."
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:524
+msgid "The style used for a column title."
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:540
+msgid "The style used for each section."
+msgstr ""
+
+#: SourcesCitationsReport/SourcesCitationsReport.py:571
+msgid "The style used for event and person details."
+msgstr ""

--- a/Sqlite/po/template.pot
+++ b/Sqlite/po/template.pot
@@ -1,0 +1,54 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: Sqlite/ExportSql.py:1238
+#, python-format
+msgid "Export Complete: %d second"
+msgid_plural "Export Complete: %d seconds"
+msgstr[0] ""
+msgstr[1] ""
+
+#: Sqlite/ImportSql.py:135
+#, python-format
+msgid "%s could not be opened\n"
+msgstr ""
+
+#: Sqlite/ImportSql.py:580
+msgid "CSV import"
+msgstr ""
+
+#: Sqlite/ImportSql.py:942
+#, python-format
+msgid "Import Complete: %d second"
+msgid_plural "Import Complete: %d seconds"
+msgstr[0] ""
+msgstr[1] ""
+
+#: Sqlite/Sqlite.gpr.py:3
+msgid "SQLite Import"
+msgstr ""
+
+#: Sqlite/Sqlite.gpr.py:4 Sqlite/Sqlite.gpr.py:16
+msgid "SQLite is a common local database format"
+msgstr ""
+
+#: Sqlite/Sqlite.gpr.py:15
+msgid "SQLite Export"
+msgstr ""

--- a/SurnameMappingGramplet/po/template.pot
+++ b/SurnameMappingGramplet/po/template.pot
@@ -1,0 +1,57 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-04 18:55-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: SurnameMappingGramplet/SurnameMappingGramplet.grp.py:3
+#: SurnameMappingGramplet/SurnameMappingGramplet.grp.py:11
+msgid "Surname Mapping"
+msgstr ""
+
+#: SurnameMappingGramplet/SurnameMappingGramplet.grp.py:4
+msgid "Gramplet for editing the grouping of surnames"
+msgstr ""
+
+#: SurnameMappingGramplet/SurnameMappingGramplet.py:67
+msgid "Add Mapping"
+msgstr ""
+
+#: SurnameMappingGramplet/SurnameMappingGramplet.py:68
+#: SurnameMappingGramplet/SurnameMappingGramplet.py:158
+msgid "Edit Mapping"
+msgstr ""
+
+#: SurnameMappingGramplet/SurnameMappingGramplet.py:69
+msgid "Remove Mapping"
+msgstr ""
+
+#: SurnameMappingGramplet/SurnameMappingGramplet.py:77
+#: SurnameMappingGramplet/SurnameMappingGramplet.py:108
+msgid "Surname"
+msgstr ""
+
+#: SurnameMappingGramplet/SurnameMappingGramplet.py:78
+msgid "Group Name"
+msgstr ""
+
+#: SurnameMappingGramplet/SurnameMappingGramplet.py:112
+msgid "Group"
+msgstr ""
+
+#: SurnameMappingGramplet/SurnameMappingGramplet.py:140
+msgid "Create Mapping"
+msgstr ""

--- a/TMGimporter/po/template.pot
+++ b/TMGimporter/po/template.pot
@@ -1,0 +1,77 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-04 18:55-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: TMGimporter/importtmg.gpr.py:72
+msgid "TMG Project Backup"
+msgstr ""
+
+#: TMGimporter/importtmg.gpr.py:73 TMGimporter/importtmg.gpr.py:86
+#: TMGimporter/importtmg.gpr.py:99 TMGimporter/importtmg.gpr.py:112
+msgid "Import TMG project files"
+msgstr ""
+
+#: TMGimporter/importtmg.gpr.py:85 TMGimporter/importtmg.gpr.py:98
+#: TMGimporter/importtmg.gpr.py:111
+msgid "TMG Unsupported"
+msgstr ""
+
+#: TMGimporter/importtmgunsupported.py:55
+#: TMGimporter/importtmgunsupported.py:76
+#: TMGimporter/importtmgunsupported.py:97
+#, python-format
+msgid "%s could not be opened"
+msgstr ""
+
+#: TMGimporter/importtmgunsupported.py:56
+#, python-format
+msgid ""
+"Directly importing from TMG files is not supported\n"
+"by the TMG Importer Addon.\n"
+"\n"
+"You need to use an backup copy of the TMG project(*.sqz)\n"
+"\n"
+"Ensure that your TMG project was created by:\n"
+"TMG version 5.x or greater.\n"
+"\n"
+"Your file:\n"
+"*.PJC - Project Configuration File for TMG 5.0 to TMG 9.05\n"
+"\n"
+"Please refer to:\n"
+"%(gramps_wiki_import_pjc_direct_url)s"
+msgstr ""
+
+#: TMGimporter/importtmgunsupported.py:77
+#, python-format
+msgid ""
+"Directly importing from TMG files is not supportedby the TMG Importer Addon."
+"You need to use an backup copy of TMG project(*.sqz)Ensure that your TMG "
+"project was created by:TMG version 5.x or greater.Your file:*.TMG - Version "
+"Control File for TMG 2.0 to TMG 4.0dPlease refer to:"
+"%(gramps_wiki_import_pjc_direct_url)s"
+msgstr ""
+
+#: TMGimporter/importtmgunsupported.py:98
+#, python-format
+msgid ""
+"Directly importing from TMG files is not supportedby the TMG Importer Addon."
+"You need to use an backup copy of TMG project(*.sqz)Ensure that your TMG "
+"project was created by:TMG version 5.x or greater.Your file:*.VER - Version "
+"Control File for TMG 1.2 and earlierPlease refer to:"
+"%(gramps_wiki_import_pjc_direct_url)s"
+msgstr ""

--- a/ThumbnailGenerator/po/template.pot
+++ b/ThumbnailGenerator/po/template.pot
@@ -1,0 +1,51 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ThumbnailGenerator/ThumbnailGenerator.gpr.py:30
+#: ThumbnailGenerator/ThumbnailGenerator.py:53
+msgid "Thumbnail Generator"
+msgstr ""
+
+#: ThumbnailGenerator/ThumbnailGenerator.gpr.py:31
+msgid "Generates thumbnails for media files"
+msgstr ""
+
+#: ThumbnailGenerator/ThumbnailGenerator.py:56
+msgid "Generating media thumbnails"
+msgstr ""
+
+#: ThumbnailGenerator/ThumbnailGenerator.py:67
+msgid "Generating thumbnails for person references"
+msgstr ""
+
+#: ThumbnailGenerator/ThumbnailGenerator.py:76
+msgid "Generating thumbnails for family references"
+msgstr ""
+
+#: ThumbnailGenerator/ThumbnailGenerator.py:85
+msgid "Generating thumbnails for event references"
+msgstr ""
+
+#: ThumbnailGenerator/ThumbnailGenerator.py:94
+msgid "Generating thumbnails for place references"
+msgstr ""
+
+#: ThumbnailGenerator/ThumbnailGenerator.py:103
+msgid "Generating thumbnails for source references"
+msgstr ""

--- a/TimelinePedigreeView/po/template.pot
+++ b/TimelinePedigreeView/po/template.pot
@@ -1,0 +1,159 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+#: TimelinePedigreeView/TimelinePedigreeView.gpr.py:44
+msgid "Timeline Pedigree"
+msgstr ""
+
+#: TimelinePedigreeView/TimelinePedigreeView.gpr.py:45
+msgid "Ancestry"
+msgstr ""
+
+#: TimelinePedigreeView/TimelinePedigreeView.gpr.py:46
+msgid ""
+"The view shows a timeline pedigree with ancestors and descendants of the "
+"selected person"
+msgstr ""
+
+#: TimelinePedigreeView/TimelinePedigreeView.py:80
+msgid "short for born|b."
+msgstr ""
+
+#: TimelinePedigreeView/TimelinePedigreeView.py:81
+msgid "short for died|d."
+msgstr ""
+
+#: TimelinePedigreeView/TimelinePedigreeView.py:82
+msgid "short for baptized|bap."
+msgstr ""
+
+#: TimelinePedigreeView/TimelinePedigreeView.py:83
+msgid "short for christened|chr."
+msgstr ""
+
+#: TimelinePedigreeView/TimelinePedigreeView.py:84
+msgid "short for buried|bur."
+msgstr ""
+
+#: TimelinePedigreeView/TimelinePedigreeView.py:85
+msgid "short for cremated|crem."
+msgstr ""
+
+#: TimelinePedigreeView/TimelinePedigreeView.py:337
+msgid "Timeline pedigree"
+msgstr ""
+
+#: TimelinePedigreeView/TimelinePedigreeView.py:518
+msgid "Person Filter Editor"
+msgstr ""
+
+#: TimelinePedigreeView/TimelinePedigreeView.py:811
+msgid "Relationship loop detected"
+msgstr ""
+
+#: TimelinePedigreeView/TimelinePedigreeView.py:812
+msgid "A person was found to be his/her own ancestor."
+msgstr ""
+
+#: TimelinePedigreeView/TimelinePedigreeView.py:1396
+msgid "_Home"
+msgstr ""
+
+#: TimelinePedigreeView/TimelinePedigreeView.py:1416
+msgid "Show images"
+msgstr ""
+
+#: TimelinePedigreeView/TimelinePedigreeView.py:1418
+msgid "Show marriage data"
+msgstr ""
+
+#: TimelinePedigreeView/TimelinePedigreeView.py:1420
+msgid "Order by timeline"
+msgstr ""
+
+#: TimelinePedigreeView/TimelinePedigreeView.py:1422
+msgid "Show lifespan"
+msgstr ""
+
+#: TimelinePedigreeView/TimelinePedigreeView.py:1425
+msgid "Mouse scroll direction"
+msgstr ""
+
+#: TimelinePedigreeView/TimelinePedigreeView.py:1429
+msgid "Top <-> Bottom"
+msgstr ""
+
+#: TimelinePedigreeView/TimelinePedigreeView.py:1436
+msgid "Left <-> Right"
+msgstr ""
+
+#: TimelinePedigreeView/TimelinePedigreeView.py:1448
+msgid "Descendant Generations"
+msgstr ""
+
+#: TimelinePedigreeView/TimelinePedigreeView.py:1453
+#: TimelinePedigreeView/TimelinePedigreeView.py:1469
+#, python-format
+msgid "%d generation"
+msgid_plural "%d generations"
+msgstr[0] ""
+msgstr[1] ""
+
+#: TimelinePedigreeView/TimelinePedigreeView.py:1464
+msgid "Ancestor Generations"
+msgstr ""
+
+#: TimelinePedigreeView/TimelinePedigreeView.py:1488
+msgid "About Timeline Pedigree View"
+msgstr ""
+
+#: TimelinePedigreeView/TimelinePedigreeView.py:1507
+msgid "_Add"
+msgstr ""
+
+#: TimelinePedigreeView/TimelinePedigreeView.py:1537
+#: TimelinePedigreeView/TimelinePedigreeView.py:1766
+msgid "_Edit"
+msgstr ""
+
+#: TimelinePedigreeView/TimelinePedigreeView.py:1542
+#: TimelinePedigreeView/TimelinePedigreeView.py:1771
+msgid "_Copy"
+msgstr ""
+
+#: TimelinePedigreeView/TimelinePedigreeView.py:1552
+msgid "Spouses"
+msgstr ""
+
+#: TimelinePedigreeView/TimelinePedigreeView.py:1585
+msgid "Siblings"
+msgstr ""
+
+#: TimelinePedigreeView/TimelinePedigreeView.py:1627
+msgid "Children"
+msgstr ""
+
+#: TimelinePedigreeView/TimelinePedigreeView.py:1664
+msgid "Parents"
+msgstr ""
+
+#: TimelinePedigreeView/TimelinePedigreeView.py:1714
+msgid "Related"
+msgstr ""

--- a/TimelineQuickview/po/template.pot
+++ b/TimelineQuickview/po/template.pot
@@ -1,0 +1,105 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: TimelineQuickview/TimelineQuickview.gpr.py:9
+msgid "Timeline"
+msgstr ""
+
+#: TimelineQuickview/TimelineQuickview.gpr.py:10
+msgid "Display a person's events on a timeline"
+msgstr ""
+
+#: TimelineQuickview/TimelineQuickview.py:46
+msgid "Parents"
+msgstr ""
+
+#: TimelineQuickview/TimelineQuickview.py:48
+msgid "Inlaw Parents"
+msgstr ""
+
+#: TimelineQuickview/TimelineQuickview.py:51
+msgid "Grandparents"
+msgstr ""
+
+#: TimelineQuickview/TimelineQuickview.py:53
+msgid "Inlaw Grandparents"
+msgstr ""
+
+#: TimelineQuickview/TimelineQuickview.py:56
+msgid "Great grandparents"
+msgstr ""
+
+#: TimelineQuickview/TimelineQuickview.py:58
+msgid "Inlaw Great grandparents"
+msgstr ""
+
+#: TimelineQuickview/TimelineQuickview.py:61
+msgid "Great, "
+msgstr ""
+
+#: TimelineQuickview/TimelineQuickview.py:61
+#: TimelineQuickview/TimelineQuickview.py:63
+msgid "great, "
+msgstr ""
+
+#: TimelineQuickview/TimelineQuickview.py:61
+#: TimelineQuickview/TimelineQuickview.py:63
+msgid "great grandparents"
+msgstr ""
+
+#: TimelineQuickview/TimelineQuickview.py:63
+msgid "Inlaw Great, "
+msgstr ""
+
+#: TimelineQuickview/TimelineQuickview.py:102
+msgid "Partner's spouse"
+msgstr ""
+
+#: TimelineQuickview/TimelineQuickview.py:156
+#, python-format
+msgid "Timeline for %s"
+msgstr ""
+
+#: TimelineQuickview/TimelineQuickview.py:159
+msgid "Date"
+msgstr ""
+
+#: TimelineQuickview/TimelineQuickview.py:160
+msgid "Event"
+msgstr ""
+
+#: TimelineQuickview/TimelineQuickview.py:161
+msgid "Age"
+msgstr ""
+
+#: TimelineQuickview/TimelineQuickview.py:162
+msgid "Place"
+msgstr ""
+
+#: TimelineQuickview/TimelineQuickview.py:163
+msgid "People involved"
+msgstr ""
+
+#: TimelineQuickview/TimelineQuickview.py:186
+msgid "Today"
+msgstr ""
+
+#: TimelineQuickview/TimelineQuickview.py:192
+msgid "Unknown"
+msgstr ""

--- a/ToDoReport/po/template.pot
+++ b/ToDoReport/po/template.pot
@@ -1,0 +1,102 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ToDoReport/TodoReport.gpr.py:24
+msgid "Todo Report"
+msgstr ""
+
+#: ToDoReport/TodoReport.gpr.py:25
+msgid ""
+"Produces a list of all the notes with a given tag along with the records "
+"that it references, the Person, Family, Event, etc."
+msgstr ""
+
+#: ToDoReport/TodoReport.py:85
+msgid "ToDo Report"
+msgstr ""
+
+#: ToDoReport/TodoReport.py:86
+msgid "You must first create a tag before running this report."
+msgstr ""
+
+#: ToDoReport/TodoReport.py:94
+#, python-format
+msgid "Report on Notes Tagged %s"
+msgstr ""
+
+#: ToDoReport/TodoReport.py:205
+msgid "Id"
+msgstr ""
+
+#: ToDoReport/TodoReport.py:211
+msgid "Text"
+msgstr ""
+
+#: ToDoReport/TodoReport.py:338
+#, python-format
+msgid "%(relationship_type)s on %(relationship_date)s"
+msgstr ""
+
+#: ToDoReport/TodoReport.py:369
+msgid "date: "
+msgstr ""
+
+#: ToDoReport/TodoReport.py:380
+msgid "place: "
+msgstr ""
+
+#: ToDoReport/TodoReport.py:486
+msgid "Report Options"
+msgstr ""
+
+#: ToDoReport/TodoReport.py:494 ToDoReport/TodoReport.py:498
+msgid "Tag"
+msgstr ""
+
+#: ToDoReport/TodoReport.py:501
+msgid "The tag to use for the report"
+msgstr ""
+
+#: ToDoReport/TodoReport.py:504
+msgid "Group by reference type"
+msgstr ""
+
+#: ToDoReport/TodoReport.py:505
+msgid "Group notes by Family, Person, Place, etc."
+msgstr ""
+
+#: ToDoReport/TodoReport.py:522
+msgid "The style used for the title of the page."
+msgstr ""
+
+#: ToDoReport/TodoReport.py:532
+msgid "The style used for the section headers."
+msgstr ""
+
+#: ToDoReport/TodoReport.py:542
+msgid "The basic style used for the text display."
+msgstr ""
+
+#: ToDoReport/TodoReport.py:553
+msgid "The basic style used for table headings."
+msgstr ""
+
+#: ToDoReport/TodoReport.py:560
+msgid "The basic style used for the note display."
+msgstr ""

--- a/UKWebConnectPack/po/template.pot
+++ b/UKWebConnectPack/po/template.pot
@@ -1,0 +1,50 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: UKWebConnectPack/UKWebPack.gpr.py:10
+msgid "UK Web Connect Pack"
+msgstr ""
+
+#: UKWebConnectPack/UKWebPack.gpr.py:11
+msgid "Collection of Web sites for the UK (requires libwebconnect)"
+msgstr ""
+
+#: UKWebConnectPack/UKWebPack.py:33
+msgid "UK Google"
+msgstr ""
+
+#: UKWebConnectPack/UKWebPack.py:34
+msgid "British, UK, and Ireland"
+msgstr ""
+
+#: UKWebConnectPack/UKWebPack.py:35
+msgid "FamilySearch.org"
+msgstr ""
+
+#: UKWebConnectPack/UKWebPack.py:37
+msgid "National Archives"
+msgstr ""
+
+#: UKWebConnectPack/UKWebPack.py:38
+msgid "Hathi Trust Digital Library"
+msgstr ""
+
+#: UKWebConnectPack/UKWebPack.py:39
+msgid "Open Library"
+msgstr ""

--- a/USWebConnectPack/po/template.pot
+++ b/USWebConnectPack/po/template.pot
@@ -1,0 +1,58 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: USWebConnectPack/USWebPack.gpr.py:10
+msgid "US Web Connect Pack"
+msgstr ""
+
+#: USWebConnectPack/USWebPack.gpr.py:11
+msgid "Collection of Web sites for the US (requires libwebconnect)"
+msgstr ""
+
+#: USWebConnectPack/USWebPack.py:33
+msgid "Find A Grave"
+msgstr ""
+
+#: USWebConnectPack/USWebPack.py:34
+msgid "FamilySearch.org"
+msgstr ""
+
+#: USWebConnectPack/USWebPack.py:35
+msgid "US Google"
+msgstr ""
+
+#: USWebConnectPack/USWebPack.py:37
+msgid "German Immigrants"
+msgstr ""
+
+#: USWebConnectPack/USWebPack.py:41
+msgid "Free Rootsweb Site Search"
+msgstr ""
+
+#: USWebConnectPack/USWebPack.py:48
+msgid "Mocavo"
+msgstr ""
+
+#: USWebConnectPack/USWebPack.py:49
+msgid "Hathi Trust Digital Library"
+msgstr ""
+
+#: USWebConnectPack/USWebPack.py:50
+msgid "Open Library"
+msgstr ""

--- a/WordleGramplet/po/template.pot
+++ b/WordleGramplet/po/template.pot
@@ -1,0 +1,74 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-04 18:55-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: WordleGramplet/WordleGramplet.gpr.py:4
+msgid "Wordle Gramplet"
+msgstr ""
+
+#: WordleGramplet/WordleGramplet.gpr.py:10
+msgid "Wordle"
+msgstr ""
+
+#: WordleGramplet/WordleGramplet.gpr.py:13
+msgid "Gramplet used to make word clouds with wordle.net"
+msgstr ""
+
+#: WordleGramplet/WordleGramplet.py:72
+msgid "Double-click surname for details"
+msgstr ""
+
+#: WordleGramplet/WordleGramplet.py:74
+msgid "No Family Tree loaded."
+msgstr ""
+
+#: WordleGramplet/WordleGramplet.py:91
+msgid "Processing..."
+msgstr ""
+
+#: WordleGramplet/WordleGramplet.py:126
+msgid "[Missing]"
+msgstr ""
+
+#: WordleGramplet/WordleGramplet.py:134
+msgid "Total unique surnames"
+msgstr ""
+
+#: WordleGramplet/WordleGramplet.py:136
+msgid "Total people"
+msgstr ""
+
+#: WordleGramplet/WordleGramplet.py:140
+msgid "Number of font sizes"
+msgstr ""
+
+#: WordleGramplet/WordleGramplet.py:143
+msgid "Filter"
+msgstr ""
+
+#: WordleGramplet/WordleGramplet.py:144
+msgid "Select filter to restrict list"
+msgstr ""
+
+#: WordleGramplet/WordleGramplet.py:148
+msgid "Filter Person"
+msgstr ""
+
+#: WordleGramplet/WordleGramplet.py:149
+msgid "The center person for the filter"
+msgstr ""

--- a/libaccess/po/template.pot
+++ b/libaccess/po/template.pot
@@ -1,0 +1,30 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: libaccess/libaccess.gpr.py:32
+msgid "Provides a library for generic access to the database and gen.lib."
+msgstr ""
+
+#: libaccess/libaccess.py:218
+msgid "libaccess edit name"
+msgstr ""
+
+#: libaccess/libaccess.py:260
+msgid "libaccess edit person"
+msgstr ""

--- a/libwebconnect/po/template.pot
+++ b/libwebconnect/po/template.pot
@@ -1,0 +1,22 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: libwebconnect/libwebconnect.gpr.py:10
+msgid "Library for web site collections"
+msgstr ""

--- a/lxml/po/template.pot
+++ b/lxml/po/template.pot
@@ -1,0 +1,476 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-04 18:55-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: lxml/etreeGramplet.gpr.py:9
+msgid "etree Gramplet"
+msgstr ""
+
+#: lxml/etreeGramplet.gpr.py:10
+msgid "Gramplet for testing etree with Gramps XML"
+msgstr ""
+
+#: lxml/etreeGramplet.gpr.py:18
+msgid "etree"
+msgstr ""
+
+#: lxml/etreeGramplet.py:85 lxml/lxmlGramplet.py:110
+msgid "Invalid timestamp"
+msgstr ""
+
+#: lxml/etreeGramplet.py:86 lxml/lxmlGramplet.py:111
+msgid "Unknown"
+msgstr ""
+
+#: lxml/etreeGramplet.py:139
+msgid "No file parsed..."
+msgstr ""
+
+#: lxml/etreeGramplet.py:146 lxml/lxmlGramplet.py:171
+msgid "Run"
+msgstr ""
+
+#: lxml/etreeGramplet.py:205 lxml/etreeGramplet.py:210
+msgid "Number of editions back"
+msgstr ""
+
+#: lxml/etreeGramplet.py:220 lxml/lxmlGramplet.py:235
+msgid "Space character on filename"
+msgstr ""
+
+#: lxml/etreeGramplet.py:220 lxml/lxmlGramplet.py:235
+#, python-format
+msgid "Please fix space on \"%s\""
+msgstr ""
+
+#: lxml/etreeGramplet.py:245 lxml/lxmlGramplet.py:265
+msgid "Sorry, no support for your OS yet!"
+msgstr ""
+
+#: lxml/etreeGramplet.py:254 lxml/lxmlGramplet.py:275
+msgid "Is it a compressed .gramps?"
+msgstr ""
+
+#: lxml/etreeGramplet.py:254 lxml/lxmlGramplet.py:275
+#, python-format
+msgid "Cannot uncompress \"%s\""
+msgstr ""
+
+#: lxml/etreeGramplet.py:256 lxml/etreeGramplet.py:263 lxml/lxmlGramplet.py:278
+#: lxml/lxmlGramplet.py:286
+#, python-format
+msgid ""
+"From:\n"
+" \"%(file1)s\"\n"
+" to:\n"
+" \"%(file2)s\".\n"
+msgstr ""
+
+#: lxml/etreeGramplet.py:261 lxml/lxmlGramplet.py:283
+#, python-format
+msgid "Cannot copy \"%s\""
+msgstr ""
+
+#: lxml/etreeGramplet.py:417
+#, python-format
+msgid "XML: Last %s editions since %s, were at/on :\n"
+msgstr ""
+
+#: lxml/etreeGramplet.py:470
+#, python-format
+msgid ""
+"\n"
+"XML: Number of records and relations : \t%s\n"
+"\n"
+msgstr ""
+
+#: lxml/etreeGramplet.py:473
+#, python-format
+msgid ""
+"Number of tags : \n"
+"\t\t\t%s\t|\t(%s)*\n"
+msgstr ""
+
+#: lxml/etreeGramplet.py:475
+#, python-format
+msgid ""
+"Number of tags : \n"
+"\t\t\t%s\n"
+msgstr ""
+
+#: lxml/etreeGramplet.py:477
+#, python-format
+msgid ""
+"Number of  events : \n"
+"\t\t\t%s\t|\t(%s)*\n"
+msgstr ""
+
+#: lxml/etreeGramplet.py:478
+#, python-format
+msgid ""
+"Number of persons : \n"
+"\t\t\t%s\t|\t(%s)* and (%s)* surnames\n"
+msgstr ""
+
+#: lxml/etreeGramplet.py:479
+#, python-format
+msgid ""
+"Number of families : \n"
+"\t\t\t%s\t|\t(%s)*\n"
+msgstr ""
+
+#: lxml/etreeGramplet.py:480
+#, python-format
+msgid ""
+"Number of sources : \n"
+"\t\t\t%s\t|\t(%s)*\n"
+msgstr ""
+
+#: lxml/etreeGramplet.py:481
+#, python-format
+msgid ""
+"Number of citations : \n"
+"\t\t\t%s\t|\t(%s)*\n"
+msgstr ""
+
+#: lxml/etreeGramplet.py:482
+#, python-format
+msgid ""
+"Number of places : \n"
+"\t\t\t%s\t|\t(%s)*\n"
+msgstr ""
+
+#: lxml/etreeGramplet.py:483
+#, python-format
+msgid ""
+"Number of media objects : \n"
+"\t\t\t%s\t|\t(%s)*\n"
+msgstr ""
+
+#: lxml/etreeGramplet.py:484
+#, python-format
+msgid ""
+"Number of repositories : \n"
+"\t\t\t%s\t|\t(%s)*\n"
+msgstr ""
+
+#: lxml/etreeGramplet.py:485
+#, python-format
+msgid ""
+"Number of notes : \n"
+"\t\t\t%s\t|\t(%s)*\n"
+msgstr ""
+
+#: lxml/etreeGramplet.py:490
+#, python-format
+msgid ""
+"\n"
+"XML: Number of additional records and relations: \t%s\n"
+msgstr ""
+
+#: lxml/etreeGramplet.py:492
+#, python-format
+msgid ""
+"* loaded Family Tree base:\n"
+" \"%s\"\n"
+msgstr ""
+
+#: lxml/lxmlGramplet.gpr.py:9
+msgid "lxml Gramplet"
+msgstr ""
+
+#: lxml/lxmlGramplet.gpr.py:10
+msgid "Gramplet for testing lxml and XSLT"
+msgstr ""
+
+#: lxml/lxmlGramplet.gpr.py:18
+msgid "lxml"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:67
+msgid "Where is gzip?"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:67
+msgid "\"gzip\" is missing"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:89
+msgid "Missing python3 lxml"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:89
+msgid "Please, try to install \"python3 lxml\" package."
+msgstr ""
+
+#: lxml/lxmlGramplet.py:164
+msgid "No file loaded..."
+msgstr ""
+
+#: lxml/lxmlGramplet.py:298
+msgid "XSD validation (lxml)"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:298
+#, python-format
+msgid "Cannot validate \"%(file)s\" !"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:306
+#, python-format
+msgid "xmllint: skip DTD validation for \"%(file)s\""
+msgstr ""
+
+#: lxml/lxmlGramplet.py:318
+#, python-format
+msgid "xmllint: skip RelaxNG validation for \"%(file)s\""
+msgstr ""
+
+#: lxml/lxmlGramplet.py:329
+msgid "Parsing issue"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:329
+#, python-format
+msgid "Cannot parse content of \"%(file)s\""
+msgstr ""
+
+#: lxml/lxmlGramplet.py:333
+msgid "Gramps version"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:333
+#, python-format
+msgid ""
+"Wrong namespace\n"
+"Need: %s"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:337
+msgid "RelaxNG validation"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:337
+#, python-format
+msgid "Cannot validate \"%(file)s\" via RelaxNG schema"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:341
+msgid "File issue"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:341
+#, python-format
+msgid "Cannot parse \"%(file)s\" via etree"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:359
+msgid "Parsing file..."
+msgstr ""
+
+#: lxml/lxmlGramplet.py:456
+msgid "Missing header"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:456
+msgid ""
+"Not a valid .gramps.\n"
+"Cannot run the gramplet...\n"
+"Please, try to use a .gramps\n"
+"generated by Gramps 4.x."
+msgstr ""
+
+#: lxml/lxmlGramplet.py:469 lxml/lxmlGramplet.py:474 lxml/lxmlGramplet.py:479
+#: lxml/lxmlGramplet.py:484
+msgid "0"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:495
+msgid "File parsed with"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:498
+msgid "File was generated on "
+msgstr ""
+
+#: lxml/lxmlGramplet.py:498
+msgid " by Gramps "
+msgstr ""
+
+#: lxml/lxmlGramplet.py:500
+msgid "Period: "
+msgstr ""
+
+#: lxml/lxmlGramplet.py:502
+msgid " entries for surname(s); no frequency yet"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:503
+msgid " entries for place(s)"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:504
+msgid " note(s)"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:505
+msgid " source(s)"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:521 lxml/lxmlGramplet.py:717
+msgid "Gallery.html"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:522
+#, python-format
+msgid "2. Has generated a media index on \"%(file)s\".\n"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:525
+#, python-format
+msgid "3. Has written entries into \"%(file)s\".\n"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:544
+msgid "Matches XSD schema."
+msgstr ""
+
+#: lxml/lxmlGramplet.py:565
+msgid "xmllint: skip DTD validation"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:589
+msgid "I am looking at ..."
+msgstr ""
+
+#: lxml/lxmlGramplet.py:590
+msgid "Content generated by Gramps"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:591
+msgid "Surnames"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:592
+msgid "Places"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:593
+msgid "List of sources"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:611
+msgid "Australia"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:612
+msgid "Brazil"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:613
+msgid "Bulgaria"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:614
+msgid "Canada"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:615
+msgid "Chile"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:616
+msgid "China"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:617
+msgid "Croatia"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:618
+msgid "Czech Republic"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:619
+msgid "England"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:620
+msgid "Finland"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:621
+msgid "France"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:622
+msgid "Germany"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:623
+msgid "India"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:624
+msgid "Japan"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:625
+msgid "Norway"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:626
+msgid "Portugal"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:627
+msgid "Russia"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:628
+msgid "Sweden"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:629
+msgid "United States of America"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:633
+msgid "Name"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:634
+msgid "Country"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:695
+#, python-format
+msgid "1. Has generated \"%s\".\n"
+msgstr ""
+
+#: lxml/lxmlGramplet.py:696
+#, python-format
+msgid ""
+"Try to open\n"
+" \"%s\"\n"
+" into your prefered web navigator ..."
+msgstr ""
+
+#: lxml/lxmlGramplet.py:715
+msgid "Gallery"
+msgstr ""


### PR DESCRIPTION
After some comments from translators that not having pot files makes their work more difficult, I think it may make sense to keep the pot files with the sources.

I've update the make.py to be able to do a "./make.py gramps50 init all" which will remake all the pot files.  We may want to do this every once in a while to make sure that the pot files are up to date with the source code.

I'm also considering modifying the make.py as-needed option to also make the pot file for any updated source files.  Let me know if you think that makes sense.