### PR TITLE
Update make.py as-needed to keep .pot files up to date

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,16 +45,26 @@ python3 make.py gramps50 build AddonDirectory
 python3 make.py gramps50 listing AddonDirectory
 ```
 
+* For the developer who is merging PRs or other commits and needs to rebuild
+    and list one or more addons
+```
+python3 make.py gramps50 as-needed
+```
+
 Valid command summary
 =====================
 
-* **clean** - Removes unnecessary files(locale etc) from the addon
+* **clean** - Removes unnecessary files (locale etc) from the addon
 
-* **init** [subcomand: **all**] - Get all of the strings from the addon and create template.po
+* **init** [subcomand: **all**] - Get all of the strings from the addon and
+create necessary subdirectories and the template.pot for the addon or all
+addons if **all** is used.
 
-* **update** - Updates the template.po file
+* **update** - Updates the language xx-local.po file from the pot file.
 
-* **compile** [subcomand: **all**] - Compiles the template.po file into 
+* **compile** [subcomand: **all**] - Compiles the language xx-local.po files
+into the locale/xx/LD_MESSAGES/addon.mo files for all languages in addon,
+or all addons if **all** is used.
 
 * **build**  [subcomand: **all**] - Builds the addon for release
 
@@ -64,10 +74,14 @@ Valid command summary
 
 * **fix**  - If the listing shows a repeated addon entry, fix it
 
-* **check** - Checks if the addon listing matches the addon download version or if missing from the listing
+* **check** - Checks if the addon listing matches the addon download version
+or if missing from the listing
 
-* **listing** [subcomand: **all**] - Builds/Creates a listing for the addon in each supported language
+* **listing** [subcomand: **all**] - Builds/Creates a listing for the addon in
+each supported language
 
-* **as-needed** [no other parameters] - Builds/Lists/Cleans only out of date addons in one step
+* **as-needed** [no other parameters] - Builds/Lists/Cleans only out of date
+addons in one step.  It also rebuilds the template.pot file so it is also
+up to date.
 
 

--- a/make.py
+++ b/make.py
@@ -47,6 +47,7 @@ import glob
 import sys
 import os
 import tarfile
+from xml.etree import ElementTree
 
 if "GRAMPSPATH" in os.environ:
     GRAMPSPATH = os.environ["GRAMPSPATH"]
@@ -208,7 +209,6 @@ elif command == "init":
         dirs = [addon]
     if len(sys.argv) == 4:
         from gramps.gen.plug import make_environment, PTYPE_STR
-        from xml.etree import ElementTree
 
         def register(ptype, **kwargs):
             global plugins
@@ -237,8 +237,7 @@ elif command == "init":
             if not listed:
                 continue  # skip this one if not listed
 
-            mkdir(r("%(addon)s/po"))
-            mkdir("%(addon)s/locale")
+            mkdir("%(addon)s/po")
             system('''xgettext --language=Python --keyword=_ --keyword=N_'''
                    ''' --from-code=UTF-8'''
                    ''' -o "%(addon)s/po/template.pot" "%(addon)s"/*.py ''')
@@ -519,6 +518,7 @@ elif command == "as-needed":
             # Build it.
             do_tar(sfiles)
             print("***Rebuilt:      %s" % addon)
+
         # Add addon to newly created listing (equivalent to 'listing all')
         for lang in languages:
             gpr_bad = False  # to flag a bad gpr
@@ -559,6 +559,45 @@ elif command == "as-needed":
             if gpr_bad or not do_list:
                 break
         cleanup(addon)
+        if todo:  # make an updated pot file
+            mkdir("%(addon)s/po")
+            system('''xgettext --language=Python --keyword=_ --keyword=N_'''
+                   ''' --from-code=UTF-8'''
+                   ''' -o "%(addon)s/po/temp.pot" "%(addon)s"/*.py ''')
+            fnames = glob.glob("%s/*.glade" % addon)
+            if fnames:
+                system('''xgettext -j --add-comments -L Glade '''
+                       '''--from-code=UTF-8 -o "%(addon)s/po/temp.pot" '''
+                       '''"%(addon)s"/*.glade''')
+
+            # scan for xml files and get translation text where the tag
+            # starts with an '_'.  Create a .h file with the text strings
+            fnames = glob.glob("%s/*.xml" % addon)
+            for filename in fnames:
+                tree = ElementTree.parse(filename)
+                root = tree.getroot()
+                with open(filename + '.h', 'w', encoding='utf-8') as head:
+                    for key in root.iter():
+                        if key.tag.startswith('_') and len(key.tag) > 1:
+                            msg = key.text.replace('"', '\\"')
+                            txl = '_("%s")\n' % msg
+                            head.write(txl)
+                root.clear()
+                # now append XML text to the pot
+                system('''xgettext -j --keyword=_ --from-code=UTF-8 '''
+                       '''--language=Python -o "%(addon)s/po/temp.pot" '''
+                       '''"%(filename)s.h"''')
+                os.remove(filename + '.h')
+            if os.path.isfile(r('''%(addon)s/po/template.pot''')):
+                # we do a merge so changes to header are not lost
+                system('''msgmerge --no-fuzzy-matching -U '''
+                       '''%(addon)s/po/template.pot '''
+                       '''%(addon)s/po/temp.pot''')
+                os.remove(r('''%(addon)s/po/temp.pot'''))
+            else:
+                os.rename(r('''%(addon)s/po/temp.pot'''),
+                          r('''%(addon)s/po/template.pot'''))
+    # write out the listings
     for lang in languages:
         fp = open(r("../addons/%(gramps_version)s/listings/") +
                   ("addons-%s.txt" % lang), "w", encoding="utf-8",


### PR DESCRIPTION
This updates make.py as-needed function to do a recreation of the *.pot file for any change in a source file found during the as-needed scan.  The recreated .pot file does keep any previous manual header changes.