### PR TITLE
[Interactive Family Tree]New Addon (Topola)[gramps51]

### DIFF
--- a/Topola/Topola.gpr.py
+++ b/Topola/Topola.gpr.py
@@ -1,0 +1,15 @@
+register(TOOL,
+         id = 'Topola',
+         name =_('Interactive Family Tree'),
+         description = _('Opens an interactive tree in the browser'),
+         status = STABLE,
+         version = '1.0.0',
+         fname = 'topola.py',
+         gramps_target_version = '5.1',
+         authors = ['Przemek Więch'],
+         authors_email = ['pwiech@gmail.com'],
+         category = TOOL_ANAL,
+         toolclass = 'Topola',
+         optionclass = 'TopolaOptions',
+         tool_modes = [TOOL_MODE_GUI]
+)

--- a/Topola/po/pl-local.po
+++ b/Topola/po/pl-local.po
@@ -1,0 +1,27 @@
+# Polish translations for PACKAGE package.
+# Copyright (C) 2019 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# Przemek Wiech <pwiech@gmail.com>, 2019.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gramps51\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-04-16 20:32+0200\n"
+"PO-Revision-Date: 2019-04-16 20:32+0200\n"
+"Last-Translator: Przemek Więch <pwiech@gmail.com>\n"
+"Language-Team: Polish\n"
+"Language: pl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2);\n"
+
+#: Topola/Topola.gpr.py:3
+msgid "Interactive Family Tree"
+msgstr "Interaktywne drzewo genealogiczne"
+
+#: Topola/Topola.gpr.py:4
+msgid "Opens an interactive tree in the browser"
+msgstr "Otwiera interaktywne drzewo genealogiczne w przeglądarce"

--- a/Topola/po/template.pot
+++ b/Topola/po/template.pot
@@ -1,0 +1,26 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-04-16 20:32+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: Topola/Topola.gpr.py:3
+msgid "Interactive Family Tree"
+msgstr ""
+
+#: Topola/Topola.gpr.py:4
+msgid "Opens an interactive tree in the browser"
+msgstr ""

--- a/Topola/topola.py
+++ b/Topola/topola.py
@@ -1,0 +1,73 @@
+"""Interactive tree tool."""
+
+from tempfile import mkstemp
+from threading import Thread
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+from gramps.plugins.export.exportgedcom import GedcomWriter
+from gramps.gui.user import User
+from gramps.gui.display import display_url
+from gramps.gui.plug import tool
+
+# Port to start the HTTP server.
+HTTP_PORT = 8156
+
+class TopolaServer(Thread):
+    """Server serving the Gramps database in GEDCOM format.
+
+    This class is used as a singleton.
+    """
+    def __init__(self):
+        Thread.__init__(self)
+        self.daemon = True
+        self.path = None
+
+    def set_path(self, path):
+        """Sets a new path of the GEDCOM to be served."""
+        self.path = path
+
+    def run(self):
+        server = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self):
+                """Serves the GEDCOM file."""
+                self.send_response(200)
+                self.send_header('Access-Control-Allow-Origin', '*')
+                self.end_headers()
+                content = open(server.path, 'rb').read()
+                self.wfile.write(content)
+
+        server_address = ('127.0.0.1', HTTP_PORT)
+        httpd = HTTPServer(server_address, Handler)
+        httpd.serve_forever()
+
+class Topola(tool.Tool):
+    """Gramps tool that opens an interactive tree in the browser.
+
+    Starts a HTTP server that serves the data in GEDCOM format, then opens
+    Topola Genealogy Viewer at https://pewu.github.io/topola-viewer pointing
+    to the local server to get data. The online viewer does not send any data
+    to a remote server. All data is only kept in the browser.
+    """
+    server = None
+    def __init__(self, dbstate, user, options_class, name, callback=None):
+        tool.Tool.__init__(self, dbstate, options_class, name)
+        if not dbstate.db:
+            return
+
+        if not Topola.server:
+            Topola.server = TopolaServer()
+            Topola.server.start()
+
+        temp_file = mkstemp()[1]
+        ged_writer = GedcomWriter(dbstate.db, User())
+        ged_writer.write_gedcom_file(temp_file)
+        Topola.server.set_path(temp_file)
+        display_url(
+            'https://pewu.github.io/topola-viewer/#/view' +
+            '?utm_source=gramps&handleCors=false&standalone=false' +
+            '&url=http://127.0.0.1:{}/'.format(HTTP_PORT))
+
+class TopolaOptions(tool.ToolOptions):
+    """Empty options class."""


### PR DESCRIPTION
### Instructions
Open the addon from the menu: Tools -> Analysis and Exploration -> Interactive Family Tree
![image](https://user-images.githubusercontent.com/6564445/56496656-95d6e180-64fa-11e9-9d29-4ee41823a59e.png)

A browser tab will be opened with an interactive tree view. See [Topola Genealogy Viewer](https://pewu.github.io/topola-viewer) for examples how the visualization works.

### How it works
This Gramps addon starts a HTTP server that serves the GEDCOM file that is loaded by the [Topola Genealogy Viewer](https://pewu.github.io/topola-viewer) interface. The user data is not sent to any remote location and only loaded into the browser memory.
