### PR TITLE
[AssociationsTool]Enhanced by calling relcal[gramps52]

### DIFF
--- a/AssociationsTool/associationstool.py
+++ b/AssociationsTool/associationstool.py
@@ -81,7 +81,7 @@ class AssociationsTool(tool.Tool, ManagedWindow):
                 (_('Name'), 0, 200),
                 (_('Type of link'), 1, 200),
                 (_('Of'), 2, 200),
-                (_('Relationship calculator'), 2, 200),
+                (_('Relationship Calculator'), 2, 200),
                 ]
 
             treeview = Gtk.TreeView()

--- a/AssociationsTool/associationstool.py
+++ b/AssociationsTool/associationstool.py
@@ -57,7 +57,6 @@ class AssociationsTool(tool.Tool, ManagedWindow):
                                                  self.__class__)
 
         stats_list = []
-        
         relationship = get_relationship_calculator()
         rel = ""
 

--- a/AssociationsTool/associationstool.py
+++ b/AssociationsTool/associationstool.py
@@ -39,6 +39,7 @@ from gramps.gui.managedwindow import ManagedWindow
 
 from gramps.gui.plug import tool
 from gramps.gen.display.name import displayer as name_displayer
+from gramps.gen.relationship import get_relationship_calculator
 
 #-------------------------------------------------------------------------
 #
@@ -56,6 +57,9 @@ class AssociationsTool(tool.Tool, ManagedWindow):
                                                  self.__class__)
 
         stats_list = []
+        
+        relationship = get_relationship_calculator()
+        rel = ""
 
         plist = dbstate.db.get_person_handles(sort_handles=True)
 
@@ -68,13 +72,16 @@ class AssociationsTool(tool.Tool, ManagedWindow):
                     (a, b, c, two, value) = ref
                     person2 = dbstate.db.get_person_from_handle(two)
                     name2 = name_displayer.display(person2)
-                    stats_list.append((name1, value, name2))
+                    rel = relationship.get_one_relationship(
+                        dbstate.db, person2, person)
+                    stats_list.append((name1, value, name2, rel))
 
         if uistate:
             titles = [
                 (_('Name'), 0, 200),
                 (_('Type of link'), 1, 200),
                 (_('Of'), 2, 200),
+                (_('Relationship calculator'), 2, 200),
                 ]
 
             treeview = Gtk.TreeView()
@@ -92,10 +99,10 @@ class AssociationsTool(tool.Tool, ManagedWindow):
             self.show()
 
         else:
-            print('\t%s'*3 % ('Name','Type of link','Of'))
+            print('\t%s'*4 % ('Name','Type of link','Of','RelCal'))
             print()
             for entry in stats_list:
-                print('\t%s'*3 % entry)
+                print('\t%s'*4 % entry)
 
     def build_menu_names(self, obj):
         return (self.label,None)

--- a/AssociationsTool/associationstool.py
+++ b/AssociationsTool/associationstool.py
@@ -89,7 +89,7 @@ class AssociationsTool(tool.Tool, ManagedWindow):
                 model.add(entry, entry[0])
 
             window = Gtk.Window()
-            window.set_default_size(800, 800)
+            window.set_default_size(1000, 600)
             s = Gtk.ScrolledWindow()
             s.add(treeview)
             window.add(s)

--- a/AssociationsTool/associationstool.py
+++ b/AssociationsTool/associationstool.py
@@ -90,7 +90,7 @@ class AssociationsTool(tool.Tool, ManagedWindow):
                 model.add(entry, entry[0])
 
             window = Gtk.Window()
-            window.set_default_size(800, 600)
+            window.set_default_size(800, 800)
             s = Gtk.ScrolledWindow()
             s.add(treeview)
             window.add(s)


### PR DESCRIPTION
Just a minor improvement on the generated output list by also displaying one relation calculated by the relationships module. The idea is to have something for comparison. Maybe a refactoring for generating a more advanced tool which can modify data could be the next step ?

The current utility only displays and returns data set but users may have "directional" issues on textual values set for ASSOciations (e.g., after a gedcoml import). Current output is just a quick way for informing, calling the relationships module can also help users to fix some mistakes on the textual value set as relation.