### PR TITLE
OSM forward all http request to https[gramps52]

### DIFF
--- a/DynamicWeb/templates/dwr_default/data/dwr_start.js
+++ b/DynamicWeb/templates/dwr_default/data/dwr_start.js
@@ -124,8 +124,8 @@ if (LOAD_GOOGLEMAP_SCRIPTS)
 if (!("LOAD_OSM_SCRIPTS" in window)) window.LOAD_OSM_SCRIPTS = false;
 if (LOAD_OSM_SCRIPTS)
 {
-	LoadJsFile('http://openlayers.org/en/latest/build/ol.js');
-	LoadCssFile('http://openlayers.org/en/latest/css/ol.css');
+	LoadJsFile('https://openlayers.org/en/latest/build/ol.js');
+	LoadCssFile('https://openlayers.org/en/latest/css/ol.css');
 }
 
 


### PR DESCRIPTION
After asking the OSM support, I was told OSM forward all http request to
https when we use .org url.
So it should work in all cases.

This has an energy cost, so it would be good for the planet to change http
to https.