### PR TITLE
[HeadlineNews]Fix text display & repeating word[gramps51]

### DIFF
--- a/HeadlineNewsGramplet/HeadlineNewsGramplet.gpr.py
+++ b/HeadlineNewsGramplet/HeadlineNewsGramplet.gpr.py
@@ -1,6 +1,6 @@
 register(GRAMPLET,
-         id="Headline News Gramplet",
-         name=_("Headline News Gramplet"),
+         id="Headline News",
+         name=_("Headline News"),
          description = _("Gramplet that shows the latest Gramps news"),
          status = STABLE,
          fname="HeadlineNewsGramplet.py",

--- a/HeadlineNewsGramplet/HeadlineNewsGramplet.py
+++ b/HeadlineNewsGramplet/HeadlineNewsGramplet.py
@@ -129,7 +129,7 @@ class HeadlineNewsGramplet(Gramplet):
             except:
                 continue
             if feed_type == "wiki":
-                text = str(fp.read())
+                text = str(fp.read().decode('utf-8'))
                 if fresh:
                     self.clear_text()
                     fresh = False


### PR DESCRIPTION
Fix two issues with Gramplet.

* Text not wrapping in top section
* Repeating word "Gramplet" in context menu