### PR TITLE
[GraphView]only check image_path when self.show_images=true[gramps51]

### DIFF
--- a/GraphView/graphview.py
+++ b/GraphView/graphview.py
@@ -2359,8 +2359,8 @@ class DotSvgGenerator(object):
         if self.show_images:
             image_path = self.view.graph_widget.get_person_image(person,
                                                                  kind='path')
-        if image_path:
-            label += ('<TR><TD><IMG SRC="%s"/></TD></TR>' % image_path)
+            if image_path:
+                label += ('<TR><TD><IMG SRC="%s"/></TD></TR>' % image_path)
 
 
         # start adding person name and dates


### PR DESCRIPTION
To avoid crashing with the "referenced before assignment" error (alternative: `add image_path = None` before `if self.show_images:`)