### PR TITLE
[Graph View]Display invalid dates when show_full_dates==True[gramps51]

### DIFF
--- a/GraphView/graphview.py
+++ b/GraphView/graphview.py
@@ -2487,7 +2487,7 @@ class DotSvgGenerator(object):
                         rtrn += ' - %s' % place_title
                 return rtrn
             else:
-                if place_title:
+                if place_title and self.show_places:
                     return place_title
         return ''
 

--- a/GraphView/graphview.py
+++ b/GraphView/graphview.py
@@ -2474,11 +2474,13 @@ class DotSvgGenerator(object):
         """
         if event:
             place_title = place_displayer.display_event(self.database, event)
-            if event.get_date_object().get_year_valid():
+            date_object = event.get_date_object()
+            #shall we display full date or do we have a valid year to display only year
+            if (self.show_full_dates and date_object.get_text()) or date_object.get_year_valid():
                 if self.show_full_dates:
                     rtrn = '%s' % datehandler.get_date(event)
                 else:
-                    rtrn = '%i' % event.get_date_object().get_year()
+                    rtrn = '%i' % date_object.get_year()
                 # shall we add the place?
                 if self.show_places:
                     if place_title:


### PR DESCRIPTION
Currently Graph View only displays dates which have at least a valid year. This behavior differs from that of other charts (Pedigree, H-Tree). The correct behavior is displaying invalid dates (`MOD_TEXTONLY`) as well when the date is not empty and `show_full_dates` is set to `True`. 

Also the addon currently erroneously displays the birth/death place when `self.show_places==False` and date is empty. Correct behavior: only display place when  `self.show_places==True`