### PR TITLE
[Graphview] Label position and font [v51]

### DIFF
--- a/GraphView/graphview.py
+++ b/GraphView/graphview.py
@@ -1501,14 +1501,6 @@ class GraphvizSvgParser(object):
         # list of persons items, used for animation class
         self.items_list = []
 
-        # This dictionary maps various specific fonts to their generic font
-        # types. Will need to include any truetype fonts here.
-        self.font_family_map = {"Times New Roman,serif": "Times",
-                                "Times Roman,serif":     "Times",
-                                "Times-Roman":           "Times",
-                                "Times,serif":           "Times",
-                                "Arial":                 "Helvetica",}
-
         self.transform_scale = 1
         self.font_changed()
 
@@ -1769,14 +1761,10 @@ class GraphvizSvgParser(object):
         # does the following always work with symbols?
         if style:
             p_style = self.parse_style(style)
-            try:
-                font_family = self.font_family_map[p_style['font-family']]
-            except KeyError:
-                font_family = p_style['font-family']
+            font_family = p_style['font-family']
             text_font = font_family + " " + p_style['font-size'] + 'px'
         else:
-            font_family = self.font_family_map[
-                self.text_attrs.get('font-family')]
+            font_family = self.text_attrs.get('font-family')
             font_size = self.text_attrs.get('font-size')
             text_font = font_family + " " + font_size + 'px'
 


### PR DESCRIPTION
Next attempt to fix [8822](https://gramps-project.org/bugs/view.php?id=8822)

Don't use `font_family_map` and just use `font-family` from SVG.

Screenshots from Windows 
Befor:
![befor](https://user-images.githubusercontent.com/8698003/65829872-97c77c80-e2b2-11e9-8378-c001712307c6.png)
After:
![after](https://user-images.githubusercontent.com/8698003/65829873-97c77c80-e2b2-11e9-821e-47b5f8ff677e.png)