### PR TITLE
Add new addon [EventDescriptionEditor] [gramps51]

### DIFF
--- a/EventDescriptionEditor/EventDescriptionEditor.gpr.py
+++ b/EventDescriptionEditor/EventDescriptionEditor.gpr.py
@@ -1,0 +1,36 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2019  Matthias Kemmer
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+register(TOOL,
+         id = 'EventDescriptionEditor',
+         name = _("Event Description Editor"),
+         description = _("A tool to find and replace a string in event "
+                         "description of multiple events."),
+         version = '1.0.0',
+         gramps_target_version = "5.1",
+         status = STABLE,
+         fname = 'EventDescriptionEditor.py',
+         authors = ["Matthias Kemmer"],
+         authors_email = ["matt.familienforschung@gmail.com"],
+         category = TOOL_DBPROC,
+         toolclass = 'EventDescriptionEditor',
+         optionclass = 'EventDescriptionEditorOptions',
+         tool_modes = [TOOL_MODE_GUI],
+         )

--- a/EventDescriptionEditor/EventDescriptionEditor.gpr.py
+++ b/EventDescriptionEditor/EventDescriptionEditor.gpr.py
@@ -17,6 +17,7 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
+"""A tool to find and replace event descriptions."""
 
 register(TOOL,
          id = 'EventDescriptionEditor',

--- a/EventDescriptionEditor/EventDescriptionEditor.py
+++ b/EventDescriptionEditor/EventDescriptionEditor.py
@@ -1,0 +1,156 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2019  Matthias Kemmer
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+# ----------------------------------------------------------------------------
+#
+# GRAMPS modules
+#
+# ----------------------------------------------------------------------------
+from gramps.gui.plug import MenuToolOptions, PluginWindows
+from gramps.gen.plug.menu import FilterOption, StringOption, BooleanOption
+from gramps.gen.filters import CustomFilters, GenericFilterFactory, rules
+from gramps.gui.dialog import OkDialog
+from gramps.gen.db import DbTxn
+
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+try:
+    _trans = glocale.get_addon_translator(__file__)
+except ValueError:
+    _trans = glocale.translation
+_ = _trans.gettext
+
+
+# ----------------------------------------------------------------------------
+#
+# Tool Class
+#
+# ----------------------------------------------------------------------------
+class EventDescriptionEditor(PluginWindows.ToolManagedWindowBatch):
+    """Handles the Event Description Editor Tool processing."""
+
+    def get_title(self):
+        return _("Event Description Editor")
+
+    def get_opt_dict(self):
+        """
+        Get the values of the menu options
+        :return: dictionary e.g. {opt_name:value}
+        """
+        dct = dict()
+        for name in self._menu.get_all_option_names():
+            opt = self._menu.get_option_by_name(name)
+            dct[name] = opt.get_value()
+        return dct
+
+    def run(self):
+        self._db = self.dbstate.get_database()
+        self._menu = self.options.menu
+        self._opt = self.get_opt_dict()
+
+        sub_str = self._opt["find"]
+        replace_str = self._opt["replace"]
+        keep_old = self._opt["keep_old"]
+        txt = _("Event Description Editor")
+
+        iter_events = self._db.iter_event_handles()
+        index = self._opt["events"]
+        filter_ = self._menu.filter_list[index]
+        events = filter_.apply(self._db, iter_events)
+
+        with DbTxn(txt, self._db, batch=True) as self.trans:
+            self._db.disable_signals()
+            num = len(events)
+            self.progress.set_pass(_('Search substring...'), num)
+            counter = 0
+
+            for handle in events:
+                Event = self._db.get_event_from_handle(handle)
+                s = Event.get_description()
+                c = s.count(sub_str)
+                if sub_str == "":
+                    Event.set_description(replace_str)
+                    counter += 1
+                elif c > 0 and not keep_old:
+                    Event.set_description(replace_str)
+                    counter += 1
+                elif c == 1 and keep_old:
+                    start = s.index(sub_str)
+                    end = start + len(sub_str)
+                    Event.set_description(s[:start] + replace_str + s[end:])
+                    counter += 1
+                elif c > 1 and keep_old:
+                    new = ""
+                    for i in range(c):
+                        if i != c:
+                            start = s.index(sub_str)
+                            end = start + len(sub_str)
+                            new += s[:start] + replace_str
+                            s = s[end:]
+                        else:
+                            new += replace_str + s[end:]
+                    Event.set_description(new)
+                    counter += 1
+
+                self._db.commit_event(Event, self.trans)
+                self.progress.step()
+
+            self._db.enable_signals()
+            self._db.request_rebuild()
+            OkDialog(_("INFO"), _("%s event descriptions of %s events were "
+                                  "changed." % (str(counter), str(num))))
+
+
+# ----------------------------------------------------------------------------
+#
+# Option Class
+#
+# ----------------------------------------------------------------------------
+class EventDescriptionEditorOptions(MenuToolOptions):
+
+    def __init__(self, name, person_id=None, dbstate=None):
+        MenuToolOptions.__init__(self, name, person_id, dbstate)
+
+    def add_menu_options(self, menu):
+        menu.filter_list = CustomFilters.get_filters("Event")
+        GenericFilter = GenericFilterFactory("Event")
+        all_filter = GenericFilter()
+        all_filter.set_name(_("All Events"))
+        all_filter.add_rule(rules.event.AllEvents([]))
+        all_filter_in_list = False
+        for fltr in menu.filter_list:
+            if fltr.get_name() == all_filter.get_name():
+                all_filter_in_list = True
+        if not all_filter_in_list:
+            menu.filter_list.insert(0, all_filter)
+
+        events = FilterOption(_("Events"), 0)
+        menu.add_option(_("Option"), "events", events)
+        events.set_filters(menu.filter_list)
+
+        find = StringOption(_("Find"), "")
+        menu.add_option(_("Option"), "find", find)
+
+        replace = StringOption(_("Replace"), "")
+        menu.add_option(_("Option"), "replace", replace)
+
+        keep_old = BooleanOption(_("Replace substring only"), False)
+        keep_old.set_help(_("If True only the substring will be replaced, "
+                            "otherwise the whole description will be deleted "
+                            "and replaced by the new one."))
+        menu.add_option(_("Option"), "keep_old", keep_old)


### PR DESCRIPTION
The Event Description Editor tool allows users to select several events, search their event descriptions for a substring and change the description or the substring to a new one. This feature was requested in [#4757](https://gramps-project.org/bugs/view.php?id=4757) and in [#2656](https://gramps-project.org/bugs/view.php?id=2656). 