### PR TITLE
[LaTeX genealogytree]Add the Language selector[v51]

### DIFF
--- a/GenealogyTree/gt_ancestor.py
+++ b/GenealogyTree/gt_ancestor.py
@@ -160,5 +160,5 @@ class AncestorTreeOptions(MenuReportOptions):
         images = BooleanOption(_("Include images"), False)
         images.set_help(_("Include images of people in the nodes."))
         menu.add_option(category_name, "images", images)
- 
+
         locale_opt = stdoptions.add_localization_option(menu, category_name)

--- a/GenealogyTree/gt_ancestor.py
+++ b/GenealogyTree/gt_ancestor.py
@@ -45,6 +45,7 @@ LOG = logging.getLogger(".Tree")
 from gramps.gen.errors import ReportError
 from gramps.gen.plug.report import Report
 from gramps.gen.plug.report import MenuReportOptions
+from gramps.gen.plug.report import stdoptions
 from gramps.gen.plug.menu import PersonOption, NumberOption, BooleanOption
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.gettext
@@ -72,6 +73,7 @@ class AncestorTree(Report):
         self._pid = get_value('pid')
         self.max_generations = menu.get_option_by_name('maxgen').get_value()
         self.include_images = menu.get_option_by_name('images').get_value()
+        self.set_locale(menu.get_option_by_name('trans').get_value())
 
     def write_report(self):
         """
@@ -158,3 +160,5 @@ class AncestorTreeOptions(MenuReportOptions):
         images = BooleanOption(_("Include images"), False)
         images.set_help(_("Include images of people in the nodes."))
         menu.add_option(category_name, "images", images)
+        
+        locale_opt = stdoptions.add_localization_option(menu, category_name)

--- a/GenealogyTree/gt_ancestor.py
+++ b/GenealogyTree/gt_ancestor.py
@@ -160,5 +160,5 @@ class AncestorTreeOptions(MenuReportOptions):
         images = BooleanOption(_("Include images"), False)
         images.set_help(_("Include images of people in the nodes."))
         menu.add_option(category_name, "images", images)
-        
+ 
         locale_opt = stdoptions.add_localization_option(menu, category_name)

--- a/GenealogyTree/gt_descendant.py
+++ b/GenealogyTree/gt_descendant.py
@@ -45,6 +45,7 @@ LOG = logging.getLogger(".Tree")
 from gramps.gen.errors import ReportError
 from gramps.gen.plug.report import Report
 from gramps.gen.plug.report import MenuReportOptions
+from gramps.gen.plug.report import stdoptions
 from gramps.gen.plug.menu import PersonOption, NumberOption, BooleanOption
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.gettext
@@ -72,6 +73,7 @@ class DescendantTree(Report):
         self._pid = get_value('pid')
         self.max_generations = menu.get_option_by_name('maxgen').get_value()
         self.include_images = menu.get_option_by_name('images').get_value()
+        self.set_locale(menu.get_option_by_name('trans').get_value())
 
     def write_report(self):
         """
@@ -166,3 +168,6 @@ class DescendantTreeOptions(MenuReportOptions):
         images = BooleanOption(_("Include images"), False)
         images.set_help(_("Include images of people in the nodes."))
         menu.add_option(category_name, "images", images)
+
+        locale_opt = stdoptions.add_localization_option(menu, category_name)
+        

--- a/GenealogyTree/gt_descendant.py
+++ b/GenealogyTree/gt_descendant.py
@@ -170,4 +170,3 @@ class DescendantTreeOptions(MenuReportOptions):
         menu.add_option(category_name, "images", images)
 
         locale_opt = stdoptions.add_localization_option(menu, category_name)
-        

--- a/GenealogyTree/gt_grandparent.py
+++ b/GenealogyTree/gt_grandparent.py
@@ -45,6 +45,7 @@ LOG = logging.getLogger(".Tree")
 from gramps.gen.errors import ReportError
 from gramps.gen.plug.report import Report
 from gramps.gen.plug.report import MenuReportOptions
+from gramps.gen.plug.report import stdoptions
 from gramps.gen.plug.menu import PersonOption, NumberOption, BooleanOption
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.gettext
@@ -73,6 +74,7 @@ class GrandparentTree(Report):
         self.max_generations = menu.get_option_by_name('maxgen').get_value()
         self.shift = menu.get_option_by_name('shift').get_value()
         self.include_images = menu.get_option_by_name('images').get_value()
+        self.set_locale(menu.get_option_by_name('trans').get_value())
         self.g1_handle = None
         self.g2_handle = None
 
@@ -219,3 +221,5 @@ class GrandparentTreeOptions(MenuReportOptions):
         images = BooleanOption(_("Include images"), False)
         images.set_help(_("Include images of people in the nodes."))
         menu.add_option(category_name, "images", images)
+
+        locale_opt = stdoptions.add_localization_option(menu, category_name)

--- a/GenealogyTree/gt_sandclock.py
+++ b/GenealogyTree/gt_sandclock.py
@@ -240,5 +240,5 @@ class SandclockTreeOptions(MenuReportOptions):
         images = BooleanOption(_("Include images"), False)
         images.set_help(_("Include images of people in the nodes."))
         menu.add_option(category_name, "images", images)
- 
+
         locale_opt = stdoptions.add_localization_option(menu, category_name)

--- a/GenealogyTree/gt_sandclock.py
+++ b/GenealogyTree/gt_sandclock.py
@@ -45,6 +45,7 @@ LOG = logging.getLogger(".Tree")
 from gramps.gen.errors import ReportError
 from gramps.gen.plug.report import Report
 from gramps.gen.plug.report import MenuReportOptions
+from gramps.gen.plug.report import stdoptions
 from gramps.gen.plug.menu import PersonOption, FamilyOption, NumberOption, BooleanOption
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.gettext
@@ -79,6 +80,7 @@ class SandclockTree(Report):
         self.max_down = menu.get_option_by_name('gendown').get_value()
         self.include_siblings = menu.get_option_by_name('siblings').get_value()
         self.include_images = menu.get_option_by_name('images').get_value()
+        self.set_locale(menu.get_option_by_name('trans').get_value())
 
     def write_report(self):
         """
@@ -238,3 +240,5 @@ class SandclockTreeOptions(MenuReportOptions):
         images = BooleanOption(_("Include images"), False)
         images.set_help(_("Include images of people in the nodes."))
         menu.add_option(category_name, "images", images)
+ 
+        locale_opt = stdoptions.add_localization_option(menu, category_name)


### PR DESCRIPTION
This can be useful for setting (and testing) a locale value on genealogytree.
Currently the date format is in english only.

See also https://github.com/gramps-project/gramps/pull/960