### PR TITLE
Form references[v52]

### DIFF
--- a/Form/editform.py
+++ b/Form/editform.py
@@ -320,7 +320,7 @@ class EditForm(ManagedWindow):
         event_type.set_from_xml_str(get_form_type(form_id))
         self.event.set_type(event_type)
 
-        # Set reference iff this is a new form
+        # Set reference if this is a new form
         if not event.get_handle():
             form_reference = get_form_reference(form_id)
             if form_reference:

--- a/Form/editform.py
+++ b/Form/editform.py
@@ -3,7 +3,7 @@
 #
 # Copyright (C) 2009-2015 Nick Hall
 # Copyright (C) 2011      Gary Burton
-# Copyright (C) 2024      Steve Youngs
+# Copyright (C) 2019-2024 Steve Youngs
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -67,6 +67,7 @@ from gramps.gen.datehandler import get_date, displayer
 from form import ORDER_ATTR, GROOM, BRIDE
 from form import (
     get_form_id,
+    get_form_reference,
     get_form_date,
     get_form_type,
     get_form_headings,
@@ -318,6 +319,13 @@ class EditForm(ManagedWindow):
         event_type = EventType()
         event_type.set_from_xml_str(get_form_type(form_id))
         self.event.set_type(event_type)
+
+        # Set reference iff this is a new form
+        if not event.get_handle():
+            form_reference = get_form_reference(form_id)
+            if form_reference:
+                ref_entry = self.widgets['ref_entry']
+                ref_entry.set_text(form_reference)
 
         # Set date
         form_date = get_form_date(form_id)

--- a/Form/form.py
+++ b/Form/form.py
@@ -2,6 +2,7 @@
 # Gramps - a GTK+/GNOME based genealogy program
 #
 # Copyright (C) 2009-2015 Nick Hall
+# Copyright (C) 2019-2024 Steve Youngs
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -107,6 +108,7 @@ class Form:
     """
 
     def __init__(self):
+        self.__references = {}
         self.__dates = {}
         self.__headings = {}
         self.__sections = {}
@@ -129,6 +131,10 @@ class Form:
             id = form.attributes["id"].value
             self.__names[id] = form.attributes["title"].value
             self.__types[id] = form.attributes["type"].value
+            if "reference" in form.attributes:
+                self.__references[id] = form.attributes["reference"].value
+            else:
+                self.__references[id] = None
             if "date" in form.attributes:
                 self.__dates[id] = form.attributes["date"].value
             else:
@@ -184,6 +190,10 @@ class Form:
         """Return the title for a given form."""
         return self.__names[form_id]
 
+    def get_reference(self, form_id):
+        """ Return the reference for a given form. """
+        return self.__references[form_id]
+
     def get_date(self, form_id):
         """Return a textual date for a given form."""
         return self.__dates[form_id]
@@ -234,6 +244,11 @@ def get_form_title(form_id):
     """
     return FORM.get_title(form_id)
 
+def get_form_reference(form_id):
+    """
+    Return the reference for a given form.
+    """
+    return FORM.get_reference(form_id)
 
 def get_form_date(form_id):
     """

--- a/Form/form_gb.xml
+++ b/Form/form_gb.xml
@@ -192,7 +192,7 @@
             </column>
         </section>
     </form>
-    <form id='UK1841' type='Census' title='1841 England and Wales Census' date='1841-06-06'>
+    <form id='UK1841' type='Census' title='1841 England and Wales Census' date='1841-06-06' reference='Department: HO, Series: 107, Piece: , Book: , Folio: , Page: , Line: '>
         <heading>
             <_attribute>City or Borough</_attribute>
         </heading>
@@ -222,7 +222,7 @@
             </column>
         </section>
     </form>
-    <form id='UK1851' type='Census' title='1851 England and Wales Census' date='1851-03-30'>
+    <form id='UK1851' type='Census' title='1851 England and Wales Census' date='1851-03-30' reference='Department: HO, Series: 107, Piece: , Folio: , Page: , Schedule: '>
         <heading>
             <_attribute>Parish or Township</_attribute>
         </heading>
@@ -273,7 +273,7 @@
             </column>
         </section>
     </form>
-    <form id='UK1861' type='Census' title='1861 England and Wales Census' date='1861-04-07'>
+    <form id='UK1861' type='Census' title='1861 England and Wales Census' date='1861-04-07' reference='Department: RG, Series: 9, Piece: , Folio: , Page: , Schedule: '>
         <heading>
             <_attribute>Parish or Township</_attribute>
         </heading>
@@ -330,7 +330,7 @@
             </column>
         </section>
     </form>
-    <form id='UK1871' type='Census' title='1871 England and Wales Census' date='1871-04-02'>
+    <form id='UK1871' type='Census' title='1871 England and Wales Census' date='1871-04-02' reference='Department: RG, Series: 10, Piece: , Folio: , Page: , Schedule: '>
         <heading>
             <_attribute>Civil Parish or Township</_attribute>
         </heading>
@@ -396,7 +396,7 @@
             </column>
         </section>
     </form>
-    <form id='UK1881' type='Census' title='1881 England and Wales Census' date='1881-04-03'>
+    <form id='UK1881' type='Census' title='1881 England and Wales Census' date='1881-04-03' reference='Department: RG, Series: 11, Piece: , Folio: , Page: , Schedule: '>
         <heading>
             <_attribute>Civil Parish or Township</_attribute>
         </heading>
@@ -462,7 +462,7 @@
             </column>
         </section>
     </form>
-    <form id='UK1891' type='Census' title='1891 England Census' date='1891-04-05'>
+    <form id='UK1891' type='Census' title='1891 England Census' date='1891-04-05' reference='Department: RG, Series: 12, Piece: , Folio: , Page: , Schedule: '>
         <heading>
             <_attribute>Administrative County</_attribute>
         </heading>
@@ -543,7 +543,7 @@
             </column>
         </section>
     </form>
-    <form id='UK1901' type='Census' title='1901 England Census' date='1901-03-31'>
+    <form id='UK1901' type='Census' title='1901 England Census' date='1901-03-31' reference='Department: RG, Series: 13, Piece: , Folio: , Page: , Schedule: '>
         <heading>
             <_attribute>Administrative County</_attribute>
         </heading>
@@ -619,7 +619,7 @@
             </column>
         </section>
     </form>
-    <form id='UK1911' type='Census' title='1911 England Census' date='1911-04-02'>
+    <form id='UK1911' type='Census' title='1911 England Census' date='1911-04-02' reference='Department: RG, Series: 14, Piece: , Schedule: '>
         <heading>
             <_attribute>Registration District</_attribute>
         </heading>
@@ -710,7 +710,7 @@
             </column>
         </section>
     </form>
-    <form id='UK1921' type='Census' title='1921 England Census' date='1921-06-19'>
+    <form id='UK1921' type='Census' title='1921 England Census' date='1921-06-19' reference='Department: RG, Series: 15, Piece: , Schedule: '>
         <heading>
             <_attribute>Registration District</_attribute>
         </heading>
@@ -792,7 +792,7 @@
             </column>
         </section>
     </form>
-    <form id='UK1939' type='Census' title='1939 England and Wales Register' date='1939-09-29'>
+    <form id='UK1939' type='Census' title='1939 England and Wales Register' date='1939-09-29' reference='Department: RG, Series: 101, Piece: , Item: , Schedule: '>
         <heading>
             <_attribute>E.D. Letter Code</_attribute>
         </heading>
@@ -839,7 +839,7 @@
             </column>
         </section>
     </form>
-    <form id='CY1891' type='Census' title='1891 Wales Census' date='1891-04-05'>
+    <form id='CY1891' type='Census' title='1891 Wales Census' date='1891-04-05' reference='Department: RG, Series: 12, Piece: , Folio: , Page: , Schedule: '>
         <heading>
             <_attribute>Administrative County</_attribute>
         </heading>
@@ -925,7 +925,7 @@
             </column>
         </section>
     </form>
-    <form id='CY1901' type='Census' title='1901 Wales Census' date='1901-03-31'>
+    <form id='CY1901' type='Census' title='1901 Wales Census' date='1901-03-31' reference='Department: RG, Series: 13, Piece: , Folio: , Page: , Schedule: '>
         <heading>
             <_attribute>Administrative County</_attribute>
         </heading>
@@ -1006,7 +1006,7 @@
             </column>
         </section>
     </form>
-    <form id='CY1911' type='Census' title='1911 Wales Census' date='1911-04-02'>
+    <form id='CY1911' type='Census' title='1911 Wales Census' date='1911-04-02' reference='Department: RG, Series: 14, Piece: , Schedule: '>
         <heading>
             <_attribute>Registration District</_attribute>
         </heading>
@@ -1102,7 +1102,7 @@
             </column>
         </section>
     </form>
-    <form id='CY1921' type='Census' title='1921 Wales Census' date='1921-06-19'>
+    <form id='CY1921' type='Census' title='1921 Wales Census' date='1921-06-19' reference='Department: RG, Series: 15, Piece: , Schedule: '>
         <heading>
             <_attribute>Registration District</_attribute>
         </heading>

--- a/Form/form_gb.xml
+++ b/Form/form_gb.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <forms>
-    <form id='UKBirth' type='Birth' title='English Birth Certificate'>
+    <form id='UKBirth' type='Birth' title='English Birth Certificate' reference='Registration District: , Registration Sub-District: , Entry Number: '>
         <heading>
             <_attribute>Certificate Number</_attribute>
         </heading>
@@ -62,7 +62,7 @@
             </column>
         </section>
     </form>
-    <form id='UKMarriage' type='Marriage' title='English Marriage Certificate'>
+    <form id='UKMarriage' type='Marriage' title='English Marriage Certificate' reference='Registration District: , Entry Number: '>
         <heading>
             <_attribute>Certificate Number</_attribute>
         </heading>
@@ -127,7 +127,7 @@
             </column>
         </section>
     </form>
-    <form id='UKDeath' type='Death' title='English Death Certificate'>
+    <form id='UKDeath' type='Death' title='English Death Certificate' reference='Registration District: , Registration Sub-District: , Entry Number: '>
         <heading>
             <_attribute>Certificate Number</_attribute>
         </heading>


### PR DESCRIPTION
Teach the Form gramplet about form specific default references. The anticipated use is for a form to optionally provide template text in the reference attribute. This text is then shown in the form GUI Reference field for the user to complete to create a fully formed reference.

The PR is broken into 3 commits:
1. read the new 'reference' attribute from the form XML file and store in the Form class
2. display a forms reference in the GUI, but only for new forms
3. add template references to a selection of forms defined in form_gb.xml

Fully backwards compatible with existing form definitions. If the reference attribute is missing from the form XML, existing behaviour is maintained.