### PR TITLE
Form Gramplet: per Form, per Column actions

### DIFF
--- a/Form/editform.py
+++ b/Form/editform.py
@@ -748,7 +748,8 @@ class MultiSection(Gtk.Box):
         self.model = Gtk.ListStore(*[str] * (len(columns) + 1))
         self.entry_grid.set_model(self.model)
         tooltips = [column[1] for column in columns]
-        self.entry_grid.set_columns(self.columns, tooltips)
+        actions = [column[3] for column in columns]
+        self.entry_grid.set_columns(self.columns, tooltips, actions)
         self.entry_grid.build()
 
     def populate_gui(self, event):

--- a/Form/entrygrid.py
+++ b/Form/entrygrid.py
@@ -69,11 +69,12 @@ class Indicator(Gtk.DrawingArea):
 #------------------------------------------------------------------------
 class EntryGrid(Gtk.Grid):
 
-    def __init__(self, headings=None, tooltips=None, model=None, callback=None):
+    def __init__(self, headings=None, tooltips=None, actions=None, model=None, callback=None):
         Gtk.Grid.__init__(self)
 
         self.headings = headings
         self.tooltips = tooltips
+        self.actions = actions
         self.model = model
         self.widgets = []
         self.indicators = []
@@ -91,9 +92,10 @@ class EntryGrid(Gtk.Grid):
         if len(self.model) > 0:
             self.selected = model.get_iter((0,))
 
-    def set_columns(self, columns, tooltips):
+    def set_columns(self, columns, tooltips, actions):
         self.headings = columns
         self.tooltips = tooltips
+        self.actions = actions
 
     def build(self):
 
@@ -187,6 +189,7 @@ class EntryGrid(Gtk.Grid):
     def clean_up(self):
         self.headings = None
         self.tooltips = None
+        self.actions = None
         self.model = None
         self.widgets = None
         self.indicators = None

--- a/Form/entrygrid.py
+++ b/Form/entrygrid.py
@@ -160,6 +160,25 @@ class EntryGrid(Gtk.Grid):
         self.selected = self.model.get_iter((row,))
         self.indicators[row].set_active(True)
 
+    def activate_action(self, widget, row, column, action):
+        pass
+
+    def populate_popup(self, entry, menu, row, column):
+        if self.actions[column - 1]:
+            action_id = 0
+            for action in self.actions[column - 1]:
+                action_menuitem = Gtk.MenuItem(label=action.title)
+                # add the action if there is no 'enable_if' expression or the result of eval(action.enable_if) is True (or convertible to True)
+                if action.enable_if is None or eval(action.enable_if):
+                    action_menuitem.connect('activate', self.activate_action, row, column, action)
+                    action_menuitem.show_all()
+                    menu.insert(action_menuitem, action_id)
+                    action_id += 1
+            if action_id:
+                separator = Gtk.SeparatorMenuItem()
+                separator.show_all()
+                menu.insert(separator, action_id)
+
     def changed(self, entry, row, column):
         set_size(entry)
         self.model.handler_block(self.sig_id)

--- a/Form/entrygrid.py
+++ b/Form/entrygrid.py
@@ -69,7 +69,7 @@ class Indicator(Gtk.DrawingArea):
 #------------------------------------------------------------------------
 class EntryGrid(Gtk.Grid):
 
-    def __init__(self, headings=None, tooltips=None, actions=None, model=None, callback=None):
+    def __init__(self, headings=None, tooltips=None, actions=None, model=None, callback=None, action_callback=None):
         Gtk.Grid.__init__(self)
 
         self.headings = headings
@@ -80,6 +80,7 @@ class EntryGrid(Gtk.Grid):
         self.indicators = []
         self.selected = None
         self.callback = callback
+        self.action_callback = action_callback
 
     def set_model(self, model):
         self.model = model
@@ -142,6 +143,7 @@ class EntryGrid(Gtk.Grid):
                 entry.set_tooltip_text(self.tooltips[column - 1])
                 entry.connect('changed', self.changed, row, column)
                 entry.connect('focus-in-event', self.got_focus, row)
+                entry.connect('populate_popup', self.populate_popup, row, column)
                 entry.show()
                 self.attach(entry, column + 1, row + 1, 1, 1)
                 entry_row.append(entry)
@@ -161,7 +163,7 @@ class EntryGrid(Gtk.Grid):
         self.indicators[row].set_active(True)
 
     def activate_action(self, widget, row, column, action):
-        pass
+        self.action_callback(row, column, action.command)
 
     def populate_popup(self, entry, menu, row, column):
         if self.actions[column - 1]:
@@ -214,6 +216,7 @@ class EntryGrid(Gtk.Grid):
         self.indicators = None
         self.selected = None
         self.callback = None
+        self.callback_action = None
 
 def set_size(entry):
     layout = entry.get_layout()

--- a/Form/form.py
+++ b/Form/form.py
@@ -26,6 +26,7 @@ Form definitions.
 # Python imports
 #
 #---------------------------------------------------------------
+from collections import namedtuple
 import os
 import xml.dom.minidom
 
@@ -158,9 +159,23 @@ class Form():
                         long_text = _(longname[0].childNodes[0].data)
                     else:
                         long_text = attr_text
+                    column_actions = column.getElementsByTagName('action')
+                    actions = []
+                    action = namedtuple('action', ['title', 'command', 'enable_if'])
+                    for act in column_actions:
+                        title = _(act.attributes['title'].value)
+                        commands = act.getElementsByTagName('command')
+                        command = commands[0].childNodes[0].wholeText
+                        enable_if = None
+                        enable_if_elements = act.getElementsByTagName('enable_if')
+                        if enable_if_elements:
+                            # strip both leading and trailing whitespace. This allows clearer formatting in the XML file.
+                            enable_if = enable_if_elements[0].firstChild.wholeText.strip()
+                        actions.append(action(title, command, enable_if))
                     self.__columns[id][role].append((attr_text,
                                                      long_text,
-                                                     int(size_text)))
+                                                     int(size_text),
+                                                     actions))
         dom.unlink()
 
     def get_form_ids(self):

--- a/Form/form_gb.xml
+++ b/Form/form_gb.xml
@@ -186,6 +186,33 @@
             <column>
                 <_attribute>Occupation</_attribute>
                 <size>25</size>
+                <action title='Create Occupation event'>
+                    <enable_if>
+                        <![CDATA[
+                        True
+                        ]]>
+                    </enable_if>
+                    <command>
+                        <![CDATA[
+# build the new OCCUPATION event
+event = Event()
+event.set_type(EventType.OCCUPATION)
+event.set_date_object(self.event.get_date_object())
+event.add_citation(self.citation.get_handle())
+event.set_description(value)
+with DbTxn("form_action", self.db) as trans:
+    # add to the database
+    self.db.add_event(event, trans)
+    # Add new event reference to the Person record
+    event_ref = EventRef()
+    event_ref.ref = event.get_handle()
+    event_ref.set_role(EventRoleType.PRIMARY)
+    person = self.db.get_person_from_handle(object)
+    person.add_event_ref(event_ref)
+    self.db.commit_person(person, trans)
+                        ]]>
+                    </command>
+                </action>
             </column>
             <column>
                 <_attribute>Where Born</_attribute>


### PR DESCRIPTION
Extend the Form gramplet so that the Form creator can specify per column actions which the user can invoke as required. An 'action' is a snippet of Python code defined in the form XML definition. These actions are intended to automate steps you can already do manually.
An example action is provided that extends the UK1841 census form to allow an 'Occupation' event to be created, with appropriate date and source citation, from the Occupation column.
It is hoped that the framework is sufficiently generic to allow more complex actions to be implemented in future. Indeed you already can add actions to other columns by simply editing the form XML file.
The XML definition of an action consists of three bits of data

1. "title" attribute is used to build the popup menu
2. "enable_if" determines if the action should be added to the popup menu
3. "command" the Python code that implements the action

**WARNING**: this is very much a proof of concept. 
- There is little error checking
- Currently you must save the form and reopen it before the exmple action will work correctly (saving the form for the first time creates the citation and census event)
- The example action does not check to see if the event already exists - so you can keep adding duplicate events to a person!

The extended popup menu
![image](https://user-images.githubusercontent.com/16954811/71490454-d07be100-2822-11ea-8363-1250593f3574.png)

The event created by this action
![image](https://user-images.githubusercontent.com/16954811/71490492-f2756380-2822-11ea-8ccf-b8c9ac401bcb.png)

To Do
- [ ] enable_if needs to be eval()'d from the EditFrom class, not EntryGrid as currently.
- [ ] implement actions in Person and Family sections of a form. Currently only Multi sections are supported
- [ ] auto-save the form before an action is run so you don't have to close and re-open a form
- [ ] check the text is localisable.
- [ ] allow an column's action to be run for all rows in the form section
- [ ] make example action robust: don't create duplicate events. 
- [ ] consider running an action for all rows in a form
- [ ] consider running all actions
- [ ] consider automatically running an action when a form is first saved
and much much more

I'm no Gramps, Gtk or Python expert so I'm sure the code can be improved - all ideas and comments welcome. In particular
- I'm not happy with the way I have action_callbacks in each class.
- Have I missed any steps when creating the Occupation event (see XML file)?
- The command implementation is tightly bound to the implementation of EditForm. Maximum flexibility now, but a problem for the future?
- Is EditForm the best place to exec() the command from?

Ideas for actions
- Add name citations
- Create Birth events from a census form Age column. Method varies by form. e.g. UK1841 rounds down ages for those over 15 so the Birth event date would be, for example, "between 1821 and 1826"
- Create a shared residence event from a census form "household"
- Create or extend a family from a birth certificate form