### PR TITLE
Fix Forms Gramplet to allow forms to be retrieved when language changes

### DIFF
--- a/Form/form.py
+++ b/Form/form.py
@@ -61,6 +61,8 @@ ORDER_ATTR = _('Order')
 
 # The key of the data item in a source to define it as a form source.
 DEFINITION_KEY = _('Form')
+# the following should be all the translations of "Form" in our po files
+INTL_FORM = {"Form", "Formular", "Formulaire", "Obrazac", "Форма"}
 
 # Prefixes for family attributes.
 GROOM = _('Groom')
@@ -269,7 +271,7 @@ def get_form_id(source):
     Return the form id attached to the given source.
     """
     for attr in source.get_attribute_list():
-        if str(attr.get_type()) == DEFINITION_KEY:
+        if str(attr.get_type()) in INTL_FORM:
             return attr.get_value()
     return None
 


### PR DESCRIPTION
Fixes #11504

The Forms Gramplet identifies forms by looking at the custom 'Form" attribute on the Source.  Since this is a custom attribute, it never gets translated when storing in the db/xml.  So when you open Gramps in a different language, the comparison to the localized "Form" fails.

The right way to fix this is to add "Form" as a standard AttributeType, so it would be localized in all supported languages.  But that won't happen quickly.  In the meantime, I have made the comparison to all the current languages that Forms supports.  It looks like it works for me.