### PR TITLE
Dutch translation for addons AncestorFill and MediaReport

### DIFF
--- a/AncestorFill/po/nl-local.po
+++ b/AncestorFill/po/nl-local.po
@@ -1,0 +1,132 @@
+# Dutch translation of Gramps addon AncestorFill.
+# Copyright (C) 2020 Gramps Project.
+# This file is distributed under the same license as the AncestorFill package.
+# Jan Sparreboom <jan@sparreboom.net>, 2020.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Gramps 5.1.x\n"
+"Report-Msgid-Bugs-To: https://www.gramps-project.org/bugs\n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: 2020-03-15 22:06+0100\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
+"Language-Team: Dutch <gramps-users@lists.sourceforge.net>\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.3\n"
+
+#: AncestorFill/AncestorFill.gpr.py:8
+msgid "AncestorFill"
+msgstr "Vooroudertelling"
+
+#: AncestorFill/AncestorFill.gpr.py:9
+msgid "Report on the filling of the tree"
+msgstr "Verslag van de bezetting van de stamboom"
+
+#: AncestorFill/AncestorFill.py:105
+#, python-format
+msgid "Person %s is not in the Database"
+msgstr "Persoon %s is niet in de Database opgenomen"
+
+#: AncestorFill/AncestorFill.py:190
+#, python-format
+msgid "AncestorFill for %s"
+msgstr "Vooroudertelling voor %s"
+
+#: AncestorFill/AncestorFill.py:206
+msgid "Generation "
+msgstr "Generatie "
+
+#: AncestorFill/AncestorFill.py:207
+msgid "Number of Ancestors found "
+msgstr "Aantal gevonden voorouders "
+
+#: AncestorFill/AncestorFill.py:208
+msgid "percent of Ancestors found "
+msgstr "Percentage gevonden voorouders "
+
+#: AncestorFill/AncestorFill.py:209
+msgid "Number of single Ancestors found "
+msgstr "Aantal gevonden individuele voorouders "
+
+#: AncestorFill/AncestorFill.py:210
+msgid "Number of theoretical Ancestors "
+msgstr "Aantal theoretische voorouders "
+
+#: AncestorFill/AncestorFill.py:211
+msgid "Pedigree Collapse "
+msgstr "Kwartierherhaling "
+
+#: AncestorFill/AncestorFill.py:254
+msgid "Total Number of Ancestors found "
+msgstr "Totaal aantal gevonden voorouders "
+
+#: AncestorFill/AncestorFill.py:256
+msgid "Total Number of single Ancestors found "
+msgstr "Totaal aantal gevonden individuele voorouders "
+
+#: AncestorFill/AncestorFill.py:293
+msgid "Report Options"
+msgstr "Rapport opties"
+
+#: AncestorFill/AncestorFill.py:295
+msgid "Center Person"
+msgstr "Hoofdpersoon"
+
+#: AncestorFill/AncestorFill.py:296
+msgid "The center person for the report"
+msgstr "De hoofdpersoon voor het rapport"
+
+#: AncestorFill/AncestorFill.py:299
+msgid "Generations"
+msgstr "Generaties"
+
+#: AncestorFill/AncestorFill.py:300
+msgid "The number of generations to include in the report"
+msgstr "Het aantal generaties dat in het rapport moet worden opgenomen"
+
+#: AncestorFill/AncestorFill.py:303
+msgid "Filled digit"
+msgstr "Aantal decimalen"
+
+#: AncestorFill/AncestorFill.py:304
+msgid ""
+"The number of digits after comma to include in the report for the percentage of "
+"ancestor found at a given generation"
+msgstr ""
+"Het aantal cijfers na de komma dat in het rapport moet worden opgenomen voor het "
+"percentage voorouders dat bij een bepaalde generatie is gevonden"
+
+#: AncestorFill/AncestorFill.py:307
+msgid "Collapsed digit"
+msgstr "Aantal decimalen Kwartierherhaling"
+
+#: AncestorFill/AncestorFill.py:308
+msgid ""
+"The number of digits after comma to include in the report for the pedigree "
+"Collapse"
+msgstr ""
+"Het aantal cijfers na de komma dat in het rapport moet worden opgenomen voor de "
+"Kwartierherhaling"
+
+#: AncestorFill/AncestorFill.py:311
+msgid "Display theoretical"
+msgstr "Theoretische weergave"
+
+#: AncestorFill/AncestorFill.py:312
+msgid "Whether to display the theoretical number of ancestor by generation"
+msgstr "Of het theoretische aantal voorouders per generatie moet worden weergegeven"
+
+#: AncestorFill/AncestorFill.py:360
+msgid "The style used for the title of the page."
+msgstr "De stijl die wordt gebruikt voor de titel van de pagina."
+
+#: AncestorFill/AncestorFill.py:373
+msgid "The style used for the generation header."
+msgstr "De stijl die wordt gebruikt voor het generatiebovenschrift."
+
+#: AncestorFill/AncestorFill.py:383
+msgid "The basic style used for the text display."
+msgstr "De basisstijl die wordt gebruikt voor de tekstweergave."

--- a/MediaReport/media_report.py
+++ b/MediaReport/media_report.py
@@ -41,9 +41,23 @@ from gramps.gen.plug.menu import (MediaOption, NoteOption, BooleanOption,
 from gramps.gen.plug.docgen import (ParagraphStyle, FontStyle, TableStyle,
                                     TableCellStyle, PARA_ALIGN_CENTER,
                                     PARA_ALIGN_LEFT)
-from gramps.gen.const import GRAMPS_LOCALE as glocale
-_ = glocale.translation.gettext
 
+# Old:
+#from gramps.gen.const import GRAMPS_LOCALE as glocale
+#_ = glocale.translation.gettext
+
+# New:
+#------------------------------------------------------------------------
+#
+# Internationalisation
+#
+#------------------------------------------------------------------------
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+try:
+    _trans = glocale.get_addon_translator(__file__)
+except ValueError:
+    _trans = glocale.translation
+_ = _trans.gettext
 
 # ----------------------------------------------------------------------------
 #

--- a/MediaReport/po/nl-local.po
+++ b/MediaReport/po/nl-local.po
@@ -1,0 +1,141 @@
+# Dutch translation of Gramps addon MediaReport
+# Copyright (C) 2020 Gramps Project.
+# This file is distributed under the same license as the MediaReport package.
+# Jan Sparreboom <jan@sparreboom.net>, 2020.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Gramps 5.1.x\n"
+"Report-Msgid-Bugs-To: https://www.gramps-project.org/bugs\n"
+"POT-Creation-Date: 2019-11-27 10:32-0600\n"
+"PO-Revision-Date: 2020-03-10 21:34+0100\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
+"Language-Team: Dutch <gramps-users@lists.sourceforge.net>\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.3\n"
+
+#: MediaReport/media_report.gpr.py:23
+msgid "Media Report"
+msgstr "Media Rapport"
+
+#: MediaReport/media_report.gpr.py:24
+msgid "Generates report including images, image data and notes."
+msgstr "Genereert rapport inclusief afbeeldingen, afbeeldingsgegevens en notities."
+
+#: MediaReport/media_report.py:92 MediaReport/media_report.py:98
+#: MediaReport/media_report.py:105 MediaReport/media_report.py:111
+msgid "INFO"
+msgstr "INFO"
+
+#: MediaReport/media_report.py:92 MediaReport/media_report.py:105
+msgid "You have to select an image to generate this report."
+msgstr "U moet een afbeelding selecteren om dit rapport te genereren."
+
+#: MediaReport/media_report.py:98
+msgid ""
+"You have to select a custom note or uncheck the option 'include custom note' to generate "
+"this report."
+msgstr ""
+"U moet een aangepaste notitie selecteren of de optie 'aangepaste notitie opnemen' "
+"uitschakelen om dit rapport te genereren."
+
+#: MediaReport/media_report.py:111
+msgid "This report only supports PDF as output file format."
+msgstr "Dit rapport ondersteunt alleen PDF als uitvoerbestandsindeling."
+
+#: MediaReport/media_report.py:215
+msgid "General:"
+msgstr "Algemeen:"
+
+#: MediaReport/media_report.py:221
+msgid "Description:"
+msgstr "Beschrijving:"
+
+#: MediaReport/media_report.py:236
+msgid "Image type:"
+msgstr "Afbeeldingstype:"
+
+#: MediaReport/media_report.py:328
+msgid "File does not exist"
+msgstr "Bestand bestaat niet"
+
+#: MediaReport/media_report.py:329
+msgid "Could not add photo to page"
+msgstr "Kan foto niet toevoegen aan pagina"
+
+#: MediaReport/media_report.py:330
+#, python-format
+msgid "%(str1)s: %(str2)s"
+msgstr "%(str1)s: %(str2)s"
+
+#: MediaReport/media_report.py:412
+msgid "Heading"
+msgstr "Titel"
+
+#: MediaReport/media_report.py:413 MediaReport/media_report.py:417
+#: MediaReport/media_report.py:421 MediaReport/media_report.py:425
+#: MediaReport/media_report.py:430 MediaReport/media_report.py:434
+#: MediaReport/media_report.py:439 MediaReport/media_report.py:444
+msgid "Report Options"
+msgstr "Rapport opties"
+
+#: MediaReport/media_report.py:415
+msgid "Media"
+msgstr "Media"
+
+#: MediaReport/media_report.py:416
+msgid "Select a media file for this report"
+msgstr "Selecteer een mediabestand voor dit rapport"
+
+#: MediaReport/media_report.py:419
+msgid "Custom note"
+msgstr "Aangepaste notitie"
+
+#: MediaReport/media_report.py:420
+msgid "Select a note for this report"
+msgstr "Selecteer een opmerking voor dit rapport"
+
+#: MediaReport/media_report.py:423
+msgid "Include custom note"
+msgstr "Aangepaste opmerking opnemen"
+
+#: MediaReport/media_report.py:424
+msgid "The custom note will be included"
+msgstr "De aangepaste opmerking wordt opgenomen"
+
+#: MediaReport/media_report.py:428
+msgid "Include referenced people"
+msgstr "Mensen opnemen waarnaar verwezen wordt"
+
+#: MediaReport/media_report.py:429
+msgid "Referenced people will be included"
+msgstr "Mensen waarnaar wordt verwezen, worden opgenomen"
+
+#: MediaReport/media_report.py:432
+msgid "Include media data"
+msgstr "Neem mediagegevens op"
+
+#: MediaReport/media_report.py:433
+msgid "Tags, notes and attributes will be included"
+msgstr "Tags, notities en attributen worden opgenomen"
+
+#: MediaReport/media_report.py:436
+msgid "Media width"
+msgstr "Media breedte"
+
+#: MediaReport/media_report.py:437
+#, python-format
+msgid "Maximum media width in % of available page width."
+msgstr "Maximale mediabreedte in % van de beschikbare paginabreedte."
+
+#: MediaReport/media_report.py:441
+msgid "Media height"
+msgstr "Media hoogte"
+
+#: MediaReport/media_report.py:442
+#, python-format
+msgid "Maximum media height in % of available page height."
+msgstr "Maximale mediahoogte in % van de beschikbare paginahoogte."


### PR DESCRIPTION
Hi team,

Unfortunately I made two commits in one branch, so now I have translations for two different addons. Sorry, I'm a beginner with Git/Github...

1] for MediaReport addon I had to modify media_report.py to get internationalization working. So you find nl-local.po with Dutch translation and a modified media_report.py.

2] for AncestorFill addon I've included nl-local.py file with Dutch translation.Though the translation works fine within Gramps I found that the generated reports unfortunately are not translated.

Please, add these changes into Gramps.
Thanks in advance!!

Kind regards,
Jan Sparreboom
