### PR TITLE
New ActivePersonRule

### DIFF
--- a/FilterRules/activepersonrule.gpr.py
+++ b/FilterRules/activepersonrule.gpr.py
@@ -1,0 +1,36 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2020       Paul Culley
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Filter rule to match an active Person.
+"""
+register(RULE,
+  id    = 'ActivePerson',
+  name  = _("The active Person"),
+  description = _("The active Person"),
+  version = '0.0.1',
+  authors = ["Paul Culley"],
+  authors_email = ["paulr2787@gmail.com"],
+  gramps_target_version = '5.1',
+  status = STABLE,
+  fname = "activepersonrule.py",
+  ruleclass = 'IsActivePerson',  # must be rule class name
+  namespace = 'Person',  # one of the primary object classes
+  )

--- a/FilterRules/activepersonrule.py
+++ b/FilterRules/activepersonrule.py
@@ -1,0 +1,60 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2020  Paul Culley
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+#-------------------------------------------------------------------------
+#
+# Standard Python modules
+#
+#-------------------------------------------------------------------------
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+_ = glocale.translation.gettext
+
+#-------------------------------------------------------------------------
+#
+# Gramps modules
+#
+#-------------------------------------------------------------------------
+from gramps.gen.filters.rules import Rule
+
+
+#-------------------------------------------------------------------------
+#
+# IsActivePerson
+#
+#-------------------------------------------------------------------------
+class IsActivePerson(Rule):
+    """Rule that checks for tha active person in the database"""
+
+    name = _('Active person')
+    category = _('General filters')
+    description = _("Matches the active person")
+
+    def prepare(self, db, user):
+        self.pers_hndl = None
+        if user.uistate:
+            self.pers_hndl = user.uistate.get_active('Person')
+            if self.pers_hndl:
+                self.apply = self.apply_real
+                return
+        self.apply = lambda db, p: False
+        user.warn("No active Person")
+
+    def apply_real(self, db, person):
+        return person.handle == self.pers_hndl


### PR DESCRIPTION
This rule allows the user to create reports with a filter that includes the active person.  The filter will generate a warning (when run with no active person or from CLI).
