### PR TITLE
[AssociationsTool]: Dutch translation

### DIFF
--- a/AssociationsTool/po/nl-local.po
+++ b/AssociationsTool/po/nl-local.po
@@ -1,0 +1,46 @@
+# Dutch translation of Gramps addon AssociationsTool
+# Copyright (C) 2020 Gramps project
+# This file is distributed under the same license as the AssociationsTool package.
+# Jan Sparreboom <jan@sparreboom.net>, 2020.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: AssociationsTool 5.1.x\n"
+"Report-Msgid-Bugs-To: https://www.gramps-project.org/bugs\n"
+"POT-Creation-Date: 2019-09-21 10:45+1000\n"
+"PO-Revision-Date: 2020-04-15 13:00+0200\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
+"Language-Team: Dutch <gramps-users@lists.sourceforge.net>\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.0.6\n"
+
+#: AssociationsTool/associationstool.gpr.py:35
+msgid "Check Associations data"
+msgstr "Controleer associatiegegevens"
+
+#: AssociationsTool/associationstool.gpr.py:36
+msgid "Will check the data on Association for people."
+msgstr "Controleert de associatiegegevens voor mensen."
+
+#: AssociationsTool/associationstool.py:53
+msgid "Associations state tool"
+msgstr "Associatiegegevens status tool"
+
+#: AssociationsTool/associationstool.py:80
+msgid "Name"
+msgstr "Naam"
+
+#: AssociationsTool/associationstool.py:81
+msgid "Type of link"
+msgstr "Soort link"
+
+#: AssociationsTool/associationstool.py:82
+msgid "Of"
+msgstr "Van"
+
+#: AssociationsTool/associationstool.py:83
+msgid "Relationship Calculator"
+msgstr "Relatiecalculator"


### PR DESCRIPTION
Please, add Dutch translation of addon AssociationsTool.
It's tested in Gramps 5.1.2 without issues.
Thanks in advance.