### PR TITLE
[BiographyQuickview]: Dutch translation and add internationalization

### DIFF
--- a/BiographyQuickview/BiographyQuickview.py
+++ b/BiographyQuickview/BiographyQuickview.py
@@ -22,6 +22,19 @@
 Display text summary of person events with sources
 """
 
+#------------------------------------------------------------------------
+#
+# Internationalisation
+#
+#------------------------------------------------------------------------
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+try:
+    trans = glocale.get_addon_translator(__file__)
+except ValueError:
+    trans = glocale.translation
+_ = trans.gettext
+ngettext = trans.ngettext
+
 from gramps.gen.simple import SimpleAccess, SimpleDoc
 from gramps.plugins.lib.libnarrate import Narrator
 
@@ -32,7 +45,7 @@ def run(database, document, person):
     """
     sa = SimpleAccess(database)
     sd = SimpleDoc(document)
-    sd.title("Biography for %s" % sa.name(person))
+    sd.title(_("Biography for %s") % sa.name(person))
     sd.paragraph('')
 
     narrator = Narrator(database, verbose=True,
@@ -76,7 +89,7 @@ def run(database, document, person):
     sd.paragraph('')
 
     # Sources
-    sd.header1('Sources')
+    sd.header1(_('Sources'))
     for source in get_sources(database, person):
         sd.paragraph(source)
 

--- a/BiographyQuickview/po/nl-local.po
+++ b/BiographyQuickview/po/nl-local.po
@@ -1,0 +1,35 @@
+# Dutch translation of Gramps addon BiographyQuickview.
+# Copyright (C) 2020 Gramps project
+# This file is distributed under the same license as the BiographyQuickview package.
+# Jan Sparreboom <jan@sparreboom.net>, 2020.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Gramps 5.1.x\n"
+"Report-Msgid-Bugs-To: https://www.gramps-project.org/bugs\n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: 2020-04-13 23:17+0200\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
+"Language-Team: Dutch <gramps-users@lists.sourceforge.net>\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.0.6\n"
+
+#: BiographyQuickview/BiographyQuickview.gpr.py:9
+msgid "Biography"
+msgstr "Biografie"
+
+#: BiographyQuickview/BiographyQuickview.gpr.py:10
+msgid "Display a text biography"
+msgstr "Geef een tekstbiografie weer"
+
+#: BiographyQuickview.py:47
+#, python-format
+msgid "Biography for %s"
+msgstr "Biografie voor %s"
+
+#: BiographyQuickview.py:92
+msgid "Sources"
+msgstr "Bronnen"

--- a/BiographyQuickview/po/template.pot
+++ b/BiographyQuickview/po/template.pot
@@ -24,3 +24,12 @@ msgstr ""
 #: BiographyQuickview/BiographyQuickview.gpr.py:10
 msgid "Display a text biography"
 msgstr ""
+
+#: BiographyQuickview.py:47
+#, python-format
+msgid "Biography for %s"
+msgstr ""
+
+#: BiographyQuickview.py:92
+msgid "Sources"
+msgstr ""


### PR DESCRIPTION
Please, add Dutch translation of addon BiographyQuickview.
It's tested in Gramps 5.1.2 without issues.
Thanks in advance.

Localisation was not implemented.
Added:
Line 25:
#------------------------------------------------------------------------
#
# Internationalization
#
#------------------------------------------------------------------------
from gramps.gen.const import GRAMPS_LOCALE as glocale
try:
    trans = glocale.get_addon_translator(__file__)
except ValueError:
    trans = glocale.translation
_ = trans.gettext
ngettext = trans.ngettext

Modified line 48:
sd.title(_("Biography for %s") % sa.name(person))

Modified line 92:
sd.header1(_('Sources'))

Created new pot-file.