### PR TITLE
[BirthdaysGramplet]: Dutch translation

### DIFF
--- a/BirthdaysGramplet/po/nl-local.po
+++ b/BirthdaysGramplet/po/nl-local.po
@@ -1,70 +1,45 @@
-# translation of nl.po to nederlands
-# Dutch translation of GRAMPS
-# Copyright (C) 2003 The Free Software Foundation,  Inc.
-#
+# Dutch translation of Gramps addon BirthdaysGramplet
+# Copyright (C) 2020 Gramps project
+# This file is distributed under the same license as the BirthdaysGramplet package.
 # Tino Meinen <a.t.meinen@chello.nl>, 2003, 2004, 2005.
 # Kees Bakker <kees.bakker@xs4all.nl>, 2005, 2006, 2007.
 # Erik De Richter <frederik.de.richter@pandora.be>, 2006, 2007, 2008, 2009, 2010.
 #
-# --------------------------------------------------
-# Conventies (kan later altijd nog aangepast worden)
-# --------------------------------------------------
-# active             actief (moet hier nog iets beters voor verzinnen)
-# attribute          kenmerk
-# bookmark           bladwijzer
-# view               scherm
-# city               plaats beter is stad dorp
-# marker             aanduiding
-# people             personen
-# place              locatie
-# record             archief/kaart
-# database           gegevensbestand (KB)
-# chart              grafiek
-# Home person        beginpersoon : (EDR)
-# spouse             echtgenoot
-# partner            partner
-# warning            let op
-# at the age of      op een leeftijd van -> toen hij/zij .. oud was
-# repositories       bibliotheken
-# regex              regex onvertaald laten
-# expression         uitdrukking
-# given name         voornaam
-# reference	     waarnaar verwezen wordt
-# count		     aantal maal
-# lineage	     lijn
-# locality	     plaats
-# u gebruiken
-# telkens werkwoord achteraan plaatsen
 msgid ""
 msgstr ""
-"Project-Id-Version: gramps\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2011-04-09 19:53+0200\n"
-"PO-Revision-Date: 2011-04-08 08:19+0100\n"
-"Last-Translator: Erik De Richter <frederik.de.richter@googlemail.com>\n"
-"Language-Team: nederlands <frederik.de.richter@googlemail.com>\n"
-"Language: \n"
+"Project-Id-Version: BirthdaysGramplet 5.1.x\n"
+"Report-Msgid-Bugs-To: https://www.gramps-project.org/bugs\n"
+"POT-Creation-Date: 2019-10-21 08:49+1100\n"
+"PO-Revision-Date: 2020-04-29 18:39+0200\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
+"Language-Team: Dutch <gramps-users@lists.sourceforge.net>\n"
+"Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Poedit-Language: Nederlands\n"
-"X-Poedit-Country: België\n"
+"X-Generator: Poedit 2.0.6\n"
 
-#: BirthdaysGramplet/BirthdaysGramplet.gpr.py:4
-#: BirthdaysGramplet/BirthdaysGramplet.gpr.py:12
-msgid "Birthdays Gramplet"
-msgstr "Verjaardagsgramplet"
+#: BirthdaysGramplet/BirthdaysGramplet.gpr.py:24
+#: BirthdaysGramplet/BirthdaysGramplet.gpr.py:32
+msgid "Birthdays"
+msgstr "Verjaardagen"
 
-#: BirthdaysGramplet/BirthdaysGramplet.gpr.py:5
+#: BirthdaysGramplet/BirthdaysGramplet.gpr.py:25
 msgid "a gramplet that displays the birthdays of the living people"
-msgstr ""
-"een gramplet dat de verjaardagen van de nog in leven zijnde personen toont"
+msgstr "een gramplet dat de verjaardagen van de nog in leven zijnde personen toont"
 
-#: BirthdaysGramplet/BirthdaysGramplet.py:36
+#: BirthdaysGramplet/BirthdaysGramplet.py:38
 msgid "No Family Tree loaded."
 msgstr "Geen familiestamboom geladen."
 
-#: BirthdaysGramplet/BirthdaysGramplet.py:49
+#: BirthdaysGramplet/BirthdaysGramplet.py:45
+msgid "Ignore birthdays with tag"
+msgstr "Negeer verjaardagen met tag"
+
+#: BirthdaysGramplet/BirthdaysGramplet.py:46
+msgid "Only show birthdays with tag"
+msgstr "Toon alleen verjaardagen met tag"
+
+#: BirthdaysGramplet/BirthdaysGramplet.py:90
 msgid "Processing..."
 msgstr "Wordt verwerkt..."


### PR DESCRIPTION
Please, add Dutch translation of addon BirthdaysGramplet.
It's tested in Gramps 5.1.2, with one minor issue which has nothing to do with the translation itself.
Thanks in advance.

Issue:
The translation is only activated after the gramplet has been removed and then added again.
Simply restarting Gramps was not enough.
But