### PR TITLE
[ClipboardGramplet]: Dutch translation

### DIFF
--- a/ClipboardGramplet/po/nl-local.po
+++ b/ClipboardGramplet/po/nl-local.po
@@ -1,71 +1,37 @@
-# translation of nl.po to nederlands
-# Dutch translation of GRAMPS
-# Copyright (C) 2003 The Free Software Foundation,  Inc.
+# Dutch translation of Gramps addon ClipboardGramplet
+# Copyright (C) 2020 Gramps project
+# This file is distributed under the same license as the ClipboardGramplet package.
 #
 # Tino Meinen <a.t.meinen@chello.nl>, 2003, 2004, 2005.
 # Kees Bakker <kees.bakker@xs4all.nl>, 2005, 2006, 2007.
 # Erik De Richter <frederik.de.richter@pandora.be>, 2006, 2007, 2008, 2009, 2010.
 #
-# --------------------------------------------------
-# Conventies (kan later altijd nog aangepast worden)
-# --------------------------------------------------
-# active             actief (moet hier nog iets beters voor verzinnen)
-# attribute          kenmerk
-# bookmark           bladwijzer
-# view               scherm
-# city               plaats beter is stad dorp
-# marker             aanduiding
-# people             personen
-# place              locatie
-# record             archief/kaart
-# database           gegevensbestand (KB)
-# chart              grafiek
-# Home person        beginpersoon : (EDR)
-# spouse             echtgenoot
-# partner            partner
-# warning            let op
-# at the age of      op een leeftijd van -> toen hij/zij .. oud was
-# repositories       bibliotheken
-# regex              regex onvertaald laten
-# expression         uitdrukking
-# given name         voornaam
-# reference	     waarnaar verwezen wordt
-# count		     aantal maal
-# lineage	     lijn
-# locality	     plaats
-# u gebruiken
-# telkens werkwoord achteraan plaatsen
 msgid ""
 msgstr ""
-"Project-Id-Version: gramps\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2011-04-09 20:03+0200\n"
-"PO-Revision-Date: 2011-04-08 08:19+0100\n"
-"Last-Translator: Erik De Richter <frederik.de.richter@googlemail.com>\n"
-"Language-Team: nederlands <frederik.de.richter@googlemail.com>\n"
-"Language: \n"
+"Project-Id-Version: ClipboardGramplet 5.1.x\n"
+"Report-Msgid-Bugs-To: https://www.gramps-project.org/bugs\n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: 2020-05-02 22:33+0200\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
+"Language-Team: Dutch <gramps-users@lists.sourceforge.net>\n"
+"Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Poedit-Language: Nederlands\n"
-"X-Poedit-Country: België\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #: ClipboardGramplet/ClipboardGramplet.gpr.py:9
-msgid "Clipboard Gramplet"
-msgstr "Klembordgramplet"
+#: ClipboardGramplet/ClipboardGramplet.gpr.py:17
+msgid "Collections Clipboard"
+msgstr "Klembord collecties"
 
 #: ClipboardGramplet/ClipboardGramplet.gpr.py:10
-msgid "Gramplet for grouping items"
-msgstr "Gramplet om gegevens te groeperen"
+msgid "Gramplet for grouping collections of items to aid in data entry."
+msgstr ""
+"Gramplet voor het groeperen van verzamelingen items om te helpen bij "
+"het invoeren van gegevens."
 
-# zie ook uncleared.
-# is dit goed?
-#: ClipboardGramplet/ClipboardGramplet.gpr.py:17
-msgid "Clipboard"
-msgstr "Klembord"
-
-#: ClipboardGramplet/ClipboardGramplet.py:93
+#: ClipboardGramplet/ClipboardGramplet.py:83
 #, python-format
 msgid "Clipboard Gramplet: %s"
 msgstr "Klembordgramplet: %s"


### PR DESCRIPTION
Please, replace Dutch translation of addon ClipboardGramplet.
It's tested in Gramps 5.1.2 without issues.
Thanks in advance.