### PR TITLE
[ClockGramplet]: Dutch translation

### DIFF
--- a/ClockGramplet/po/nl-local.po
+++ b/ClockGramplet/po/nl-local.po
@@ -1,6 +1,6 @@
 # Dutch translation of Gramps addon ClockGramplet
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
+# Copyright (C) 2020 Gramps project
+# This file is distributed under the same license as the ClockGramplet package.
 #
 # Tino Meinen <a.t.meinen@chello.nl>, 2003, 2004, 2005.
 # Kees Bakker <kees.bakker@xs4all.nl>, 2005, 2006, 2007.

--- a/ClockGramplet/po/nl-local.po
+++ b/ClockGramplet/po/nl-local.po
@@ -1,64 +1,29 @@
-# translation of nl.po to nederlands
-# Dutch translation of GRAMPS
-# Copyright (C) 2003 The Free Software Foundation,  Inc.
+# Dutch translation of Gramps addon ClockGramplet
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
 #
 # Tino Meinen <a.t.meinen@chello.nl>, 2003, 2004, 2005.
 # Kees Bakker <kees.bakker@xs4all.nl>, 2005, 2006, 2007.
 # Erik De Richter <frederik.de.richter@pandora.be>, 2006, 2007, 2008, 2009, 2010.
 #
-# --------------------------------------------------
-# Conventies (kan later altijd nog aangepast worden)
-# --------------------------------------------------
-# active             actief (moet hier nog iets beters voor verzinnen)
-# attribute          kenmerk
-# bookmark           bladwijzer
-# view               scherm
-# city               plaats beter is stad dorp
-# marker             aanduiding
-# people             personen
-# place              locatie
-# record             archief/kaart
-# database           gegevensbestand (KB)
-# chart              grafiek
-# Home person        beginpersoon : (EDR)
-# spouse             echtgenoot
-# partner            partner
-# warning            let op
-# at the age of      op een leeftijd van -> toen hij/zij .. oud was
-# repositories       bibliotheken
-# regex              regex onvertaald laten
-# expression         uitdrukking
-# given name         voornaam
-# reference	     waarnaar verwezen wordt
-# count		     aantal maal
-# lineage	     lijn
-# locality	     plaats
-# u gebruiken
-# telkens werkwoord achteraan plaatsen
 msgid ""
 msgstr ""
-"Project-Id-Version: gramps\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2011-04-10 08:50+0200\n"
-"PO-Revision-Date: 2011-04-08 08:19+0100\n"
-"Last-Translator: Erik De Richter <frederik.de.richter@googlemail.com>\n"
-"Language-Team: nederlands <frederik.de.richter@googlemail.com>\n"
-"Language: \n"
+"Project-Id-Version: Gramps 5.1.x\n"
+"Report-Msgid-Bugs-To: https://www.gramps-project.org/bugs\n"
+"POT-Creation-Date: 2019-10-21 08:49+1100\n"
+"PO-Revision-Date: 2020-05-02 22:56+0200\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
+"Language-Team: Dutch <gramps-users@lists.sourceforge.net>\n"
+"Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Poedit-Language: Nederlands\n"
-"X-Poedit-Country: België\n"
+"X-Generator: Poedit 2.0.6\n"
 
-#: ClockGramplet/ClockGramplet.gpr.py:3
-msgid "Clock Gramplet"
-msgstr "Klokgramplet"
+#: ClockGramplet/ClockGramplet.gpr.py:3 ClockGramplet/ClockGramplet.gpr.py:8
+msgid "Clock"
+msgstr "Klok"
 
 #: ClockGramplet/ClockGramplet.gpr.py:4
 msgid "Gramplet for demonstrating Cairo graphics"
-msgstr "Gramplet om de grafische mogelijkheden van 'Cairo' te tonen"
-
-#: ClockGramplet/ClockGramplet.gpr.py:8
-msgid "Clock"
-msgstr "Klok"
+msgstr "Gramplet voor het demonstreren van Cairo graphics"


### PR DESCRIPTION
Please, replace Dutch translation of addon ClockGramplet.
It's tested in Gramps 5.1.2 without issues.
Thanks in advance.