### PR TITLE
[Themes] Dutch translation

### DIFF
--- a/Themes/po/nl-local.po
+++ b/Themes/po/nl-local.po
@@ -1,0 +1,71 @@
+# Dutch translation of addon Themes
+# Copyright (C) 2020 Gramps project
+# This file is distributed under the same license as the Themes package.
+# Jan Sparreboom <jan@sparreboom.net>, 2020.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Themes 5.1.x\n"
+"Report-Msgid-Bugs-To: https://www.gramps-project.org/bugs\n"
+"POT-Creation-Date: 2019-07-08 16:30-0500\n"
+"PO-Revision-Date: 2020-07-01 21:24+0200\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
+"Language-Team: Dutch <gramps-users@lists.sourceforge.net>\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.0.6\n"
+
+#: Themes/themes.gpr.py:28
+msgid "Theme preferences"
+msgstr "Thema-voorkeuren"
+
+#: Themes/themes.gpr.py:29
+msgid ""
+"An addition to Preferences for simple Theme and Font adjustment.  Especially "
+"useful for Windows users."
+msgstr ""
+"Een aanvulling op Voorkeuren voor eenvoudige aanpassing van thema en "
+"lettertype. Vooral handig voor Windows-gebruikers."
+
+#: Themes/themes.py:112
+msgid "_Help"
+msgstr "_Help"
+
+#: Themes/themes.py:156 Themes/themes.py:174
+msgid "Theme is hardcoded by GTK_THEME"
+msgstr "Thema is hard gecodeerd door GTK_THEME"
+
+#: Themes/themes.py:159 Themes/themes.py:182
+#, python-format
+msgid "%s: "
+msgstr "%s: "
+
+#: Themes/themes.py:159 Themes/themes.py:209
+msgid "Theme"
+msgstr "Thema"
+
+#: Themes/themes.py:164
+msgid "Dark Variant"
+msgstr "Donkere variant"
+
+#: Themes/themes.py:182
+msgid "Font"
+msgstr "Lettertype"
+
+#: Themes/themes.py:189
+msgid "_Toolbar"
+msgstr "_Werkbalk"
+
+#: Themes/themes.py:189
+msgid "Text"
+msgstr "Tekst"
+
+#: Themes/themes.py:198
+msgid "Fixed Scrollbar (requires restart)"
+msgstr "Vaste schuifbalk (opnieuw opstarten vereist)"
+
+#: Themes/themes.py:205
+msgid "Restore to defaults"
+msgstr "Herstel naar standaardinstellingen"

--- a/Themes/themes.py
+++ b/Themes/themes.py
@@ -38,9 +38,23 @@ from gramps.gui.configure import (GrampsPreferences, ConfigureDialog,
 from gramps.gui.display import display_help
 from gramps.gen.utils.alive import update_constants
 from gramps.gen.constfunc import win
-from gramps.gen.const import GRAMPS_LOCALE as glocale
-_ = glocale.translation.gettext
 
+# old
+# from gramps.gen.const import GRAMPS_LOCALE as glocale
+# _ = glocale.translation.gettext
+
+# New:
+#------------------------------------------------------------------------
+#
+# Internationalisation
+#
+#------------------------------------------------------------------------
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+try:
+    _trans = glocale.get_addon_translator(__file__)
+except ValueError:
+    _trans = glocale.translation
+_ = _trans.gettext
 
 #-------------------------------------------------------------------------
 #


### PR DESCRIPTION
Please,  add Dutch translation of addon Themes.
It has been tested in Gramps 5.1.2 after some issues with internationalisation part in themes.py.
See code changes below.

Thanks in advance!