### PR TITLE
[Deterministic ID] Dutch translation

### DIFF
--- a/DetId/po/nl-local.po
+++ b/DetId/po/nl-local.po
@@ -1,0 +1,34 @@
+# Dutch translation of addon DetId.
+# Copyright (C) 2020 Gramps project
+# This file is distributed under the same license as the PACKAGE package.
+# Jan Sparreboom <jan@sparreboom.net>, 2020.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: DetId 5.x\n"
+"Report-Msgid-Bugs-To: https://www.gramps-project.org/bugs\n"
+"POT-Creation-Date: 2019-01-04 18:55-0600\n"
+"PO-Revision-Date: 2020-07-15 19:34+0200\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
+"Language-Team: Dutch <gramps-users@lists.sourceforge.net>\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.3\n"
+
+#: DetId/DetId.gpr.py:30
+msgid "Deterministic ID"
+msgstr "Deterministisch ID"
+
+#: DetId/DetId.gpr.py:31
+msgid "Set/reset Gramps to use a Deterministic ID"
+msgstr "Stel / reset Gramps in om een deterministisch ID te gebruiken"
+
+#: DetId/DetId.py:74
+msgid "Deterministic ID Tool"
+msgstr "Deterministisch ID hulpmiddel"
+
+#: DetId/DetId.py:80
+msgid "The ID and handles now start at 0x00000000, and increment by 0x100000001"
+msgstr "Het ID en ingangen beginnen nu bij 0x00000000 en worden verhoogd met 0x100000001"


### PR DESCRIPTION
Dutch translation for addon Deterministic ID.
Tested without issues in Gramps 5.1.2 on Linux Mint 20.

Please, add it to this branch.
Thanks in advance!