### PR TITLE
[Differences] Addon update and new translations DE, FR, NL

### DIFF
--- a/Differences/differences.py
+++ b/Differences/differences.py
@@ -35,9 +35,7 @@ import os
 # GRAMPS modules
 #
 #------------------------------------------------------------------------
-#from gramps.gen.const import GRAMPS_LOCALE as glocale
-#_ = glocale.translation.gettext
-#ngettext = glocale.translation.ngettext
+#
 from gramps.gen.display.name import displayer as global_name_display
 from gramps.gen.plug.docgen import (FontStyle, ParagraphStyle, GraphicsStyle,
                              FONT_SERIF, PARA_ALIGN_RIGHT,

--- a/Differences/differences.py
+++ b/Differences/differences.py
@@ -35,9 +35,9 @@ import os
 # GRAMPS modules
 #
 #------------------------------------------------------------------------
-from gramps.gen.const import GRAMPS_LOCALE as glocale
-_ = glocale.translation.gettext
-ngettext = glocale.translation.ngettext
+#from gramps.gen.const import GRAMPS_LOCALE as glocale
+#_ = glocale.translation.gettext
+#ngettext = glocale.translation.ngettext
 from gramps.gen.display.name import displayer as global_name_display
 from gramps.gen.plug.docgen import (FontStyle, ParagraphStyle, GraphicsStyle,
                              FONT_SERIF, PARA_ALIGN_RIGHT,
@@ -51,6 +51,18 @@ from gramps.gen.merge.diff import diff_dbs, to_struct
 from gramps.gen.db.utils import import_as_dict
 from gramps.gen.simple import SimpleAccess
 from gramps.gen.config import config
+
+#------------------------------------------------------------------------
+#
+# Internationalisation
+#
+#------------------------------------------------------------------------
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+try:
+    _trans = glocale.get_addon_translator(__file__)
+except ValueError:
+    _trans = glocale.translation
+_ = _trans.gettext
 
 #------------------------------------------------------------------------
 #
@@ -82,7 +94,7 @@ class DifferencesReport(Report):
     def write_report(self):
         """ The short method that runs through each month and creates a page. """
         self.doc.start_paragraph('DIFF-Title')
-        self.doc.write_text("Database Differences Report")
+        self.doc.write_text(_("Database Differences Report"))
         self.doc.end_paragraph()
 
         self.doc.start_table('DiffTable','DIFF-Table2')
@@ -101,7 +113,7 @@ class DifferencesReport(Report):
         self.doc.start_row()
         self.doc.start_cell('DIFF-TableCellNoBorder')
         self.doc.start_paragraph('DIFF-TableHeading')
-        self.doc.write_text("File:")
+        self.doc.write_text(_("File:"))
         self.doc.end_paragraph()
         self.doc.end_cell()
         self.doc.start_cell('DIFF-TableCellNoBorder')
@@ -121,7 +133,7 @@ class DifferencesReport(Report):
         diffs, added, missing = diff_dbs(self.database, self.database2, self._user)
         if self.show_diff:
             self.doc.start_paragraph('DIFF-Heading')
-            self.doc.write_text("Differences between Database and File")
+            self.doc.write_text(_("Differences between Database and File"))
             self.doc.end_paragraph()
             last_object = None
             if diffs:
@@ -148,41 +160,41 @@ class DifferencesReport(Report):
                 self.doc.end_table()
             else:
                 self.doc.start_table('DiffTable','DIFF-Table3')
-                self.start_list(self.doc, "No differences", "", "")
+                self.start_list(self.doc, _("No differences"), "", "")
                 self.doc.end_table()
             self.doc.start_paragraph('DIFF-Heading')
             self.doc.write_text("")
             self.doc.end_paragraph()
         if self.show_missing:
             self.doc.start_paragraph('DIFF-Heading')
-            self.doc.write_text("Missing items in File that are added in Database")
+            self.doc.write_text(_("Missing items in File that are added in Database"))
             self.doc.end_paragraph()
             if missing:
                 for pair in missing:
                     obj_type, item = pair
                     self.doc.start_paragraph('DIFF-Text')
-                    self.doc.write_text("Missing %s: %s" % (obj_type, self.sa[0].describe(item)))
+                    self.doc.write_text(_("Missing %s: %s") % (obj_type, self.sa[0].describe(item)))
                     self.doc.end_paragraph()
             else:
                 self.doc.start_paragraph('DIFF-Text')
-                self.doc.write_text("Nothing missing")
+                self.doc.write_text(_("Nothing missing"))
                 self.doc.end_paragraph()
             self.doc.start_paragraph('DIFF-Heading')
             self.doc.write_text("")
             self.doc.end_paragraph()
         if self.show_added:
             self.doc.start_paragraph('DIFF-Heading')
-            self.doc.write_text("Added items in File that are missing in Database")
+            self.doc.write_text(_("Added items in File that are missing in Database"))
             self.doc.end_paragraph()
             if added:
                 for pair in added:
                     obj_type, item = pair
                     self.doc.start_paragraph('DIFF-Text')
-                    self.doc.write_text("Added %s: %s " % (obj_type, self.sa[1].describe(item)))
+                    self.doc.write_text(_("Added %s: %s ") % (obj_type, self.sa[1].describe(item)))
                     self.doc.end_paragraph()
             else:
                 self.doc.start_paragraph('DIFF-Text')
-                self.doc.write_text("Nothing added")
+                self.doc.write_text(_("Nothing added"))
                 self.doc.end_paragraph()
             self.doc.start_paragraph('DIFF-Heading')
             self.doc.write_text("")

--- a/Differences/po/de-local.po
+++ b/Differences/po/de-local.po
@@ -13,9 +13,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-04-21 23:23+0200\n"
+"POT-Creation-Date: 2020-07-17 17:41+0200\n"
 "PO-Revision-Date: 2013-09-21 14:55+0200\n"
-"Last-Translator: Mirko Leonhäuser <mirko@leonhaeuser.de>\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
 "Language-Team: German <kde-i18n-de@kde.org>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
@@ -24,7 +24,7 @@ msgstr ""
 "X-Generator: Lokalize 1.5\n"
 "Plural-Forms:  nplurals=2; plural=(n != 1);\n"
 
-#: Differences/differences.gpr.py:4
+#: Differences/differences.gpr.py:4 Differences/differences.py:97
 msgid "Database Differences Report"
 msgstr "Datenbankunterschiede Bericht"
 
@@ -32,63 +32,101 @@ msgstr "Datenbankunterschiede Bericht"
 msgid "Compares an external database with the current one."
 msgstr "Vergleicht eine externe Datenbank mit der aktuell geöffneten."
 
-#: Differences/differences.py:126
+#: Differences/differences.py:116
+msgid "File:"
+msgstr "Datei:"
+
+#: Differences/differences.py:136
+msgid "Differences between Database and File"
+msgstr "Unterschiede zwischen Datenbank und Datei"
+
+#: Differences/differences.py:140 Differences/differences_old.py:128
 msgid "Family Tree Differences"
 msgstr "Stammbaumunterschiede"
 
-#: Differences/differences.py:127
+#: Differences/differences.py:141 Differences/differences_old.py:129
 msgid "Processing..."
 msgstr "Verarbeitung..."
 
-#: Differences/differences.py:294
+#: Differences/differences.py:163
+msgid "No differences"
+msgstr "Keine Unterschiede"
+
+#: Differences/differences.py:170
+#, fuzzy
+msgid "Missing items in File that are added in Database"
+msgstr "Fehlende Elemente in der Datei, die in der Datenbank hinzugefügt wurden"
+
+#: Differences/differences.py:176
+#, python-format
+msgid "Missing %s: %s"
+msgstr "Fehlende %s: %s"
+
+#: Differences/differences.py:180
+msgid "Nothing missing"
+msgstr "Es fehlt nichts"
+
+#: Differences/differences.py:187
+msgid "Added items in File that are missing in Database"
+msgstr "Elemente in Datei hinzugefügt, die in der Datenbank fehlen"
+
+#: Differences/differences.py:193
+#, python-format
+msgid "Added %s: %s "
+msgstr "Hinzugefügt %s: %s "
+
+#: Differences/differences.py:197
+msgid "Nothing added"
+msgstr "Nichts hinzugefügt"
+
+#: Differences/differences.py:308 Differences/differences_old.py:296
 msgid "Report Options"
 msgstr "Berichtsoptionen"
 
-#: Differences/differences.py:295
+#: Differences/differences.py:310 Differences/differences_old.py:298
 msgid "Family Tree file"
 msgstr "Stammbaumdatei"
 
-#: Differences/differences.py:296
+#: Differences/differences.py:312 Differences/differences_old.py:300
 msgid "Select a .gpkg or .gramps file"
 msgstr "Eine .gpkg oder .gramps Datei wählen"
 
-#: Differences/differences.py:299
+#: Differences/differences.py:315 Differences/differences_old.py:303
 msgid "Show items that are different"
 msgstr "Zeige unterschiedliche Elemente"
 
-#: Differences/differences.py:300
+#: Differences/differences.py:316 Differences/differences_old.py:304
 msgid "Include items that are different"
 msgstr "Elemente die unterschiedlich sind aufnehmen"
 
-#: Differences/differences.py:303
+#: Differences/differences.py:319 Differences/differences_old.py:307
 msgid "Show items missing from file"
 msgstr "Zeige Elemente, die in der Datei fehlen"
 
-#: Differences/differences.py:304
+#: Differences/differences.py:320 Differences/differences_old.py:308
 msgid "Include items not in file but in database"
 msgstr ""
 "Elemente die sich nicht in der Datei aber in der Datenbank befinden aufnehmen"
 
-#: Differences/differences.py:307
+#: Differences/differences.py:323 Differences/differences_old.py:311
 msgid "Show items added in file"
 msgstr "Zeige Elemente, die in der Datei hinzugefügt wurden"
 
-#: Differences/differences.py:308
+#: Differences/differences.py:324 Differences/differences_old.py:312
 msgid "Include items in file but not in database"
 msgstr ""
 "Elemente die sich  in der Datei aber nicht in der Datenbank befinden "
 "aufnehmen"
 
-#: Differences/differences.py:353 Differences/differences.py:355
-#: Differences/differences.py:358 Differences/differences.py:361
+#: Differences/differences.py:369 Differences/differences.py:371
+#: Differences/differences.py:374 Differences/differences.py:377
+#: Differences/differences_old.py:357 Differences/differences_old.py:359
+#: Differences/differences_old.py:362 Differences/differences_old.py:365
 msgid "Text"
 msgstr "Text"
 
 #~ msgid "Differences Report"
 #~ msgstr "Unterschiedebericht"
-
-#~ msgid "Looking for differences..."
-#~ msgstr "Suche nach Unterschieden..."
 
 #~ msgid "Show deleted items"
 #~ msgstr "Zeige gelöschte Elemente"

--- a/Differences/po/fr-local.po
+++ b/Differences/po/fr-local.po
@@ -24,7 +24,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 4.0-beta1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-02-25 15:50+0100\n"
+"POT-Creation-Date: 2020-07-17 17:41+0200\n"
 "PO-Revision-Date: 2013-02-25 15:57+0100\n"
 "Last-Translator: \n"
 "Language-Team: French <traduc@traduc.org>\n"
@@ -35,7 +35,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Lokalize 1.4\n"
 
-#: Differences/differences.gpr.py:4
+#: Differences/differences.gpr.py:4 Differences/differences.py:97
 msgid "Database Differences Report"
 msgstr "Rapport des différences dans la base de données"
 
@@ -43,55 +43,102 @@ msgstr "Rapport des différences dans la base de données"
 msgid "Compares an external database with the current one."
 msgstr "Compare une base de données externe avec la base actuelle."
 
-#: Differences/differences.py:157
-msgid "Differences Report"
-msgstr "Rapport des différences"
+#: Differences/differences.py:116
+msgid "File:"
+msgstr "Fichier :"
+
+#: Differences/differences.py:136
+msgid "Differences between Database and File"
+msgstr "Différences entre la base de données et le fichier"
+
+#: Differences/differences.py:140 Differences/differences_old.py:128
+msgid "Family Tree Differences"
+msgstr "Différences de l'arbre généalogique"
+
+#: Differences/differences.py:141 Differences/differences_old.py:129
+msgid "Processing..."
+msgstr "En traitement..."
 
 # Substantif (GNOME fr)
-#: Differences/differences.py:158
-msgid "Looking for differences..."
-msgstr "Recherche des différences..."
+#: Differences/differences.py:163
+msgid "No differences"
+msgstr "Pas de différences"
 
-#: Differences/differences.py:272
+#: Differences/differences.py:170
+msgid "Missing items in File that are added in Database"
+msgstr "Éléments manquants dans le fichier qui sont ajoutés dans la base de données"
+
+#: Differences/differences.py:176
+#, python-format
+msgid "Missing %s: %s"
+msgstr "Disparu %s: %s"
+
+#: Differences/differences.py:180
+msgid "Nothing missing"
+msgstr "Rien ne manque"
+
+#: Differences/differences.py:187
+msgid "Added items in File that are missing in Database"
+msgstr "Ajout d'éléments dans le fichier qui manquent dans la base de données"
+
+#: Differences/differences.py:193
+#, python-format
+msgid "Added %s: %s "
+msgstr "Ajoutée %s: %s "
+
+#: Differences/differences.py:197
+msgid "Nothing added"
+msgstr "Rien ajouté"
+
+#: Differences/differences.py:308 Differences/differences_old.py:296
 msgid "Report Options"
 msgstr "Options du rapport"
 
-#: Differences/differences.py:273
+#: Differences/differences.py:310 Differences/differences_old.py:298
 msgid "Family Tree file"
 msgstr "Fichier arbre familial"
 
-#: Differences/differences.py:274
+#: Differences/differences.py:312 Differences/differences_old.py:300
 msgid "Select a .gpkg or .gramps file"
 msgstr "Sélectionner un fichier .gpkg ou .gramps"
 
-#: Differences/differences.py:277
+#: Differences/differences.py:315 Differences/differences_old.py:303
 msgid "Show items that are different"
 msgstr "Afficher les parties différentes"
 
-#: Differences/differences.py:278
+#: Differences/differences.py:316 Differences/differences_old.py:304
 msgid "Include items that are different"
 msgstr "Inclure les parties différentes"
 
-#: Differences/differences.py:281
-msgid "Show deleted items"
-msgstr "Afficher les parties supprimées"
+#: Differences/differences.py:319 Differences/differences_old.py:307
+msgid "Show items missing from file"
+msgstr "Afficher les éléments manquants dans le fichier"
 
-#: Differences/differences.py:282
+#: Differences/differences.py:320 Differences/differences_old.py:308
 msgid "Include items not in file but in database"
-msgstr "Inclure les parties non-présentes dans le fichier mais dans la base de données"
+msgstr ""
+"Inclure les parties non-présentes dans le fichier mais dans la base de "
+"données"
 
-#: Differences/differences.py:285
-msgid "Show added items"
-msgstr "Afficher les parties nouvelles"
+#: Differences/differences.py:323 Differences/differences_old.py:311
+msgid "Show items added in file"
+msgstr "Afficher les éléments ajoutés dans le fichier"
 
-#: Differences/differences.py:286
+#: Differences/differences.py:324 Differences/differences_old.py:312
 msgid "Include items in file but not in database"
-msgstr "Inclure les parties présentes dans le fichier mais absentes dans la base de données"
+msgstr ""
+"Inclure les parties présentes dans le fichier mais absentes dans la base de "
+"données"
 
-#: Differences/differences.py:331
-#: Differences/differences.py:333
-#: Differences/differences.py:336
-#: Differences/differences.py:339
+#: Differences/differences.py:369 Differences/differences.py:371
+#: Differences/differences.py:374 Differences/differences.py:377
+#: Differences/differences_old.py:357 Differences/differences_old.py:359
+#: Differences/differences_old.py:362 Differences/differences_old.py:365
 msgid "Text"
 msgstr "Texte"
 
+#~ msgid "Differences Report"
+#~ msgstr "Rapport des différences"
+
+#~ msgid "Show deleted items"
+#~ msgstr "Afficher les parties supprimées"

--- a/Differences/po/nl-local.po
+++ b/Differences/po/nl-local.po
@@ -1,75 +1,115 @@
-# Dutch translations for gramps package.
-# Copyright (C) 2013 THE gramps'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the gramps package.
-# erik_de_richter <frederik.de.richter@telenet.be>, 2013.
+# Dutch translation of addon Differences.
+# Copyright (C) 2020 Gramps project
+# This file is distributed under the same license as the Differences package.
+# Jan Sparreboom <jan@sparreboom.net>.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: gramps 40_addons\n"
+"Project-Id-Version: Differences 5.x\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-01-29 14:38+0100\n"
-"PO-Revision-Date: 2013-01-29 14:38+0100\n"
-"Last-Translator: erik_de_richter <frederik.de.richter@telenet.be>\n"
-"Language-Team: Dutch\n"
+"POT-Creation-Date: 2020-07-17 17:41+0200\n"
+"PO-Revision-Date: 2020-07-17 17:28+0200\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
+"Language-Team: Dutch <gramps-users@lists.sourceforge.net>\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.3\n"
 
-#: Differences/differences.gpr.py:4
+#: Differences/differences.gpr.py:4 Differences/differences.py:97
 msgid "Database Differences Report"
-msgstr ""
+msgstr "Databaseverschillenverslag"
 
 #: Differences/differences.gpr.py:5
 msgid "Compares an external database with the current one."
-msgstr ""
+msgstr "Vergelijkt een externe database met de huidige."
 
-#: Differences/differences.py:157
-msgid "Differences Report"
-msgstr ""
+#: Differences/differences.py:116
+msgid "File:"
+msgstr "Bestand:"
 
-#: Differences/differences.py:158
-msgid "Looking for differences..."
-msgstr ""
+#: Differences/differences.py:136
+msgid "Differences between Database and File"
+msgstr "Verschillen tussen database en bestand"
 
-#: Differences/differences.py:272
+#: Differences/differences.py:140 Differences/differences_old.py:128
+msgid "Family Tree Differences"
+msgstr "Stamboomverschillen"
+
+#: Differences/differences.py:141 Differences/differences_old.py:129
+msgid "Processing..."
+msgstr "Verwerken..."
+
+#: Differences/differences.py:163
+msgid "No differences"
+msgstr "Geen verschillen"
+
+#: Differences/differences.py:170
+msgid "Missing items in File that are added in Database"
+msgstr "Ontbrekende items in bestand die zijn toegevoegd aan database"
+
+#: Differences/differences.py:176
+#, python-format
+msgid "Missing %s: %s"
+msgstr "Ontbrekend %s: %s"
+
+#: Differences/differences.py:180
+msgid "Nothing missing"
+msgstr "Er ontbreekt niets"
+
+#: Differences/differences.py:187
+msgid "Added items in File that are missing in Database"
+msgstr "Items toegevoegd in het bestand die ontbreken in de database"
+
+#: Differences/differences.py:193
+#, python-format
+msgid "Added %s: %s "
+msgstr "Toegevoegd %s: %s "
+
+#: Differences/differences.py:197
+msgid "Nothing added"
+msgstr "Niets toegevoegd"
+
+#: Differences/differences.py:308 Differences/differences_old.py:296
 msgid "Report Options"
-msgstr ""
+msgstr "Verslagopties"
 
-#: Differences/differences.py:273
+#: Differences/differences.py:310 Differences/differences_old.py:298
 msgid "Family Tree file"
-msgstr ""
+msgstr "Stamboombestand"
 
-#: Differences/differences.py:274
+#: Differences/differences.py:312 Differences/differences_old.py:300
 msgid "Select a .gpkg or .gramps file"
-msgstr ""
+msgstr "Selecteer een .gpkg- of .gramps-bestand"
 
-#: Differences/differences.py:277
+#: Differences/differences.py:315 Differences/differences_old.py:303
 msgid "Show items that are different"
-msgstr ""
+msgstr "Toon items die verschillend zijn"
 
-#: Differences/differences.py:278
+#: Differences/differences.py:316 Differences/differences_old.py:304
 msgid "Include items that are different"
-msgstr ""
+msgstr "Voeg items toe die verschillend zijn"
 
-#: Differences/differences.py:281
-msgid "Show deleted items"
-msgstr ""
+#: Differences/differences.py:319 Differences/differences_old.py:307
+msgid "Show items missing from file"
+msgstr "Toon items die ontbreken in het bestand"
 
-#: Differences/differences.py:282
+#: Differences/differences.py:320 Differences/differences_old.py:308
 msgid "Include items not in file but in database"
-msgstr ""
+msgstr "Neem items op die niet in het bestand maar in de database staan"
 
-#: Differences/differences.py:285
-msgid "Show added items"
-msgstr ""
+#: Differences/differences.py:323 Differences/differences_old.py:311
+msgid "Show items added in file"
+msgstr "Toon items die in het bestand zijn toegevoegd"
 
-#: Differences/differences.py:286
+#: Differences/differences.py:324 Differences/differences_old.py:312
 msgid "Include items in file but not in database"
-msgstr ""
+msgstr "Neem items op in het bestand maar niet in de database"
 
-#: Differences/differences.py:331 Differences/differences.py:333
-#: Differences/differences.py:336 Differences/differences.py:339
+#: Differences/differences.py:369 Differences/differences.py:371
+#: Differences/differences.py:374 Differences/differences.py:377
+#: Differences/differences_old.py:357 Differences/differences_old.py:359
+#: Differences/differences_old.py:362 Differences/differences_old.py:365
 msgid "Text"
-msgstr ""
+msgstr "Tekst"

--- a/Differences/po/template.pot
+++ b/Differences/po/template.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"POT-Creation-Date: 2020-07-17 17:41+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: Differences/differences.gpr.py:4
+#: Differences/differences.gpr.py:4 Differences/differences.py:97
 msgid "Database Differences Report"
 msgstr ""
 
@@ -25,51 +25,91 @@ msgstr ""
 msgid "Compares an external database with the current one."
 msgstr ""
 
-#: Differences/differences.py:128
+#: Differences/differences.py:116
+msgid "File:"
+msgstr ""
+
+#: Differences/differences.py:136
+msgid "Differences between Database and File"
+msgstr ""
+
+#: Differences/differences.py:140 Differences/differences_old.py:128
 msgid "Family Tree Differences"
 msgstr ""
 
-#: Differences/differences.py:129
+#: Differences/differences.py:141 Differences/differences_old.py:129
 msgid "Processing..."
 msgstr ""
 
-#: Differences/differences.py:296
+#: Differences/differences.py:163
+msgid "No differences"
+msgstr ""
+
+#: Differences/differences.py:170
+msgid "Missing items in File that are added in Database"
+msgstr ""
+
+#: Differences/differences.py:176
+#, python-format
+msgid "Missing %s: %s"
+msgstr ""
+
+#: Differences/differences.py:180
+msgid "Nothing missing"
+msgstr ""
+
+#: Differences/differences.py:187
+msgid "Added items in File that are missing in Database"
+msgstr ""
+
+#: Differences/differences.py:193
+#, python-format
+msgid "Added %s: %s "
+msgstr ""
+
+#: Differences/differences.py:197
+msgid "Nothing added"
+msgstr ""
+
+#: Differences/differences.py:308 Differences/differences_old.py:296
 msgid "Report Options"
 msgstr ""
 
-#: Differences/differences.py:298
+#: Differences/differences.py:310 Differences/differences_old.py:298
 msgid "Family Tree file"
 msgstr ""
 
-#: Differences/differences.py:300
+#: Differences/differences.py:312 Differences/differences_old.py:300
 msgid "Select a .gpkg or .gramps file"
 msgstr ""
 
-#: Differences/differences.py:303
+#: Differences/differences.py:315 Differences/differences_old.py:303
 msgid "Show items that are different"
 msgstr ""
 
-#: Differences/differences.py:304
+#: Differences/differences.py:316 Differences/differences_old.py:304
 msgid "Include items that are different"
 msgstr ""
 
-#: Differences/differences.py:307
+#: Differences/differences.py:319 Differences/differences_old.py:307
 msgid "Show items missing from file"
 msgstr ""
 
-#: Differences/differences.py:308
+#: Differences/differences.py:320 Differences/differences_old.py:308
 msgid "Include items not in file but in database"
 msgstr ""
 
-#: Differences/differences.py:311
+#: Differences/differences.py:323 Differences/differences_old.py:311
 msgid "Show items added in file"
 msgstr ""
 
-#: Differences/differences.py:312
+#: Differences/differences.py:324 Differences/differences_old.py:312
 msgid "Include items in file but not in database"
 msgstr ""
 
-#: Differences/differences.py:357 Differences/differences.py:359
-#: Differences/differences.py:362 Differences/differences.py:365
+#: Differences/differences.py:369 Differences/differences.py:371
+#: Differences/differences.py:374 Differences/differences.py:377
+#: Differences/differences_old.py:357 Differences/differences_old.py:359
+#: Differences/differences_old.py:362 Differences/differences_old.py:365
 msgid "Text"
 msgstr ""


### PR DESCRIPTION
Updated internationalisation for addon Differences.
Translation didn't work correctly and some often used items were not translated.
Based on this update of differences.py a new template.pot created.
Updated DE, FR, NL po-files based on new template.

Tested without issues in Gramps 5.1.2 on Linux Mint 20.
Please, add it to this branch.
Thanks in advance!