### PR TITLE
[EditExifMetadata] Translation for buttons; updated po(t) files DE, FR, NL

### DIFF
--- a/EditExifMetadata/editexifmetadata.py
+++ b/EditExifMetadata/editexifmetadata.py
@@ -48,8 +48,17 @@ from gi.repository import GExiv2
 # -----------------------------------------------------------------------------
 from gramps.gui.display import display_help
 
-from gramps.gen.const import GRAMPS_LOCALE as glocale
-_ = glocale.translation.gettext
+#------------------------------------------------------------------------
+#
+# Internationalisation
+#
+#------------------------------------------------------------------------
+from gramps.gen.const import IMAGE_DIR, GRAMPS_LOCALE as glocale
+try:
+    _trans = glocale.get_addon_translator(__file__)
+except ValueError:
+    _trans = glocale.translation
+_ = _trans.sgettext
 
 from gramps.gen.datehandler import displayer as _dd
 from gramps.gen.datehandler import parser as _dp
@@ -200,7 +209,13 @@ _BUTTONTIPS = {
     "Delete" : _("WARNING:  This will completely erase all Exif metadata "
                  "from this image!  Are you sure that you want to do this?")
 }
-_CLEAR_GPS = _("Clear GPS")  # just to do translation
+# Words needed for translation and creating a template.pot
+_CLEAR_GPS = _("Clear GPS")
+_THUMBNAIL = _("Thumbnail")
+_COPY = _("Copy")
+_CONVERT = _("Convert")
+_CLEAR = _("Clear")
+
 # ----------------------------------------------------
 
 
@@ -295,7 +310,7 @@ class EditExifMetadata(Gramplet):
         event_box = Gtk.EventBox()
         new_hbox.pack_start(event_box, expand=False, fill=False, padding=0)
         event_box.show()
-
+        
         button = self.__create_button("Thumbnail", [self.thumbnail_view], )
         event_box.add(button)
 
@@ -557,7 +572,8 @@ class EditExifMetadata(Gramplet):
         """
         creates and returns a button for display
         """
-        button = Gtk.Button(label=text)
+        #lbl=_(text)
+        button = Gtk.Button(label=_(text))
 
         if callback is not []:
             for call_ in callback:

--- a/EditExifMetadata/editexifmetadata.py
+++ b/EditExifMetadata/editexifmetadata.py
@@ -310,7 +310,7 @@ class EditExifMetadata(Gramplet):
         event_box = Gtk.EventBox()
         new_hbox.pack_start(event_box, expand=False, fill=False, padding=0)
         event_box.show()
-        
+
         button = self.__create_button("Thumbnail", [self.thumbnail_view], )
         event_box.add(button)
 

--- a/EditExifMetadata/editexifmetadata.py
+++ b/EditExifMetadata/editexifmetadata.py
@@ -572,7 +572,6 @@ class EditExifMetadata(Gramplet):
         """
         creates and returns a button for display
         """
-        #lbl=_(text)
         button = Gtk.Button(label=_(text))
 
         if callback is not []:

--- a/EditExifMetadata/po/de-local.po
+++ b/EditExifMetadata/po/de-local.po
@@ -14,36 +14,37 @@ msgid ""
 msgstr ""
 "Project-Id-Version: de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-04-23 22:21+0200\n"
-"PO-Revision-Date: 2018-04-11 19:24+0100\n"
+"POT-Creation-Date: 2020-07-21 14:47+0200\n"
+"PO-Revision-Date: 2020-07-21 15:24+0200\n"
 "Last-Translator: Mirko Leonhäuser <mirko@leonhaeuser.de>\n"
 "Language-Team: German <kde-i18n-de@kde.org>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Lokalize 2.0\n"
+"X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: EditExifMetadata/editexifmetadata.gpr.py:29
-#: EditExifMetadata/editexifmetadata.py:749
-#: EditExifMetadata/editexifmetadata.py:1155
+#: EditExifMetadata//editexifmetadata.gpr.py:29
+#: EditExifMetadata//editexifmetadata.py:724
+#: EditExifMetadata//editexifmetadata.py:1136
+#: EditExifMetadata//editexifmetadata.py:1148
 msgid "Edit Image Exif Metadata"
 msgstr "Bild Exif Metadaten bearbeiten"
 
-#: EditExifMetadata/editexifmetadata.gpr.py:30
+#: EditExifMetadata//editexifmetadata.gpr.py:30
 msgid "Gramplet to view, edit, and save image Exif metadata"
 msgstr "Gramplet zum ansehen, bearbeiten und speichern von Exif Metadaten"
 
-#: EditExifMetadata/editexifmetadata.gpr.py:34
+#: EditExifMetadata//editexifmetadata.gpr.py:34
 msgid "Edit Exif Metadata"
 msgstr "Exif Metadaten bearbeiten"
 
-#: EditExifMetadata/editexifmetadata.py:147
+#: EditExifMetadata//editexifmetadata.py:135
 msgid "<-- Image Types -->"
 msgstr "<-- Bildformate -->"
 
-#: EditExifMetadata/editexifmetadata.py:170
+#: EditExifMetadata//editexifmetadata.py:158
 msgid ""
 "Warning:  Changing this entry will update the Media object title field in "
 "Gramps not Exiv2 metadata."
@@ -51,11 +52,11 @@ msgstr ""
 "Warnung: Änderungen an diesem Eintrag aktualisieren das "
 "Medienobjekttitelfeld in Gramps nicht die Exiv2 Metadaten."
 
-#: EditExifMetadata/editexifmetadata.py:173
+#: EditExifMetadata//editexifmetadata.py:161
 msgid "Provide a short description for this image."
 msgstr "Gib eine kurze Beschreibung für dieses Bild."
 
-#: EditExifMetadata/editexifmetadata.py:175
+#: EditExifMetadata//editexifmetadata.py:163
 msgid ""
 "Enter the Artist/ Author of this image.  The person's name or the company "
 "who is responsible for the creation of this image."
@@ -63,11 +64,11 @@ msgstr ""
 "Gib den Künstler/Urheber dieses Bildes ein. Der Name der Person oder Firma "
 "die für die Erstellung des Bildes verantwortlich ist."
 
-#: EditExifMetadata/editexifmetadata.py:178
+#: EditExifMetadata//editexifmetadata.py:167
 msgid "Enter the copyright information for this image. \n"
 msgstr "Gib die copyright Informationen für dieses Bild ein.\n"
 
-#: EditExifMetadata/editexifmetadata.py:180
+#: EditExifMetadata//editexifmetadata.py:169
 msgid ""
 "The original date/ time when the image was first created/ taken as in a "
 "photograph.\n"
@@ -76,7 +77,7 @@ msgstr ""
 "Das original Datum/Zeit an dem das Bild ursprünglich erstellt wurde.\n"
 "Beispiel: 1830-01-1 09:30:59"
 
-#: EditExifMetadata/editexifmetadata.py:183
+#: EditExifMetadata//editexifmetadata.py:173
 msgid ""
 "This is the date/ time that the image was last changed/ modified.\n"
 "Example: 2011-05-24 14:30:00"
@@ -84,31 +85,31 @@ msgstr ""
 "Dies ist das Datum/Zeit an dem das Bild zuletzt geändert wurde.\n"
 "Beispiel: 2011-05-24 14:30:00"
 
-#: EditExifMetadata/editexifmetadata.py:186
+#: EditExifMetadata//editexifmetadata.py:176
 msgid ""
 "Enter the Latitude GPS coordinates for this image,\n"
-"Example: 43.722965, 43 43 22 N, 38° 38′ 03″ N, 38 38 3"
+"Example: -43.722965, -43:43:22, 38° 38′ 03″ N"
 msgstr ""
 "Gib die GPS Breitenkoordinaten für dein Bild ein,\n"
 "Beispiel: 43.722965, 43 43 22 N, 38° 38' 03\" N, 38 38 3"
 
-#: EditExifMetadata/editexifmetadata.py:189
+#: EditExifMetadata//editexifmetadata.py:179
 msgid ""
 "Enter the Longitude GPS coordinates for this image,\n"
-"Example: 10.396378, 10 23 46 E, 105° 6′ 6″ W, -105 6 6"
+"Example: -10.396378, -10:23:46, 105° 6′ 6″ W"
 msgstr ""
 "Gib die GPS Längenkoordinaten für dein Bild ein,\n"
 "Beispiele: 10.396378, 10 23 46 E, 105° 6′ 6″ W, -105 6 6"
 
-#: EditExifMetadata/editexifmetadata.py:192
+#: EditExifMetadata//editexifmetadata.py:182
 msgid ""
 "This is the measurement of Above or Below Sea Level.  It is measured in "
-"meters.Example: 200.558, -200.558"
+"meters.  Example: 200.558, -200.558"
 msgstr ""
 "Dies ist der Messwert über oder unter dem Meeresspiegel. Es wird in Metern "
 "gemessen. Beispiel: 200.558, -200.558"
 
-#: EditExifMetadata/editexifmetadata.py:201
+#: EditExifMetadata//editexifmetadata.py:191
 msgid ""
 "Displays the Gramps Wiki Help page for 'Edit Image Exif Metadata' in your "
 "web browser."
@@ -116,7 +117,7 @@ msgstr ""
 "Zeigt die Gramps Wiki Hilfe Seite für 'Bild Exif Metadaten bearbeiten' in "
 "deinem Browser."
 
-#: EditExifMetadata/editexifmetadata.py:204
+#: EditExifMetadata//editexifmetadata.py:194
 msgid ""
 "This will open up a new window to allow you to edit/ modify this image's "
 "Exif metadata.\n"
@@ -126,12 +127,12 @@ msgstr ""
 "ändern kannst.\n"
 " Es ermöglicht dir auch die geänderten Metadaten zu speichern."
 
-#: EditExifMetadata/editexifmetadata.py:208
+#: EditExifMetadata//editexifmetadata.py:198
 msgid "Will produce a Popup window showing a Thumbnail Viewing Area"
 msgstr ""
 "Erstellt ein Dialogfenster welches einen Vorschaubildanzeigebereich zeigt"
 
-#: EditExifMetadata/editexifmetadata.py:210
+#: EditExifMetadata//editexifmetadata.py:201
 msgid ""
 "Select from a drop- down box the image file type that you would like to "
 "convert your non- Exiv2 compatible media object to."
@@ -139,7 +140,7 @@ msgstr ""
 "Wähle aus einer Aufklappliste das Bilddateiformat in das du dein nicht Exiv2 "
 "kompatibles Medienobjekt konvertieren willst."
 
-#: EditExifMetadata/editexifmetadata.py:213
+#: EditExifMetadata//editexifmetadata.py:205
 msgid ""
 "If your image is not of an image type that can have Exif metadata read/ "
 "written to/from, convert it to a type that can?"
@@ -147,7 +148,7 @@ msgstr ""
 "Wenn dein Bild kein Bildtyp ist, aus/in den man Exif Metadaten lesen/"
 "schreiben kann, konvertiere es zu einem Typ mit dem das möglich ist."
 
-#: EditExifMetadata/editexifmetadata.py:216
+#: EditExifMetadata//editexifmetadata.py:209
 msgid ""
 "WARNING:  This will completely erase all Exif metadata from this image!  Are "
 "you sure that you want to do this?"
@@ -155,15 +156,32 @@ msgstr ""
 "WARNUNG: Dies löscht alle Exif Metadaten von diesem Bild! Bist du sicher, "
 "das du dies tun willst?"
 
-#: EditExifMetadata/editexifmetadata.py:311
+#: EditExifMetadata//editexifmetadata.py:213
+msgid "Clear GPS"
+msgstr "GPS löschen"
+
+#: EditExifMetadata//editexifmetadata.py:214
 msgid "Thumbnail"
 msgstr "Miniaturbild"
 
-#: EditExifMetadata/editexifmetadata.py:393
+#: EditExifMetadata//editexifmetadata.py:215
+msgid "Copy"
+msgstr "Kopieren"
+
+#: EditExifMetadata//editexifmetadata.py:216
+#: EditExifMetadata//editexifmetadata.py:727
+msgid "Convert"
+msgstr "Konvertiere"
+
+#: EditExifMetadata//editexifmetadata.py:217
+msgid "Clear"
+msgstr "Löschen"
+
+#: EditExifMetadata//editexifmetadata.py:402
 msgid "Select an image to begin..."
 msgstr "Wähle zum Start ein Bild..."
 
-#: EditExifMetadata/editexifmetadata.py:415
+#: EditExifMetadata//editexifmetadata.py:421
 msgid ""
 "Image is NOT readable,\n"
 "Please choose a different image..."
@@ -171,7 +189,17 @@ msgstr ""
 "Bild kann NICHT gelesen werden,\n"
 "Bitte wähle ein anderes Bild..."
 
-#: EditExifMetadata/editexifmetadata.py:431
+#: EditExifMetadata//editexifmetadata.py:441
+msgid "Please convert this image to an Exiv2- compatible image type..."
+msgstr "Bitte dieses Bild in ein Exiv2 kompatibles Format umwandeln..."
+
+#: EditExifMetadata//editexifmetadata.py:465
+#, python-brace-format
+msgid "Image Size : {width} x {height} pixels"
+msgstr "Bildgröße : %04(width)d x %04(height)d Punkte"
+
+#: EditExifMetadata//editexifmetadata.py:481
+#: EditExifMetadata//editexifmetadata.py:1441
 msgid ""
 "Image is NOT writable,\n"
 "You will NOT be able to save Exif metadata...."
@@ -179,27 +207,15 @@ msgstr ""
 "Bild kann NICHT geschrieben werden,\n"
 "Du kannst KEINE Exif Metadaten speichern...."
 
-#: EditExifMetadata/editexifmetadata.py:443
-msgid "Please convert this image to an Exiv2- compatible image type..."
-msgstr "Bitte dieses Bild in ein Exiv2 kompatibles Format umwandeln..."
-
-#: EditExifMetadata/editexifmetadata.py:466
-msgid "Image Size : %04(width)d x %04(height)d pixels"
-msgstr "Bildgröße : %04(width)d x %04(height)d Punkte"
-
-#: EditExifMetadata/editexifmetadata.py:499
-msgid "Displaying Exif metadata..."
-msgstr "Exif Metadaten zeigen..."
-
-#: EditExifMetadata/editexifmetadata.py:666
+#: EditExifMetadata//editexifmetadata.py:649
 msgid "Click Close to close this Thumbnail View Area."
 msgstr "Klicke auf Schließen um den Vorschaubildanzeigebereich zu schließen."
 
-#: EditExifMetadata/editexifmetadata.py:670
+#: EditExifMetadata//editexifmetadata.py:655
 msgid "Thumbnail View Area"
 msgstr "Vorschaubildanzeigebereich"
 
-#: EditExifMetadata/editexifmetadata.py:749
+#: EditExifMetadata//editexifmetadata.py:725
 msgid ""
 "WARNING: You are about to convert this image into a .jpeg image.  Are you "
 "sure that you want to do this?"
@@ -207,15 +223,11 @@ msgstr ""
 "ACHTUNG: Du bist dabei dieses Bild in ein .jpeg Bild zu umzuwandeln. Bist du "
 "dir sicher, das tu das tun willst?"
 
-#: EditExifMetadata/editexifmetadata.py:751
+#: EditExifMetadata//editexifmetadata.py:727
 msgid "Convert and Delete"
 msgstr "Konvertieren und Löschen"
 
-#: EditExifMetadata/editexifmetadata.py:751
-msgid "Convert"
-msgstr "Konvertiere"
-
-#: EditExifMetadata/editexifmetadata.py:837
+#: EditExifMetadata//editexifmetadata.py:808
 msgid ""
 "Your image has been converted and the original file has been deleted, and "
 "the full path has been updated!"
@@ -223,7 +235,7 @@ msgstr ""
 "Dein Bild wurde konvertiert, das Original gelöscht und der komplette Pfad "
 "wurde aktualisiert!"
 
-#: EditExifMetadata/editexifmetadata.py:841
+#: EditExifMetadata//editexifmetadata.py:813
 msgid ""
 "There has been an error, Please check your source and destination file "
 "paths..."
@@ -231,7 +243,7 @@ msgstr ""
 "Es ist ein Fehler aufgetreten, Bitte überprüfe deine Quell und "
 "Zieldateipfade..."
 
-#: EditExifMetadata/editexifmetadata.py:844
+#: EditExifMetadata//editexifmetadata.py:817
 msgid ""
 "There was an error in deleting the original file.  You will need to delete "
 "it yourself!"
@@ -239,19 +251,19 @@ msgstr ""
 "Beim Löschen der original Datei ist ein Fehler aufgetreten. Du musst sie "
 "selbst löschen!"
 
-#: EditExifMetadata/editexifmetadata.py:861
+#: EditExifMetadata//editexifmetadata.py:835
 msgid "There was an error in converting your image file."
 msgstr "Beim Konvertieren deines Bildes ist ein Fehler aufgetreten."
 
-#: EditExifMetadata/editexifmetadata.py:872
+#: EditExifMetadata//editexifmetadata.py:845
 msgid "Media Path Update"
 msgstr "Medienpfad aktualisiert"
 
-#: EditExifMetadata/editexifmetadata.py:878
+#: EditExifMetadata//editexifmetadata.py:854
 msgid "There has been an error in updating the image file's path!"
 msgstr "Beim Aktualisieren des Bilddateipfad ist ein Fehler aufgetreten!"
 
-#: EditExifMetadata/editexifmetadata.py:912
+#: EditExifMetadata//editexifmetadata.py:887
 msgid ""
 "Click the close button when you are finished modifying this image's Exif "
 "metadata."
@@ -259,20 +271,24 @@ msgstr ""
 "Klicke die Schließen Schaltfläche wenn du das Ändern dieser Bild Exif "
 "Metadaten abgeschlossen hast."
 
-#: EditExifMetadata/editexifmetadata.py:950
+#: EditExifMetadata//editexifmetadata.py:925
 msgid "Saves a copy of the data fields into the image's Exif metadata."
 msgstr "Speichert eine Kopie der Datenfelder in den Exif Metadaten des Bild."
 
-#: EditExifMetadata/editexifmetadata.py:953
+#: EditExifMetadata//editexifmetadata.py:929
 msgid "Re -display the data fields that were cleared from the Edit Area."
 msgstr ""
 "Zeigt die Datenfelder die aus dem Editorbereich entfernt wurden wieder an."
 
-#: EditExifMetadata/editexifmetadata.py:956
+#: EditExifMetadata//editexifmetadata.py:933
 msgid "This button will clear all of the data fields shown here."
 msgstr "Diese Schaltfläche leert alle hier gezeigten Datenfelder."
 
-#: EditExifMetadata/editexifmetadata.py:959
+#: EditExifMetadata//editexifmetadata.py:937
+msgid "This button will clear all of the GPS fields shown here."
+msgstr "Diese Schaltfläche leert alle hier gezeigten Datenfelder."
+
+#: EditExifMetadata//editexifmetadata.py:941
 msgid ""
 "Closes this popup Edit window.\n"
 "WARNING: This action will NOT Save any changes/ modification made to this "
@@ -281,102 +297,116 @@ msgstr ""
 "Schließt dieses Editorfenster.\n"
 "WARNUNG: Diese Aktion speichert KEINE Änderungen, dieser Bild Exif Metadaten."
 
-#: EditExifMetadata/editexifmetadata.py:986
+#: EditExifMetadata//editexifmetadata.py:970
 msgid "Media Object Title"
 msgstr "Medienobjekttitel"
 
-#: EditExifMetadata/editexifmetadata.py:996
+#: EditExifMetadata//editexifmetadata.py:979
 msgid "media Title: "
 msgstr "Mediumtitel: "
 
-#: EditExifMetadata/editexifmetadata.py:1010
+#: EditExifMetadata//editexifmetadata.py:994
 msgid "General Data"
 msgstr "Allgemeine Daten"
 
-#: EditExifMetadata/editexifmetadata.py:1020
+#: EditExifMetadata//editexifmetadata.py:1004
 msgid "Description: "
 msgstr "Beschreibung: "
 
-#: EditExifMetadata/editexifmetadata.py:1021
+#: EditExifMetadata//editexifmetadata.py:1005
 msgid "Artist: "
 msgstr "Künstler: "
 
-#: EditExifMetadata/editexifmetadata.py:1022
+#: EditExifMetadata//editexifmetadata.py:1006
 msgid "Copyright: "
 msgstr "Copyright: "
 
-#: EditExifMetadata/editexifmetadata.py:1035
+#: EditExifMetadata//editexifmetadata.py:1020
 msgid "Date/ Time"
 msgstr "Datum/Zeit"
 
-#: EditExifMetadata/editexifmetadata.py:1049
+#: EditExifMetadata//editexifmetadata.py:1035
 msgid "Original: "
 msgstr "Original: "
 
-#: EditExifMetadata/editexifmetadata.py:1050
+#: EditExifMetadata//editexifmetadata.py:1036
 msgid "Modified: "
 msgstr "Geändert: "
 
-#: EditExifMetadata/editexifmetadata.py:1067
+#: EditExifMetadata//editexifmetadata.py:1055
 msgid "Latitude/ Longitude/ Altitude GPS coordinates"
 msgstr "Breite/Länge/Höhe GPS Koordinaten"
 
-#: EditExifMetadata/editexifmetadata.py:1081
+#: EditExifMetadata//editexifmetadata.py:1070
 msgid "Latitude :"
 msgstr "Breitengrad:"
 
-#: EditExifMetadata/editexifmetadata.py:1082
+#: EditExifMetadata//editexifmetadata.py:1071
 msgid "Longitude :"
 msgstr "Längengrad:"
 
-#: EditExifMetadata/editexifmetadata.py:1083
+#: EditExifMetadata//editexifmetadata.py:1072
 msgid "Altitude :"
 msgstr "Höhe:"
 
-#: EditExifMetadata/editexifmetadata.py:1135
+#: EditExifMetadata//editexifmetadata.py:1115
 msgid "Bad Date/Time"
 msgstr "Falsches Datum/Zeit"
 
-#: EditExifMetadata/editexifmetadata.py:1143
+#: EditExifMetadata//editexifmetadata.py:1123
 msgid "Invalid latitude (syntax: 18\\u00b09'"
 msgstr "Ungültiger Breitengrad (Syntax: 18\\u00b09'"
 
-#: EditExifMetadata/editexifmetadata.py:1144
+#: EditExifMetadata//editexifmetadata.py:1124
 msgid "48.21\"S, -18.2412 or -18:9:48.21)"
 msgstr "48.21\"S, -18.2412 oder -18:9:48.21)"
 
-#: EditExifMetadata/editexifmetadata.py:1148
+#: EditExifMetadata//editexifmetadata.py:1128
 msgid "Invalid longitude (syntax: 18\\u00b09'"
 msgstr "Ungültiger Längengrad (Syntax: 18\\u00b09'"
 
-#: EditExifMetadata/editexifmetadata.py:1149
+#: EditExifMetadata//editexifmetadata.py:1129
 msgid "48.21\"E, -18.2412 or -18:9:48.21)"
 msgstr "48.21\"O, -18.2412 oder -18:9:48.21)"
 
-#: EditExifMetadata/editexifmetadata.py:1155
+#: EditExifMetadata//editexifmetadata.py:1137
 msgid ""
 "WARNING!  You are about to completely delete the Exif metadata from this "
 "image?"
 msgstr "ACHTUNG! Du bist dabei alle Exif Metadaten von diesem Bild zu löschen?"
 
-#: EditExifMetadata/editexifmetadata.py:1318
+#: EditExifMetadata//editexifmetadata.py:1139
+#: EditExifMetadata//editexifmetadata.py:1151
+msgid "Delete"
+msgstr "Löschen"
+
+#: EditExifMetadata//editexifmetadata.py:1149
+msgid ""
+"WARNING!  You are about to completely delete the GPS metadata from this "
+"image?"
+msgstr "ACHTUNG! Du bist dabei alle Exif Metadaten von diesem Bild zu löschen?"
+
+#: EditExifMetadata//editexifmetadata.py:1334
 msgid "Media Title Update"
 msgstr "Medientitel aktualisiert"
 
-#: EditExifMetadata/editexifmetadata.py:1344
+#: EditExifMetadata//editexifmetadata.py:1358
 msgid "Media Object Date Created"
 msgstr "Medienobjektdatum erstellt"
 
-#: EditExifMetadata/editexifmetadata.py:1416
+#: EditExifMetadata//editexifmetadata.py:1423
 msgid "Saving Exif metadata to this image..."
 msgstr "Speichere Exif Metadaten in dieses Bild..."
 
-#: EditExifMetadata/editexifmetadata.py:1463
+#: EditExifMetadata//editexifmetadata.py:1466
 msgid "All Exif metadata has been deleted from this image..."
 msgstr "Alle Exif Metadaten wurden von diesem Bild entfernt..."
 
-#: EditExifMetadata/editexifmetadata.py:1468
+#: EditExifMetadata//editexifmetadata.py:1471
 msgid "There was an error in stripping the Exif metadata from this image..."
 msgstr ""
 "Beim reinitialisieren der Exif Metadaten für dieses Bild ist ein Fehler "
 "aufgetreten..."
+
+#~ msgid "Displaying Exif metadata..."
+#~ msgstr "Exif Metadaten zeigen..."

--- a/EditExifMetadata/po/fr-local.po
+++ b/EditExifMetadata/po/fr-local.po
@@ -24,8 +24,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 4.0-beta1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-02-25 15:21+0100\n"
-"PO-Revision-Date: 2013-02-25 15:01+0100\n"
+"POT-Creation-Date: 2020-07-21 14:47+0200\n"
+"PO-Revision-Date: 2020-07-21 15:14+0200\n"
 "Last-Translator: \n"
 "Language-Team: French <traduc@traduc.org>\n"
 "Language: fr\n"
@@ -33,30 +33,31 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Lokalize 1.4\n"
+"X-Generator: Poedit 2.3\n"
 
-#: EditExifMetadata/editexifmetadata.gpr.py:29
-#: EditExifMetadata/editexifmetadata.py:753
-#: EditExifMetadata/editexifmetadata.py:1159
+#: EditExifMetadata//editexifmetadata.gpr.py:29
+#: EditExifMetadata//editexifmetadata.py:724
+#: EditExifMetadata//editexifmetadata.py:1136
+#: EditExifMetadata//editexifmetadata.py:1148
 msgid "Edit Image Exif Metadata"
 msgstr "Éditer les métadonnées Exif de l'image"
 
-#: EditExifMetadata/editexifmetadata.gpr.py:30
+#: EditExifMetadata//editexifmetadata.gpr.py:30
 msgid "Gramplet to view, edit, and save image Exif metadata"
 msgstr ""
 "Gramplet pour voir, éditer, et enregistrer les métadonnées Exif de l'image"
 
-#: EditExifMetadata/editexifmetadata.gpr.py:34
+#: EditExifMetadata//editexifmetadata.gpr.py:34
 msgid "Edit Exif Metadata"
 msgstr "Édition des métadonnées Exif"
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:148
+#: EditExifMetadata//editexifmetadata.py:135
 msgid "<-- Image Types -->"
 msgstr "<-- Types d'image -->"
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:171
+#: EditExifMetadata//editexifmetadata.py:158
 msgid ""
 "Warning:  Changing this entry will update the Media object title field in "
 "Gramps not Exiv2 metadata."
@@ -65,11 +66,11 @@ msgstr ""
 "pas les métadonnées Exiv2 du medium."
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:174
+#: EditExifMetadata//editexifmetadata.py:161
 msgid "Provide a short description for this image."
 msgstr "Fournit une description sommaire de l'image."
 
-#: EditExifMetadata/editexifmetadata.py:176
+#: EditExifMetadata//editexifmetadata.py:163
 msgid ""
 "Enter the Artist/ Author of this image.  The person's name or the company "
 "who is responsible for the creation of this image."
@@ -78,12 +79,12 @@ msgstr ""
 "compagnie créatrice de cette image."
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:179
+#: EditExifMetadata//editexifmetadata.py:167
 msgid "Enter the copyright information for this image. \n"
 msgstr "Entrez l'information sur le droit à la copie pour cette image.\n"
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:181
+#: EditExifMetadata//editexifmetadata.py:169
 msgid ""
 "The original date/ time when the image was first created/ taken as in a "
 "photograph.\n"
@@ -93,7 +94,7 @@ msgstr ""
 "Exemple: 1830-01-1 09:30:59"
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:184
+#: EditExifMetadata//editexifmetadata.py:173
 msgid ""
 "This is the date/ time that the image was last changed/ modified.\n"
 "Example: 2011-05-24 14:30:00"
@@ -102,33 +103,34 @@ msgstr ""
 "Exemple : 2011-05-24 14:30:00"
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:187
+#: EditExifMetadata//editexifmetadata.py:176
 msgid ""
 "Enter the Latitude GPS coordinates for this image,\n"
-"Example: 43.722965, 43 43 22 N, 38° 38′ 03″ N, 38 38 3"
+"Example: -43.722965, -43:43:22, 38° 38′ 03″ N"
 msgstr ""
 "Entrez les coordonnées GPS de la latitude pour votre image,\n"
 "Exemple : 43.722965, 43 43 22 N, 38° 38′ 03″ N, 38 38 3"
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:190
+#: EditExifMetadata//editexifmetadata.py:179
 msgid ""
 "Enter the Longitude GPS coordinates for this image,\n"
-"Example: 10.396378, 10 23 46 E, 105° 6′ 6″ W, -105 6 6"
+"Example: -10.396378, -10:23:46, 105° 6′ 6″ W"
 msgstr ""
 "Entrez les coordonnées GPS de la longitude pour votre image,\n"
 "Exemple : 10.396378, 10 23 46 E, 105° 6′ 6″ W, -105 6 6"
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:193
+#: EditExifMetadata//editexifmetadata.py:182
+
 msgid ""
 "This is the measurement of Above or Below Sea Level.  It is measured in "
-"meters.Example: 200.558, -200.558"
+"meters.  Example: 200.558, -200.558"
 msgstr ""
 "Il s'agit de l'altitude au-dessus et en-dessous de la mer. L'unité est le "
 "mètre. Exemple : 200.558, -200.558"
 
-#: EditExifMetadata/editexifmetadata.py:202
+#: EditExifMetadata//editexifmetadata.py:191
 msgid ""
 "Displays the Gramps Wiki Help page for 'Edit Image Exif Metadata' in your "
 "web browser."
@@ -137,7 +139,7 @@ msgstr ""
 "l« image » dans votre navigateur internet."
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:205
+#: EditExifMetadata//editexifmetadata.py:194
 msgid ""
 "This will open up a new window to allow you to edit/ modify this image's "
 "Exif metadata.\n"
@@ -148,12 +150,12 @@ msgstr ""
 "  Vous permettant également d'enregistrer les métadonnées modifiées."
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:209
+#: EditExifMetadata//editexifmetadata.py:198
 msgid "Will produce a Popup window showing a Thumbnail Viewing Area"
 msgstr "Va générer une fenêtre avec une aire pour visualiser l'aperçu"
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:211
+#: EditExifMetadata//editexifmetadata.py:201
 msgid ""
 "Select from a drop- down box the image file type that you would like to "
 "convert your non- Exiv2 compatible media object to."
@@ -162,7 +164,7 @@ msgstr ""
 "vous souhaitez convertir votre image."
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:214
+#: EditExifMetadata//editexifmetadata.py:205
 msgid ""
 "If your image is not of an image type that can have Exif metadata read/ "
 "written to/from, convert it to a type that can?"
@@ -170,7 +172,7 @@ msgstr ""
 "Si votre image n'est pas un type d'image supportant les métadonnées Exif, "
 "doit-on la convertir dans un format les supportant ?"
 
-#: EditExifMetadata/editexifmetadata.py:217
+#: EditExifMetadata//editexifmetadata.py:209
 msgid ""
 "WARNING:  This will completely erase all Exif metadata from this image!  Are "
 "you sure that you want to do this?"
@@ -178,17 +180,34 @@ msgstr ""
 "ATTENTION : ceci va complètement écraser les métadonnées Exif de cette "
 "image ! Êtes-vous certain(e) de vouloir faire cela ?"
 
-# trunk
-#: EditExifMetadata/editexifmetadata.py:315
-msgid "Thumbnail"
-msgstr "Aperçu"
+#: EditExifMetadata//editexifmetadata.py:213
+msgid "Clear GPS"
+msgstr "Effacer le GPS"
 
-#: EditExifMetadata/editexifmetadata.py:397
+# trunk
+#: EditExifMetadata//editexifmetadata.py:214
+msgid "Thumbnail"
+msgstr "La vignette"
+
+#: EditExifMetadata//editexifmetadata.py:215
+msgid "Copy"
+msgstr "Copie"
+
+#: EditExifMetadata//editexifmetadata.py:216
+#: EditExifMetadata//editexifmetadata.py:727
+msgid "Convert"
+msgstr "Convertir"
+
+#: EditExifMetadata//editexifmetadata.py:217
+msgid "Clear"
+msgstr "Nette"
+
+#: EditExifMetadata//editexifmetadata.py:402
 msgid "Select an image to begin..."
 msgstr "Sélectionnez une image pour commencer..."
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:419
+#: EditExifMetadata//editexifmetadata.py:421
 msgid ""
 "Image is NOT readable,\n"
 "Please choose a different image..."
@@ -196,7 +215,21 @@ msgstr ""
 "Cette image N'EST PAS lisible.\n"
 "Choisissez une autre image..."
 
-#: EditExifMetadata/editexifmetadata.py:435
+# trunk
+#: EditExifMetadata//editexifmetadata.py:441
+msgid "Please convert this image to an Exiv2- compatible image type..."
+msgstr ""
+"Vous pouvez essayer de convertir cette image vers Exiv2- type d'image "
+"compatible..."
+
+# trunk
+#: EditExifMetadata//editexifmetadata.py:465
+#, python-brace-format
+msgid "Image Size : {width} x {height} pixels"
+msgstr "Taille de l'image : %04(width)d x %04(height)d pixels"
+
+#: EditExifMetadata//editexifmetadata.py:481
+#: EditExifMetadata//editexifmetadata.py:1441
 msgid ""
 "Image is NOT writable,\n"
 "You will NOT be able to save Exif metadata...."
@@ -205,35 +238,17 @@ msgstr ""
 "Vous NE pourrez PAS enregistrer les métadonnées Exif..."
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:447
-msgid "Please convert this image to an Exiv2- compatible image type..."
-msgstr ""
-"Vous pouvez essayer de convertir cette image vers Exiv2- type d'image "
-"compatible..."
-
-# trunk
-#: EditExifMetadata/editexifmetadata.py:470
-msgid "Image Size : %04(width)d x %04(height)d pixels"
-msgstr "Taille de l'image : %04(width)d x %04(height)d pixels"
-
-# Substantif (GNOME fr)
-# trunk
-#: EditExifMetadata/editexifmetadata.py:503
-msgid "Displaying Exif metadata..."
-msgstr "Affichage des métadonnées Exif de l'image..."
-
-# trunk
-#: EditExifMetadata/editexifmetadata.py:670
+#: EditExifMetadata//editexifmetadata.py:649
 msgid "Click Close to close this Thumbnail View Area."
-msgstr "Cliquez ici pour fermer l'aire d'affichage de l'aperçu"
+msgstr "Cliquez ici pour fermer l'aire d'affichage de l'aperçu."
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:674
+#: EditExifMetadata//editexifmetadata.py:655
 msgid "Thumbnail View Area"
 msgstr "Aire d'aperçu"
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:753
+#: EditExifMetadata//editexifmetadata.py:725
 msgid ""
 "WARNING: You are about to convert this image into a .jpeg image.  Are you "
 "sure that you want to do this?"
@@ -241,16 +256,12 @@ msgstr ""
 "ATTENTION : vous êtes en train de convertir cette image en .jpeg.  Êtes-vous "
 "certain(e) de vouloir faire cela ?"
 
-#: EditExifMetadata/editexifmetadata.py:755
+#: EditExifMetadata//editexifmetadata.py:727
 msgid "Convert and Delete"
 msgstr "Convertir et supprimer"
 
-#: EditExifMetadata/editexifmetadata.py:755
-msgid "Convert"
-msgstr "Convertir"
-
 # trunk
-#: EditExifMetadata/editexifmetadata.py:841
+#: EditExifMetadata//editexifmetadata.py:808
 msgid ""
 "Your image has been converted and the original file has been deleted, and "
 "the full path has been updated!"
@@ -259,7 +270,7 @@ msgstr ""
 "complet a été mis à jour !"
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:845
+#: EditExifMetadata//editexifmetadata.py:813
 msgid ""
 "There has been an error, Please check your source and destination file "
 "paths..."
@@ -268,7 +279,7 @@ msgstr ""
 "de fichier..."
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:848
+#: EditExifMetadata//editexifmetadata.py:817
 msgid ""
 "There was an error in deleting the original file.  You will need to delete "
 "it yourself!"
@@ -277,23 +288,23 @@ msgstr ""
 "supprimer vous-même !"
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:865
+#: EditExifMetadata//editexifmetadata.py:835
 msgid "There was an error in converting your image file."
 msgstr "Il y a eut une erreur dans la conversion de votre fichier image."
 
 # trunk
 # metadata Exiv pour image
-#: EditExifMetadata/editexifmetadata.py:876
+#: EditExifMetadata//editexifmetadata.py:845
 msgid "Media Path Update"
 msgstr "Mise à jour de votre chemin image"
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:882
+#: EditExifMetadata//editexifmetadata.py:854
 msgid "There has been an error in updating the image file's path!"
 msgstr "Il y a eut une erreur dans la mise à jour du chemin de l'image !"
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:916
+#: EditExifMetadata//editexifmetadata.py:887
 msgid ""
 "Click the close button when you are finished modifying this image's Exif "
 "metadata."
@@ -302,24 +313,29 @@ msgstr ""
 "métadonnées Exif de l'image."
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:954
+#: EditExifMetadata//editexifmetadata.py:925
 msgid "Saves a copy of the data fields into the image's Exif metadata."
 msgstr "Enregistre une copie des données dans les métadonnées Exif de l'image."
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:957
+#: EditExifMetadata//editexifmetadata.py:929
 msgid "Re -display the data fields that were cleared from the Edit Area."
 msgstr ""
 "Afficher une nouvelle fois les données qui ont été effacées de l'aire "
 "d'édition."
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:960
+#: EditExifMetadata//editexifmetadata.py:933
 msgid "This button will clear all of the data fields shown here."
 msgstr "Ce bouton effacera toutes les données affichées ici."
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:963
+#: EditExifMetadata//editexifmetadata.py:937
+msgid "This button will clear all of the GPS fields shown here."
+msgstr "Ce bouton effacera toutes les données affichées ici."
+
+# trunk
+#: EditExifMetadata//editexifmetadata.py:941
 msgid ""
 "Closes this popup Edit window.\n"
 "WARNING: This action will NOT Save any changes/ modification made to this "
@@ -331,95 +347,95 @@ msgstr ""
 
 # trunk
 # metadata Exiv pour image
-#: EditExifMetadata/editexifmetadata.py:990
+#: EditExifMetadata//editexifmetadata.py:970
 msgid "Media Object Title"
 msgstr "Titre de l'objet medium"
 
 # trunk
 # metadata Exiv pour image
-#: EditExifMetadata/editexifmetadata.py:1000
+#: EditExifMetadata//editexifmetadata.py:979
 msgid "media Title: "
-msgstr "Titre :"
+msgstr "titre du média : "
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:1014
+#: EditExifMetadata//editexifmetadata.py:994
 msgid "General Data"
 msgstr "Général"
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:1024
+#: EditExifMetadata//editexifmetadata.py:1004
 msgid "Description: "
 msgstr "Description : "
 
 # trunk
 # auteur dans le contexte
-#: EditExifMetadata/editexifmetadata.py:1025
+#: EditExifMetadata//editexifmetadata.py:1005
 msgid "Artist: "
-msgstr "Auteur :"
+msgstr "Artiste : "
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:1026
+#: EditExifMetadata//editexifmetadata.py:1006
 msgid "Copyright: "
 msgstr "Copyright : "
 
-#: EditExifMetadata/editexifmetadata.py:1039
+#: EditExifMetadata//editexifmetadata.py:1020
 msgid "Date/ Time"
 msgstr "Date / Heure"
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:1053
+#: EditExifMetadata//editexifmetadata.py:1035
 msgid "Original: "
-msgstr "Temps originel"
+msgstr "Original : "
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:1054
+#: EditExifMetadata//editexifmetadata.py:1036
 msgid "Modified: "
-msgstr "Modifié :"
+msgstr "Modifié : "
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:1071
+#: EditExifMetadata//editexifmetadata.py:1055
 msgid "Latitude/ Longitude/ Altitude GPS coordinates"
 msgstr "Latitude / Longitude / Altitude des coordonnées GPS"
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:1085
+#: EditExifMetadata//editexifmetadata.py:1070
 msgid "Latitude :"
 msgstr "Latitude :"
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:1086
+#: EditExifMetadata//editexifmetadata.py:1071
 msgid "Longitude :"
 msgstr "Longitude :"
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:1087
+#: EditExifMetadata//editexifmetadata.py:1072
 msgid "Altitude :"
 msgstr "Altitude :"
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:1139
+#: EditExifMetadata//editexifmetadata.py:1115
 msgid "Bad Date/Time"
 msgstr "Mauvaise date / heure"
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:1147
+#: EditExifMetadata//editexifmetadata.py:1123
 msgid "Invalid latitude (syntax: 18\\u00b09'"
 msgstr "Latitude invalide (syntaxe : 18\\u00b09'"
 
-#: EditExifMetadata/editexifmetadata.py:1148
+#: EditExifMetadata//editexifmetadata.py:1124
 msgid "48.21\"S, -18.2412 or -18:9:48.21)"
 msgstr "48.21\"S, -18.2412 ou -18:9:48.21)"
 
 # trunk
-#: EditExifMetadata/editexifmetadata.py:1152
+#: EditExifMetadata//editexifmetadata.py:1128
 msgid "Invalid longitude (syntax: 18\\u00b09'"
 msgstr "Longitude invalide (syntaxe : 18\\u00b09'"
 
-#: EditExifMetadata/editexifmetadata.py:1153
+#: EditExifMetadata//editexifmetadata.py:1129
 msgid "48.21\"E, -18.2412 or -18:9:48.21)"
 msgstr "48.21\"E, -18.2412 ou -18:9:48.21)"
 
-#: EditExifMetadata/editexifmetadata.py:1159
+#: EditExifMetadata//editexifmetadata.py:1137
 msgid ""
 "WARNING!  You are about to completely delete the Exif metadata from this "
 "image?"
@@ -427,30 +443,48 @@ msgstr ""
 "ATTENTION ! Voulez vous supprimer toutes les métadonnées Exif de cette "
 "image ?"
 
+#: EditExifMetadata//editexifmetadata.py:1139
+#: EditExifMetadata//editexifmetadata.py:1151
+msgid "Delete"
+msgstr "Supprimer"
+
+#: EditExifMetadata//editexifmetadata.py:1149
+msgid ""
+"WARNING!  You are about to completely delete the GPS metadata from this "
+"image?"
+msgstr ""
+"ATTENTION ! Voulez vous supprimer toutes les métadonnées Exif de cette "
+"image ?"
+
 # trunk
 # metadata Exiv pour image
-#: EditExifMetadata/editexifmetadata.py:1324
+#: EditExifMetadata//editexifmetadata.py:1334
 msgid "Media Title Update"
 msgstr "Mise à jour du titre"
 
 # trunk
 # metadata Exiv pour image
-#: EditExifMetadata/editexifmetadata.py:1350
+#: EditExifMetadata//editexifmetadata.py:1358
 msgid "Media Object Date Created"
 msgstr "Date de création"
 
 # trunk
 # Substantif (GNOME fr)
-#: EditExifMetadata/editexifmetadata.py:1422
+#: EditExifMetadata//editexifmetadata.py:1423
 msgid "Saving Exif metadata to this image..."
 msgstr "Enregistrement des métadonnées Exif dans l'image..."
 
-#: EditExifMetadata/editexifmetadata.py:1469
+#: EditExifMetadata//editexifmetadata.py:1466
 msgid "All Exif metadata has been deleted from this image..."
 msgstr "Toutes les métadonnées Exif ont été supprimées de cette image..."
 
-#: EditExifMetadata/editexifmetadata.py:1474
+#: EditExifMetadata//editexifmetadata.py:1471
 msgid "There was an error in stripping the Exif metadata from this image..."
 msgstr ""
 "Il y a eut une erreur dans la ré-initialisation des métadonnées pour cette "
 "image..."
+
+# Substantif (GNOME fr)
+# trunk
+#~ msgid "Displaying Exif metadata..."
+#~ msgstr "Affichage des métadonnées Exif de l'image..."

--- a/EditExifMetadata/po/nl-local.po
+++ b/EditExifMetadata/po/nl-local.po
@@ -1,418 +1,421 @@
-# translation of nl.po to nederlands
-# Dutch translation of GRAMPS
-# Copyright (C) 2003 The Free Software Foundation,  Inc.
+# Dutch translation of addon EditExifMetadata.
+# Copyright (C) 2020 Gramps project
+# This file is distributed under the same license as the EditExifMetadata package.
 #
 # Tino Meinen <a.t.meinen@chello.nl>, 2003, 2004, 2005.
 # Kees Bakker <kees.bakker@xs4all.nl>, 2005, 2006, 2007.
 # Erik De Richter <frederik.de.richter@pandora.be>, 2006, 2007, 2008, 2009, 2010 , 2011, 2012.
+# Jan Sparreboom <jan@sparreboom.net>, 2020.
 #
-# --------------------------------------------------
-# Conventies (kan later altijd nog aangepast worden)
-# --------------------------------------------------
-# active             actief (moet hier nog iets beters voor verzinnen)
-# attribute          kenmerk
-# bookmark           bladwijzer
-# view               scherm
-# city               plaats beter is stad dorp
-# marker             merkpunt
-# people             personen
-# place              locatie
-# record             archief/kaart
-# database           gegevensbestand (KB)
-# chart              grafiek
-# Home person        beginpersoon : (EDR)
-# spouse             echtgenoot
-# partner            partner
-# warning            let op
-# at the age of      op een leeftijd van -> toen hij/zij .. oud was
-# repositories       bibliotheken
-# regex              regex onvertaald laten
-# expression         uitdrukking
-# given name         voornaam
-# reference	     waarnaar verwezen wordt
-# count		     aantal maal
-# lineage	     lijn
-# locality	     plaats
-# u gebruiken
-# telkens werkwoord achteraan plaatsen
 msgid ""
 msgstr ""
-"Project-Id-Version: gramps\n"
+"Project-Id-Version: EditExifMetadata 5.x\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-02-25 15:32+0100\n"
-"PO-Revision-Date: 2013-02-11 20:58+0100\n"
-"Last-Translator: Erik De Richter <frederik.de.richter@gmail.com>\n"
-"Language-Team: nederlands <frederik.de.richter@googlemail.com>\n"
-"Language: \n"
+"POT-Creation-Date: 2020-07-21 14:47+0200\n"
+"PO-Revision-Date: 2020-07-21 15:21+0200\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
+"Language-Team: Dutch <gramps-users@lists.sourceforge.net>\n"
+"Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 1.5.4\n"
+"X-Generator: Poedit 2.3\n"
 
-#: EditExifMetadata/editexifmetadata.gpr.py:29
-#: EditExifMetadata/editexifmetadata.py:753
-#: EditExifMetadata/editexifmetadata.py:1159
+#: EditExifMetadata//editexifmetadata.gpr.py:29
+#: EditExifMetadata//editexifmetadata.py:724
+#: EditExifMetadata//editexifmetadata.py:1136
+#: EditExifMetadata//editexifmetadata.py:1148
 msgid "Edit Image Exif Metadata"
-msgstr "Exif-metagegevens aanpassen"
+msgstr "Bewerk afbeeldings-Exif-metagegevens"
 
-#: EditExifMetadata/editexifmetadata.gpr.py:30
+#: EditExifMetadata//editexifmetadata.gpr.py:30
 msgid "Gramplet to view, edit, and save image Exif metadata"
 msgstr ""
-"Een gramplet om de Exif-beeldmetagegevens te zien, aan te passen of op te "
-"slaan"
+"Gramplet om Exif-metagegevens van afbeeldingen weer te geven, te bewerken en "
+"op te slaan"
 
-#: EditExifMetadata/editexifmetadata.gpr.py:34
+#: EditExifMetadata//editexifmetadata.gpr.py:34
 msgid "Edit Exif Metadata"
-msgstr "Exif-metadata aanpassen"
+msgstr "Exif-metagegevens bewerken"
 
-#: EditExifMetadata/editexifmetadata.py:148
+#: EditExifMetadata//editexifmetadata.py:135
 msgid "<-- Image Types -->"
-msgstr "<-- Beeldtypes -->"
+msgstr "<-- Afbeeldingstypen -->"
 
-#: EditExifMetadata/editexifmetadata.py:171
+#: EditExifMetadata//editexifmetadata.py:158
 msgid ""
 "Warning:  Changing this entry will update the Media object title field in "
 "Gramps not Exiv2 metadata."
 msgstr ""
-"Waarschuwing:   Wanneer u dit gegeven verandert zal de titel van het media-"
-"object worden aangepast in Gramps, maar geen 'Exiv2'-metagegeven."
+"Waarschuwing: als u dit item wijzigt wordt het titelveld van het Media-"
+"object in Gramps bijgewerkt, niet Exiv2-metadata."
 
-#: EditExifMetadata/editexifmetadata.py:174
+#: EditExifMetadata//editexifmetadata.py:161
 msgid "Provide a short description for this image."
-msgstr "Geef een korte beschrijving voor dit beeld."
+msgstr "Geef een korte beschrijving voor deze afbeelding."
 
-#: EditExifMetadata/editexifmetadata.py:176
+#: EditExifMetadata//editexifmetadata.py:163
 msgid ""
 "Enter the Artist/ Author of this image.  The person's name or the company "
 "who is responsible for the creation of this image."
 msgstr ""
-"De auteur van dit beeld ingeven. De naam van de persoon of het bedrijf dat "
-"verantwoordelijk is voor de beeldcreatie."
+"Voer de artiest / auteur van deze afbeelding in. De naam van de persoon of "
+"het bedrijf dat verantwoordelijk is voor het maken van deze afbeelding."
 
-#: EditExifMetadata/editexifmetadata.py:179
+#: EditExifMetadata//editexifmetadata.py:167
 msgid "Enter the copyright information for this image. \n"
-msgstr "De informatie van de auteursrechten van dit beeld opgeven. \n"
+msgstr "Voer de copyrightinformatie voor deze afbeelding in.\n"
 
-#: EditExifMetadata/editexifmetadata.py:181
+#: EditExifMetadata//editexifmetadata.py:169
 msgid ""
 "The original date/ time when the image was first created/ taken as in a "
 "photograph.\n"
 "Example: 1830-01-1 09:30:59"
 msgstr ""
-"De oorspronkelijke datum/tijd wanneer het beeld aangemaakt werd.\n"
-"Voorbeeld: 1/01/1895 09:30:59"
+"De oorspronkelijke datum / tijd waarop de afbeelding voor het eerst werd "
+"gemaakt / genomen zoals op een foto.\n"
+"Voorbeeld: 1830-01-1 09:30:59"
 
-#: EditExifMetadata/editexifmetadata.py:184
+#: EditExifMetadata//editexifmetadata.py:173
 msgid ""
 "This is the date/ time that the image was last changed/ modified.\n"
 "Example: 2011-05-24 14:30:00"
 msgstr ""
-"Dit is de datum/tijd dat het beeld werd veranderd.\n"
-"Voorbeeld: 24/05/2011 14:30:00"
+"Dit is de datum / tijd waarop de afbeelding voor het laatst is gewijzigd / "
+"gewijzigd.\n"
+"Voorbeeld: 2011-05-24 14:30:00"
 
-#: EditExifMetadata/editexifmetadata.py:187
+#: EditExifMetadata//editexifmetadata.py:176
 msgid ""
 "Enter the Latitude GPS coordinates for this image,\n"
-"Example: 43.722965, 43 43 22 N, 38° 38′ 03″ N, 38 38 3"
+"Example: -43.722965, -43:43:22, 38° 38′ 03″ N"
 msgstr ""
-"De GPS-breedtecoördinaten van het beeld ingeven\n"
-"Voorbeeld: 43.722965, 43 43 22 N, 38° 38′ 03″ N, 38 38 3"
+"Voer de GPS-coördinaten voor de breedtegraad in voor deze afbeelding.\n"
+"Voorbeeld: -43.722965, -43:43:22, 38° 38′ 03″ N"
 
-#: EditExifMetadata/editexifmetadata.py:190
+#: EditExifMetadata//editexifmetadata.py:179
 msgid ""
 "Enter the Longitude GPS coordinates for this image,\n"
-"Example: 10.396378, 10 23 46 E, 105° 6′ 6″ W, -105 6 6"
+"Example: -10.396378, -10:23:46, 105° 6′ 6″ W"
 msgstr ""
-"De GPS-lengtecoördinaten van het beeld ingeven,\n"
-"Voorbeeld: 10.396378, 10 23 46 O, 105° 6′ 6″ W, -105 6 6"
+"Voer de GPS-coördinaten voor de lengtegraad in voor deze afbeelding.\n"
+"Voorbeeld: -10.396378, -10:23:46, 105° 6′ 6″ W"
 
-#: EditExifMetadata/editexifmetadata.py:193
+#: EditExifMetadata//editexifmetadata.py:182
 msgid ""
 "This is the measurement of Above or Below Sea Level.  It is measured in "
-"meters.Example: 200.558, -200.558"
+"meters.  Example: 200.558, -200.558"
 msgstr ""
-"Dit is een maat voor de hoogte boven of onder zeeniveau. Dit wordt "
-"uitgedrukt in meters. Bijvoorbeeld: 200,558, -200,558"
+"Dit is de meting van boven of onder zeeniveau. Het wordt gemeten in meters. "
+"Voorbeeld: 200.558, -200.558"
 
-#: EditExifMetadata/editexifmetadata.py:202
+#: EditExifMetadata//editexifmetadata.py:191
 msgid ""
 "Displays the Gramps Wiki Help page for 'Edit Image Exif Metadata' in your "
 "web browser."
 msgstr ""
-"De Gramps-wiki helppagina voor 'aanpassen van de metabeeldgegevens' in uw "
-"webbrowser tonen."
+"Toont de Gramps Wiki Help-pagina voor 'Bewerk afbeeldings-Exif-metagegevens' "
+"in uw webbrowser."
 
-#: EditExifMetadata/editexifmetadata.py:205
+#: EditExifMetadata//editexifmetadata.py:194
 msgid ""
 "This will open up a new window to allow you to edit/ modify this image's "
 "Exif metadata.\n"
 "  It will also allow you to be able to Save the modified metadata."
 msgstr ""
-"Hiermee wordt een nieuw scherm geopend waar u de 'Evif'-metagegevens van het "
-"beeld kunt aanpassen.\n"
-"  Tevens kunt u hier de aangepaste metagegevens opslaan."
+"Dit zal een nieuw venster openen waarin u de Exif-metagegevens van deze "
+"afbeelding kunt bewerken / wijzigen.\n"
+" Het stelt u ook in staat om de gewijzigde metadata op te slaan."
 
-#: EditExifMetadata/editexifmetadata.py:209
+#: EditExifMetadata//editexifmetadata.py:198
 msgid "Will produce a Popup window showing a Thumbnail Viewing Area"
-msgstr "Een scherm wordt getoond met ruimte voor de bekijken van de miniaturen"
+msgstr ""
+"Geeft een pop-upvenster weer met een miniatuurafbeelding weergavegebied"
 
-#: EditExifMetadata/editexifmetadata.py:211
+#: EditExifMetadata//editexifmetadata.py:201
 msgid ""
 "Select from a drop- down box the image file type that you would like to "
 "convert your non- Exiv2 compatible media object to."
 msgstr ""
-"Via een uitvalsmenu kunt u het bestandstype kiezen dat u kunt te gebruiken "
-"om uw 'non-Exiv2' media-object om te zetten."
+"Selecteer in een vervolgkeuzelijst het type afbeeldingsbestand waarnaar u uw "
+"niet-Exiv2-compatibele media-object wilt converteren."
 
-#: EditExifMetadata/editexifmetadata.py:214
+#: EditExifMetadata//editexifmetadata.py:205
 msgid ""
 "If your image is not of an image type that can have Exif metadata read/ "
 "written to/from, convert it to a type that can?"
 msgstr ""
-"Indien uw beeld geen formaat heeft dat 'Exiv2'-metagegevens kan opslaan, "
-"wenst u dit beeld dan om te zetten naar een formaat dat wel geschikt is?"
+"Als uw afbeelding niet van een afbeeldingstype is dat Exif-metagegevens kan "
+"lezen / schrijven naar / van, converteert u deze naar een type dat dat wel "
+"kan?"
 
-#: EditExifMetadata/editexifmetadata.py:217
+#: EditExifMetadata//editexifmetadata.py:209
 msgid ""
 "WARNING:  This will completely erase all Exif metadata from this image!  Are "
 "you sure that you want to do this?"
 msgstr ""
-"WAARSCHUWING: dit zal al uw Exif-metagegevens van dit beeld volledig wissen! "
-"Bent u zeker dat u dit wilt doen?"
+"WAARSCHUWING: Hiermee worden alle Exif-metadata van deze afbeelding volledig "
+"gewist! Weet u zeker dat u dit wilt doen?"
 
-#: EditExifMetadata/editexifmetadata.py:315
+#: EditExifMetadata//editexifmetadata.py:213
+msgid "Clear GPS"
+msgstr "Wis GPS"
+
+#: EditExifMetadata//editexifmetadata.py:214
 msgid "Thumbnail"
-msgstr "Miniatuur"
+msgstr "Miniatuurbeeld"
 
-# dit is een soort titel in een file-selector
-#: EditExifMetadata/editexifmetadata.py:397
+#: EditExifMetadata//editexifmetadata.py:215
+msgid "Copy"
+msgstr "Kopieer"
+
+#: EditExifMetadata//editexifmetadata.py:216
+#: EditExifMetadata//editexifmetadata.py:727
+msgid "Convert"
+msgstr "Converteren"
+
+#: EditExifMetadata//editexifmetadata.py:217
+msgid "Clear"
+msgstr "Wissen"
+
+#: EditExifMetadata//editexifmetadata.py:402
 msgid "Select an image to begin..."
-msgstr "Beeld selecteren om te starten..."
+msgstr "Selecteer een afbeelding om mee te beginnen..."
 
-#: EditExifMetadata/editexifmetadata.py:419
+#: EditExifMetadata//editexifmetadata.py:421
 msgid ""
 "Image is NOT readable,\n"
 "Please choose a different image..."
 msgstr ""
-"Beeld is NIET leesbaar,\n"
-"een ander beeld kiezen..."
+"Afbeelding is NIET leesbaar,\n"
+"kies een andere afbeelding ..."
 
-#: EditExifMetadata/editexifmetadata.py:435
+#: EditExifMetadata//editexifmetadata.py:441
+msgid "Please convert this image to an Exiv2- compatible image type..."
+msgstr ""
+"Converteer deze afbeelding naar een Exiv2-compatibel afbeeldingstype..."
+
+#: EditExifMetadata//editexifmetadata.py:465
+#, python-brace-format
+msgid "Image Size : {width} x {height} pixels"
+msgstr "Afbeeldingsgrootte: {width} x {height} pixels"
+
+#: EditExifMetadata//editexifmetadata.py:481
+#: EditExifMetadata//editexifmetadata.py:1441
 msgid ""
 "Image is NOT writable,\n"
 "You will NOT be able to save Exif metadata...."
 msgstr ""
-"Beeld is niet beschrijfbaar.\n"
-"U kunt geen Exif-metagegevens opslaan...."
+"Afbeelding is NIET beschrijfbaar,\n"
+"U kunt geen Exif-metagegevens opslaan..."
 
-#: EditExifMetadata/editexifmetadata.py:447
-msgid "Please convert this image to an Exiv2- compatible image type..."
-msgstr "Dit beeld in een beeldtype omzetten dat compatibel is met 'Exiv2'..."
-
-#: EditExifMetadata/editexifmetadata.py:470
-msgid "Image Size : %04(width)d x %04(height)d pixels"
-msgstr "Beeldgrootte : %04(width)d x %04(height)d pixels"
-
-#: EditExifMetadata/editexifmetadata.py:503
-msgid "Displaying Exif metadata..."
-msgstr "Exif-metagegevens weergeven..."
-
-#: EditExifMetadata/editexifmetadata.py:670
+#: EditExifMetadata//editexifmetadata.py:649
 msgid "Click Close to close this Thumbnail View Area."
-msgstr ""
-"Op Sluiten klikken om dit scherm met de voorvertoning van de miniaturen te "
-"sluiten."
+msgstr "Klik op Sluiten om dit miniatuurafbeelding weergavegebied te sluiten."
 
-#: EditExifMetadata/editexifmetadata.py:674
+#: EditExifMetadata//editexifmetadata.py:655
 msgid "Thumbnail View Area"
-msgstr "Thumbnail View Area"
+msgstr "Miniatuurafbeeldingsweergave"
 
-#: EditExifMetadata/editexifmetadata.py:753
+#: EditExifMetadata//editexifmetadata.py:725
 msgid ""
 "WARNING: You are about to convert this image into a .jpeg image.  Are you "
 "sure that you want to do this?"
 msgstr ""
-"WAARSCHUWING: dit zal al dit beeld omzetten naar een '.jpeg'-formaat. Bent u "
-"zeker dat u dit wilt doen?"
+"WAARSCHUWING: U staat op het punt deze afbeelding te converteren naar een ."
+"jpeg-afbeelding. Weet u zeker dat u dit wilt doen?"
 
-#: EditExifMetadata/editexifmetadata.py:755
+#: EditExifMetadata//editexifmetadata.py:727
 msgid "Convert and Delete"
-msgstr "Omzetten en verwijderen"
+msgstr "Converteren en verwijderen"
 
-#: EditExifMetadata/editexifmetadata.py:755
-msgid "Convert"
-msgstr "Omzetten"
-
-#: EditExifMetadata/editexifmetadata.py:841
+#: EditExifMetadata//editexifmetadata.py:808
 msgid ""
 "Your image has been converted and the original file has been deleted, and "
 "the full path has been updated!"
 msgstr ""
-"Uw beeld werd omgezet, het oorspronkelijk bestand werd gewist en het "
-"volledige pad werd opgewaardeerd!"
+"Uw afbeelding is geconverteerd, het originele bestand is verwijderd en het "
+"volledige pad is bijgewerkt!"
 
-#: EditExifMetadata/editexifmetadata.py:845
+#: EditExifMetadata//editexifmetadata.py:813
 msgid ""
 "There has been an error, Please check your source and destination file "
 "paths..."
 msgstr ""
-"Er trad een fout op. Gelieve het mappad van uw bron en bestemming na te "
-"kijken..."
+"Er is een fout opgetreden, controleer alstublieft uw bron- en "
+"bestemmingsbestandspaden..."
 
-#: EditExifMetadata/editexifmetadata.py:848
+#: EditExifMetadata//editexifmetadata.py:817
 msgid ""
 "There was an error in deleting the original file.  You will need to delete "
 "it yourself!"
 msgstr ""
-"Er was een fout bij het verwijderen van het oorspronkelijke bestand. U dient "
-"dit bestand zelf te verwijderen!"
+"Er is een fout opgetreden bij het verwijderen van het oorspronkelijke "
+"bestand. U moet het zelf verwijderen!"
 
-#: EditExifMetadata/editexifmetadata.py:865
+#: EditExifMetadata//editexifmetadata.py:835
 msgid "There was an error in converting your image file."
-msgstr "Er onstond een fout bij het converteren van uw beeldbestand."
+msgstr ""
+"Er is een fout opgetreden bij het converteren van uw afbeeldingsbestand."
 
-#: EditExifMetadata/editexifmetadata.py:876
+#: EditExifMetadata//editexifmetadata.py:845
 msgid "Media Path Update"
-msgstr "Mediapad opwaarderen"
+msgstr "Mediapad-update"
 
-#: EditExifMetadata/editexifmetadata.py:882
+#: EditExifMetadata//editexifmetadata.py:854
 msgid "There has been an error in updating the image file's path!"
 msgstr ""
-"Er onstond een fout bij het opwaarderen van het bestandspad van het beeld!."
+"Er is een fout opgetreden bij het bijwerken van het pad van het "
+"afbeeldingsbestand!"
 
-#: EditExifMetadata/editexifmetadata.py:916
+#: EditExifMetadata//editexifmetadata.py:887
 msgid ""
 "Click the close button when you are finished modifying this image's Exif "
 "metadata."
 msgstr ""
-"Wanneer u de aanpassingen van de 'Exif'-metagegevens hebt beëindigd klikt u "
-"op de knop sluiten."
+"Klik op de sluitknop als u klaar bent met het wijzigen van de Exif-"
+"metagegevens van deze afbeelding."
 
-#: EditExifMetadata/editexifmetadata.py:954
+#: EditExifMetadata//editexifmetadata.py:925
 msgid "Saves a copy of the data fields into the image's Exif metadata."
 msgstr ""
-"Een kopie van de gegevens in de invoervelden worden in de 'Exif'-"
-"metagegevens opgeslagen."
+"Slaat een kopie van de gegevensvelden op in de Exif-metagegevens van de "
+"afbeelding."
 
-#: EditExifMetadata/editexifmetadata.py:957
+#: EditExifMetadata//editexifmetadata.py:929
 msgid "Re -display the data fields that were cleared from the Edit Area."
 msgstr ""
-"Opnieuw tonen van de gegevens in de invoervelden die gewist werden in het "
-"aanpasscherm."
+"Geef de gegevensvelden opnieuw weer die zijn gewist uit het bewerkingsgebied."
 
-#: EditExifMetadata/editexifmetadata.py:960
+#: EditExifMetadata//editexifmetadata.py:933
 msgid "This button will clear all of the data fields shown here."
-msgstr ""
-"Deze knop zal alle gegevens in alle invoervelden die getoond worden, wissen."
+msgstr "Deze knop wist alle hier getoonde gegevensvelden."
 
-#: EditExifMetadata/editexifmetadata.py:963
+#: EditExifMetadata//editexifmetadata.py:937
+msgid "This button will clear all of the GPS fields shown here."
+msgstr "Deze knop wist alle hier getoonde GPS-velden."
+
+#: EditExifMetadata//editexifmetadata.py:941
 msgid ""
 "Closes this popup Edit window.\n"
 "WARNING: This action will NOT Save any changes/ modification made to this "
 "image's Exif metadata."
 msgstr ""
-"Dit aanpasscherm sluiten.\n"
-"WAARSCHUWING: met deze actie worden de aanpassingen NIET opgeslagen in de "
-"'Exif'-metagegevens."
+"Sluit dit pop-upvenster Bewerken.\n"
+"WAARSCHUWING: Met deze actie worden GEEN wijzigingen / aanpassingen in de "
+"Exif-metadata van deze afbeelding opgeslagen."
 
-#: EditExifMetadata/editexifmetadata.py:990
+#: EditExifMetadata//editexifmetadata.py:970
 msgid "Media Object Title"
-msgstr "Titel van het media-object"
+msgstr "Titel van mediaobject"
 
-#: EditExifMetadata/editexifmetadata.py:1000
+#: EditExifMetadata//editexifmetadata.py:979
 msgid "media Title: "
 msgstr "mediatitel: "
 
-#: EditExifMetadata/editexifmetadata.py:1014
+#: EditExifMetadata//editexifmetadata.py:994
 msgid "General Data"
 msgstr "Algemene gegevens"
 
-#: EditExifMetadata/editexifmetadata.py:1024
+#: EditExifMetadata//editexifmetadata.py:1004
 msgid "Description: "
-msgstr "Beschrijving: "
+msgstr "Omschrijving: "
 
-#: EditExifMetadata/editexifmetadata.py:1025
+#: EditExifMetadata//editexifmetadata.py:1005
 msgid "Artist: "
-msgstr "Auteur: "
+msgstr "Artiest: "
 
-#: EditExifMetadata/editexifmetadata.py:1026
+#: EditExifMetadata//editexifmetadata.py:1006
 msgid "Copyright: "
-msgstr "Copyright: "
+msgstr "Auteursrechten: "
 
-#: EditExifMetadata/editexifmetadata.py:1039
+#: EditExifMetadata//editexifmetadata.py:1020
 msgid "Date/ Time"
-msgstr "Datum/ tijd"
+msgstr "Datum / Tijd"
 
-#: EditExifMetadata/editexifmetadata.py:1053
+#: EditExifMetadata//editexifmetadata.py:1035
 msgid "Original: "
 msgstr "Origineel: "
 
-#: EditExifMetadata/editexifmetadata.py:1054
+#: EditExifMetadata//editexifmetadata.py:1036
 msgid "Modified: "
-msgstr "Laatst veranderd op: "
+msgstr "Aangepast: "
 
-#: EditExifMetadata/editexifmetadata.py:1071
+#: EditExifMetadata//editexifmetadata.py:1055
 msgid "Latitude/ Longitude/ Altitude GPS coordinates"
-msgstr "Breedte/ Lengte/ hoogte GPS-coördinaten"
+msgstr "Breedtegraad / lengtegraad / hoogte GPS-coördinaten"
 
-#: EditExifMetadata/editexifmetadata.py:1085
+#: EditExifMetadata//editexifmetadata.py:1070
 msgid "Latitude :"
-msgstr "Breedtegraad:"
+msgstr "Breedtegraad :"
 
-#: EditExifMetadata/editexifmetadata.py:1086
+#: EditExifMetadata//editexifmetadata.py:1071
 msgid "Longitude :"
-msgstr "Lengtegraad:"
+msgstr "Lengtegraad :"
 
-#: EditExifMetadata/editexifmetadata.py:1087
+#: EditExifMetadata//editexifmetadata.py:1072
 msgid "Altitude :"
-msgstr "Hoogte:"
+msgstr "Hoogte :"
 
-#: EditExifMetadata/editexifmetadata.py:1139
+#: EditExifMetadata//editexifmetadata.py:1115
 msgid "Bad Date/Time"
-msgstr "Verkeerde datum/tijd"
+msgstr "Slechte datum / tijd"
 
-#: EditExifMetadata/editexifmetadata.py:1147
+#: EditExifMetadata//editexifmetadata.py:1123
 msgid "Invalid latitude (syntax: 18\\u00b09'"
-msgstr "Ongeldige breedtegraad (syntax: 18\\u00b09'"
+msgstr "Ongeldige breedtegraad (syntaxis: 18\\u00b09'"
 
-#: EditExifMetadata/editexifmetadata.py:1148
+#: EditExifMetadata//editexifmetadata.py:1124
 msgid "48.21\"S, -18.2412 or -18:9:48.21)"
-msgstr "48.21\"Z, -18.2412 of -18:9:48.21)"
+msgstr "48.21\"S, -18.2412 of -18:9:48.21)"
 
-#: EditExifMetadata/editexifmetadata.py:1152
+#: EditExifMetadata//editexifmetadata.py:1128
 msgid "Invalid longitude (syntax: 18\\u00b09'"
-msgstr "Ongeldige lengtegraad (syntax: 18\\u00b09'"
+msgstr "Ongeldige lengtegraad (syntaxis: 18\\u00b09'"
 
-#: EditExifMetadata/editexifmetadata.py:1153
+#: EditExifMetadata//editexifmetadata.py:1129
 msgid "48.21\"E, -18.2412 or -18:9:48.21)"
-msgstr "48.21\"O, -18.2412 of -18:9:48.21)"
+msgstr "48.21\"E, -18.2412 of -18:9:48.21)"
 
-#: EditExifMetadata/editexifmetadata.py:1159
+#: EditExifMetadata//editexifmetadata.py:1137
 msgid ""
 "WARNING!  You are about to completely delete the Exif metadata from this "
 "image?"
 msgstr ""
-"WAARSCHUWING! U staat op het punt om alle Exif-metagegevens van dit beeld te "
-"verwijderen?"
+"WAARSCHUWING! U staat op het punt de Exif-metagegevens van deze afbeelding "
+"volledig te verwijderen?"
 
-#: EditExifMetadata/editexifmetadata.py:1324
+#: EditExifMetadata//editexifmetadata.py:1139
+#: EditExifMetadata//editexifmetadata.py:1151
+msgid "Delete"
+msgstr "Verwijderen"
+
+#: EditExifMetadata//editexifmetadata.py:1149
+msgid ""
+"WARNING!  You are about to completely delete the GPS metadata from this "
+"image?"
+msgstr ""
+"WAARSCHUWING! U staat op het punt de GPS-metagegevens volledig uit deze "
+"afbeelding te verwijderen?"
+
+#: EditExifMetadata//editexifmetadata.py:1334
 msgid "Media Title Update"
-msgstr "Mediatitel opwaarderen"
+msgstr "Mediatitel update"
 
-#: EditExifMetadata/editexifmetadata.py:1350
+#: EditExifMetadata//editexifmetadata.py:1358
 msgid "Media Object Date Created"
-msgstr "Datum waarop media-objecten werd aangemaakt"
+msgstr "Creatie-datum media-object"
 
-#: EditExifMetadata/editexifmetadata.py:1422
+#: EditExifMetadata//editexifmetadata.py:1423
 msgid "Saving Exif metadata to this image..."
-msgstr "Exif-metabeeldgegevens worden opgeslagen..."
+msgstr "Exif-metagegevens in deze afbeelding opslaan..."
 
-#: EditExifMetadata/editexifmetadata.py:1469
+#: EditExifMetadata//editexifmetadata.py:1466
 msgid "All Exif metadata has been deleted from this image..."
-msgstr "Alle Exif-beeldgegevens werden gewist..."
+msgstr "Alle Exif-metagegevens zijn verwijderd uit deze afbeelding..."
 
-#: EditExifMetadata/editexifmetadata.py:1474
+#: EditExifMetadata//editexifmetadata.py:1471
 msgid "There was an error in stripping the Exif metadata from this image..."
 msgstr ""
-"Er ontstond een fout bij het wissen van de exif-metagegevens van dit beeld..."
+"Er is een fout opgetreden bij het verwijderen van de Exif-metagegevens van "
+"deze afbeelding..."

--- a/EditExifMetadata/po/template.pot
+++ b/EditExifMetadata/po/template.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-14 16:46-0500\n"
+"POT-Creation-Date: 2020-07-21 14:47+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,327 +17,340 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: EditExifMetadata/editexifmetadata.gpr.py:29
-#: EditExifMetadata/editexifmetadata.py:708
-#: EditExifMetadata/editexifmetadata.py:1120
-#: EditExifMetadata/editexifmetadata.py:1132
+#: EditExifMetadata//editexifmetadata.gpr.py:29
+#: EditExifMetadata//editexifmetadata.py:724
+#: EditExifMetadata//editexifmetadata.py:1136
+#: EditExifMetadata//editexifmetadata.py:1148
 msgid "Edit Image Exif Metadata"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.gpr.py:30
+#: EditExifMetadata//editexifmetadata.gpr.py:30
 msgid "Gramplet to view, edit, and save image Exif metadata"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.gpr.py:34
+#: EditExifMetadata//editexifmetadata.gpr.py:34
 msgid "Edit Exif Metadata"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:126
+#: EditExifMetadata//editexifmetadata.py:135
 msgid "<-- Image Types -->"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:149
+#: EditExifMetadata//editexifmetadata.py:158
 msgid ""
 "Warning:  Changing this entry will update the Media object title field in "
 "Gramps not Exiv2 metadata."
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:152
+#: EditExifMetadata//editexifmetadata.py:161
 msgid "Provide a short description for this image."
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:154
+#: EditExifMetadata//editexifmetadata.py:163
 msgid ""
 "Enter the Artist/ Author of this image.  The person's name or the company "
 "who is responsible for the creation of this image."
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:158
+#: EditExifMetadata//editexifmetadata.py:167
 msgid "Enter the copyright information for this image. \n"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:160
+#: EditExifMetadata//editexifmetadata.py:169
 msgid ""
 "The original date/ time when the image was first created/ taken as in a "
 "photograph.\n"
 "Example: 1830-01-1 09:30:59"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:164
+#: EditExifMetadata//editexifmetadata.py:173
 msgid ""
 "This is the date/ time that the image was last changed/ modified.\n"
 "Example: 2011-05-24 14:30:00"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:167
+#: EditExifMetadata//editexifmetadata.py:176
 msgid ""
 "Enter the Latitude GPS coordinates for this image,\n"
 "Example: -43.722965, -43:43:22, 38° 38′ 03″ N"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:170
+#: EditExifMetadata//editexifmetadata.py:179
 msgid ""
 "Enter the Longitude GPS coordinates for this image,\n"
 "Example: -10.396378, -10:23:46, 105° 6′ 6″ W"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:173
+#: EditExifMetadata//editexifmetadata.py:182
 msgid ""
 "This is the measurement of Above or Below Sea Level.  It is measured in "
 "meters.  Example: 200.558, -200.558"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:182
+#: EditExifMetadata//editexifmetadata.py:191
 msgid ""
 "Displays the Gramps Wiki Help page for 'Edit Image Exif Metadata' in your "
 "web browser."
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:185
+#: EditExifMetadata//editexifmetadata.py:194
 msgid ""
 "This will open up a new window to allow you to edit/ modify this image's "
 "Exif metadata.\n"
 "  It will also allow you to be able to Save the modified metadata."
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:189
+#: EditExifMetadata//editexifmetadata.py:198
 msgid "Will produce a Popup window showing a Thumbnail Viewing Area"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:192
+#: EditExifMetadata//editexifmetadata.py:201
 msgid ""
 "Select from a drop- down box the image file type that you would like to "
 "convert your non- Exiv2 compatible media object to."
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:196
+#: EditExifMetadata//editexifmetadata.py:205
 msgid ""
 "If your image is not of an image type that can have Exif metadata read/ "
 "written to/from, convert it to a type that can?"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:200
+#: EditExifMetadata//editexifmetadata.py:209
 msgid ""
 "WARNING:  This will completely erase all Exif metadata from this image!  Are "
 "you sure that you want to do this?"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:203
+#: EditExifMetadata//editexifmetadata.py:213
 msgid "Clear GPS"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:387
+#: EditExifMetadata//editexifmetadata.py:214
+msgid "Thumbnail"
+msgstr ""
+
+#: EditExifMetadata//editexifmetadata.py:215
+msgid "Copy"
+msgstr ""
+
+#: EditExifMetadata//editexifmetadata.py:216
+#: EditExifMetadata//editexifmetadata.py:727
+msgid "Convert"
+msgstr ""
+
+#: EditExifMetadata//editexifmetadata.py:217
+msgid "Clear"
+msgstr ""
+
+#: EditExifMetadata//editexifmetadata.py:402
 msgid "Select an image to begin..."
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:406
+#: EditExifMetadata//editexifmetadata.py:421
 msgid ""
 "Image is NOT readable,\n"
 "Please choose a different image..."
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:426
+#: EditExifMetadata//editexifmetadata.py:441
 msgid "Please convert this image to an Exiv2- compatible image type..."
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:450
+#: EditExifMetadata//editexifmetadata.py:465
 #, python-brace-format
 msgid "Image Size : {width} x {height} pixels"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:466
-#: EditExifMetadata/editexifmetadata.py:1425
+#: EditExifMetadata//editexifmetadata.py:481
+#: EditExifMetadata//editexifmetadata.py:1441
 msgid ""
 "Image is NOT writable,\n"
 "You will NOT be able to save Exif metadata...."
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:633
+#: EditExifMetadata//editexifmetadata.py:649
 msgid "Click Close to close this Thumbnail View Area."
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:639
+#: EditExifMetadata//editexifmetadata.py:655
 msgid "Thumbnail View Area"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:709
+#: EditExifMetadata//editexifmetadata.py:725
 msgid ""
 "WARNING: You are about to convert this image into a .jpeg image.  Are you "
 "sure that you want to do this?"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:711
+#: EditExifMetadata//editexifmetadata.py:727
 msgid "Convert and Delete"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:711
-msgid "Convert"
-msgstr ""
-
-#: EditExifMetadata/editexifmetadata.py:792
+#: EditExifMetadata//editexifmetadata.py:808
 msgid ""
 "Your image has been converted and the original file has been deleted, and "
 "the full path has been updated!"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:797
+#: EditExifMetadata//editexifmetadata.py:813
 msgid ""
 "There has been an error, Please check your source and destination file "
 "paths..."
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:801
+#: EditExifMetadata//editexifmetadata.py:817
 msgid ""
 "There was an error in deleting the original file.  You will need to delete "
 "it yourself!"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:819
+#: EditExifMetadata//editexifmetadata.py:835
 msgid "There was an error in converting your image file."
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:829
+#: EditExifMetadata//editexifmetadata.py:845
 msgid "Media Path Update"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:838
+#: EditExifMetadata//editexifmetadata.py:854
 msgid "There has been an error in updating the image file's path!"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:871
+#: EditExifMetadata//editexifmetadata.py:887
 msgid ""
 "Click the close button when you are finished modifying this image's Exif "
 "metadata."
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:909
+#: EditExifMetadata//editexifmetadata.py:925
 msgid "Saves a copy of the data fields into the image's Exif metadata."
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:913
+#: EditExifMetadata//editexifmetadata.py:929
 msgid "Re -display the data fields that were cleared from the Edit Area."
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:917
+#: EditExifMetadata//editexifmetadata.py:933
 msgid "This button will clear all of the data fields shown here."
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:921
+#: EditExifMetadata//editexifmetadata.py:937
 msgid "This button will clear all of the GPS fields shown here."
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:925
+#: EditExifMetadata//editexifmetadata.py:941
 msgid ""
 "Closes this popup Edit window.\n"
 "WARNING: This action will NOT Save any changes/ modification made to this "
 "image's Exif metadata."
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:954
+#: EditExifMetadata//editexifmetadata.py:970
 msgid "Media Object Title"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:963
+#: EditExifMetadata//editexifmetadata.py:979
 msgid "media Title: "
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:978
+#: EditExifMetadata//editexifmetadata.py:994
 msgid "General Data"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:988
+#: EditExifMetadata//editexifmetadata.py:1004
 msgid "Description: "
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:989
+#: EditExifMetadata//editexifmetadata.py:1005
 msgid "Artist: "
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:990
+#: EditExifMetadata//editexifmetadata.py:1006
 msgid "Copyright: "
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:1004
+#: EditExifMetadata//editexifmetadata.py:1020
 msgid "Date/ Time"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:1019
+#: EditExifMetadata//editexifmetadata.py:1035
 msgid "Original: "
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:1020
+#: EditExifMetadata//editexifmetadata.py:1036
 msgid "Modified: "
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:1039
+#: EditExifMetadata//editexifmetadata.py:1055
 msgid "Latitude/ Longitude/ Altitude GPS coordinates"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:1054
+#: EditExifMetadata//editexifmetadata.py:1070
 msgid "Latitude :"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:1055
+#: EditExifMetadata//editexifmetadata.py:1071
 msgid "Longitude :"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:1056
+#: EditExifMetadata//editexifmetadata.py:1072
 msgid "Altitude :"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:1099
+#: EditExifMetadata//editexifmetadata.py:1115
 msgid "Bad Date/Time"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:1107
+#: EditExifMetadata//editexifmetadata.py:1123
 msgid "Invalid latitude (syntax: 18\\u00b09'"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:1108
+#: EditExifMetadata//editexifmetadata.py:1124
 msgid "48.21\"S, -18.2412 or -18:9:48.21)"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:1112
+#: EditExifMetadata//editexifmetadata.py:1128
 msgid "Invalid longitude (syntax: 18\\u00b09'"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:1113
+#: EditExifMetadata//editexifmetadata.py:1129
 msgid "48.21\"E, -18.2412 or -18:9:48.21)"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:1121
+#: EditExifMetadata//editexifmetadata.py:1137
 msgid ""
 "WARNING!  You are about to completely delete the Exif metadata from this "
 "image?"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:1123
-#: EditExifMetadata/editexifmetadata.py:1135
+#: EditExifMetadata//editexifmetadata.py:1139
+#: EditExifMetadata//editexifmetadata.py:1151
 msgid "Delete"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:1133
+#: EditExifMetadata//editexifmetadata.py:1149
 msgid ""
 "WARNING!  You are about to completely delete the GPS metadata from this "
 "image?"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:1318
+#: EditExifMetadata//editexifmetadata.py:1334
 msgid "Media Title Update"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:1342
+#: EditExifMetadata//editexifmetadata.py:1358
 msgid "Media Object Date Created"
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:1407
+#: EditExifMetadata//editexifmetadata.py:1423
 msgid "Saving Exif metadata to this image..."
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:1450
+#: EditExifMetadata//editexifmetadata.py:1466
 msgid "All Exif metadata has been deleted from this image..."
 msgstr ""
 
-#: EditExifMetadata/editexifmetadata.py:1455
+#: EditExifMetadata//editexifmetadata.py:1471
 msgid "There was an error in stripping the Exif metadata from this image..."
 msgstr ""


### PR DESCRIPTION
Updated internationalisation for addon EditExifMetadata.
Translation didn't work correctly and buttons were not translated.
Based on this update a new template.pot created.
Updated DE, FR, NL po-files based on new template.

Tested without issues in Gramps 5.1.2 on Linux Mint 20.
Please, add it to this branch.
Thanks in advance!