### PR TITLE
[Dynamicweb] Repaired localisation and updated po-files of all languages

### DIFF
--- a/DynamicWeb/dynamicweb.py
+++ b/DynamicWeb/dynamicweb.py
@@ -154,7 +154,11 @@ log = logging.getLogger(".DynamicWeb")
 # Gramps module
 #------------------------------------------------
 
-
+#------------------------------------------------------------------------
+#
+# Internationalisation
+#
+#------------------------------------------------------------------------
 from gramps.gen.const import IMAGE_DIR, GRAMPS_LOCALE as glocale
 try:
     _trans = glocale.get_addon_translator(__file__)
@@ -2187,7 +2191,7 @@ class DynamicWebReport(Report):
         #  - Javascript code for generating the page
         self.page_list = [
             # Menu pages
-            ("index.html", _("Html|Home"), PAGE_HOME in self.page_content, True, "Dwr.Main(Dwr.PAGE_HOME);"),
+            ("index.html", _("DynWeb|Home"), PAGE_HOME in self.page_content, True, "Dwr.Main(Dwr.PAGE_HOME);"),
             ("tree_svg.html", _("Tree"), PAGE_SVG_TREE in self.page_content, True, "Dwr.Main(Dwr.PAGE_SVG_TREE);"),
             ("statistics_conf.html", _("Statistics"), True, True, "printStatisticsConf();"),
             # ("statistics_conf.html", _("Statistics"), PAGE_STATISTICS in self.page_content, True, "printStatisticsConf();"),

--- a/DynamicWeb/po/cs-local.po
+++ b/DynamicWeb/po/cs-local.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-08-19 17:39+0200\n"
+"POT-Creation-Date: 2020-07-24 17:33+0200\n"
 "PO-Revision-Date: 2016-08-08 12:31+0200\n"
 "Last-Translator: Petr Hejl <hejl.petr@gmail.com>\n"
 "Language-Team: Czech\n"
@@ -17,298 +17,358 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
-#: DynamicWeb/dynamicweb.gpr.py:15
+#: DynamicWeb//dynamicweb.gpr.py:15
 msgid "Dynamic Web Report"
 msgstr "Dynamické WWW stránky"
 
-#: DynamicWeb/dynamicweb.gpr.py:16
+#: DynamicWeb//dynamicweb.gpr.py:16
 msgid "Produces dynamic web pages for the database"
 msgstr "Vytváří z databáze dynamické WWW stránky"
 
-#: DynamicWeb/dynamicweb.py:262
+#: DynamicWeb//dynamicweb.py:269
+#, fuzzy
+msgid "Street"
+msgstr "OpenStreetMap"
+
+#: DynamicWeb//dynamicweb.py:270
+#, fuzzy
+msgid "Locality"
+msgstr "Místo"
+
+#: DynamicWeb//dynamicweb.py:271
+msgid "City"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:272
+msgid "Church Parish"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:273
+#, fuzzy
+msgid "County"
+msgstr "Počet"
+
+#: DynamicWeb//dynamicweb.py:274
+msgid "State/ Province"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:275
+msgid "Postal Code"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:276
+#, fuzzy
+msgid "Country"
+msgstr "Počet"
+
+#: DynamicWeb//dynamicweb.py:277
+msgid "Phone"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:283
 msgid "Home Page"
 msgstr "Domovská stránka"
 
-#: DynamicWeb/dynamicweb.py:263
+#: DynamicWeb//dynamicweb.py:284
 msgid "SVG graphical tree"
 msgstr "SVG grafický strom"
 
-#: DynamicWeb/dynamicweb.py:266
+#: DynamicWeb//dynamicweb.py:287
 msgid "Indexes pages"
 msgstr "Indexové stránky"
 
-#: DynamicWeb/dynamicweb.py:270 DynamicWeb/dynamicweb.py:4040
+#: DynamicWeb//dynamicweb.py:291 DynamicWeb//dynamicweb.py:4252
 #, python-format
 msgid "Custom page %(index)i"
 msgstr "Vlastní stránka %(index)i"
 
-#: DynamicWeb/dynamicweb.py:288
+#: DynamicWeb//dynamicweb.py:309
 msgid "Ascending tree"
 msgstr "Strom předků"
 
-#: DynamicWeb/dynamicweb.py:289
+#: DynamicWeb//dynamicweb.py:310
 msgid "Descending tree"
 msgstr "Strom potomků"
 
-#: DynamicWeb/dynamicweb.py:290
+#: DynamicWeb//dynamicweb.py:311
 msgid "Descending tree with spouses"
 msgstr "Strom potomků s partnery"
 
-#: DynamicWeb/dynamicweb.py:291
+#: DynamicWeb//dynamicweb.py:312
 msgid "Ascending and descending tree"
 msgstr "Strom předků a potomků"
 
-#: DynamicWeb/dynamicweb.py:292
+#: DynamicWeb//dynamicweb.py:313
 msgid "Ascending and descending tree with spouses"
 msgstr "Strom předků a potomků s partnery"
 
-#: DynamicWeb/dynamicweb.py:304
+#: DynamicWeb//dynamicweb.py:325
 msgid "Vertical (↓)"
 msgstr "Svislý  (↓)"
 
-#: DynamicWeb/dynamicweb.py:305
+#: DynamicWeb//dynamicweb.py:326
 msgid "Vertical (↑)"
 msgstr "Svislý (↑)"
 
-#: DynamicWeb/dynamicweb.py:306
+#: DynamicWeb//dynamicweb.py:327
 msgid "Horizontal (→)"
 msgstr "Vodorovný (→)"
 
-#: DynamicWeb/dynamicweb.py:307
+#: DynamicWeb//dynamicweb.py:328
 msgid "Horizontal (←)"
 msgstr "Vodorovný (←)"
 
-#: DynamicWeb/dynamicweb.py:308
+#: DynamicWeb//dynamicweb.py:329
 msgid "Full Circle"
 msgstr "Celý kruh"
 
-#: DynamicWeb/dynamicweb.py:309
+#: DynamicWeb//dynamicweb.py:330
 msgid "Half Circle"
 msgstr "Půlkruh"
 
-#: DynamicWeb/dynamicweb.py:310
+#: DynamicWeb//dynamicweb.py:331
 msgid "Quadrant"
 msgstr "Kvadrant"
 
-#: DynamicWeb/dynamicweb.py:322
+#: DynamicWeb//dynamicweb.py:343
 msgid "Size proportional to number of ancestors"
 msgstr "Velikost úměrná počtu předků"
 
-#: DynamicWeb/dynamicweb.py:323
+#: DynamicWeb//dynamicweb.py:344
 msgid "Homogeneous parents distribution"
 msgstr "Stejnoměrné rozložení rodičů"
 
-#: DynamicWeb/dynamicweb.py:326
+#: DynamicWeb//dynamicweb.py:347
 msgid "Size proportional to number of descendants"
 msgstr "Velikost úměrná počtu potomků"
 
-#: DynamicWeb/dynamicweb.py:327
+#: DynamicWeb//dynamicweb.py:348
 msgid "Homogeneous children distribution"
 msgstr "Stejnoměrné rozložení potomků"
 
-#: DynamicWeb/dynamicweb.py:334 DynamicWeb/dynamicweb.py:357
+#: DynamicWeb//dynamicweb.py:355 DynamicWeb//dynamicweb.py:378
 msgid "Gender colors"
 msgstr "Barvy pohlaví"
 
-#: DynamicWeb/dynamicweb.py:335
+#: DynamicWeb//dynamicweb.py:356
 msgid "Generation based gradient"
 msgstr "Přechod založený na generacích"
 
-#: DynamicWeb/dynamicweb.py:336
+#: DynamicWeb//dynamicweb.py:357
 msgid "Age based gradient"
 msgstr "Přechod založený na věku"
 
-#: DynamicWeb/dynamicweb.py:337 DynamicWeb/dynamicweb.py:356
+#: DynamicWeb//dynamicweb.py:358 DynamicWeb//dynamicweb.py:377
 msgid "Single main (filter) color"
 msgstr "Základní hlavní barva (filtru)"
 
-#: DynamicWeb/dynamicweb.py:338
+#: DynamicWeb//dynamicweb.py:359
 msgid "Time period based gradient"
 msgstr "Přechod založený na časovém období"
 
-#: DynamicWeb/dynamicweb.py:339 DynamicWeb/dynamicweb.py:361
+#: DynamicWeb//dynamicweb.py:360 DynamicWeb//dynamicweb.py:382
 msgid "White"
 msgstr "Bílá"
 
-#: DynamicWeb/dynamicweb.py:340 DynamicWeb/dynamicweb.py:359
+#: DynamicWeb//dynamicweb.py:361 DynamicWeb//dynamicweb.py:380
 msgid "Color scheme classic report"
 msgstr "Barevné schéma klasická sestava"
 
-#: DynamicWeb/dynamicweb.py:341 DynamicWeb/dynamicweb.py:360
+#: DynamicWeb//dynamicweb.py:362 DynamicWeb//dynamicweb.py:381
 msgid "Color scheme classic view"
 msgstr "Barevné schéma klasický pohled"
 
-#: DynamicWeb/dynamicweb.py:358
+#: DynamicWeb//dynamicweb.py:379
 msgid "Gradient"
 msgstr "Přechod"
 
-#: DynamicWeb/dynamicweb.py:377
+#: DynamicWeb//dynamicweb.py:398
 msgid "Default"
 msgstr "Výchozí"
 
-#: DynamicWeb/dynamicweb.py:378
+#: DynamicWeb//dynamicweb.py:399
 msgid "Mainz"
 msgstr "Mainz"
 
-#: DynamicWeb/dynamicweb.py:663
+#: DynamicWeb//dynamicweb.py:707
 #, python-format
 msgid "Neither %(current)s nor %(parent)s are directories"
 msgstr "%(current)s ani %(parent)s nejsou adresářem"
 
-#: DynamicWeb/dynamicweb.py:671 DynamicWeb/dynamicweb.py:676
+#: DynamicWeb//dynamicweb.py:715 DynamicWeb//dynamicweb.py:720
 #, python-format
 msgid "Could not create the directory: %(path)s"
 msgstr "Nezdařilo se vytvořit adresář: %(path)s"
 
-#: DynamicWeb/dynamicweb.py:701 DynamicWeb/dynamicweb.py:3191
-#: DynamicWeb/dynamicweb.py:3197
+#: DynamicWeb//dynamicweb.py:746 DynamicWeb//dynamicweb.py:3385
 msgid "Dynamic Web Site Report"
 msgstr "Sestava Dynamické WWW stránky"
 
-#: DynamicWeb/dynamicweb.py:701
+#: DynamicWeb//dynamicweb.py:746
 msgid "Exporting family tree data ..."
 msgstr "Exportují se data rodokmenu..."
 
-#: DynamicWeb/dynamicweb.py:1200 DynamicWeb/dynamicweb.py:2405
+#: DynamicWeb//dynamicweb.py:1237 DynamicWeb//dynamicweb.py:2461
 msgid "Author"
 msgstr "Autor"
 
-#: DynamicWeb/dynamicweb.py:1201 DynamicWeb/dynamicweb.py:2395
+#: DynamicWeb//dynamicweb.py:1238 DynamicWeb//dynamicweb.py:2451
 msgid "Abbreviation"
 msgstr "Zkratka"
 
-#: DynamicWeb/dynamicweb.py:1202 DynamicWeb/dynamicweb.py:2490
+#: DynamicWeb//dynamicweb.py:1239 DynamicWeb//dynamicweb.py:2548
 msgid "Publication information"
 msgstr "Informace o publikaci"
 
-#: DynamicWeb/dynamicweb.py:1277 DynamicWeb/dynamicweb.py:2423
+#: DynamicWeb//dynamicweb.py:1309 DynamicWeb//dynamicweb.py:2479
 msgid "Date"
 msgstr "Datum"
 
-#: DynamicWeb/dynamicweb.py:1278
+#: DynamicWeb//dynamicweb.py:1310
 msgid "Page"
 msgstr "Strana"
 
-#: DynamicWeb/dynamicweb.py:1279
+#: DynamicWeb//dynamicweb.py:1311
 msgid "Confidence"
 msgstr "Důvěryhodnost"
 
-#: DynamicWeb/dynamicweb.py:1607
+#: DynamicWeb//dynamicweb.py:1630
 #, python-format
 msgid "%(type)s: %(value)s"
 msgstr "%(type)s: %(value)s"
 
-#: DynamicWeb/dynamicweb.py:1830
+#: DynamicWeb//dynamicweb.py:1877
 #, python-format
 msgid "Impossible to convert \"%(path)s\" to a relative path."
 msgstr "Není možné převést \"%(path)s\" na relativní cestu."
 
-#: DynamicWeb/dynamicweb.py:2132
+#: DynamicWeb//dynamicweb.py:2183
 msgid ""
 "The pages configuration is not valid: several pages have the same content"
 msgstr "Tato konfigurace stránek je neplatná: několik stránek má stejný obsah"
 
-#: DynamicWeb/dynamicweb.py:2171
-msgid "Html|Home"
+#: DynamicWeb//dynamicweb.py:2194
+msgid "DynWeb|Home"
 msgstr "Domů"
 
-#: DynamicWeb/dynamicweb.py:2172 DynamicWeb/dynamicweb.py:2185
-#: DynamicWeb/dynamicweb.py:2186 DynamicWeb/dynamicweb.py:2187
+#: DynamicWeb//dynamicweb.py:2195 DynamicWeb//dynamicweb.py:2208
+#: DynamicWeb//dynamicweb.py:2209 DynamicWeb//dynamicweb.py:2210
 msgid "Tree"
 msgstr "Strom"
 
-#: DynamicWeb/dynamicweb.py:2173 DynamicWeb/dynamicweb.py:2188
-#: DynamicWeb/dynamicweb.py:2189 DynamicWeb/dynamicweb.py:2190
+#: DynamicWeb//dynamicweb.py:2196 DynamicWeb//dynamicweb.py:2211
+#: DynamicWeb//dynamicweb.py:2212 DynamicWeb//dynamicweb.py:2213
 msgid "Statistics"
 msgstr "Statistiky"
 
-#: DynamicWeb/dynamicweb.py:2176 DynamicWeb/dynamicweb.py:2419
+#: DynamicWeb//dynamicweb.py:2199 DynamicWeb//dynamicweb.py:2475
 msgid "Configuration"
 msgstr "Nastavení"
 
-#: DynamicWeb/dynamicweb.py:2178 DynamicWeb/dynamicweb.py:2482
+#: DynamicWeb//dynamicweb.py:2201 DynamicWeb//dynamicweb.py:2540
 msgid "Person"
 msgstr "Osoba"
 
-#: DynamicWeb/dynamicweb.py:2179
+#: DynamicWeb//dynamicweb.py:2202
 msgid "Family"
 msgstr "Rodina"
 
-#: DynamicWeb/dynamicweb.py:2180 DynamicWeb/dynamicweb.py:2518
+#: DynamicWeb//dynamicweb.py:2203 DynamicWeb//dynamicweb.py:2580
 msgid "Source"
 msgstr "Pramen"
 
-#: DynamicWeb/dynamicweb.py:2181 DynamicWeb/dynamicweb.py:2201
-#: DynamicWeb/dynamicweb.py:2465
+#: DynamicWeb//dynamicweb.py:2204 DynamicWeb//dynamicweb.py:2223
+#: DynamicWeb//dynamicweb.py:2523
 msgid "Media"
 msgstr "Média"
 
-#: DynamicWeb/dynamicweb.py:2182 DynamicWeb/dynamicweb.py:2485
+#: DynamicWeb//dynamicweb.py:2205 DynamicWeb//dynamicweb.py:2543
 msgid "Place"
 msgstr "Místo"
 
-#: DynamicWeb/dynamicweb.py:2183 DynamicWeb/dynamicweb.py:2496
+#: DynamicWeb//dynamicweb.py:2206 DynamicWeb//dynamicweb.py:2555
 msgid "Repository"
 msgstr "Archiv"
 
-#: DynamicWeb/dynamicweb.py:2184
+#: DynamicWeb//dynamicweb.py:2207
 msgid "Search results"
 msgstr "Výsledky hledání"
 
-#: DynamicWeb/dynamicweb.py:2195 DynamicWeb/dynamicweb.py:2196
-#: DynamicWeb/dynamicweb.py:2197 DynamicWeb/dynamicweb.py:2525
+#: DynamicWeb//dynamicweb.py:2218 DynamicWeb//dynamicweb.py:2219
+#: DynamicWeb//dynamicweb.py:2587
 msgid "Surnames"
 msgstr "Příjmení"
 
-#: DynamicWeb/dynamicweb.py:2198 DynamicWeb/dynamicweb.py:2450
+#: DynamicWeb//dynamicweb.py:2220 DynamicWeb//dynamicweb.py:2508
 msgid "Individuals"
 msgstr "Jednotlivci"
 
-#: DynamicWeb/dynamicweb.py:2199 DynamicWeb/dynamicweb.py:2434
+#: DynamicWeb//dynamicweb.py:2221 DynamicWeb//dynamicweb.py:2491
 msgid "Families"
 msgstr "Rodiny"
 
-#: DynamicWeb/dynamicweb.py:2200 DynamicWeb/dynamicweb.py:2520
+#: DynamicWeb//dynamicweb.py:2222 DynamicWeb//dynamicweb.py:2582
 msgid "Sources"
 msgstr "Prameny"
 
-#: DynamicWeb/dynamicweb.py:2202 DynamicWeb/dynamicweb.py:2487
+#: DynamicWeb//dynamicweb.py:2224 DynamicWeb//dynamicweb.py:2545
 msgid "Places"
 msgstr "Místa"
 
-#: DynamicWeb/dynamicweb.py:2203 DynamicWeb/dynamicweb.py:2397
+#: DynamicWeb//dynamicweb.py:2225 DynamicWeb//dynamicweb.py:2453
 msgid "Addresses"
 msgstr "Adresy"
 
-#: DynamicWeb/dynamicweb.py:2204 DynamicWeb/dynamicweb.py:2495
+#: DynamicWeb//dynamicweb.py:2226 DynamicWeb//dynamicweb.py:2554
 msgid "Repositories"
 msgstr "Archivy"
 
-#: DynamicWeb/dynamicweb.py:2236 DynamicWeb/dynamicweb.py:2449
+#: DynamicWeb//dynamicweb.py:2277 DynamicWeb//dynamicweb.py:2507
+#: DynamicWeb//dynamicweb.py:4126
 msgid "Indexes"
 msgstr "Rejstříky"
 
-#: DynamicWeb/dynamicweb.py:2389
+#: DynamicWeb//dynamicweb.py:2441
+#, python-format
+msgid "(b. %(birthdate)s, d. %(deathdate)s)"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:2442
+#, python-format
+msgid "(b. %s)"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:2443
+#, python-format
+msgid "(d. %s)"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:2444
 msgid "(filtered from _MAX_ total entries)"
 msgstr "(filtrováno z _MAX_ položek celkem)"
 
-#: DynamicWeb/dynamicweb.py:2390
+#: DynamicWeb//dynamicweb.py:2445
+#, python-format
+msgid "(m. %s)"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:2446
 msgid "(sort by name)"
 msgstr "(seřadit dle jména)"
 
-#: DynamicWeb/dynamicweb.py:2391
+#: DynamicWeb//dynamicweb.py:2447
 msgid "(sort by quantity)"
 msgstr "(seřadit dle množství)"
 
-#: DynamicWeb/dynamicweb.py:2392
+#: DynamicWeb//dynamicweb.py:2448
 msgid ": activate to sort column ascending"
 msgstr ": aktivujte pro řazení sloupce vzestupně"
 
-#: DynamicWeb/dynamicweb.py:2393
+#: DynamicWeb//dynamicweb.py:2449
 msgid ": activate to sort column descending"
 msgstr ": aktivujte pro řazení sloupce sestupně"
 
-#: DynamicWeb/dynamicweb.py:2394
+#: DynamicWeb//dynamicweb.py:2450
 msgid ""
 "<p>This page provides the SVG raw code.<br>Copy the contents into a text "
 "editor and save as an SVG file.<br>Make sure that the text editor encoding "
@@ -318,524 +378,567 @@ msgstr ""
 "editoru a uložte jej jako SVG soubor.<br>Ubezpečte se, že kódování znaků v "
 "textovém editoru je UTF-8.</p>"
 
-#: DynamicWeb/dynamicweb.py:2396
+#: DynamicWeb//dynamicweb.py:2452
 msgid "Address"
 msgstr "Adresa"
 
-#: DynamicWeb/dynamicweb.py:2398
+#: DynamicWeb//dynamicweb.py:2454
 msgid "Age at death"
 msgstr "Věk při úmrtí"
 
-#: DynamicWeb/dynamicweb.py:2399
+#: DynamicWeb//dynamicweb.py:2455
 msgid "Alternate Marriage"
 msgstr "Alternativní sňatek"
 
-#: DynamicWeb/dynamicweb.py:2400
+#: DynamicWeb//dynamicweb.py:2456
 msgid "Alternate Name"
 msgstr "Alternativní jméno"
 
-#: DynamicWeb/dynamicweb.py:2401
+#: DynamicWeb//dynamicweb.py:2457
 msgid "Ancestors"
 msgstr "Předci"
 
-#: DynamicWeb/dynamicweb.py:2402
+#: DynamicWeb//dynamicweb.py:2458
 msgid "Associations"
 msgstr "Asociace"
 
-#: DynamicWeb/dynamicweb.py:2403
+#: DynamicWeb//dynamicweb.py:2459
 msgid "Attribute"
 msgstr "Atribut"
 
-#: DynamicWeb/dynamicweb.py:2404
+#: DynamicWeb//dynamicweb.py:2460
 msgid "Attributes"
 msgstr "Atributy"
 
-#: DynamicWeb/dynamicweb.py:2406 DynamicWeb/dynamicweb.py:3997
+#: DynamicWeb//dynamicweb.py:2462 DynamicWeb//dynamicweb.py:4209
 msgid "Background"
 msgstr "Pozadí"
 
-#: DynamicWeb/dynamicweb.py:2407
+#: DynamicWeb//dynamicweb.py:2463
 msgid "Baptism"
 msgstr "Baptistické křtiny"
 
-#: DynamicWeb/dynamicweb.py:2408
+#: DynamicWeb//dynamicweb.py:2464
 msgid "Birth"
 msgstr "Narození"
 
-#: DynamicWeb/dynamicweb.py:2409
+#: DynamicWeb//dynamicweb.py:2465
 msgid "Burial"
 msgstr "Pohřeb"
 
-#: DynamicWeb/dynamicweb.py:2410
+#: DynamicWeb//dynamicweb.py:2466
 msgid "Call Name"
 msgstr "Běžné jméno"
 
-#: DynamicWeb/dynamicweb.py:2411
+#: DynamicWeb//dynamicweb.py:2467
 msgid "Call Number"
 msgstr "Signatura"
 
-#: DynamicWeb/dynamicweb.py:2412
+#: DynamicWeb//dynamicweb.py:2468
 msgid "Cause Of Death"
 msgstr "Příčina úmrtí"
 
-#: DynamicWeb/dynamicweb.py:2413
+#: DynamicWeb//dynamicweb.py:2469
 msgid "Children"
 msgstr "Děti"
 
-#: DynamicWeb/dynamicweb.py:2414
+#: DynamicWeb//dynamicweb.py:2470
 msgid "Christening"
 msgstr "Křest"
 
-#: DynamicWeb/dynamicweb.py:2415
+#: DynamicWeb//dynamicweb.py:2471
 msgid "Citation"
 msgstr "Citace"
 
-#: DynamicWeb/dynamicweb.py:2416
+#: DynamicWeb//dynamicweb.py:2472
 msgid "Citations"
 msgstr "Citace"
 
-#: DynamicWeb/dynamicweb.py:2417
+#: DynamicWeb//dynamicweb.py:2473
 msgid "Click on the map to show it full-screen"
 msgstr "Klikněte na mapu pro zobrazení na celou obrazovku"
 
-#: DynamicWeb/dynamicweb.py:2418
+#: DynamicWeb//dynamicweb.py:2474
 msgid "Code"
 msgstr "Kód"
 
-#: DynamicWeb/dynamicweb.py:2420
+#: DynamicWeb//dynamicweb.py:2476
 msgid "Configure"
 msgstr "Nastavit"
 
-#: DynamicWeb/dynamicweb.py:2421
+#: DynamicWeb//dynamicweb.py:2477
 msgid "Count"
 msgstr "Počet"
 
-#: DynamicWeb/dynamicweb.py:2422
+#: DynamicWeb//dynamicweb.py:2478
 msgid "Cremation"
 msgstr "Kremace"
 
-#: DynamicWeb/dynamicweb.py:2424
+#: DynamicWeb//dynamicweb.py:2480
 msgid "Death"
 msgstr "Úmrtí"
 
-#: DynamicWeb/dynamicweb.py:2425
+#: DynamicWeb//dynamicweb.py:2481
 msgid "Descendants"
 msgstr "Potomci"
 
-#: DynamicWeb/dynamicweb.py:2426
+#: DynamicWeb//dynamicweb.py:2482
 msgid "Description"
 msgstr "Popis"
 
-#: DynamicWeb/dynamicweb.py:2427
+#: DynamicWeb//dynamicweb.py:2483
+#, fuzzy
+msgid "DynamicWeb_report#Help"
+msgstr "Dynamické WWW stránky"
+
+#: DynamicWeb//dynamicweb.py:2484
 msgid "Enclosed By"
 msgstr "Ohraničeno"
 
-#: DynamicWeb/dynamicweb.py:2428
+#: DynamicWeb//dynamicweb.py:2485
 msgid "Engagement"
 msgstr "Zasnoubení"
 
-#: DynamicWeb/dynamicweb.py:2429
+#: DynamicWeb//dynamicweb.py:2486
 msgid "Event"
 msgstr "Událost"
 
-#: DynamicWeb/dynamicweb.py:2430
+#: DynamicWeb//dynamicweb.py:2487
 msgid "Events"
 msgstr "Události"
 
-#: DynamicWeb/dynamicweb.py:2431
+#: DynamicWeb//dynamicweb.py:2488
 msgid "Examples"
 msgstr "Příklady"
 
-#: DynamicWeb/dynamicweb.py:2432
+#: DynamicWeb//dynamicweb.py:2489
 msgid "F"
 msgstr "Ž"
 
-#: DynamicWeb/dynamicweb.py:2433
+#: DynamicWeb//dynamicweb.py:2490
 msgid "Families Index"
 msgstr "Rejstřík rodin"
 
-#: DynamicWeb/dynamicweb.py:2435
+#: DynamicWeb//dynamicweb.py:2492
 msgid "Family Nick Name"
 msgstr "Přezdívka rodiny"
 
-#: DynamicWeb/dynamicweb.py:2436
+#: DynamicWeb//dynamicweb.py:2493
 msgid "Father"
 msgstr "Otec"
 
-#: DynamicWeb/dynamicweb.py:2437
+#: DynamicWeb//dynamicweb.py:2494
 msgid "Female"
 msgstr "Žena"
 
-#: DynamicWeb/dynamicweb.py:2438
+#: DynamicWeb//dynamicweb.py:2495
 msgid "File ready"
 msgstr "Soubor připraven"
 
-#: DynamicWeb/dynamicweb.py:2447
-msgid "Help"
-msgstr "Nápověda"
-
-#: DynamicWeb/dynamicweb.py:2439
+#: DynamicWeb//dynamicweb.py:2496
 msgid "Gender"
 msgstr "Pohlaví"
 
-#: DynamicWeb/dynamicweb.py:2440 DynamicWeb/dynamicweb.py:3862
+#: DynamicWeb//dynamicweb.py:2497
+msgid "Help"
+msgstr "Nápověda"
+
+#: DynamicWeb//dynamicweb.py:2498
+msgid "ID"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:2499 DynamicWeb//dynamicweb.py:4041
 msgid "Include Place map on Place Pages"
 msgstr "Zahrnout mapu místa na stránce míst"
 
-#: DynamicWeb/dynamicweb.py:2441 DynamicWeb/dynamicweb.py:3924
-msgid "Include a column for birth dates on the index pages"
-msgstr "Zahrnout sloupec s daty narození na indexových stránkách"
-
-#: DynamicWeb/dynamicweb.py:2442 DynamicWeb/dynamicweb.py:3928
-msgid "Include a column for death dates on the index pages"
+#: DynamicWeb//dynamicweb.py:2500 DynamicWeb//dynamicweb.py:4146
+#, fuzzy
+msgid "Include dates columns on the index pages"
 msgstr "Zahrnout sloupec s daty úmrtí na indexových stránkách"
 
-#: DynamicWeb/dynamicweb.py:2443 DynamicWeb/dynamicweb.py:3932
-msgid "Include a column for marriage dates on the index pages"
-msgstr "Zahrnout sloupec s daty svateb na indexových stránkách"
-
-#: DynamicWeb/dynamicweb.py:2444 DynamicWeb/dynamicweb.py:3940
+#: DynamicWeb//dynamicweb.py:2501 DynamicWeb//dynamicweb.py:4154
 msgid "Include a column for parents on the index pages"
 msgstr "Zahrnout sloupec s daty úmrtí na indexových stránkách"
 
-#: DynamicWeb/dynamicweb.py:2445 DynamicWeb/dynamicweb.py:3936
+#: DynamicWeb//dynamicweb.py:2502 DynamicWeb//dynamicweb.py:4162
+#, fuzzy
+msgid "Include a column for media path on the index pages"
+msgstr "Zahrnout sloupec s daty úmrtí na indexových stránkách"
+
+#: DynamicWeb//dynamicweb.py:2503 DynamicWeb//dynamicweb.py:4150
 msgid "Include a column for partners on the index pages"
 msgstr "Zahrnout sloupec s rodiči na indexových stránkách"
 
-#: DynamicWeb/dynamicweb.py:2446 DynamicWeb/dynamicweb.py:3870
+#: DynamicWeb//dynamicweb.py:2504 DynamicWeb//dynamicweb.py:4049
 msgid "Include a map in the individuals and family pages"
 msgstr "Zahrnout mapu na stránkách osob a rodin"
 
-#: DynamicWeb/dynamicweb.py:2447 DynamicWeb/dynamicweb.py:3944
+#: DynamicWeb//dynamicweb.py:2505 DynamicWeb//dynamicweb.py:4096
 msgid "Include half and/ or step-siblings on the individual pages"
 msgstr ""
 "Zahrnout nevlastní a/nebo nemanželské sourozence na jednotlivých stránkách"
 
-#: DynamicWeb/dynamicweb.py:2448 DynamicWeb/dynamicweb.py:3952
+#: DynamicWeb//dynamicweb.py:2506 DynamicWeb//dynamicweb.py:4166
 msgid "Include references in indexes"
 msgstr "Zahrnout odkazy v indexech"
 
-#: DynamicWeb/dynamicweb.py:2451 DynamicWeb/dynamicweb.py:3948
+#: DynamicWeb//dynamicweb.py:2509 DynamicWeb//dynamicweb.py:4116
 msgid "Insert sources author in the sources title"
 msgstr "Vložit autora pramenů do názvu pramenů"
 
-#: DynamicWeb/dynamicweb.py:2452
+#: DynamicWeb//dynamicweb.py:2510
 msgid "Last Modified"
 msgstr "Poslední změna"
 
-#: DynamicWeb/dynamicweb.py:2453
+#: DynamicWeb//dynamicweb.py:2511
 msgid "Latitude"
 msgstr "Zeměpisná šířka"
 
-#: DynamicWeb/dynamicweb.py:2454
+#: DynamicWeb//dynamicweb.py:2512
 msgid "Link"
 msgstr "Odkaz"
 
-#: DynamicWeb/dynamicweb.py:2455
+#: DynamicWeb//dynamicweb.py:2513
 msgid "Loading..."
 msgstr "Nahrává se..."
 
-#: DynamicWeb/dynamicweb.py:2456
+#: DynamicWeb//dynamicweb.py:2514
 msgid "Location"
 msgstr "Místo"
 
-#: DynamicWeb/dynamicweb.py:2457
+#: DynamicWeb//dynamicweb.py:2515
 msgid "Longitude"
 msgstr "Zeměpisná délka"
 
-#: DynamicWeb/dynamicweb.py:2458
+#: DynamicWeb//dynamicweb.py:2516
 msgid "M"
 msgstr "M"
 
-#: DynamicWeb/dynamicweb.py:2459
+#: DynamicWeb//dynamicweb.py:2517
 msgid "Male"
 msgstr "Muž"
 
-#: DynamicWeb/dynamicweb.py:2460
+#: DynamicWeb//dynamicweb.py:2518
 msgid "Map"
 msgstr "Mapa"
 
-#: DynamicWeb/dynamicweb.py:2461
+#: DynamicWeb//dynamicweb.py:2519
 msgid "Marriage"
 msgstr "Manželství"
 
-#: DynamicWeb/dynamicweb.py:2462
+#: DynamicWeb//dynamicweb.py:2520
 msgid "Maximize"
 msgstr "Maximalizovat"
 
-#: DynamicWeb/dynamicweb.py:2463
+#: DynamicWeb//dynamicweb.py:2521
 msgid "Media Index"
 msgstr "Rejstřík médií"
 
-#: DynamicWeb/dynamicweb.py:2464
+#: DynamicWeb//dynamicweb.py:2522
 msgid "Media Type"
 msgstr "Typ média"
 
-#: DynamicWeb/dynamicweb.py:2466
+#: DynamicWeb//dynamicweb.py:2524
 msgid "Mother"
 msgstr "Matka"
 
-#: DynamicWeb/dynamicweb.py:2467
+#: DynamicWeb//dynamicweb.py:2525
 msgid "Name"
 msgstr "Jméno"
 
-#: DynamicWeb/dynamicweb.py:2468
+#: DynamicWeb//dynamicweb.py:2526
 msgid "Nick Name"
 msgstr "Přezdívka"
 
-#: DynamicWeb/dynamicweb.py:2469
+#: DynamicWeb//dynamicweb.py:2527
 msgid "No data available in table"
 msgstr "Tabulka neobsahuje žádná data"
 
-#: DynamicWeb/dynamicweb.py:2470
+#: DynamicWeb//dynamicweb.py:2528
 msgid "No matches found"
 msgstr "Nebyly nalezeny shody"
 
-#: DynamicWeb/dynamicweb.py:2471
+#: DynamicWeb//dynamicweb.py:2529
 msgid "No matching records found"
 msgstr "Nebyly nalezeny odpovídající záznamy"
 
-#: DynamicWeb/dynamicweb.py:2472
+#: DynamicWeb//dynamicweb.py:2530
 msgid "No matching surname."
 msgstr "Žádné odpovídající příjmení"
 
-#: DynamicWeb/dynamicweb.py:2473
+#: DynamicWeb//dynamicweb.py:2531
 msgid "None"
 msgstr "Žádný"
 
-#: DynamicWeb/dynamicweb.py:2474
+#: DynamicWeb//dynamicweb.py:2532
 msgid "Notes"
 msgstr "Poznámky"
 
-#: DynamicWeb/dynamicweb.py:2475
-msgid "Number of entries in the tables"
-msgstr "Počet položek v tabulkách"
+#: DynamicWeb//dynamicweb.py:2533
+#, fuzzy
+msgid "Number"
+msgstr "Signatura"
 
-#: DynamicWeb/dynamicweb.py:2476
+#: DynamicWeb//dynamicweb.py:2534
 msgid "OK"
 msgstr "Budiž"
 
-#: DynamicWeb/dynamicweb.py:2477
+#: DynamicWeb//dynamicweb.py:2535
 msgid "Other participants"
 msgstr "Ostatní účastníci"
 
-#: DynamicWeb/dynamicweb.py:2478
+#: DynamicWeb//dynamicweb.py:2536
 msgid "Parents"
 msgstr "Rodiče"
 
-#: DynamicWeb/dynamicweb.py:2479
+#: DynamicWeb//dynamicweb.py:2537
 msgid "Path"
 msgstr "Cesta"
 
-#: DynamicWeb/dynamicweb.py:2480
+#: DynamicWeb//dynamicweb.py:2538
 msgid "Person page"
 msgstr "Stránka osoby"
 
-#: DynamicWeb/dynamicweb.py:2481
+#: DynamicWeb//dynamicweb.py:2539
 msgid "Person to search for"
 msgstr "Vyhledat osobu"
 
-#: DynamicWeb/dynamicweb.py:2483
+#: DynamicWeb//dynamicweb.py:2541
 msgid "Persons Index"
 msgstr "Rejstřík osob"
 
-#: DynamicWeb/dynamicweb.py:2484
+#: DynamicWeb//dynamicweb.py:2542
 msgid "Persons"
 msgstr "Osoby"
 
-#: DynamicWeb/dynamicweb.py:2486
+#: DynamicWeb//dynamicweb.py:2544
 msgid "Places Index"
 msgstr "Rejstřík míst"
 
-#: DynamicWeb/dynamicweb.py:2488
+#: DynamicWeb//dynamicweb.py:2546
 msgid "Preparing file ..."
 msgstr "Připravuji soubor ..."
 
-#: DynamicWeb/dynamicweb.py:2489
+#: DynamicWeb//dynamicweb.py:2547
 msgid "Processing..."
 msgstr "Zpracovávání..."
 
-#: DynamicWeb/dynamicweb.py:2491
+#: DynamicWeb//dynamicweb.py:2549
 msgid "References"
 msgstr "Odkazy"
 
-#: DynamicWeb/dynamicweb.py:2492
+#: DynamicWeb//dynamicweb.py:2550
 msgid "Relationship to Father"
 msgstr "Vztah k otci"
 
-#: DynamicWeb/dynamicweb.py:2493
+#: DynamicWeb//dynamicweb.py:2551
 msgid "Relationship to Mother"
 msgstr "Vztah k matce"
 
-#: DynamicWeb/dynamicweb.py:2494
+#: DynamicWeb//dynamicweb.py:2552
 msgid "Relationship"
 msgstr "Vztah"
 
-#: DynamicWeb/dynamicweb.py:2497
+#: DynamicWeb//dynamicweb.py:2553
+#, fuzzy
+msgid "Repositories Index"
+msgstr "Archivy"
+
+#: DynamicWeb//dynamicweb.py:2556
 msgid "Restore"
 msgstr "Obnovit"
 
-#: DynamicWeb/dynamicweb.py:2505
+#: DynamicWeb//dynamicweb.py:2557
 msgid "Restore default settings"
 msgstr "Obnovit výchozí nastavení"
 
-#: DynamicWeb/dynamicweb.py:2498 DynamicWeb/dynamicweb.py:3920
+#: DynamicWeb//dynamicweb.py:2558 DynamicWeb//dynamicweb.py:4112
 msgid "Show last modification time"
 msgstr "Zobrazit čas poslední úpravy"
 
-#: DynamicWeb/dynamicweb.py:2499 DynamicWeb/dynamicweb.py:3991
+#: DynamicWeb//dynamicweb.py:2559 DynamicWeb//dynamicweb.py:4203
 msgid "SVG tree children distribution"
 msgstr "Rozdělení dětí v SVG stromu"
 
-#: DynamicWeb/dynamicweb.py:2500 DynamicWeb/dynamicweb.py:3979
+#: DynamicWeb//dynamicweb.py:2560
+#, fuzzy
+msgid "SVG tree configuration"
+msgstr "Nastavení"
+
+#: DynamicWeb//dynamicweb.py:2561 DynamicWeb//dynamicweb.py:4191
 msgid "SVG tree graph shape"
 msgstr "Tvar grafu SVG stromu"
 
-#: DynamicWeb/dynamicweb.py:2501 DynamicWeb/dynamicweb.py:3973
+#: DynamicWeb//dynamicweb.py:2562 DynamicWeb//dynamicweb.py:4185
 msgid "SVG tree graph type"
 msgstr "Typ grafu SVG stromu"
 
-#: DynamicWeb/dynamicweb.py:2502 DynamicWeb/dynamicweb.py:3985
+#: DynamicWeb//dynamicweb.py:2563 DynamicWeb//dynamicweb.py:4197
 msgid "SVG tree parents distribution"
 msgstr "Rozdělení rodičů v SVG stromu"
 
-#: DynamicWeb/dynamicweb.py:2503
+#: DynamicWeb//dynamicweb.py:2564
 msgid "Save tree as file"
 msgstr "Uložit strom jako soubor"
 
-#: DynamicWeb/dynamicweb.py:2504
+#: DynamicWeb//dynamicweb.py:2565
 msgid "Search:"
 msgstr "Hledat:"
 
-#: DynamicWeb/dynamicweb.py:2505
+#: DynamicWeb//dynamicweb.py:2566
 msgid "Select the background color scheme"
 msgstr "Zvolte barevné schéma pozadí"
 
-#: DynamicWeb/dynamicweb.py:2506
+#: DynamicWeb//dynamicweb.py:2567
 msgid "Select the children distribution (fan charts only)"
 msgstr "Zvolte rozdělení dětí (pouze vějířový graf)"
 
-#: DynamicWeb/dynamicweb.py:2507
+#: DynamicWeb//dynamicweb.py:2568
 msgid "Select the number of ascending generations"
 msgstr "Zvolte počet generací předků"
 
-#: DynamicWeb/dynamicweb.py:2508
+#: DynamicWeb//dynamicweb.py:2569
 msgid "Select the number of descending generations"
 msgstr "Zvolte počet generací potomků"
 
-#: DynamicWeb/dynamicweb.py:2509
+#: DynamicWeb//dynamicweb.py:2570
 msgid "Select the parents distribution (fan charts only)"
 msgstr "Zvolte rozdělení rodičů (pouze vějířový graf)"
 
-#: DynamicWeb/dynamicweb.py:2510
+#: DynamicWeb//dynamicweb.py:2571
 msgid "Select the shape of graph"
 msgstr "Zvolte tvar grafu"
 
-#: DynamicWeb/dynamicweb.py:2511
+#: DynamicWeb//dynamicweb.py:2572
 msgid "Select the type of graph"
 msgstr "Zvolte typ grafu"
 
-#: DynamicWeb/dynamicweb.py:2512
+#: DynamicWeb//dynamicweb.py:2573
 msgid "Several matches.<br>Precise your search or choose in the lists below."
 msgstr "Několik shod.<br>Upřesněte vyhledávání nebo vyberte ze seznamu níže."
 
-#: DynamicWeb/dynamicweb.py:2513
+#: DynamicWeb//dynamicweb.py:2574
 msgid "Show _MENU_ entries"
 msgstr "Zobrazi položky _MENU_"
 
-#: DynamicWeb/dynamicweb.py:2514 DynamicWeb/dynamicweb.py:4009
+#: DynamicWeb//dynamicweb.py:2575 DynamicWeb//dynamicweb.py:4221
 msgid "Show duplicates"
 msgstr "Zobrazit duplicity"
 
-#: DynamicWeb/dynamicweb.py:2515
+#: DynamicWeb//dynamicweb.py:2576
 msgid "Showing 0 to 0 of 0 entries"
 msgstr "Zobrazuji 0 až 0 z 0 záznamů"
 
-#: DynamicWeb/dynamicweb.py:2516
+#: DynamicWeb//dynamicweb.py:2577
 msgid "Showing _START_ to _END_ of _TOTAL_ entries"
 msgstr "Zobrazuji _START_ až _END_ z _TOTAL_ záznamů"
 
-#: DynamicWeb/dynamicweb.py:2517
+#: DynamicWeb//dynamicweb.py:2578
 msgid "Siblings"
 msgstr "Sourozenci"
 
-#: DynamicWeb/dynamicweb.py:2519
+#: DynamicWeb//dynamicweb.py:2579
+msgid "Sort by:"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:2581
 msgid "Sources Index"
 msgstr "Rejtřík pramenů"
 
-#: DynamicWeb/dynamicweb.py:2521
+#: DynamicWeb//dynamicweb.py:2583
 msgid "Spouses"
 msgstr "Partneři(ky)"
 
-#: DynamicWeb/dynamicweb.py:2522
+#: DynamicWeb//dynamicweb.py:2584 DynamicWeb//dynamicweb.py:4120
 msgid "Suppress Gramps ID"
 msgstr "Potlačit Gramps ID"
 
-#: DynamicWeb/dynamicweb.py:2523
+#: DynamicWeb//dynamicweb.py:2585
 msgid "Surname"
 msgstr "Příjmení"
 
-#: DynamicWeb/dynamicweb.py:2524
+#: DynamicWeb//dynamicweb.py:2586
 msgid "Surnames Index"
 msgstr "Rejstřík příjmení"
 
-#: DynamicWeb/dynamicweb.py:2526
+#: DynamicWeb//dynamicweb.py:2588
 msgid "Title"
 msgstr "Název"
 
-#: DynamicWeb/dynamicweb.py:2527
+#: DynamicWeb//dynamicweb.py:2589
 msgid "Type"
 msgstr "Typ"
 
-#: DynamicWeb/dynamicweb.py:2528
+#: DynamicWeb//dynamicweb.py:2590
 msgid "U"
 msgstr "N"
 
-#: DynamicWeb/dynamicweb.py:2529
+#: DynamicWeb//dynamicweb.py:2591
 msgid "Unknown"
 msgstr "Neznámý"
 
-#: DynamicWeb/dynamicweb.py:2530 DynamicWeb/dynamicweb.py:3916
+#: DynamicWeb//dynamicweb.py:2592 DynamicWeb//dynamicweb.py:4108
 msgid "Use tabbed panels instead of sections"
 msgstr "Použít tabelované panely místo sekcí"
 
-#: DynamicWeb/dynamicweb.py:2531
+#: DynamicWeb//dynamicweb.py:2593
 msgid "Use the search box above in order to find a person."
 msgstr "Použijte vyhledávací políčko výše k vyhledání osoby"
 
-#: DynamicWeb/dynamicweb.py:2532
+#: DynamicWeb//dynamicweb.py:2594
+msgid "Use a table format for the surnames index"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:2595
+msgid "Use a table format for the persons index"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:2596
+msgid "Use a table format for the families index"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:2597
+#, fuzzy
+msgid "Use a table format for the sources index"
+msgstr "Vložit autora pramenů do názvu pramenů"
+
+#: DynamicWeb//dynamicweb.py:2598
+msgid "Use a table format for the places index"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:2599
 msgid "Used for family"
 msgstr "Použito pro rodinu"
 
-#: DynamicWeb/dynamicweb.py:2533
+#: DynamicWeb//dynamicweb.py:2600
 msgid "Used for media"
 msgstr "Použito pro média"
 
-#: DynamicWeb/dynamicweb.py:2534
+#: DynamicWeb//dynamicweb.py:2601
 msgid "Used for person"
 msgstr "Použito pro osobu"
 
-#: DynamicWeb/dynamicweb.py:2535
+#: DynamicWeb//dynamicweb.py:2602
 msgid "Used for place"
 msgstr "Použito pro místo"
 
-#: DynamicWeb/dynamicweb.py:2536
+#: DynamicWeb//dynamicweb.py:2603
 msgid "Used for source"
 msgstr "Použito pro pramen"
 
-#: DynamicWeb/dynamicweb.py:2537
+#: DynamicWeb//dynamicweb.py:2604
 msgid "Value"
 msgstr "Hodnota"
 
-#: DynamicWeb/dynamicweb.py:2538
+#: DynamicWeb//dynamicweb.py:2605
 msgid "Web Link"
 msgstr "Webový odkaz"
 
-#: DynamicWeb/dynamicweb.py:2539
+#: DynamicWeb//dynamicweb.py:2606
 msgid "Web Links"
 msgstr "Webové odkazy"
 
-#: DynamicWeb/dynamicweb.py:2540 DynamicWeb/dynamicweb.py:4010
+#: DynamicWeb//dynamicweb.py:2607 DynamicWeb//dynamicweb.py:4222
 msgid ""
 "Whether to use a special color for the persons that appear several times in "
 "the SVG tree"
@@ -843,37 +946,52 @@ msgstr ""
 "Zda použít zvláštní barvu pro osoby, které se v SVG stromě objevují "
 "několikrát"
 
-#: DynamicWeb/dynamicweb.py:2541
+#: DynamicWeb//dynamicweb.py:2608
+#, fuzzy
+msgid "Without name"
+msgstr "Bez příjmení"
+
+#: DynamicWeb//dynamicweb.py:2609
 msgid "Without surname"
 msgstr "Bez příjmení"
 
-#: DynamicWeb/dynamicweb.py:2542
+#: DynamicWeb//dynamicweb.py:2610
+#, fuzzy
+msgid "Without title"
+msgstr "Hlavička nadpisu na WWW"
+
+#: DynamicWeb//dynamicweb.py:2611
 msgid "Zoom in"
 msgstr "Přiblížit"
 
-#: DynamicWeb/dynamicweb.py:2543
+#: DynamicWeb//dynamicweb.py:2612
 msgid "Zoom out"
 msgstr "Oddálit"
 
-#: DynamicWeb/dynamicweb.py:2544
+#: DynamicWeb//dynamicweb.py:2613
 msgid "all"
 msgstr "vše"
 
-#: DynamicWeb/dynamicweb.py:2798
+#: DynamicWeb//dynamicweb.py:2816
+#, fuzzy
+msgid "No Home Person"
+msgstr "Domovská stránka"
+
+#: DynamicWeb//dynamicweb.py:2957
 #, python-format
 msgid "Copying error: %(error)s"
 msgstr "Chyba kopírování: %(error)s"
 
-#: DynamicWeb/dynamicweb.py:2799
+#: DynamicWeb//dynamicweb.py:2958
 #, python-format
 msgid "Impossible to copy \"%(src)s\" to \"%(dst)s\""
 msgstr "Není možné zkopírovat \"%(src)s\" do \"%(dst)s\""
 
-#: DynamicWeb/dynamicweb.py:2802
+#: DynamicWeb//dynamicweb.py:2961
 msgid "Possible destination error"
 msgstr "Možná chyba cíle"
 
-#: DynamicWeb/dynamicweb.py:2803
+#: DynamicWeb//dynamicweb.py:2962
 msgid ""
 "You appear to have set your target directory to a directory used for data "
 "storage. This could create problems with file management. It is recommended "
@@ -884,74 +1002,71 @@ msgstr ""
 "způsobit problémy se správou souborů. Pro uložení generovaných webových "
 "stránek je doporučujeme zvážit použití jiného adresáře."
 
-#: DynamicWeb/dynamicweb.py:2830
+#: DynamicWeb//dynamicweb.py:2989
 #, python-format
 msgid "Unable to copy web site template files from \"%(path)s\""
 msgstr "Nelze zkopírovat soubory šablony WWW stránek z \"%(path)s\""
 
-#: DynamicWeb/dynamicweb.py:2874
+#: DynamicWeb//dynamicweb.py:3033
 #, python-format
 msgid "Keeping \"%(dst)s\" (newer than \"%(src)s\")"
 msgstr "Ponechávám \"%(dst)s\" (novější než \"%(src)s\")"
 
-#: DynamicWeb/dynamicweb.py:2877
+#: DynamicWeb//dynamicweb.py:3036
 #, python-format
 msgid "Copying \"%(src)s\" to \"%(dst)s\""
 msgstr "Kopíruji \"%(src)s\" do \"%(dst)s\""
 
-#: DynamicWeb/dynamicweb.py:2895
+#: DynamicWeb//dynamicweb.py:3054
 msgid "Invalid file name"
 msgstr "Neplatný název souboru"
 
-#: DynamicWeb/dynamicweb.py:2896
+#: DynamicWeb//dynamicweb.py:3055
 msgid "The archive file must be a file, not a directory"
 msgstr "Archiv musí být soubor, ne adresář"
 
-#: DynamicWeb/dynamicweb.py:2906 DynamicWeb/dynamicweb.py:2924
+#: DynamicWeb//dynamicweb.py:3065 DynamicWeb//dynamicweb.py:3083
 #, python-format
 msgid "Unable to overwrite archive file \"%(path)s\""
 msgstr "Nelze přepsat archivní soubor \"%(path)s\""
 
-#: DynamicWeb/dynamicweb.py:2916 DynamicWeb/dynamicweb.py:2931
+#: DynamicWeb//dynamicweb.py:3075 DynamicWeb//dynamicweb.py:3090
 #, python-format
 msgid "Unable to add file \"%(file)s\" to archive \"%(archive)s\""
 msgstr "Nelze přidat soubor \"%(file)s\" do archivu \"%(archive)s\""
 
-#: DynamicWeb/dynamicweb.py:2983
+#: DynamicWeb//dynamicweb.py:3143
 #, python-format
 msgid "DynamicWebReport ignoring link type '%(class)s'"
 msgstr "DynamicWebReport ignoruje odkaz typu '%(class)s'"
 
-#: DynamicWeb/dynamicweb.py:3192
-msgid "Applying Person Filter..."
-msgstr "Aplikuje se filtr osob..."
-
-#: DynamicWeb/dynamicweb.py:3198
+#: DynamicWeb//dynamicweb.py:3386
 msgid "Constructing list of other objects..."
 msgstr "Vytváří se seznam ostatních objektů..."
 
-#: DynamicWeb/dynamicweb.py:3354
+#: DynamicWeb//dynamicweb.py:3521
 #, python-format
 msgid "Family of %(husband)s and %(spouse)s"
 msgstr "Rodina %(husband)s a %(spouse)s"
 
-#: DynamicWeb/dynamicweb.py:3360
+#: DynamicWeb//dynamicweb.py:3527
 #, python-format
 msgid "Family of %(father)s"
 msgstr "Rodina %(father)s"
 
-#: DynamicWeb/dynamicweb.py:3364
+#: DynamicWeb//dynamicweb.py:3531
 #, python-format
 msgid "Family of %(mother)s"
 msgstr "Rodina %(mother)s"
 
-#: DynamicWeb/dynamicweb.py:3677
+#: DynamicWeb//dynamicweb.py:3846
+#, fuzzy
 msgid ""
 "In this note, the following special words are processed:\n"
 "__SEARCH_FORM__ is replaced by a search form.\n"
 "__NB_INDIVIDUALS__ is replaced by the number of persons.\n"
 "__NB_FAMILIES__ is replaced by the number of families.\n"
-"__NB_MEDIA__ is replaced by the number of media objects.\n"
+"__NB_MEDIA__ is replaced by the number of media.\n"
 "__NB_SOURCES__ is replaced by the number of sources.\n"
 "__NB_REPOSITORIES__ is replaced by the number of repositories.\n"
 "__NB_PLACES__ is replaced by the number of places.\n"
@@ -980,217 +1095,229 @@ msgstr ""
 "URL začínající \"relative://relative.<link>\" jsou nahrazena relativním URL "
 "\"<link>\".\n"
 
-#: DynamicWeb/dynamicweb.py:3715
+#: DynamicWeb//dynamicweb.py:3886
 msgid "Report"
 msgstr "Zpráva"
 
-#: DynamicWeb/dynamicweb.py:3720
+#: DynamicWeb//dynamicweb.py:3891
 msgid "Destination"
 msgstr "Cíl"
 
-#: DynamicWeb/dynamicweb.py:3722
+#: DynamicWeb//dynamicweb.py:3893
 msgid "The destination directory for the web files"
 msgstr "Cílový adresář pro soubory webových stránek"
 
-#: DynamicWeb/dynamicweb.py:3726
+#: DynamicWeb//dynamicweb.py:3897
 msgid "Store web pages in archive"
 msgstr "Uložit WWW stránky v archivu"
 
-#: DynamicWeb/dynamicweb.py:3727
+#: DynamicWeb//dynamicweb.py:3898
 msgid ""
 "Whether to create an archive file (in ZIP or TGZ format) containing the web "
 "site"
 msgstr ""
 "Zda vytvořit archivní soubor (v ZIP nebo TGZ formátu) obsahující WWW stránky"
 
-#: DynamicWeb/dynamicweb.py:3731
+#: DynamicWeb//dynamicweb.py:3902
 msgid "Archive file"
 msgstr "Archivni soubor"
 
-#: DynamicWeb/dynamicweb.py:3733
+#: DynamicWeb//dynamicweb.py:3904
 msgid "The archive file name (with \".zip\" or \".tgz\" extension)"
 msgstr "Jméno archivního souboru (s příponou \".zip\" nebo \".tgz\")"
 
-#: DynamicWeb/dynamicweb.py:3739
+#: DynamicWeb//dynamicweb.py:3910
 msgid "Web site title"
 msgstr "Hlavička nadpisu na WWW"
 
-#: DynamicWeb/dynamicweb.py:3739
+#: DynamicWeb//dynamicweb.py:3910
 msgid "My Family Tree"
 msgstr "Můj rodokmen"
 
-#: DynamicWeb/dynamicweb.py:3740
+#: DynamicWeb//dynamicweb.py:3911
 msgid "The title of the web site"
 msgstr "Název webové stránky"
 
-#: DynamicWeb/dynamicweb.py:3743
+#: DynamicWeb//dynamicweb.py:3914
 msgid "Filter"
 msgstr "Filtr"
 
-#: DynamicWeb/dynamicweb.py:3745
+#: DynamicWeb//dynamicweb.py:3916
 msgid "Select filter to restrict people that appear on web site"
 msgstr ""
 "Vyberte filtr pro omezení osob, které se objeví v na webových stránkách"
 
-#: DynamicWeb/dynamicweb.py:3749
+#: DynamicWeb//dynamicweb.py:3920
 msgid "Filter Person"
 msgstr "Filtrovat osobu"
 
-#: DynamicWeb/dynamicweb.py:3750
+#: DynamicWeb//dynamicweb.py:3921
 msgid "The center person for the filter"
 msgstr "Výchozí osoba filtru"
 
-#: DynamicWeb/dynamicweb.py:3764
-msgid "Name format"
-msgstr "Formát jména"
-
-#: DynamicWeb/dynamicweb.py:3767
-msgid "Select the format to display the complete names"
-msgstr "Zvolte formát pro zobrazení úplných jmen"
-
-#: DynamicWeb/dynamicweb.py:3769
+#: DynamicWeb//dynamicweb.py:3929 DynamicWeb//dynamicweb.py:3949
 msgid "Name format (short)"
 msgstr "Formát jména (krátký)"
 
-#: DynamicWeb/dynamicweb.py:3772
+#: DynamicWeb//dynamicweb.py:3930 DynamicWeb//dynamicweb.py:3952
 msgid "Select the format to display a shorter version of the names"
 msgstr "Zvolte formát pro zobrazení zkrácených variant jmen"
 
-#: DynamicWeb/dynamicweb.py:3775
+#: DynamicWeb//dynamicweb.py:3944
+msgid "Name format"
+msgstr "Formát jména"
+
+#: DynamicWeb//dynamicweb.py:3947
+#, fuzzy
+msgid "Select the format to display names"
+msgstr "Zvolte formát pro zobrazení úplných jmen"
+
+#: DynamicWeb//dynamicweb.py:3955
 msgid "Web site template"
 msgstr "Šablona pro WWW stránky"
 
-#: DynamicWeb/dynamicweb.py:3778
+#: DynamicWeb//dynamicweb.py:3958
 msgid "Select the template of the web site"
 msgstr "Zvolte šablonu pro WWW stránky"
 
-#: DynamicWeb/dynamicweb.py:3781
+#: DynamicWeb//dynamicweb.py:3961
 msgid "Copyright"
 msgstr "Copyright"
 
-#: DynamicWeb/dynamicweb.py:3784
+#: DynamicWeb//dynamicweb.py:3964
 msgid "The copyright to be used for the web files"
 msgstr "Autorská práva použitá pro webové stránky"
 
-#: DynamicWeb/dynamicweb.py:3792
+#: DynamicWeb//dynamicweb.py:3972
 msgid "Privacy"
 msgstr "Soukromí"
 
-#: DynamicWeb/dynamicweb.py:3795
+#: DynamicWeb//dynamicweb.py:3980
 msgid "Include records marked private"
 msgstr "Zahrnout záznamy označené jako důvěrné"
 
-#: DynamicWeb/dynamicweb.py:3796
+#: DynamicWeb//dynamicweb.py:3981
 msgid "Whether to include private objects"
 msgstr "Zda zahrnout soukromé objekty"
 
-#: DynamicWeb/dynamicweb.py:3799
-msgid "Export notes"
-msgstr "Exportovat poznámky"
-
-#: DynamicWeb/dynamicweb.py:3800
-msgid "Whether to export notes in the web pages"
-msgstr "Zda exportovat poznámky do WWW stránek"
-
-#: DynamicWeb/dynamicweb.py:3803
-msgid "Export sources"
-msgstr "Exportovat prameny"
-
-#: DynamicWeb/dynamicweb.py:3804
-msgid "Whether to export sources and citations in the web pages"
-msgstr "Zda exportovat prameny a citace do WWW stránek"
-
-#: DynamicWeb/dynamicweb.py:3807
-msgid "Export addresses"
-msgstr "Exportovat adresy"
-
-#: DynamicWeb/dynamicweb.py:3808
-msgid "Whether to export addresses in the web pages"
-msgstr "Zda exportovat adresy do WWW stránek"
-
-#: DynamicWeb/dynamicweb.py:3811
+#: DynamicWeb//dynamicweb.py:3983
 msgid "Living People"
 msgstr "Žijící osoby"
 
-#: DynamicWeb/dynamicweb.py:3814
+#: DynamicWeb//dynamicweb.py:3984
 msgid "Exclude"
 msgstr "Vyjmout"
 
-#: DynamicWeb/dynamicweb.py:3816
+#: DynamicWeb//dynamicweb.py:3985
 msgid "Include Last Name Only"
 msgstr "Zahrnout pouze příjmení"
 
-#: DynamicWeb/dynamicweb.py:3818
+#: DynamicWeb//dynamicweb.py:3986
 msgid "Include Full Name Only"
 msgstr "Zahrnout pouze celá jména"
 
-#: DynamicWeb/dynamicweb.py:3820
+#: DynamicWeb//dynamicweb.py:3987
 msgid "Include"
 msgstr "Zahrnout"
 
-#: DynamicWeb/dynamicweb.py:3821
+#: DynamicWeb//dynamicweb.py:3988
 msgid "How to handle living people"
 msgstr "Jak jednat s živými osobami"
 
-#: DynamicWeb/dynamicweb.py:3825
+#: DynamicWeb//dynamicweb.py:3991
 msgid "Years from death to consider living"
 msgstr "Počet let od úmrtí v kterých jsou osoby považovány za živé"
 
-#: DynamicWeb/dynamicweb.py:3827
+#: DynamicWeb//dynamicweb.py:3992
 msgid ""
 "This allows you to restrict information on people who have not been dead for "
 "very long"
 msgstr "Umožní omezit informace na osoby, které nezemřely dávno"
 
-#: DynamicWeb/dynamicweb.py:3837
+#: DynamicWeb//dynamicweb.py:3996
+msgid "Export notes"
+msgstr "Exportovat poznámky"
+
+#: DynamicWeb//dynamicweb.py:3997
+msgid "Whether to export notes in the web pages"
+msgstr "Zda exportovat poznámky do WWW stránek"
+
+#: DynamicWeb//dynamicweb.py:4000
+msgid "Export sources"
+msgstr "Exportovat prameny"
+
+#: DynamicWeb//dynamicweb.py:4001
+msgid "Whether to export sources and citations in the web pages"
+msgstr "Zda exportovat prameny a citace do WWW stránek"
+
+#: DynamicWeb//dynamicweb.py:4004
+msgid "Export addresses"
+msgstr "Exportovat adresy"
+
+#: DynamicWeb//dynamicweb.py:4005
+msgid "Whether to export addresses in the web pages"
+msgstr "Zda exportovat adresy do WWW stránek"
+
+#: DynamicWeb//dynamicweb.py:4010
 msgid "Options"
 msgstr "Nastavení"
 
-#: DynamicWeb/dynamicweb.py:3840
+#: DynamicWeb//dynamicweb.py:4013
 msgid "Include repository pages"
 msgstr "Zahrnout stránky archivů"
 
-#: DynamicWeb/dynamicweb.py:3841
+#: DynamicWeb//dynamicweb.py:4014
 msgid "Whether or not to include the Repository Pages."
 msgstr "Zda zahrnovat stránky archivů či nikoli."
 
-#: DynamicWeb/dynamicweb.py:3844
-msgid "Include images and media objects"
+#: DynamicWeb//dynamicweb.py:4017
+#, fuzzy
+msgid "Include images and media"
 msgstr "Zahrnout obrázky a mediální objekty"
 
-#: DynamicWeb/dynamicweb.py:3845
-msgid "Whether to include a media objects in the web pages"
+#: DynamicWeb//dynamicweb.py:4018
+#, fuzzy
+msgid "Whether to include images and media in the web pages"
 msgstr "Zda zahrnout mediální objekty do WWW stránek"
 
-#: DynamicWeb/dynamicweb.py:3848
-msgid "Copy images and media objects"
-msgstr "Kopírovat obrázky a mediální objekty"
-
-#: DynamicWeb/dynamicweb.py:3849
-msgid ""
-"Whether to make a copy of the media objects. When the objects are not "
-"copied, they are referenced by their relative path name"
+#: DynamicWeb//dynamicweb.py:4022
+msgid "Copy, rename files with an internal Gramps identifier"
 msgstr ""
-"Zda zkopírovat mediální objekty. Když objekty nejsou zkopírovány, jsou "
-"odkazovány jménem jejich relativní cesty"
 
-#: DynamicWeb/dynamicweb.py:3853
+#: DynamicWeb//dynamicweb.py:4023
+msgid "Copy, keep file names unchanged"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:4024
+msgid "Do not copy, reference existing files"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:4026
+#, fuzzy
+msgid "Images and media"
+msgstr "Zahrnout obrázky a mediální objekty"
+
+#: DynamicWeb//dynamicweb.py:4029
+msgid "Whether to make a copy of the media"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:4032
 msgid "Print the notes type"
 msgstr "Tisknout typ poznámek"
 
-#: DynamicWeb/dynamicweb.py:3854
+#: DynamicWeb//dynamicweb.py:4033
 msgid "Whether to print the notes type in the notes text"
 msgstr "Zda tisknout typ poznámky v textu poznámky"
 
-#: DynamicWeb/dynamicweb.py:3857
+#: DynamicWeb//dynamicweb.py:4036
 msgid "Print place pages"
 msgstr "Tisknout stránky míst"
 
-#: DynamicWeb/dynamicweb.py:3858
+#: DynamicWeb//dynamicweb.py:4037
 msgid "Whether to show pages for the places"
 msgstr "Zda zobrazit stránky pro místa"
 
-#: DynamicWeb/dynamicweb.py:3864
+#: DynamicWeb//dynamicweb.py:4043
 msgid ""
 "Whether to include a place map on the Place Pages, where Latitude/ Longitude "
 "are available."
@@ -1198,7 +1325,7 @@ msgstr ""
 "Zda zahrnout mapu míst na stránkách míst pokud jsou dostupné zeměpisné "
 "souřadnice."
 
-#: DynamicWeb/dynamicweb.py:3872
+#: DynamicWeb//dynamicweb.py:4051
 msgid ""
 "Whether or not to add an individual page map showing all the places on this "
 "page. This will allow you to see how your family traveled around the country."
@@ -1206,89 +1333,167 @@ msgstr ""
 "Zda přidat zvláštní mapovou stránku ukazující všechna místa. To vám umožní "
 "sledovat jak vaše rodina cestovala po celé zemi(státě)."
 
-#: DynamicWeb/dynamicweb.py:3880
+#: DynamicWeb//dynamicweb.py:4059
 msgid "Google"
 msgstr "Google"
 
-#: DynamicWeb/dynamicweb.py:3881
+#: DynamicWeb//dynamicweb.py:4060
 msgid "OpenStreetMap"
 msgstr "OpenStreetMap"
 
-#: DynamicWeb/dynamicweb.py:3883
+#: DynamicWeb//dynamicweb.py:4062
 msgid "Map Service"
 msgstr "Mapová služba"
 
-#: DynamicWeb/dynamicweb.py:3886
+#: DynamicWeb//dynamicweb.py:4065
 msgid "Choose your choice of map service for creating the Place Map Pages"
 msgstr "Zvolte mapovou službu pro vytváření stránek map míst"
 
-#: DynamicWeb/dynamicweb.py:3890
+#: DynamicWeb//dynamicweb.py:4069
 msgid "Google map API key"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3891
+#: DynamicWeb//dynamicweb.py:4070
 msgid "The API key used for the Google map"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3898
+#: DynamicWeb//dynamicweb.py:4077
 msgid "Advanced"
 msgstr "Pokročilé"
 
-#: DynamicWeb/dynamicweb.py:3901
+#: DynamicWeb//dynamicweb.py:4080
 msgid "Character set encoding"
 msgstr "Znaková sada"
 
-#: DynamicWeb/dynamicweb.py:3904
+#: DynamicWeb//dynamicweb.py:4083
 msgid "The encoding to be used for the web files"
 msgstr "Kódování webových stránek"
 
-#: DynamicWeb/dynamicweb.py:3907
+#: DynamicWeb//dynamicweb.py:4086
 msgid "Include family pages"
 msgstr "Zahrnout stránky rodin"
 
-#: DynamicWeb/dynamicweb.py:3908
+#: DynamicWeb//dynamicweb.py:4087
 msgid "Whether or not to include family pages"
 msgstr "Zda zahrnout stránky rodin"
 
-#: DynamicWeb/dynamicweb.py:3917
-msgid "Whether to use tabbed panels for the different sections of the pages."
-msgstr "Zda použít tabelované panly pro různé sekce stránek"
-
-#: DynamicWeb/dynamicweb.py:3921
-msgid "Whether to show the last modification time in the pages footer"
-msgstr "Zda zobrazit čas poslední změny v patičce stránek"
-
-#: DynamicWeb/dynamicweb.py:3925
-msgid "Whether to include a birth column"
-msgstr "Zda zahrnout sloupec narození"
-
-#: DynamicWeb/dynamicweb.py:3929
-msgid "Whether to include a death column"
-msgstr "Zda zahrnout sloupec úmrtí"
-
-#: DynamicWeb/dynamicweb.py:3933
-msgid "Whether to include a marriage column"
-msgstr "Zda zahrnout sloupec svatby"
-
-#: DynamicWeb/dynamicweb.py:3937
-msgid "Whether to include a partners column"
-msgstr "Zda zahrnout sloupec rodičů"
-
-#: DynamicWeb/dynamicweb.py:3941
-msgid "Whether to include a parents column"
-msgstr "Zda zahrnout sloupec rodičů"
-
-#: DynamicWeb/dynamicweb.py:3945
+#: DynamicWeb//dynamicweb.py:4097
 msgid ""
 "Whether to include half and/ or step-siblings with the parents and siblings"
 msgstr ""
 "Zda zahrnovat nevlastní a/nebo nemanželské sourozence s rodiči a sourozenci"
 
-#: DynamicWeb/dynamicweb.py:3949
+#: DynamicWeb//dynamicweb.py:4100
+msgid "Include GENDEX file (/gendex.txt)"
+msgstr "Zahrnout soubor GENDEX (/gendex.txt)"
+
+#: DynamicWeb//dynamicweb.py:4101
+msgid "Whether to include a GENDEX file or not"
+msgstr "Zda zahrnovat soubor GENDEX či nikoli"
+
+#: DynamicWeb//dynamicweb.py:4104
+msgid "Enable page configuration"
+msgstr "Zapnout nastavení stránky"
+
+#: DynamicWeb//dynamicweb.py:4105
+msgid "Whether to enable page configuration"
+msgstr "Zda zapnout nastavení stránky"
+
+#: DynamicWeb//dynamicweb.py:4109
+msgid "Whether to use tabbed panels for the different sections of the pages."
+msgstr "Zda použít tabelované panly pro různé sekce stránek"
+
+#: DynamicWeb//dynamicweb.py:4113
+msgid "Whether to show the last modification time in the pages footer"
+msgstr "Zda zobrazit čas poslední změny v patičce stránek"
+
+#: DynamicWeb//dynamicweb.py:4117
 msgid "Whether to insert sources author in the sources title"
 msgstr "Zda vložit autora pramene do názvu pramene"
 
-#: DynamicWeb/dynamicweb.py:3953
+#: DynamicWeb//dynamicweb.py:4121
+#, fuzzy
+msgid "Whether to hide the Gramps ID"
+msgstr "Zda zobrazit stránky pro místa"
+
+#: DynamicWeb//dynamicweb.py:4130
+msgid "List"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:4131
+msgid "Table"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:4134
+msgid "Default format for the surnames index"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:4134
+msgid "The default format for the surnames index"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:4135
+msgid "Default format for the persons index"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:4135
+msgid "The default format for the persons index"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:4136
+msgid "Default format for the families index"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:4136
+msgid "The default format for the families index"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:4137
+#, fuzzy
+msgid "Default format for the sources index"
+msgstr "Vložit autora pramenů do názvu pramenů"
+
+#: DynamicWeb//dynamicweb.py:4137
+msgid "The default format for the sources index"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:4138
+msgid "Default format for the places index"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:4138
+msgid "The default format for the places index"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:4147
+#, fuzzy
+msgid ""
+"Whether to include dates columns (birth, death, marriage) on the index pages"
+msgstr "Zahrnout sloupec s daty úmrtí na indexových stránkách"
+
+#: DynamicWeb//dynamicweb.py:4151
+msgid "Whether to include a partners column"
+msgstr "Zda zahrnout sloupec rodičů"
+
+#: DynamicWeb//dynamicweb.py:4155
+msgid "Whether to include a parents column"
+msgstr "Zda zahrnout sloupec rodičů"
+
+#: DynamicWeb//dynamicweb.py:4158
+msgid "Generate a families index page"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:4159
+#, fuzzy
+msgid "Whether to generate an index page for families"
+msgstr "Zda zahrnout stránky rodin"
+
+#: DynamicWeb//dynamicweb.py:4163
+#, fuzzy
+msgid "Whether to include a column showing the media path"
+msgstr "Zda zahrnout mediální objekty do WWW stránek"
+
+#: DynamicWeb//dynamicweb.py:4167
 msgid ""
 "Whether to include the references to the items in the index pages. For "
 "example, in the media index page, the names of the individuals, families, "
@@ -1298,148 +1503,172 @@ msgstr ""
 "rejstříku médií jména jednotlivců, rodiny, místa, pramene odkazující na "
 "médium."
 
-#: DynamicWeb/dynamicweb.py:3956
-msgid "Include GENDEX file (/gendex.txt)"
-msgstr "Zahrnout soubor GENDEX (/gendex.txt)"
+#: DynamicWeb//dynamicweb.py:4170
+#, fuzzy
+msgid "Default number of entries in the indexes"
+msgstr "Počet položek v tabulkách"
 
-#: DynamicWeb/dynamicweb.py:3957
-msgid "Whether to include a GENDEX file or not"
-msgstr "Zda zahrnovat soubor GENDEX či nikoli"
+#: DynamicWeb//dynamicweb.py:4173
+msgid "The default number of entries shown in one index page"
+msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3960
-msgid "Enable page configuration"
-msgstr "Zapnout nastavení stránky"
-
-#: DynamicWeb/dynamicweb.py:3961
-msgid "Whether to enable page configuration"
-msgstr "Zda zapnout nastavení stránky"
-
-#: DynamicWeb/dynamicweb.py:3966
+#: DynamicWeb//dynamicweb.py:4178
 msgid "Trees"
 msgstr "Stromy"
 
-#: DynamicWeb/dynamicweb.py:3969
+#: DynamicWeb//dynamicweb.py:4181
 msgid "Maximum number of generations"
 msgstr "Maximální počet generací"
 
-#: DynamicWeb/dynamicweb.py:3970
+#: DynamicWeb//dynamicweb.py:4182
 msgid ""
 "The maximum number of generations to include in the ancestor and descendant "
 "trees and graphs"
 msgstr ""
 "Maximální počet generací obsažených ve stromech a grafech předků a potomků"
 
-#: DynamicWeb/dynamicweb.py:3976
+#: DynamicWeb//dynamicweb.py:4188
 msgid "Choose the default SVG tree graph type"
 msgstr "Vyberte výchozí typ grafu SVG stromu"
 
-#: DynamicWeb/dynamicweb.py:3982
+#: DynamicWeb//dynamicweb.py:4194
 msgid "Choose the default SVG tree graph shape"
 msgstr "Vyberte výchozí tvar grafu SVG stromu"
 
-#: DynamicWeb/dynamicweb.py:3988
+#: DynamicWeb//dynamicweb.py:4200
 msgid "Choose the default SVG tree parents distribution (for fan charts only)"
 msgstr ""
 "Vyberte výchozí rozdělení rodičů v SVG stromu (pouze pro vějířový graf)"
 
-#: DynamicWeb/dynamicweb.py:3994
+#: DynamicWeb//dynamicweb.py:4206
 msgid "Choose the default SVG tree children distribution (for fan charts only)"
 msgstr "Vyberte výchozí rozdělení dětí v SVG stromu (pouze pro vějířový graf)"
 
-#: DynamicWeb/dynamicweb.py:4000
+#: DynamicWeb//dynamicweb.py:4212
 msgid ""
 "Choose the background color scheme for the persons in the SVG tree graph"
 msgstr "Zvolte barevné schéma pozadí pro osoby v grafu SVG stromu"
 
-#: DynamicWeb/dynamicweb.py:4003
+#: DynamicWeb//dynamicweb.py:4215
 msgid "Start gradient/Main color"
 msgstr "Počáteční přechod/Hlavní barva"
 
-#: DynamicWeb/dynamicweb.py:4006
+#: DynamicWeb//dynamicweb.py:4218
 msgid "End gradient/2nd color"
 msgstr "Koncový přechod/druhá barva"
 
-#: DynamicWeb/dynamicweb.py:4014
+#: DynamicWeb//dynamicweb.py:4226
 msgid "Color for duplicates"
 msgstr "Barva pro duplicity"
 
-#: DynamicWeb/dynamicweb.py:4019
+#: DynamicWeb//dynamicweb.py:4231
 msgid "Pages"
 msgstr "Stránky"
 
-#: DynamicWeb/dynamicweb.py:4022
+#: DynamicWeb//dynamicweb.py:4234
 msgid "HTML user header"
 msgstr "Uživatelská HTML hlavička"
 
-#: DynamicWeb/dynamicweb.py:4023
+#: DynamicWeb//dynamicweb.py:4235
 msgid "A note to be used as the page header"
 msgstr "Záznam použitý jako hlavička stránky"
 
-#: DynamicWeb/dynamicweb.py:4026
+#: DynamicWeb//dynamicweb.py:4238
 msgid "HTML user brand name / icon"
 msgstr "Užitalská HTML značka / ikona"
 
-#: DynamicWeb/dynamicweb.py:4027
+#: DynamicWeb//dynamicweb.py:4239
 msgid "A note to be used as the brand name or image in the menu"
 msgstr "Záznam použitý jako značka nebo obrázek v menu"
 
-#: DynamicWeb/dynamicweb.py:4030
+#: DynamicWeb//dynamicweb.py:4242
 msgid "HTML user footer"
 msgstr "Uživatelská HTML patička"
 
-#: DynamicWeb/dynamicweb.py:4031
+#: DynamicWeb//dynamicweb.py:4243
 msgid "A note to be used as the page footer"
 msgstr "Záznam použitý jako patička stránky"
 
-#: DynamicWeb/dynamicweb.py:4036
+#: DynamicWeb//dynamicweb.py:4248
 msgid "Custom pages"
 msgstr "Vlastní stránky"
 
-#: DynamicWeb/dynamicweb.py:4040
+#: DynamicWeb//dynamicweb.py:4252
 #, python-format
 msgid "Title for the custom page %(index)i"
 msgstr "Titulek pro vlastní stránku %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4041
+#: DynamicWeb//dynamicweb.py:4253
 #, python-format
 msgid "Name for the custom page %(index)i"
 msgstr "Jméno pro vlastní stránku %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4044
+#: DynamicWeb//dynamicweb.py:4256
 #, python-format
 msgid "Note for custom page %(index)i"
 msgstr "Poznámka pro vlastní stránku %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4045
+#: DynamicWeb//dynamicweb.py:4257
 msgid "A note to be used for the custom page content.\n"
 msgstr "Záznam použitý pro obsah vlastní stránky.\n"
 
-#: DynamicWeb/dynamicweb.py:4048
+#: DynamicWeb//dynamicweb.py:4260
 #, python-format
 msgid "Menu for the custom page %(index)i"
 msgstr "Nabídka pro vlastní stránku %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4049
+#: DynamicWeb//dynamicweb.py:4261
 msgid "Whether to print a menu for the custom page"
 msgstr "Zda zobrazit menu ve vlastní stránce"
 
-#: DynamicWeb/dynamicweb.py:4054
+#: DynamicWeb//dynamicweb.py:4266
 msgid "Pages selection"
 msgstr "Výběr stránek"
 
-#: DynamicWeb/dynamicweb.py:4057
+#: DynamicWeb//dynamicweb.py:4269
 msgid "Number of pages"
 msgstr "Počet stránek"
 
-#: DynamicWeb/dynamicweb.py:4058
+#: DynamicWeb//dynamicweb.py:4270
 msgid "Number pages in the web site menu."
 msgstr "Číslovat stránky v menu WWW stránek"
 
-#: DynamicWeb/dynamicweb.py:4074
+#: DynamicWeb//dynamicweb.py:4286
 #, python-format
 msgid "Contents of page %(index)i"
 msgstr "Obsah stránky %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4077
+#: DynamicWeb//dynamicweb.py:4289
 msgid "Contents of the page"
 msgstr "Obsah stránky"
+
+#~ msgid "Html|Home"
+#~ msgstr "Domů"
+
+#~ msgid "Include a column for birth dates on the index pages"
+#~ msgstr "Zahrnout sloupec s daty narození na indexových stránkách"
+
+#~ msgid "Include a column for marriage dates on the index pages"
+#~ msgstr "Zahrnout sloupec s daty svateb na indexových stránkách"
+
+#~ msgid "Applying Person Filter..."
+#~ msgstr "Aplikuje se filtr osob..."
+
+#~ msgid "Copy images and media objects"
+#~ msgstr "Kopírovat obrázky a mediální objekty"
+
+#~ msgid ""
+#~ "Whether to make a copy of the media objects. When the objects are not "
+#~ "copied, they are referenced by their relative path name"
+#~ msgstr ""
+#~ "Zda zkopírovat mediální objekty. Když objekty nejsou zkopírovány, jsou "
+#~ "odkazovány jménem jejich relativní cesty"
+
+#~ msgid "Whether to include a birth column"
+#~ msgstr "Zda zahrnout sloupec narození"
+
+#~ msgid "Whether to include a death column"
+#~ msgstr "Zda zahrnout sloupec úmrtí"
+
+#~ msgid "Whether to include a marriage column"
+#~ msgstr "Zda zahrnout sloupec svatby"

--- a/DynamicWeb/po/de-local.po
+++ b/DynamicWeb/po/de-local.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-04-22 19:40+0200\n"
+"POT-Creation-Date: 2020-07-24 17:33+0200\n"
 "PO-Revision-Date: 2018-04-23 21:38+0100\n"
 "Last-Translator: Mirko Leonhäuser <mirko@leonhaeuser.de>\n"
 "Language-Team: German <kde-i18n-de@kde.org>\n"
@@ -25,356 +25,356 @@ msgstr ""
 "X-Generator: Lokalize 2.0\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: DynamicWeb/dynamicweb.gpr.py:15
+#: DynamicWeb//dynamicweb.gpr.py:15
 msgid "Dynamic Web Report"
 msgstr "Dynamische Website"
 
-#: DynamicWeb/dynamicweb.gpr.py:16
+#: DynamicWeb//dynamicweb.gpr.py:16
 msgid "Produces dynamic web pages for the database"
 msgstr "Erstellt dynamische Webseiten aus der Datenbank"
 
-#: DynamicWeb/dynamicweb.py:265
+#: DynamicWeb//dynamicweb.py:269
 msgid "Street"
 msgstr "Straße"
 
-#: DynamicWeb/dynamicweb.py:266
+#: DynamicWeb//dynamicweb.py:270
 msgid "Locality"
 msgstr "Lokalität"
 
-#: DynamicWeb/dynamicweb.py:267
+#: DynamicWeb//dynamicweb.py:271
 msgid "City"
 msgstr "Stadt"
 
-#: DynamicWeb/dynamicweb.py:268
+#: DynamicWeb//dynamicweb.py:272
 msgid "Church Parish"
 msgstr "Kirchengemeinde"
 
-#: DynamicWeb/dynamicweb.py:269
+#: DynamicWeb//dynamicweb.py:273
 msgid "County"
 msgstr "Kreis"
 
-#: DynamicWeb/dynamicweb.py:270
+#: DynamicWeb//dynamicweb.py:274
 msgid "State/ Province"
 msgstr "Bundesland/ Provinz"
 
-#: DynamicWeb/dynamicweb.py:271
+#: DynamicWeb//dynamicweb.py:275
 msgid "Postal Code"
 msgstr "Postleitzahl"
 
-#: DynamicWeb/dynamicweb.py:272
+#: DynamicWeb//dynamicweb.py:276
 msgid "Country"
 msgstr "Land"
 
-#: DynamicWeb/dynamicweb.py:273
+#: DynamicWeb//dynamicweb.py:277
 msgid "Phone"
 msgstr "Telefon"
 
-#: DynamicWeb/dynamicweb.py:279
+#: DynamicWeb//dynamicweb.py:283
 msgid "Home Page"
 msgstr "Homepage"
 
-#: DynamicWeb/dynamicweb.py:280
+#: DynamicWeb//dynamicweb.py:284
 msgid "SVG graphical tree"
 msgstr "Grafischer SVG-Baum"
 
-#: DynamicWeb/dynamicweb.py:283
+#: DynamicWeb//dynamicweb.py:287
 msgid "Indexes pages"
 msgstr "Indices-Seiten"
 
-#: DynamicWeb/dynamicweb.py:287 DynamicWeb/dynamicweb.py:4235
+#: DynamicWeb//dynamicweb.py:291 DynamicWeb//dynamicweb.py:4252
 #, python-format
 msgid "Custom page %(index)i"
 msgstr "Selbst definierte Seite %(index)i"
 
-#: DynamicWeb/dynamicweb.py:305
+#: DynamicWeb//dynamicweb.py:309
 msgid "Ascending tree"
 msgstr "Aufsteigender Baum"
 
-#: DynamicWeb/dynamicweb.py:306
+#: DynamicWeb//dynamicweb.py:310
 msgid "Descending tree"
 msgstr "Absteigender Baum"
 
-#: DynamicWeb/dynamicweb.py:307
+#: DynamicWeb//dynamicweb.py:311
 msgid "Descending tree with spouses"
 msgstr "Absteigender Baum mit (Ehe-)Partner"
 
-#: DynamicWeb/dynamicweb.py:308
+#: DynamicWeb//dynamicweb.py:312
 msgid "Ascending and descending tree"
 msgstr "Aufsteigender Baum mit (Ehe-)Partner"
 
-#: DynamicWeb/dynamicweb.py:309
+#: DynamicWeb//dynamicweb.py:313
 msgid "Ascending and descending tree with spouses"
 msgstr "Auf- und absteigender Baum mit (Ehe-)Partner"
 
-#: DynamicWeb/dynamicweb.py:321
+#: DynamicWeb//dynamicweb.py:325
 msgid "Vertical (↓)"
 msgstr "Vertikal (↓)"
 
-#: DynamicWeb/dynamicweb.py:322
+#: DynamicWeb//dynamicweb.py:326
 msgid "Vertical (↑)"
 msgstr "Vertikal (↑)"
 
-#: DynamicWeb/dynamicweb.py:323
+#: DynamicWeb//dynamicweb.py:327
 msgid "Horizontal (→)"
 msgstr "Horizontal (→)"
 
-#: DynamicWeb/dynamicweb.py:324
+#: DynamicWeb//dynamicweb.py:328
 msgid "Horizontal (←)"
 msgstr "Horizontal (←)"
 
-#: DynamicWeb/dynamicweb.py:325
+#: DynamicWeb//dynamicweb.py:329
 msgid "Full Circle"
 msgstr "Vollkreis"
 
-#: DynamicWeb/dynamicweb.py:326
+#: DynamicWeb//dynamicweb.py:330
 msgid "Half Circle"
 msgstr "Halbkreis"
 
-#: DynamicWeb/dynamicweb.py:327
+#: DynamicWeb//dynamicweb.py:331
 msgid "Quadrant"
 msgstr "Viertelkreis"
 
-#: DynamicWeb/dynamicweb.py:339
+#: DynamicWeb//dynamicweb.py:343
 msgid "Size proportional to number of ancestors"
 msgstr "Größe proportional zur Anzahl der Vorfahren"
 
-#: DynamicWeb/dynamicweb.py:340
+#: DynamicWeb//dynamicweb.py:344
 msgid "Homogeneous parents distribution"
 msgstr "Einheitliche Elternverteilung"
 
-#: DynamicWeb/dynamicweb.py:343
+#: DynamicWeb//dynamicweb.py:347
 msgid "Size proportional to number of descendants"
 msgstr "Größe proportional zur Anzahl der Nachfahren"
 
-#: DynamicWeb/dynamicweb.py:344
+#: DynamicWeb//dynamicweb.py:348
 msgid "Homogeneous children distribution"
 msgstr "Einheitliche Kinderaufteilung"
 
-#: DynamicWeb/dynamicweb.py:351 DynamicWeb/dynamicweb.py:374
+#: DynamicWeb//dynamicweb.py:355 DynamicWeb//dynamicweb.py:378
 msgid "Gender colors"
 msgstr "Geschlechtsfarben"
 
-#: DynamicWeb/dynamicweb.py:352
+#: DynamicWeb//dynamicweb.py:356
 msgid "Generation based gradient"
 msgstr "Auf Generationen basierender Farbverlauf"
 
-#: DynamicWeb/dynamicweb.py:353
+#: DynamicWeb//dynamicweb.py:357
 msgid "Age based gradient"
 msgstr "Auf Alter basierender Farbverlauf"
 
-#: DynamicWeb/dynamicweb.py:354 DynamicWeb/dynamicweb.py:373
+#: DynamicWeb//dynamicweb.py:358 DynamicWeb//dynamicweb.py:377
 msgid "Single main (filter) color"
 msgstr "Einzelne Haupt(filter)farbe"
 
-#: DynamicWeb/dynamicweb.py:355
+#: DynamicWeb//dynamicweb.py:359
 msgid "Time period based gradient"
 msgstr "Auf Zeitraum basierender Farbverlauf"
 
-#: DynamicWeb/dynamicweb.py:356 DynamicWeb/dynamicweb.py:378
+#: DynamicWeb//dynamicweb.py:360 DynamicWeb//dynamicweb.py:382
 msgid "White"
 msgstr "Weiß"
 
-#: DynamicWeb/dynamicweb.py:357 DynamicWeb/dynamicweb.py:376
+#: DynamicWeb//dynamicweb.py:361 DynamicWeb//dynamicweb.py:380
 msgid "Color scheme classic report"
 msgstr "Farbschema klassischer Bericht"
 
-#: DynamicWeb/dynamicweb.py:358 DynamicWeb/dynamicweb.py:377
+#: DynamicWeb//dynamicweb.py:362 DynamicWeb//dynamicweb.py:381
 msgid "Color scheme classic view"
 msgstr "Farbschema klassische Ansicht"
 
-#: DynamicWeb/dynamicweb.py:375
+#: DynamicWeb//dynamicweb.py:379
 msgid "Gradient"
 msgstr "Gradient"
 
-#: DynamicWeb/dynamicweb.py:394
+#: DynamicWeb//dynamicweb.py:398
 msgid "Default"
 msgstr "Vorgabe"
 
-#: DynamicWeb/dynamicweb.py:395
+#: DynamicWeb//dynamicweb.py:399
 msgid "Mainz"
 msgstr "Mainz"
 
-#: DynamicWeb/dynamicweb.py:703
+#: DynamicWeb//dynamicweb.py:707
 #, python-format
 msgid "Neither %(current)s nor %(parent)s are directories"
 msgstr "Weder %(current)s noch %(parent)s ist ein Verzeichnis"
 
-#: DynamicWeb/dynamicweb.py:711 DynamicWeb/dynamicweb.py:716
+#: DynamicWeb//dynamicweb.py:715 DynamicWeb//dynamicweb.py:720
 #, python-format
 msgid "Could not create the directory: %(path)s"
 msgstr "Konnte Verzeichnis %(path)s nicht anlegen"
 
-#: DynamicWeb/dynamicweb.py:742 DynamicWeb/dynamicweb.py:3369
+#: DynamicWeb//dynamicweb.py:746 DynamicWeb//dynamicweb.py:3385
 msgid "Dynamic Web Site Report"
 msgstr "Dynamische Website"
 
-#: DynamicWeb/dynamicweb.py:742
+#: DynamicWeb//dynamicweb.py:746
 msgid "Exporting family tree data ..."
 msgstr "Exportiere Stammbaum-Daten ..."
 
-#: DynamicWeb/dynamicweb.py:1232 DynamicWeb/dynamicweb.py:2456
+#: DynamicWeb//dynamicweb.py:1237 DynamicWeb//dynamicweb.py:2461
 msgid "Author"
 msgstr "Autor"
 
-#: DynamicWeb/dynamicweb.py:1233 DynamicWeb/dynamicweb.py:2446
+#: DynamicWeb//dynamicweb.py:1238 DynamicWeb//dynamicweb.py:2451
 msgid "Abbreviation"
 msgstr "Abkürzung"
 
-#: DynamicWeb/dynamicweb.py:1234 DynamicWeb/dynamicweb.py:2542
+#: DynamicWeb//dynamicweb.py:1239 DynamicWeb//dynamicweb.py:2548
 msgid "Publication information"
 msgstr "Informationen zur Veröffentlichung"
 
-#: DynamicWeb/dynamicweb.py:1304 DynamicWeb/dynamicweb.py:2474
+#: DynamicWeb//dynamicweb.py:1309 DynamicWeb//dynamicweb.py:2479
 msgid "Date"
 msgstr "Datum"
 
-#: DynamicWeb/dynamicweb.py:1305
+#: DynamicWeb//dynamicweb.py:1310
 msgid "Page"
 msgstr "Seite"
 
-#: DynamicWeb/dynamicweb.py:1306
+#: DynamicWeb//dynamicweb.py:1311
 msgid "Confidence"
 msgstr "Vertraulichkeit"
 
-#: DynamicWeb/dynamicweb.py:1625
+#: DynamicWeb//dynamicweb.py:1630
 #, python-format
 msgid "%(type)s: %(value)s"
 msgstr "%(type)s: %(value)s"
 
-#: DynamicWeb/dynamicweb.py:1872
+#: DynamicWeb//dynamicweb.py:1877
 #, python-format
 msgid "Impossible to convert \"%(path)s\" to a relative path."
 msgstr "Konvertierung von \"%(path)s\" in einen relativen Pfad nicht möglich."
 
-#: DynamicWeb/dynamicweb.py:2178
+#: DynamicWeb//dynamicweb.py:2183
 msgid ""
 "The pages configuration is not valid: several pages have the same content"
 msgstr ""
 "Die Seiten-Konfiguration ist nicht gültig: mehrere Seiten haben den\n"
 "selben Inhalt"
 
-#: DynamicWeb/dynamicweb.py:2189
-msgid "Html|Home"
-msgstr "Startseite"
+#: DynamicWeb//dynamicweb.py:2194
+msgid "DynWeb|Home"
+msgstr "Anfang"
 
-#: DynamicWeb/dynamicweb.py:2190 DynamicWeb/dynamicweb.py:2203
-#: DynamicWeb/dynamicweb.py:2204 DynamicWeb/dynamicweb.py:2205
+#: DynamicWeb//dynamicweb.py:2195 DynamicWeb//dynamicweb.py:2208
+#: DynamicWeb//dynamicweb.py:2209 DynamicWeb//dynamicweb.py:2210
 msgid "Tree"
 msgstr "Baum"
 
-#: DynamicWeb/dynamicweb.py:2191 DynamicWeb/dynamicweb.py:2206
-#: DynamicWeb/dynamicweb.py:2207 DynamicWeb/dynamicweb.py:2208
+#: DynamicWeb//dynamicweb.py:2196 DynamicWeb//dynamicweb.py:2211
+#: DynamicWeb//dynamicweb.py:2212 DynamicWeb//dynamicweb.py:2213
 msgid "Statistics"
 msgstr "Statistik"
 
-#: DynamicWeb/dynamicweb.py:2194 DynamicWeb/dynamicweb.py:2470
+#: DynamicWeb//dynamicweb.py:2199 DynamicWeb//dynamicweb.py:2475
 msgid "Configuration"
 msgstr "Konfiguration"
 
-#: DynamicWeb/dynamicweb.py:2196 DynamicWeb/dynamicweb.py:2534
+#: DynamicWeb//dynamicweb.py:2201 DynamicWeb//dynamicweb.py:2540
 msgid "Person"
 msgstr "Person"
 
-#: DynamicWeb/dynamicweb.py:2197
+#: DynamicWeb//dynamicweb.py:2202
 msgid "Family"
 msgstr "Familie"
 
-#: DynamicWeb/dynamicweb.py:2198 DynamicWeb/dynamicweb.py:2572
+#: DynamicWeb//dynamicweb.py:2203 DynamicWeb//dynamicweb.py:2580
 msgid "Source"
 msgstr "Quelle"
 
-#: DynamicWeb/dynamicweb.py:2199 DynamicWeb/dynamicweb.py:2218
-#: DynamicWeb/dynamicweb.py:2518
+#: DynamicWeb//dynamicweb.py:2204 DynamicWeb//dynamicweb.py:2223
+#: DynamicWeb//dynamicweb.py:2523
 msgid "Media"
 msgstr "Medien"
 
-#: DynamicWeb/dynamicweb.py:2200 DynamicWeb/dynamicweb.py:2537
+#: DynamicWeb//dynamicweb.py:2205 DynamicWeb//dynamicweb.py:2543
 msgid "Place"
 msgstr "Ort"
 
-#: DynamicWeb/dynamicweb.py:2201 DynamicWeb/dynamicweb.py:2548
+#: DynamicWeb//dynamicweb.py:2206 DynamicWeb//dynamicweb.py:2555
 msgid "Repository"
 msgstr "Aufbewahrungsort"
 
-#: DynamicWeb/dynamicweb.py:2202
+#: DynamicWeb//dynamicweb.py:2207
 msgid "Search results"
 msgstr "Suchergebnisse"
 
-#: DynamicWeb/dynamicweb.py:2213 DynamicWeb/dynamicweb.py:2214
-#: DynamicWeb/dynamicweb.py:2579
+#: DynamicWeb//dynamicweb.py:2218 DynamicWeb//dynamicweb.py:2219
+#: DynamicWeb//dynamicweb.py:2587
 msgid "Surnames"
 msgstr "Nachnamen"
 
-#: DynamicWeb/dynamicweb.py:2215 DynamicWeb/dynamicweb.py:2503
+#: DynamicWeb//dynamicweb.py:2220 DynamicWeb//dynamicweb.py:2508
 msgid "Individuals"
 msgstr "Personen"
 
-#: DynamicWeb/dynamicweb.py:2216 DynamicWeb/dynamicweb.py:2486
+#: DynamicWeb//dynamicweb.py:2221 DynamicWeb//dynamicweb.py:2491
 msgid "Families"
 msgstr "Familien"
 
-#: DynamicWeb/dynamicweb.py:2217 DynamicWeb/dynamicweb.py:2574
+#: DynamicWeb//dynamicweb.py:2222 DynamicWeb//dynamicweb.py:2582
 msgid "Sources"
 msgstr "Quellen"
 
-#: DynamicWeb/dynamicweb.py:2219 DynamicWeb/dynamicweb.py:2539
+#: DynamicWeb//dynamicweb.py:2224 DynamicWeb//dynamicweb.py:2545
 msgid "Places"
 msgstr "Orte"
 
-#: DynamicWeb/dynamicweb.py:2220 DynamicWeb/dynamicweb.py:2448
+#: DynamicWeb//dynamicweb.py:2225 DynamicWeb//dynamicweb.py:2453
 msgid "Addresses"
 msgstr "Adressen"
 
-#: DynamicWeb/dynamicweb.py:2221 DynamicWeb/dynamicweb.py:2547
+#: DynamicWeb//dynamicweb.py:2226 DynamicWeb//dynamicweb.py:2554
 msgid "Repositories"
 msgstr "Aufbewahrungsorte"
 
-#: DynamicWeb/dynamicweb.py:2272 DynamicWeb/dynamicweb.py:2502
-#: DynamicWeb/dynamicweb.py:4109
+#: DynamicWeb//dynamicweb.py:2277 DynamicWeb//dynamicweb.py:2507
+#: DynamicWeb//dynamicweb.py:4126
 msgid "Indexes"
 msgstr "Indices"
 
-#: DynamicWeb/dynamicweb.py:2436
+#: DynamicWeb//dynamicweb.py:2441
 #, python-format
 msgid "(b. %(birthdate)s, d. %(deathdate)s)"
 msgstr "(* %(birthdate)s, † %(deathdate)s)"
 
-#: DynamicWeb/dynamicweb.py:2437
+#: DynamicWeb//dynamicweb.py:2442
 #, python-format
 msgid "(b. %s)"
 msgstr "(* %s)"
 
-#: DynamicWeb/dynamicweb.py:2438
+#: DynamicWeb//dynamicweb.py:2443
 #, python-format
 msgid "(d. %s)"
 msgstr "(† %s)"
 
-#: DynamicWeb/dynamicweb.py:2439
+#: DynamicWeb//dynamicweb.py:2444
 msgid "(filtered from _MAX_ total entries)"
 msgstr "(aus _MAX_ Gesamteinträgen gefiltert)"
 
-#: DynamicWeb/dynamicweb.py:2440
+#: DynamicWeb//dynamicweb.py:2445
 #, python-format
 msgid "(m. %s)"
 msgstr "(⚭ %s)"
 
-#: DynamicWeb/dynamicweb.py:2441
+#: DynamicWeb//dynamicweb.py:2446
 msgid "(sort by name)"
 msgstr "(nach Name sortiert)"
 
-#: DynamicWeb/dynamicweb.py:2442
+#: DynamicWeb//dynamicweb.py:2447
 msgid "(sort by quantity)"
 msgstr "(nach Anzahl sortiert)"
 
-#: DynamicWeb/dynamicweb.py:2443
+#: DynamicWeb//dynamicweb.py:2448
 msgid ": activate to sort column ascending"
 msgstr ": aktiviere um Spalte aufsteigend zu sortieren"
 
-#: DynamicWeb/dynamicweb.py:2444
+#: DynamicWeb//dynamicweb.py:2449
 msgid ": activate to sort column descending"
 msgstr ": aktiviere um Spalte absteigend zu sortieren"
 
-#: DynamicWeb/dynamicweb.py:2445
+#: DynamicWeb//dynamicweb.py:2450
 msgid ""
 "<p>This page provides the SVG raw code.<br>Copy the contents into a text "
 "editor and save as an SVG file.<br>Make sure that the text editor encoding "
@@ -385,529 +385,568 @@ msgstr ""
 "SVG-Datei.<br>Stelle dabei sicher, dass die Kodierung des Texteditors\n"
 "UTF-8 ist."
 
-#: DynamicWeb/dynamicweb.py:2447
+#: DynamicWeb//dynamicweb.py:2452
 msgid "Address"
 msgstr "Adresse"
 
-#: DynamicWeb/dynamicweb.py:2449
+#: DynamicWeb//dynamicweb.py:2454
 msgid "Age at death"
 msgstr "Alter beim Tod"
 
-#: DynamicWeb/dynamicweb.py:2450
+#: DynamicWeb//dynamicweb.py:2455
 msgid "Alternate Marriage"
 msgstr "Alternative Hochzeit"
 
-#: DynamicWeb/dynamicweb.py:2451
+#: DynamicWeb//dynamicweb.py:2456
 msgid "Alternate Name"
 msgstr "Alternativer Name"
 
-#: DynamicWeb/dynamicweb.py:2452
+#: DynamicWeb//dynamicweb.py:2457
 msgid "Ancestors"
 msgstr "Vorfahren"
 
-#: DynamicWeb/dynamicweb.py:2453
+#: DynamicWeb//dynamicweb.py:2458
 msgid "Associations"
 msgstr "Verknüpfungen"
 
-#: DynamicWeb/dynamicweb.py:2454
+#: DynamicWeb//dynamicweb.py:2459
 msgid "Attribute"
 msgstr "Attribut"
 
-#: DynamicWeb/dynamicweb.py:2455
+#: DynamicWeb//dynamicweb.py:2460
 msgid "Attributes"
 msgstr "Attribute"
 
-#: DynamicWeb/dynamicweb.py:2457 DynamicWeb/dynamicweb.py:4192
+#: DynamicWeb//dynamicweb.py:2462 DynamicWeb//dynamicweb.py:4209
 msgid "Background"
 msgstr "Hintergrund"
 
-#: DynamicWeb/dynamicweb.py:2458
+#: DynamicWeb//dynamicweb.py:2463
 msgid "Baptism"
 msgstr "Taufe"
 
-#: DynamicWeb/dynamicweb.py:2459
+#: DynamicWeb//dynamicweb.py:2464
 msgid "Birth"
 msgstr "Geburt"
 
-#: DynamicWeb/dynamicweb.py:2460
+#: DynamicWeb//dynamicweb.py:2465
 msgid "Burial"
 msgstr "Beerdigung"
 
-#: DynamicWeb/dynamicweb.py:2461
+#: DynamicWeb//dynamicweb.py:2466
 msgid "Call Name"
 msgstr "Rufname"
 
-#: DynamicWeb/dynamicweb.py:2462
+#: DynamicWeb//dynamicweb.py:2467
 msgid "Call Number"
 msgstr "Standortnummer/Signatur"
 
-#: DynamicWeb/dynamicweb.py:2463
+#: DynamicWeb//dynamicweb.py:2468
 msgid "Cause Of Death"
 msgstr "Todesursache"
 
-#: DynamicWeb/dynamicweb.py:2464
+#: DynamicWeb//dynamicweb.py:2469
 msgid "Children"
 msgstr "Kinder"
 
-#: DynamicWeb/dynamicweb.py:2465
+#: DynamicWeb//dynamicweb.py:2470
 msgid "Christening"
 msgstr "Kleinkindtaufe"
 
-#: DynamicWeb/dynamicweb.py:2466
+#: DynamicWeb//dynamicweb.py:2471
 msgid "Citation"
 msgstr "Fundstelle"
 
-#: DynamicWeb/dynamicweb.py:2467
+#: DynamicWeb//dynamicweb.py:2472
 msgid "Citations"
 msgstr "Fundstellen"
 
-#: DynamicWeb/dynamicweb.py:2468
+#: DynamicWeb//dynamicweb.py:2473
 msgid "Click on the map to show it full-screen"
 msgstr "Klicke auf die Karte um sie auf dem ganzen Bildschirm zu zeigen"
 
-#: DynamicWeb/dynamicweb.py:2469
+#: DynamicWeb//dynamicweb.py:2474
 msgid "Code"
 msgstr "Kennung"
 
-#: DynamicWeb/dynamicweb.py:2471
+#: DynamicWeb//dynamicweb.py:2476
 msgid "Configure"
 msgstr "Konfiguriere"
 
-#: DynamicWeb/dynamicweb.py:2472
+#: DynamicWeb//dynamicweb.py:2477
 msgid "Count"
 msgstr "Zählung"
 
-#: DynamicWeb/dynamicweb.py:2473
+#: DynamicWeb//dynamicweb.py:2478
 msgid "Cremation"
 msgstr "Einäscherung"
 
-#: DynamicWeb/dynamicweb.py:2475
+#: DynamicWeb//dynamicweb.py:2480
 msgid "Death"
 msgstr "Tod"
 
-#: DynamicWeb/dynamicweb.py:2476
+#: DynamicWeb//dynamicweb.py:2481
 msgid "Descendants"
 msgstr "Nachkommen"
 
-#: DynamicWeb/dynamicweb.py:2477
+#: DynamicWeb//dynamicweb.py:2482
 msgid "Description"
 msgstr "Beschreibung"
 
-#: DynamicWeb/dynamicweb.py:2478
+#: DynamicWeb//dynamicweb.py:2483
 msgid "DynamicWeb_report#Help"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2479
+#: DynamicWeb//dynamicweb.py:2484
 msgid "Enclosed By"
 msgstr "Teil von"
 
-#: DynamicWeb/dynamicweb.py:2480
+#: DynamicWeb//dynamicweb.py:2485
 msgid "Engagement"
 msgstr "Verlobung"
 
-#: DynamicWeb/dynamicweb.py:2481
+#: DynamicWeb//dynamicweb.py:2486
 msgid "Event"
 msgstr "Ereignis"
 
-#: DynamicWeb/dynamicweb.py:2482
+#: DynamicWeb//dynamicweb.py:2487
 msgid "Events"
 msgstr "Ereignisse"
 
-#: DynamicWeb/dynamicweb.py:2483
+#: DynamicWeb//dynamicweb.py:2488
 msgid "Examples"
 msgstr "Beispiele"
 
-#: DynamicWeb/dynamicweb.py:2484
+#: DynamicWeb//dynamicweb.py:2489
 msgid "F"
 msgstr "W"
 
-#: DynamicWeb/dynamicweb.py:2485
+#: DynamicWeb//dynamicweb.py:2490
 msgid "Families Index"
 msgstr "Familienindex"
 
-#: DynamicWeb/dynamicweb.py:2487
+#: DynamicWeb//dynamicweb.py:2492
 msgid "Family Nick Name"
 msgstr "Familienspitzname"
 
-#: DynamicWeb/dynamicweb.py:2488
+#: DynamicWeb//dynamicweb.py:2493
 msgid "Father"
 msgstr "Vater"
 
-#: DynamicWeb/dynamicweb.py:2489
+#: DynamicWeb//dynamicweb.py:2494
 msgid "Female"
 msgstr "Weiblich"
 
-#: DynamicWeb/dynamicweb.py:2490
+#: DynamicWeb//dynamicweb.py:2495
 msgid "File ready"
 msgstr "Datei fertig"
 
-#: DynamicWeb/dynamicweb.py:2491
+#: DynamicWeb//dynamicweb.py:2496
 msgid "Gender"
 msgstr "Geschlecht"
 
-#: DynamicWeb/dynamicweb.py:2492
+#: DynamicWeb//dynamicweb.py:2497
 msgid "Help"
 msgstr "Hilfe"
 
-#: DynamicWeb/dynamicweb.py:2493
+#: DynamicWeb//dynamicweb.py:2498
 msgid "ID"
 msgstr "ID"
 
-#: DynamicWeb/dynamicweb.py:2494 DynamicWeb/dynamicweb.py:4024
+#: DynamicWeb//dynamicweb.py:2499 DynamicWeb//dynamicweb.py:4041
 msgid "Include Place map on Place Pages"
 msgstr "Mit Orte Karte auf den Ortsseiten"
 
-#: DynamicWeb/dynamicweb.py:2495 DynamicWeb/dynamicweb.py:4129
+#: DynamicWeb//dynamicweb.py:2500 DynamicWeb//dynamicweb.py:4146
 msgid "Include dates columns on the index pages"
 msgstr "Füge Datumsspalten auf den Indexseiten hinzu"
 
-#: DynamicWeb/dynamicweb.py:2496 DynamicWeb/dynamicweb.py:4137
+#: DynamicWeb//dynamicweb.py:2501 DynamicWeb//dynamicweb.py:4154
 msgid "Include a column for parents on the index pages"
 msgstr "Spalte für Eltern auf den Indexseiten"
 
-#: DynamicWeb/dynamicweb.py:2497 DynamicWeb/dynamicweb.py:4145
+#: DynamicWeb//dynamicweb.py:2502 DynamicWeb//dynamicweb.py:4162
 msgid "Include a column for media path on the index pages"
 msgstr "Füge auf den Indexseiten eine Spalte für den Medienpfad ein"
 
-#: DynamicWeb/dynamicweb.py:2498 DynamicWeb/dynamicweb.py:4133
+#: DynamicWeb//dynamicweb.py:2503 DynamicWeb//dynamicweb.py:4150
 msgid "Include a column for partners on the index pages"
 msgstr "Spalte für Partner auf den Indexseiten"
 
-#: DynamicWeb/dynamicweb.py:2499 DynamicWeb/dynamicweb.py:4032
+#: DynamicWeb//dynamicweb.py:2504 DynamicWeb//dynamicweb.py:4049
 msgid "Include a map in the individuals and family pages"
 msgstr "Karte auf den Personen- und Familienseiten aufnehmen"
 
-#: DynamicWeb/dynamicweb.py:2500 DynamicWeb/dynamicweb.py:4079
+#: DynamicWeb//dynamicweb.py:2505 DynamicWeb//dynamicweb.py:4096
 msgid "Include half and/ or step-siblings on the individual pages"
 msgstr "Halb- und/oder Stiefgeschwister auf den Personenseiten aufnehmen"
 
-#: DynamicWeb/dynamicweb.py:2501 DynamicWeb/dynamicweb.py:4149
+#: DynamicWeb//dynamicweb.py:2506 DynamicWeb//dynamicweb.py:4166
 msgid "Include references in indexes"
 msgstr "Referenzen in den Indices ausgeben"
 
-#: DynamicWeb/dynamicweb.py:2504 DynamicWeb/dynamicweb.py:4099
+#: DynamicWeb//dynamicweb.py:2509 DynamicWeb//dynamicweb.py:4116
 msgid "Insert sources author in the sources title"
 msgstr "Autor der Quellen in den Quelltitel einfügen"
 
-#: DynamicWeb/dynamicweb.py:2505
+#: DynamicWeb//dynamicweb.py:2510
 msgid "Last Modified"
 msgstr "Zuletzt geändert"
 
-#: DynamicWeb/dynamicweb.py:2506
+#: DynamicWeb//dynamicweb.py:2511
 msgid "Latitude"
 msgstr "Breitengrad"
 
-#: DynamicWeb/dynamicweb.py:2507
+#: DynamicWeb//dynamicweb.py:2512
 msgid "Link"
 msgstr "Verknüpfung"
 
-#: DynamicWeb/dynamicweb.py:2508
+#: DynamicWeb//dynamicweb.py:2513
 msgid "Loading..."
 msgstr "Lade..."
 
-#: DynamicWeb/dynamicweb.py:2509
+#: DynamicWeb//dynamicweb.py:2514
 msgid "Location"
 msgstr "Standort"
 
-#: DynamicWeb/dynamicweb.py:2510
+#: DynamicWeb//dynamicweb.py:2515
 msgid "Longitude"
 msgstr "Längengrad"
 
-#: DynamicWeb/dynamicweb.py:2511
+#: DynamicWeb//dynamicweb.py:2516
 msgid "M"
 msgstr "M"
 
-#: DynamicWeb/dynamicweb.py:2512
+#: DynamicWeb//dynamicweb.py:2517
 msgid "Male"
 msgstr "Männlich"
 
-#: DynamicWeb/dynamicweb.py:2513
+#: DynamicWeb//dynamicweb.py:2518
 msgid "Map"
 msgstr "Karte"
 
-#: DynamicWeb/dynamicweb.py:2514
+#: DynamicWeb//dynamicweb.py:2519
 msgid "Marriage"
 msgstr "Hochzeit"
 
-#: DynamicWeb/dynamicweb.py:2515
+#: DynamicWeb//dynamicweb.py:2520
 msgid "Maximize"
 msgstr "Maximieren"
 
-#: DynamicWeb/dynamicweb.py:2516
+#: DynamicWeb//dynamicweb.py:2521
 msgid "Media Index"
 msgstr "Medienindex"
 
-#: DynamicWeb/dynamicweb.py:2517
+#: DynamicWeb//dynamicweb.py:2522
 msgid "Media Type"
 msgstr "Medientyp"
 
-#: DynamicWeb/dynamicweb.py:2519
+#: DynamicWeb//dynamicweb.py:2524
 msgid "Mother"
 msgstr "Mutter"
 
-#: DynamicWeb/dynamicweb.py:2520
+#: DynamicWeb//dynamicweb.py:2525
 msgid "Name"
 msgstr "Name"
 
-#: DynamicWeb/dynamicweb.py:2521
+#: DynamicWeb//dynamicweb.py:2526
 msgid "Nick Name"
 msgstr "Spitzname"
 
-#: DynamicWeb/dynamicweb.py:2522
+#: DynamicWeb//dynamicweb.py:2527
 msgid "No data available in table"
 msgstr "Keine Daten in der Tabelle verfügbar"
 
-#: DynamicWeb/dynamicweb.py:2523
+#: DynamicWeb//dynamicweb.py:2528
 msgid "No matches found"
 msgstr "Keine Treffer gefunden"
 
-#: DynamicWeb/dynamicweb.py:2524
+#: DynamicWeb//dynamicweb.py:2529
 msgid "No matching records found"
 msgstr "Keine passenden Einträge gefunden"
 
-#: DynamicWeb/dynamicweb.py:2525
+#: DynamicWeb//dynamicweb.py:2530
 msgid "No matching surname."
 msgstr "Keine passenden Nachnahmen."
 
-#: DynamicWeb/dynamicweb.py:2526
+#: DynamicWeb//dynamicweb.py:2531
 msgid "None"
 msgstr "Ohne"
 
-#: DynamicWeb/dynamicweb.py:2527
+#: DynamicWeb//dynamicweb.py:2532
 msgid "Notes"
 msgstr "Notizen"
 
-#: DynamicWeb/dynamicweb.py:2528
+#: DynamicWeb//dynamicweb.py:2533
+#, fuzzy
+msgid "Number"
+msgstr "Standortnummer/Signatur"
+
+#: DynamicWeb//dynamicweb.py:2534
 msgid "OK"
 msgstr "OK"
 
-#: DynamicWeb/dynamicweb.py:2529
+#: DynamicWeb//dynamicweb.py:2535
 msgid "Other participants"
 msgstr "Andere Beteiligte"
 
-#: DynamicWeb/dynamicweb.py:2530
+#: DynamicWeb//dynamicweb.py:2536
 msgid "Parents"
 msgstr "Eltern"
 
-#: DynamicWeb/dynamicweb.py:2531
+#: DynamicWeb//dynamicweb.py:2537
 msgid "Path"
 msgstr "Pfad"
 
-#: DynamicWeb/dynamicweb.py:2532
+#: DynamicWeb//dynamicweb.py:2538
 msgid "Person page"
 msgstr "Personen-Seite"
 
-#: DynamicWeb/dynamicweb.py:2533
+#: DynamicWeb//dynamicweb.py:2539
 msgid "Person to search for"
 msgstr "Zu suchende Person"
 
-#: DynamicWeb/dynamicweb.py:2535
+#: DynamicWeb//dynamicweb.py:2541
 msgid "Persons Index"
 msgstr "Personenindex"
 
-#: DynamicWeb/dynamicweb.py:2536
+#: DynamicWeb//dynamicweb.py:2542
 msgid "Persons"
 msgstr "Personen"
 
-#: DynamicWeb/dynamicweb.py:2538
+#: DynamicWeb//dynamicweb.py:2544
 msgid "Places Index"
 msgstr "Ortsindex:"
 
-#: DynamicWeb/dynamicweb.py:2540
+#: DynamicWeb//dynamicweb.py:2546
 msgid "Preparing file ..."
 msgstr "Datei vorbereiten ..."
 
-#: DynamicWeb/dynamicweb.py:2541
+#: DynamicWeb//dynamicweb.py:2547
 msgid "Processing..."
 msgstr "Verarbeitung..."
 
-#: DynamicWeb/dynamicweb.py:2543
+#: DynamicWeb//dynamicweb.py:2549
 msgid "References"
 msgstr "Referenzen"
 
-#: DynamicWeb/dynamicweb.py:2544
+#: DynamicWeb//dynamicweb.py:2550
 msgid "Relationship to Father"
 msgstr "Beziehung zum Vater"
 
-#: DynamicWeb/dynamicweb.py:2545
+#: DynamicWeb//dynamicweb.py:2551
 msgid "Relationship to Mother"
 msgstr "Beziehung zur Mutter"
 
-#: DynamicWeb/dynamicweb.py:2546
+#: DynamicWeb//dynamicweb.py:2552
 msgid "Relationship"
 msgstr "Beziehung"
 
-#: DynamicWeb/dynamicweb.py:2549
+#: DynamicWeb//dynamicweb.py:2553
+#, fuzzy
+msgid "Repositories Index"
+msgstr "Aufbewahrungsortsindex-Seite"
+
+#: DynamicWeb//dynamicweb.py:2556
 msgid "Restore"
 msgstr "Wiederherstellen"
 
-#: DynamicWeb/dynamicweb.py:2550
+#: DynamicWeb//dynamicweb.py:2557
 msgid "Restore default settings"
 msgstr "Standardeinstellungen wiederherstellen"
 
-#: DynamicWeb/dynamicweb.py:2551 DynamicWeb/dynamicweb.py:4095
+#: DynamicWeb//dynamicweb.py:2558 DynamicWeb//dynamicweb.py:4112
 msgid "Show last modification time"
 msgstr "Zeige den Zeitpunkt der letzten Änderung"
 
-#: DynamicWeb/dynamicweb.py:2552 DynamicWeb/dynamicweb.py:4186
+#: DynamicWeb//dynamicweb.py:2559 DynamicWeb//dynamicweb.py:4203
 msgid "SVG tree children distribution"
 msgstr "SVG-Baum Kinderverteilung"
 
-#: DynamicWeb/dynamicweb.py:2553
+#: DynamicWeb//dynamicweb.py:2560
 msgid "SVG tree configuration"
 msgstr "SVG Baumkonfiguration"
 
-#: DynamicWeb/dynamicweb.py:2554 DynamicWeb/dynamicweb.py:4174
+#: DynamicWeb//dynamicweb.py:2561 DynamicWeb//dynamicweb.py:4191
 msgid "SVG tree graph shape"
 msgstr "SVG-Baum Grafikform"
 
-#: DynamicWeb/dynamicweb.py:2555 DynamicWeb/dynamicweb.py:4168
+#: DynamicWeb//dynamicweb.py:2562 DynamicWeb//dynamicweb.py:4185
 msgid "SVG tree graph type"
 msgstr "SVG-Baum Grafiktyp"
 
-#: DynamicWeb/dynamicweb.py:2556 DynamicWeb/dynamicweb.py:4180
+#: DynamicWeb//dynamicweb.py:2563 DynamicWeb//dynamicweb.py:4197
 msgid "SVG tree parents distribution"
 msgstr "SVG-Baum Elternverteilung"
 
-#: DynamicWeb/dynamicweb.py:2557
+#: DynamicWeb//dynamicweb.py:2564
 msgid "Save tree as file"
 msgstr "Speichere Baum als Datei"
 
-#: DynamicWeb/dynamicweb.py:2558
+#: DynamicWeb//dynamicweb.py:2565
 msgid "Search:"
 msgstr "Suchen:"
 
-#: DynamicWeb/dynamicweb.py:2559
+#: DynamicWeb//dynamicweb.py:2566
 msgid "Select the background color scheme"
 msgstr "Wähle das Schema für die Hintergrundfarbe"
 
-#: DynamicWeb/dynamicweb.py:2560
+#: DynamicWeb//dynamicweb.py:2567
 msgid "Select the children distribution (fan charts only)"
 msgstr "Wähle die Verteilung der Kinder (nur Fächergrafik)"
 
-#: DynamicWeb/dynamicweb.py:2561
+#: DynamicWeb//dynamicweb.py:2568
 msgid "Select the number of ascending generations"
 msgstr "Wähle die Anzahl der Vorfahren-Generationen"
 
-#: DynamicWeb/dynamicweb.py:2562
+#: DynamicWeb//dynamicweb.py:2569
 msgid "Select the number of descending generations"
 msgstr "Wähle die Anzahl der Nachfahren-Generationen"
 
-#: DynamicWeb/dynamicweb.py:2563
+#: DynamicWeb//dynamicweb.py:2570
 msgid "Select the parents distribution (fan charts only)"
 msgstr "Wähle die Verteilung der Eltern (nur Fächergrafik)"
 
-#: DynamicWeb/dynamicweb.py:2564
+#: DynamicWeb//dynamicweb.py:2571
 msgid "Select the shape of graph"
 msgstr "Wähle die Form der Grafik"
 
-#: DynamicWeb/dynamicweb.py:2565
+#: DynamicWeb//dynamicweb.py:2572
 msgid "Select the type of graph"
 msgstr "Wähle den Typ der Grafik"
 
-#: DynamicWeb/dynamicweb.py:2566
+#: DynamicWeb//dynamicweb.py:2573
 msgid "Several matches.<br>Precise your search or choose in the lists below."
 msgstr ""
 "Mehrere Übereinstimmungen.<br>Präzisiere deine Suche oder wähle in der\n"
 "unteren Liste."
 
-#: DynamicWeb/dynamicweb.py:2567
+#: DynamicWeb//dynamicweb.py:2574
 msgid "Show _MENU_ entries"
 msgstr "Zeige _MENU_ Einträge"
 
-#: DynamicWeb/dynamicweb.py:2568 DynamicWeb/dynamicweb.py:4204
+#: DynamicWeb//dynamicweb.py:2575 DynamicWeb//dynamicweb.py:4221
 msgid "Show duplicates"
 msgstr "Zeige Duplikate"
 
-#: DynamicWeb/dynamicweb.py:2569
+#: DynamicWeb//dynamicweb.py:2576
 msgid "Showing 0 to 0 of 0 entries"
 msgstr "Zeige 0 bis 0 von 0 Einträgen"
 
-#: DynamicWeb/dynamicweb.py:2570
+#: DynamicWeb//dynamicweb.py:2577
 msgid "Showing _START_ to _END_ of _TOTAL_ entries"
 msgstr "Zeige _START_ bis _END_ von _TOTAL_ Einträgen"
 
-#: DynamicWeb/dynamicweb.py:2571
+#: DynamicWeb//dynamicweb.py:2578
 msgid "Siblings"
 msgstr "Geschwister"
 
-#: DynamicWeb/dynamicweb.py:2573
+#: DynamicWeb//dynamicweb.py:2579
+msgid "Sort by:"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:2581
 msgid "Sources Index"
 msgstr "Quellen Index"
 
-#: DynamicWeb/dynamicweb.py:2575
+#: DynamicWeb//dynamicweb.py:2583
 msgid "Spouses"
 msgstr "(Ehe-)Partner"
 
-#: DynamicWeb/dynamicweb.py:2576 DynamicWeb/dynamicweb.py:4103
+#: DynamicWeb//dynamicweb.py:2584 DynamicWeb//dynamicweb.py:4120
 msgid "Suppress Gramps ID"
 msgstr "Gramps-IDs ausblenden"
 
-#: DynamicWeb/dynamicweb.py:2577
+#: DynamicWeb//dynamicweb.py:2585
 msgid "Surname"
 msgstr "Nachname"
 
-#: DynamicWeb/dynamicweb.py:2578
+#: DynamicWeb//dynamicweb.py:2586
 msgid "Surnames Index"
 msgstr "Nachnahmensindex"
 
-#: DynamicWeb/dynamicweb.py:2580
+#: DynamicWeb//dynamicweb.py:2588
 msgid "Title"
 msgstr "Titel"
 
-#: DynamicWeb/dynamicweb.py:2581
+#: DynamicWeb//dynamicweb.py:2589
 msgid "Type"
 msgstr "Art"
 
-#: DynamicWeb/dynamicweb.py:2582
+#: DynamicWeb//dynamicweb.py:2590
 msgid "U"
 msgstr "U"
 
-#: DynamicWeb/dynamicweb.py:2583
+#: DynamicWeb//dynamicweb.py:2591
 msgid "Unknown"
 msgstr "Unbekannt"
 
-#: DynamicWeb/dynamicweb.py:2584 DynamicWeb/dynamicweb.py:4091
+#: DynamicWeb//dynamicweb.py:2592 DynamicWeb//dynamicweb.py:4108
 msgid "Use tabbed panels instead of sections"
 msgstr "Verwende Registerkarten anstatt Abschnitte"
 
-#: DynamicWeb/dynamicweb.py:2585
+#: DynamicWeb//dynamicweb.py:2593
 msgid "Use the search box above in order to find a person."
 msgstr "Benutze die obige Suchbox um eine Person zu finden."
 
-#: DynamicWeb/dynamicweb.py:2586
+#: DynamicWeb//dynamicweb.py:2594
+#, fuzzy
+msgid "Use a table format for the surnames index"
+msgstr "Standardformat für den Nachnamenindex"
+
+#: DynamicWeb//dynamicweb.py:2595
+#, fuzzy
+msgid "Use a table format for the persons index"
+msgstr "Standardformat für den Personenindex"
+
+#: DynamicWeb//dynamicweb.py:2596
+#, fuzzy
+msgid "Use a table format for the families index"
+msgstr "Standardformat für den Familienindex"
+
+#: DynamicWeb//dynamicweb.py:2597
+#, fuzzy
+msgid "Use a table format for the sources index"
+msgstr "Standardformat für den Quellenindex"
+
+#: DynamicWeb//dynamicweb.py:2598
+#, fuzzy
+msgid "Use a table format for the places index"
+msgstr "Standardformat für den Orteindex"
+
+#: DynamicWeb//dynamicweb.py:2599
 msgid "Used for family"
 msgstr "Verwendet für Familie"
 
-#: DynamicWeb/dynamicweb.py:2587
+#: DynamicWeb//dynamicweb.py:2600
 msgid "Used for media"
 msgstr "Verwendet für Medien"
 
-#: DynamicWeb/dynamicweb.py:2588
+#: DynamicWeb//dynamicweb.py:2601
 msgid "Used for person"
 msgstr "Verwendet für Person"
 
-#: DynamicWeb/dynamicweb.py:2589
+#: DynamicWeb//dynamicweb.py:2602
 msgid "Used for place"
 msgstr "Verwendet für Ort"
 
-#: DynamicWeb/dynamicweb.py:2590
+#: DynamicWeb//dynamicweb.py:2603
 msgid "Used for source"
 msgstr "Verwendet für Quelle"
 
-#: DynamicWeb/dynamicweb.py:2591
+#: DynamicWeb//dynamicweb.py:2604
 msgid "Value"
 msgstr "Wert"
 
-#: DynamicWeb/dynamicweb.py:2592
+#: DynamicWeb//dynamicweb.py:2605
 msgid "Web Link"
 msgstr "Weblink"
 
-#: DynamicWeb/dynamicweb.py:2593
+#: DynamicWeb//dynamicweb.py:2606
 msgid "Web Links"
 msgstr "Weblinks"
 
-#: DynamicWeb/dynamicweb.py:2594 DynamicWeb/dynamicweb.py:4205
+#: DynamicWeb//dynamicweb.py:2607 DynamicWeb//dynamicweb.py:4222
 msgid ""
 "Whether to use a special color for the persons that appear several times in "
 "the SVG tree"
@@ -915,45 +954,50 @@ msgstr ""
 "Legt fest, ob eine spezielle Farbe für eine Person verwendet wird, die "
 "mehrfach im SVG-Baum erscheint"
 
-#: DynamicWeb/dynamicweb.py:2595
+#: DynamicWeb//dynamicweb.py:2608
 msgid "Without name"
 msgstr "Ohne Name"
 
-#: DynamicWeb/dynamicweb.py:2596
+#: DynamicWeb//dynamicweb.py:2609
 msgid "Without surname"
 msgstr "Ohne Nachnahme"
 
-#: DynamicWeb/dynamicweb.py:2597
+#: DynamicWeb//dynamicweb.py:2610
 msgid "Without title"
 msgstr "Ohne Titel"
 
-#: DynamicWeb/dynamicweb.py:2598
+#: DynamicWeb//dynamicweb.py:2611
 msgid "Zoom in"
 msgstr "Hineinzoomen"
 
-#: DynamicWeb/dynamicweb.py:2599
+#: DynamicWeb//dynamicweb.py:2612
 msgid "Zoom out"
 msgstr "Herauszoomen"
 
-#: DynamicWeb/dynamicweb.py:2600
+#: DynamicWeb//dynamicweb.py:2613
 msgid "all"
 msgstr "alle"
 
-#: DynamicWeb/dynamicweb.py:2941
+#: DynamicWeb//dynamicweb.py:2816
+#, fuzzy
+msgid "No Home Person"
+msgstr "Homepage"
+
+#: DynamicWeb//dynamicweb.py:2957
 #, python-format
 msgid "Copying error: %(error)s"
 msgstr "Kopierfehler: %(error)s"
 
-#: DynamicWeb/dynamicweb.py:2942
+#: DynamicWeb//dynamicweb.py:2958
 #, python-format
 msgid "Impossible to copy \"%(src)s\" to \"%(dst)s\""
 msgstr "Kopieren von \"%(src)s\" nach \"%(dst)s\" nicht möglich"
 
-#: DynamicWeb/dynamicweb.py:2945
+#: DynamicWeb//dynamicweb.py:2961
 msgid "Possible destination error"
 msgstr "Möglicher Fehler im Ziel."
 
-#: DynamicWeb/dynamicweb.py:2946
+#: DynamicWeb//dynamicweb.py:2962
 msgid ""
 "You appear to have set your target directory to a directory used for data "
 "storage. This could create problems with file management. It is recommended "
@@ -965,64 +1009,64 @@ msgstr ""
 "Dateimanagement führen. Es wird empfohlen, dass du ein anderes Verzeichnis "
 "für deine erstellten Websites wählst."
 
-#: DynamicWeb/dynamicweb.py:2973
+#: DynamicWeb//dynamicweb.py:2989
 #, python-format
 msgid "Unable to copy web site template files from \"%(path)s\""
 msgstr "Kann Webseitenvorlage von \"%(path)s\" nicht kopieren"
 
-#: DynamicWeb/dynamicweb.py:3017
+#: DynamicWeb//dynamicweb.py:3033
 #, python-format
 msgid "Keeping \"%(dst)s\" (newer than \"%(src)s\")"
 msgstr "Behalte \"%(dst)s\" (neuer als \"%(src)s\")"
 
-#: DynamicWeb/dynamicweb.py:3020
+#: DynamicWeb//dynamicweb.py:3036
 #, python-format
 msgid "Copying \"%(src)s\" to \"%(dst)s\""
 msgstr "Kopiere \"%(src)s\" nach \"%(dst)s\""
 
-#: DynamicWeb/dynamicweb.py:3038
+#: DynamicWeb//dynamicweb.py:3054
 msgid "Invalid file name"
 msgstr "Ungültiger Dateiname"
 
-#: DynamicWeb/dynamicweb.py:3039
+#: DynamicWeb//dynamicweb.py:3055
 msgid "The archive file must be a file, not a directory"
 msgstr "Das Archiv muss eine Datei sein, kein Verzeichnis"
 
-#: DynamicWeb/dynamicweb.py:3049 DynamicWeb/dynamicweb.py:3067
+#: DynamicWeb//dynamicweb.py:3065 DynamicWeb//dynamicweb.py:3083
 #, python-format
 msgid "Unable to overwrite archive file \"%(path)s\""
 msgstr "Kann Archivdatei \"%(path)s\" nicht überschreiben"
 
-#: DynamicWeb/dynamicweb.py:3059 DynamicWeb/dynamicweb.py:3074
+#: DynamicWeb//dynamicweb.py:3075 DynamicWeb//dynamicweb.py:3090
 #, python-format
 msgid "Unable to add file \"%(file)s\" to archive \"%(archive)s\""
 msgstr "Kann Datei \"%(file)s\" dem Archiv \"%(archive)s\" nicht hinzufügen"
 
-#: DynamicWeb/dynamicweb.py:3127
+#: DynamicWeb//dynamicweb.py:3143
 #, python-format
 msgid "DynamicWebReport ignoring link type '%(class)s'"
 msgstr "DynamicWebReport ignoriert Linktype '%(class)s'"
 
-#: DynamicWeb/dynamicweb.py:3370
+#: DynamicWeb//dynamicweb.py:3386
 msgid "Constructing list of other objects..."
 msgstr "Erstelle Liste der anderen Objekte..."
 
-#: DynamicWeb/dynamicweb.py:3505
+#: DynamicWeb//dynamicweb.py:3521
 #, python-format
 msgid "Family of %(husband)s and %(spouse)s"
 msgstr "Familie von %(husband)s und %(spouse)s"
 
-#: DynamicWeb/dynamicweb.py:3511
+#: DynamicWeb//dynamicweb.py:3527
 #, python-format
 msgid "Family of %(father)s"
 msgstr "Familie von %(father)s"
 
-#: DynamicWeb/dynamicweb.py:3515
+#: DynamicWeb//dynamicweb.py:3531
 #, python-format
 msgid "Family of %(mother)s"
 msgstr "Familie von %(mother)s"
 
-#: DynamicWeb/dynamicweb.py:3830
+#: DynamicWeb//dynamicweb.py:3846
 msgid ""
 "In this note, the following special words are processed:\n"
 "__SEARCH_FORM__ is replaced by a search form.\n"
@@ -1055,26 +1099,26 @@ msgstr ""
 "__EXPORT_DATE__ wird durch das aktuelle Datum ersetzt.\n"
 "__GRAMPS_VERSION__ wird durch die Gramps Version ersetzt.\n"
 "__GRAMPS_HOMEPAGE__ wird durch dem Gramps homepage Link ersetzt.\n"
-"URLs die mit  \"relative://relative.<link>\" starten werden ersetzt durch die "
-"relative URL \"<link>\".\n"
+"URLs die mit  \"relative://relative.<link>\" starten werden ersetzt durch "
+"die relative URL \"<link>\".\n"
 
-#: DynamicWeb/dynamicweb.py:3869
+#: DynamicWeb//dynamicweb.py:3886
 msgid "Report"
 msgstr "Bericht"
 
-#: DynamicWeb/dynamicweb.py:3874
+#: DynamicWeb//dynamicweb.py:3891
 msgid "Destination"
 msgstr "Ziel"
 
-#: DynamicWeb/dynamicweb.py:3876
+#: DynamicWeb//dynamicweb.py:3893
 msgid "The destination directory for the web files"
 msgstr "Das Zielverzeichnis für die Webdateien"
 
-#: DynamicWeb/dynamicweb.py:3880
+#: DynamicWeb//dynamicweb.py:3897
 msgid "Store web pages in archive"
 msgstr "Speichere Webseiten in Archiv"
 
-#: DynamicWeb/dynamicweb.py:3881
+#: DynamicWeb//dynamicweb.py:3898
 msgid ""
 "Whether to create an archive file (in ZIP or TGZ format) containing the web "
 "site"
@@ -1082,116 +1126,116 @@ msgstr ""
 "Legt fest, ob eine Archivdatei (im ZIP oder TGZ Format) erstellt werden "
 "soll, die die Webseite enthält"
 
-#: DynamicWeb/dynamicweb.py:3885
+#: DynamicWeb//dynamicweb.py:3902
 msgid "Archive file"
 msgstr "Archivdatei"
 
-#: DynamicWeb/dynamicweb.py:3887
+#: DynamicWeb//dynamicweb.py:3904
 msgid "The archive file name (with \".zip\" or \".tgz\" extension)"
 msgstr "Der Archivdateiname (mit \".zip\" or \".tgz\" extension)"
 
-#: DynamicWeb/dynamicweb.py:3893
+#: DynamicWeb//dynamicweb.py:3910
 msgid "Web site title"
 msgstr "Webseitentitel"
 
-#: DynamicWeb/dynamicweb.py:3893
+#: DynamicWeb//dynamicweb.py:3910
 msgid "My Family Tree"
 msgstr "Mein Stammbaum"
 
-#: DynamicWeb/dynamicweb.py:3894
+#: DynamicWeb//dynamicweb.py:3911
 msgid "The title of the web site"
 msgstr "Der Titel der Website"
 
-#: DynamicWeb/dynamicweb.py:3897
+#: DynamicWeb//dynamicweb.py:3914
 msgid "Filter"
 msgstr "Filter"
 
-#: DynamicWeb/dynamicweb.py:3899
+#: DynamicWeb//dynamicweb.py:3916
 msgid "Select filter to restrict people that appear on web site"
 msgstr ""
 "Filter wählen, um Personen zu begrenzen, die auf der Website erscheinen."
 
-#: DynamicWeb/dynamicweb.py:3903
+#: DynamicWeb//dynamicweb.py:3920
 msgid "Filter Person"
 msgstr "Personenfilter"
 
-#: DynamicWeb/dynamicweb.py:3904
+#: DynamicWeb//dynamicweb.py:3921
 msgid "The center person for the filter"
 msgstr "Die Hauptperson für den Filter"
 
-#: DynamicWeb/dynamicweb.py:3912 DynamicWeb/dynamicweb.py:3932
+#: DynamicWeb//dynamicweb.py:3929 DynamicWeb//dynamicweb.py:3949
 msgid "Name format (short)"
 msgstr "Namensformat (kurz)"
 
-#: DynamicWeb/dynamicweb.py:3913 DynamicWeb/dynamicweb.py:3935
+#: DynamicWeb//dynamicweb.py:3930 DynamicWeb//dynamicweb.py:3952
 msgid "Select the format to display a shorter version of the names"
 msgstr "Wähle das Format aus um eine kürzere Version der Namen anzuzeigen"
 
-#: DynamicWeb/dynamicweb.py:3927
+#: DynamicWeb//dynamicweb.py:3944
 msgid "Name format"
 msgstr "Namensformat"
 
-#: DynamicWeb/dynamicweb.py:3930
+#: DynamicWeb//dynamicweb.py:3947
 msgid "Select the format to display names"
 msgstr "Wähle das Format zum Anzeigen von Namen."
 
-#: DynamicWeb/dynamicweb.py:3938
+#: DynamicWeb//dynamicweb.py:3955
 msgid "Web site template"
 msgstr "Webseitenvorlage"
 
-#: DynamicWeb/dynamicweb.py:3941
+#: DynamicWeb//dynamicweb.py:3958
 msgid "Select the template of the web site"
 msgstr "Wähle die Vorlage der Website aus"
 
-#: DynamicWeb/dynamicweb.py:3944
+#: DynamicWeb//dynamicweb.py:3961
 msgid "Copyright"
 msgstr "Copyright"
 
-#: DynamicWeb/dynamicweb.py:3947
+#: DynamicWeb//dynamicweb.py:3964
 msgid "The copyright to be used for the web files"
 msgstr "Das Copyright, das für die Webdateien verwendet wird."
 
-#: DynamicWeb/dynamicweb.py:3955
+#: DynamicWeb//dynamicweb.py:3972
 msgid "Privacy"
 msgstr "Privatsphäre"
 
-#: DynamicWeb/dynamicweb.py:3963
+#: DynamicWeb//dynamicweb.py:3980
 msgid "Include records marked private"
 msgstr "Mit als vertraulich markierten Datensätzen"
 
-#: DynamicWeb/dynamicweb.py:3964
+#: DynamicWeb//dynamicweb.py:3981
 msgid "Whether to include private objects"
 msgstr "Legt fest, ob eine Spalte für Partner aufgenommen wird."
 
-#: DynamicWeb/dynamicweb.py:3966
+#: DynamicWeb//dynamicweb.py:3983
 msgid "Living People"
 msgstr "Lebende Personen"
 
-#: DynamicWeb/dynamicweb.py:3967
+#: DynamicWeb//dynamicweb.py:3984
 msgid "Exclude"
 msgstr "Ausschließen"
 
-#: DynamicWeb/dynamicweb.py:3968
+#: DynamicWeb//dynamicweb.py:3985
 msgid "Include Last Name Only"
 msgstr "Nur Nachnamen aufnehmen"
 
-#: DynamicWeb/dynamicweb.py:3969
+#: DynamicWeb//dynamicweb.py:3986
 msgid "Include Full Name Only"
 msgstr "Nur vollständigen Namen aufnehmen"
 
-#: DynamicWeb/dynamicweb.py:3970
+#: DynamicWeb//dynamicweb.py:3987
 msgid "Include"
 msgstr "Einbeziehen"
 
-#: DynamicWeb/dynamicweb.py:3971
+#: DynamicWeb//dynamicweb.py:3988
 msgid "How to handle living people"
 msgstr "Wie lebende Personen behandelt werden"
 
-#: DynamicWeb/dynamicweb.py:3974
+#: DynamicWeb//dynamicweb.py:3991
 msgid "Years from death to consider living"
 msgstr "Definiere 'lebende Person' über die Anzahl der Jahre seit Todesjahr."
 
-#: DynamicWeb/dynamicweb.py:3975
+#: DynamicWeb//dynamicweb.py:3992
 msgid ""
 "This allows you to restrict information on people who have not been dead for "
 "very long"
@@ -1199,89 +1243,89 @@ msgstr ""
 "Dies erlaubt dir, die Daten von Personen einzugrenzen, die noch nicht lange "
 "tot sind."
 
-#: DynamicWeb/dynamicweb.py:3979
+#: DynamicWeb//dynamicweb.py:3996
 msgid "Export notes"
 msgstr "Notizen exportiere"
 
-#: DynamicWeb/dynamicweb.py:3980
+#: DynamicWeb//dynamicweb.py:3997
 msgid "Whether to export notes in the web pages"
 msgstr "Legt fest, ob Notizen exportiert in the Website werden sollen"
 
-#: DynamicWeb/dynamicweb.py:3983
+#: DynamicWeb//dynamicweb.py:4000
 msgid "Export sources"
 msgstr "Quellen exportiere"
 
-#: DynamicWeb/dynamicweb.py:3984
+#: DynamicWeb//dynamicweb.py:4001
 msgid "Whether to export sources and citations in the web pages"
 msgstr ""
 "Legt fest, ob Quellen und Fundstellen in die Webseite exportiert\n"
 "werden sollen"
 
-#: DynamicWeb/dynamicweb.py:3987
+#: DynamicWeb//dynamicweb.py:4004
 msgid "Export addresses"
 msgstr "Adressen exportieren"
 
-#: DynamicWeb/dynamicweb.py:3988
+#: DynamicWeb//dynamicweb.py:4005
 msgid "Whether to export addresses in the web pages"
 msgstr "Legt fest, ob Adressen in die Website exportiert werden sollen"
 
-#: DynamicWeb/dynamicweb.py:3993
+#: DynamicWeb//dynamicweb.py:4010
 msgid "Options"
 msgstr "Optionen"
 
-#: DynamicWeb/dynamicweb.py:3996
+#: DynamicWeb//dynamicweb.py:4013
 msgid "Include repository pages"
 msgstr "Aufbewahrungsorteseiten aufnehmen"
 
-#: DynamicWeb/dynamicweb.py:3997
+#: DynamicWeb//dynamicweb.py:4014
 msgid "Whether or not to include the Repository Pages."
 msgstr "Legt fest, ob Aufbewahrungsorteseiten enthalten sind."
 
-#: DynamicWeb/dynamicweb.py:4000
+#: DynamicWeb//dynamicweb.py:4017
 msgid "Include images and media"
 msgstr "Bilder und Medien aufnehmen"
 
-#: DynamicWeb/dynamicweb.py:4001
+#: DynamicWeb//dynamicweb.py:4018
 msgid "Whether to include images and media in the web pages"
 msgstr "Ob Bilder und Medien in den Webseiten aufgenommen werden."
 
-#: DynamicWeb/dynamicweb.py:4005
+#: DynamicWeb//dynamicweb.py:4022
 msgid "Copy, rename files with an internal Gramps identifier"
 msgstr "Kopieren, Dateien umbenennen mit einer internen Gramps-Kennung"
 
-#: DynamicWeb/dynamicweb.py:4006
+#: DynamicWeb//dynamicweb.py:4023
 msgid "Copy, keep file names unchanged"
 msgstr "Kopieren, Dateinamen unverändert lassen"
 
-#: DynamicWeb/dynamicweb.py:4007
+#: DynamicWeb//dynamicweb.py:4024
 msgid "Do not copy, reference existing files"
 msgstr "Nicht kopieren, auf existierende Dateien verweisen"
 
-#: DynamicWeb/dynamicweb.py:4009
+#: DynamicWeb//dynamicweb.py:4026
 msgid "Images and media"
 msgstr "Bilder und Medien"
 
-#: DynamicWeb/dynamicweb.py:4012
+#: DynamicWeb//dynamicweb.py:4029
 msgid "Whether to make a copy of the media"
 msgstr "Ob eine Kopie der Medien erstellt wird"
 
-#: DynamicWeb/dynamicweb.py:4015
+#: DynamicWeb//dynamicweb.py:4032
 msgid "Print the notes type"
 msgstr "Notiztyp aufnehmen"
 
-#: DynamicWeb/dynamicweb.py:4016
+#: DynamicWeb//dynamicweb.py:4033
 msgid "Whether to print the notes type in the notes text"
 msgstr "Legt fest, ob der Notiztype ausgegeben wird"
 
-#: DynamicWeb/dynamicweb.py:4019
+#: DynamicWeb//dynamicweb.py:4036
 msgid "Print place pages"
 msgstr "Ortsseiten aufnehmen"
 
-#: DynamicWeb/dynamicweb.py:4020
+#: DynamicWeb//dynamicweb.py:4037
 msgid "Whether to show pages for the places"
 msgstr "Legt fest, ob Seiten für die Orte gezeigt werden"
 
-#: DynamicWeb/dynamicweb.py:4026
+#: DynamicWeb//dynamicweb.py:4043
 msgid ""
 "Whether to include a place map on the Place Pages, where Latitude/ Longitude "
 "are available."
@@ -1289,7 +1333,7 @@ msgstr ""
 "Legt fest, ob eine Ortskarte auf der Ortsseite aufgenommen wird, wo Längen-/"
 "Breitenangaben vorhanden sind."
 
-#: DynamicWeb/dynamicweb.py:4034
+#: DynamicWeb//dynamicweb.py:4051
 msgid ""
 "Whether or not to add an individual page map showing all the places on this "
 "page. This will allow you to see how your family traveled around the country."
@@ -1298,166 +1342,167 @@ msgstr ""
 "wird. Dies ermöglicht es dir zu sehen, wie deine Familie im Land gewandert "
 "ist."
 
-#: DynamicWeb/dynamicweb.py:4042
+#: DynamicWeb//dynamicweb.py:4059
 msgid "Google"
 msgstr "Google"
 
-#: DynamicWeb/dynamicweb.py:4043
+#: DynamicWeb//dynamicweb.py:4060
 msgid "OpenStreetMap"
 msgstr "OpenStreetMap"
 
-#: DynamicWeb/dynamicweb.py:4045
+#: DynamicWeb//dynamicweb.py:4062
 msgid "Map Service"
 msgstr "Kartenservice"
 
-#: DynamicWeb/dynamicweb.py:4048
+#: DynamicWeb//dynamicweb.py:4065
 msgid "Choose your choice of map service for creating the Place Map Pages"
 msgstr "Wähle einen Kartendienst zur Erstellung der Ortskartenseiten"
 
-#: DynamicWeb/dynamicweb.py:4052
+#: DynamicWeb//dynamicweb.py:4069
 msgid "Google map API key"
 msgstr "Google map API-Schlüssel"
 
-#: DynamicWeb/dynamicweb.py:4053
+#: DynamicWeb//dynamicweb.py:4070
 msgid "The API key used for the Google map"
 msgstr "Der für Google map verwendete API-Schlüssel"
 
-#: DynamicWeb/dynamicweb.py:4060
+#: DynamicWeb//dynamicweb.py:4077
 msgid "Advanced"
 msgstr "Erweitert"
 
-#: DynamicWeb/dynamicweb.py:4063
+#: DynamicWeb//dynamicweb.py:4080
 msgid "Character set encoding"
 msgstr "Codierung der Zeichensetzung"
 
-#: DynamicWeb/dynamicweb.py:4066
+#: DynamicWeb//dynamicweb.py:4083
 msgid "The encoding to be used for the web files"
 msgstr "Die Kodierung, die für die Webdateien verwendet wird."
 
-#: DynamicWeb/dynamicweb.py:4069
+#: DynamicWeb//dynamicweb.py:4086
 msgid "Include family pages"
 msgstr "Familienseiten aufnehmen"
 
-#: DynamicWeb/dynamicweb.py:4070
+#: DynamicWeb//dynamicweb.py:4087
 msgid "Whether or not to include family pages"
 msgstr "Legt fest, ob Familienseiten aufgenommen werden"
 
-#: DynamicWeb/dynamicweb.py:4080
+#: DynamicWeb//dynamicweb.py:4097
 msgid ""
 "Whether to include half and/ or step-siblings with the parents and siblings"
 msgstr ""
 "Legt fest, ob Halb- und/oder Stiefgeschwister mit den Eltern und "
 "Geschwistern aufgenommen werden."
 
-#: DynamicWeb/dynamicweb.py:4083
+#: DynamicWeb//dynamicweb.py:4100
 msgid "Include GENDEX file (/gendex.txt)"
 msgstr "GENDEX-Datei (/gendex.txt) aufnehmen"
 
-#: DynamicWeb/dynamicweb.py:4084
+#: DynamicWeb//dynamicweb.py:4101
 msgid "Whether to include a GENDEX file or not"
 msgstr "Legt fest, ob eine GENDEX-Datei aufgenommen wird."
 
-#: DynamicWeb/dynamicweb.py:4087
+#: DynamicWeb//dynamicweb.py:4104
 msgid "Enable page configuration"
 msgstr "Erlaube Seitenkonfiguration"
 
-#: DynamicWeb/dynamicweb.py:4088
+#: DynamicWeb//dynamicweb.py:4105
 msgid "Whether to enable page configuration"
 msgstr "Ob eine Seitenkonfiguration erlaubt wird"
 
-#: DynamicWeb/dynamicweb.py:4092
+#: DynamicWeb//dynamicweb.py:4109
 msgid "Whether to use tabbed panels for the different sections of the pages."
 msgstr ""
 "Ob Registerkarten anstelle von unterschiedlichen Abschnitten verwendet\n"
 "werden."
 
-#: DynamicWeb/dynamicweb.py:4096
+#: DynamicWeb//dynamicweb.py:4113
 msgid "Whether to show the last modification time in the pages footer"
 msgstr "Ob der Zeitpunkt der letzten Änderung in der Füßzeile angezeigt wird"
 
-#: DynamicWeb/dynamicweb.py:4100
+#: DynamicWeb//dynamicweb.py:4117
 msgid "Whether to insert sources author in the sources title"
 msgstr "Ob der Autor der Quellen in den Quelltitel eingefügt wird"
 
-#: DynamicWeb/dynamicweb.py:4104
+#: DynamicWeb//dynamicweb.py:4121
 msgid "Whether to hide the Gramps ID"
 msgstr "Ob die Gramps ID verborgen wird"
 
-#: DynamicWeb/dynamicweb.py:4113
+#: DynamicWeb//dynamicweb.py:4130
 msgid "List"
 msgstr "Liste"
 
-#: DynamicWeb/dynamicweb.py:4114
+#: DynamicWeb//dynamicweb.py:4131
 msgid "Table"
 msgstr "Tabelle"
 
-#: DynamicWeb/dynamicweb.py:4117
+#: DynamicWeb//dynamicweb.py:4134
 msgid "Default format for the surnames index"
 msgstr "Standardformat für den Nachnamenindex"
 
-#: DynamicWeb/dynamicweb.py:4117
+#: DynamicWeb//dynamicweb.py:4134
 msgid "The default format for the surnames index"
 msgstr "Das Standardformat für den Nachnamenindex"
 
-#: DynamicWeb/dynamicweb.py:4118
+#: DynamicWeb//dynamicweb.py:4135
 msgid "Default format for the persons index"
 msgstr "Standardformat für den Personenindex"
 
-#: DynamicWeb/dynamicweb.py:4118
+#: DynamicWeb//dynamicweb.py:4135
 msgid "The default format for the persons index"
 msgstr "Das Standardformat für den Personenindex"
 
-#: DynamicWeb/dynamicweb.py:4119
+#: DynamicWeb//dynamicweb.py:4136
 msgid "Default format for the families index"
 msgstr "Standardformat für den Familienindex"
 
-#: DynamicWeb/dynamicweb.py:4119
+#: DynamicWeb//dynamicweb.py:4136
 msgid "The default format for the families index"
 msgstr "Das Standardformat für den Familienindex"
 
-#: DynamicWeb/dynamicweb.py:4120
+#: DynamicWeb//dynamicweb.py:4137
 msgid "Default format for the sources index"
 msgstr "Standardformat für den Quellenindex"
 
-#: DynamicWeb/dynamicweb.py:4120
+#: DynamicWeb//dynamicweb.py:4137
 msgid "The default format for the sources index"
 msgstr "Das Standardformat für den Quellenindex"
 
-#: DynamicWeb/dynamicweb.py:4121
+#: DynamicWeb//dynamicweb.py:4138
 msgid "Default format for the places index"
 msgstr "Standardformat für den Orteindex"
 
-#: DynamicWeb/dynamicweb.py:4121
+#: DynamicWeb//dynamicweb.py:4138
 msgid "The default format for the places index"
 msgstr "Das Standardformat für den Orteindex"
 
-#: DynamicWeb/dynamicweb.py:4130
+#: DynamicWeb//dynamicweb.py:4147
 msgid ""
 "Whether to include dates columns (birth, death, marriage) on the index pages"
 msgstr ""
-"Ob Datumsspalten (Geburt, Tod, Hochzeit) in die Indexseiten aufgenommen werden"
+"Ob Datumsspalten (Geburt, Tod, Hochzeit) in die Indexseiten aufgenommen "
+"werden"
 
-#: DynamicWeb/dynamicweb.py:4134
+#: DynamicWeb//dynamicweb.py:4151
 msgid "Whether to include a partners column"
 msgstr "Ob eine Spalte für Partner aufgenommen wird"
 
-#: DynamicWeb/dynamicweb.py:4138
+#: DynamicWeb//dynamicweb.py:4155
 msgid "Whether to include a parents column"
 msgstr "Ob eine Spalte für Eltern aufgenommen wird"
 
-#: DynamicWeb/dynamicweb.py:4141
+#: DynamicWeb//dynamicweb.py:4158
 msgid "Generate a families index page"
 msgstr "Erstelle eine Familienindex Seite"
 
-#: DynamicWeb/dynamicweb.py:4142
+#: DynamicWeb//dynamicweb.py:4159
 msgid "Whether to generate an index page for families"
 msgstr "Ob eine Indexseite für Familien erstellt wird"
 
-#: DynamicWeb/dynamicweb.py:4146
+#: DynamicWeb//dynamicweb.py:4163
 msgid "Whether to include a column showing the media path"
 msgstr "Ob eine Spalte für den Medienpfad aufgenommen wird"
 
-#: DynamicWeb/dynamicweb.py:4150
+#: DynamicWeb//dynamicweb.py:4167
 msgid ""
 "Whether to include the references to the items in the index pages. For "
 "example, in the media index page, the names of the individuals, families, "
@@ -1467,24 +1512,24 @@ msgstr ""
 "werden. Das sind zum Beispiel auf der Medienindexseite die Namen der\n"
 "Personen, Familien, Orte und Quellen, die die Medien referenzieren."
 
-#: DynamicWeb/dynamicweb.py:4153
+#: DynamicWeb//dynamicweb.py:4170
 msgid "Default number of entries in the indexes"
 msgstr "Standardanzahl der Einträge in den Indizes"
 
-#: DynamicWeb/dynamicweb.py:4156
+#: DynamicWeb//dynamicweb.py:4173
 msgid "The default number of entries shown in one index page"
 msgstr ""
 "Die Standardanzahl der Einträge die auf einer Indexseite gezeigt werden"
 
-#: DynamicWeb/dynamicweb.py:4161
+#: DynamicWeb//dynamicweb.py:4178
 msgid "Trees"
 msgstr "Bäume"
 
-#: DynamicWeb/dynamicweb.py:4164
+#: DynamicWeb//dynamicweb.py:4181
 msgid "Maximum number of generations"
 msgstr "Maximale Anzahl der Generationen"
 
-#: DynamicWeb/dynamicweb.py:4165
+#: DynamicWeb//dynamicweb.py:4182
 msgid ""
 "The maximum number of generations to include in the ancestor and descendant "
 "trees and graphs"
@@ -1492,124 +1537,127 @@ msgstr ""
 "Die maximale Anzahl von Generationen, welche in den Vorfahren- und\n"
 "Nachkommenbäumen enthalten sein sollen."
 
-#: DynamicWeb/dynamicweb.py:4171
+#: DynamicWeb//dynamicweb.py:4188
 msgid "Choose the default SVG tree graph type"
 msgstr "Wähle den Standard für den Grafiktyps des SVG-Baums"
 
-#: DynamicWeb/dynamicweb.py:4177
+#: DynamicWeb//dynamicweb.py:4194
 msgid "Choose the default SVG tree graph shape"
 msgstr "Wähle den Standard für die Grafikform des SVG-Baums"
 
-#: DynamicWeb/dynamicweb.py:4183
+#: DynamicWeb//dynamicweb.py:4200
 msgid "Choose the default SVG tree parents distribution (for fan charts only)"
 msgstr ""
 "Wähle den Standard für die Elternverteilung des SVG-Baums (nur für "
 "Fächergrafiken)"
 
-#: DynamicWeb/dynamicweb.py:4189
+#: DynamicWeb//dynamicweb.py:4206
 msgid "Choose the default SVG tree children distribution (for fan charts only)"
 msgstr ""
 "Wähle den Standard für die Kinderverteilung des SVG-Baums (nur für "
 "Fächergrafiken)"
 
-#: DynamicWeb/dynamicweb.py:4195
+#: DynamicWeb//dynamicweb.py:4212
 msgid ""
 "Choose the background color scheme for the persons in the SVG tree graph"
 msgstr "Wähle das Hintergrundfarbschema für die Personen in der SVG-Baumgrafik"
 
-#: DynamicWeb/dynamicweb.py:4198
+#: DynamicWeb//dynamicweb.py:4215
 msgid "Start gradient/Main color"
 msgstr "Start Farbverlauf/Hauptfarbe"
 
-#: DynamicWeb/dynamicweb.py:4201
+#: DynamicWeb//dynamicweb.py:4218
 msgid "End gradient/2nd color"
 msgstr "Ende Farbverlauf/2. Farbe"
 
-#: DynamicWeb/dynamicweb.py:4209
+#: DynamicWeb//dynamicweb.py:4226
 msgid "Color for duplicates"
 msgstr "Farbe für Duplikate"
 
-#: DynamicWeb/dynamicweb.py:4214
+#: DynamicWeb//dynamicweb.py:4231
 msgid "Pages"
 msgstr "Seiten"
 
-#: DynamicWeb/dynamicweb.py:4217
+#: DynamicWeb//dynamicweb.py:4234
 msgid "HTML user header"
 msgstr "HTML Kopfzeile"
 
-#: DynamicWeb/dynamicweb.py:4218
+#: DynamicWeb//dynamicweb.py:4235
 msgid "A note to be used as the page header"
 msgstr "Eine Notiz, die als Kopfzeile benutzt wird."
 
-#: DynamicWeb/dynamicweb.py:4221
+#: DynamicWeb//dynamicweb.py:4238
 msgid "HTML user brand name / icon"
 msgstr "HTML Benutzer-Markenzeichen / -icon"
 
-#: DynamicWeb/dynamicweb.py:4222
+#: DynamicWeb//dynamicweb.py:4239
 msgid "A note to be used as the brand name or image in the menu"
 msgstr "Eine Notiz, die als Markenzeichen oder Bild im Menü verwendet wird"
 
-#: DynamicWeb/dynamicweb.py:4225
+#: DynamicWeb//dynamicweb.py:4242
 msgid "HTML user footer"
 msgstr "HTML Fußzeile"
 
-#: DynamicWeb/dynamicweb.py:4226
+#: DynamicWeb//dynamicweb.py:4243
 msgid "A note to be used as the page footer"
 msgstr "Eine Notiz, die als Fußzeile benutzt wird."
 
-#: DynamicWeb/dynamicweb.py:4231
+#: DynamicWeb//dynamicweb.py:4248
 msgid "Custom pages"
 msgstr "Benutzerdefinierte Seiten"
 
-#: DynamicWeb/dynamicweb.py:4235
+#: DynamicWeb//dynamicweb.py:4252
 #, python-format
 msgid "Title for the custom page %(index)i"
 msgstr "Titel der benutzerdefinierte Seite %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4236
+#: DynamicWeb//dynamicweb.py:4253
 #, python-format
 msgid "Name for the custom page %(index)i"
 msgstr "Name der benutzerdefinierte Seite %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4239
+#: DynamicWeb//dynamicweb.py:4256
 #, python-format
 msgid "Note for custom page %(index)i"
 msgstr "Notiz der benutzerdefinierte Seite %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4240
+#: DynamicWeb//dynamicweb.py:4257
 msgid "A note to be used for the custom page content.\n"
 msgstr ""
 "Eine Notiz, welche als Inhalt der benutzerdefinierten Seite verwendet wird.\n"
 
-#: DynamicWeb/dynamicweb.py:4243
+#: DynamicWeb//dynamicweb.py:4260
 #, python-format
 msgid "Menu for the custom page %(index)i"
 msgstr "Menü der benutzerdefinierten Seite %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4244
+#: DynamicWeb//dynamicweb.py:4261
 msgid "Whether to print a menu for the custom page"
 msgstr "Legt fest, ob ein Menü für die benutzerdefinierte Seite angezeigt wird"
 
-#: DynamicWeb/dynamicweb.py:4249
+#: DynamicWeb//dynamicweb.py:4266
 msgid "Pages selection"
 msgstr "Seitenauswahl"
 
-#: DynamicWeb/dynamicweb.py:4252
+#: DynamicWeb//dynamicweb.py:4269
 msgid "Number of pages"
 msgstr "Anzahl der Seiten"
 
-#: DynamicWeb/dynamicweb.py:4253
+#: DynamicWeb//dynamicweb.py:4270
 msgid "Number pages in the web site menu."
 msgstr "Anzahl der Seiten im Webseitenmenü."
 
-#: DynamicWeb/dynamicweb.py:4269
+#: DynamicWeb//dynamicweb.py:4286
 #, python-format
 msgid "Contents of page %(index)i"
 msgstr "Inhalt der Seite %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4272
+#: DynamicWeb//dynamicweb.py:4289
 msgid "Contents of the page"
 msgstr "Inhalt der Seite"
+
+#~ msgid "Html|Home"
+#~ msgstr "Startseite"
 
 #~ msgid "Include a column for birth dates on the index pages"
 #~ msgstr "Spalte für Geburtsdaten auf den Indexseiten"
@@ -1881,9 +1929,6 @@ msgstr "Inhalt der Seite"
 
 #~ msgid "Addresses page"
 #~ msgstr "Adressen-Seite"
-
-#~ msgid "Repositories index page"
-#~ msgstr "Aufbewahrungsortsindex-Seite"
 
 #~ msgid "Custom"
 #~ msgstr "Selbst definiert"

--- a/DynamicWeb/po/fi-local.po
+++ b/DynamicWeb/po/fi-local.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 5.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-06 09:18+0200\n"
+"POT-Creation-Date: 2020-07-24 17:33+0200\n"
 "PO-Revision-Date: 2018-11-06 09:22+0200\n"
 "Last-Translator: Matti Niemelä <niememat@gmail.com>\n"
 "Language-Team: Finnish <niememat@gmail,com>\n"
@@ -18,349 +18,354 @@ msgstr ""
 "X-Generator: Poedit 2.0.6\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: dynamicweb.gpr.py:15
+#: DynamicWeb//dynamicweb.gpr.py:15
 msgid "Dynamic Web Report"
 msgstr "Dynaaminen-nettisivusto"
 
-#: dynamicweb.gpr.py:16
+#: DynamicWeb//dynamicweb.gpr.py:16
 msgid "Produces dynamic web pages for the database"
 msgstr "Tuottaa dynaamiset verkkosivut tietokannasta"
 
-#: dynamicweb.py:265
+#: DynamicWeb//dynamicweb.py:269
 msgid "Street"
 msgstr "Katu"
 
-#: dynamicweb.py:266
+#: DynamicWeb//dynamicweb.py:270
 msgid "Locality"
 msgstr "Taajama"
 
-#: dynamicweb.py:267
+#: DynamicWeb//dynamicweb.py:271
 msgid "City"
 msgstr "Paikkakunta"
 
-#: dynamicweb.py:268
+#: DynamicWeb//dynamicweb.py:272
 msgid "Church Parish"
 msgstr "Seurakunta"
 
-#: dynamicweb.py:269
+#: DynamicWeb//dynamicweb.py:273
 msgid "County"
 msgstr "Maakunta"
 
-#: dynamicweb.py:270
+#: DynamicWeb//dynamicweb.py:274
 msgid "State/ Province"
 msgstr "Lääni, Osavaltio tai Provinssi"
 
-#: dynamicweb.py:271
+#: DynamicWeb//dynamicweb.py:275
 msgid "Postal Code"
 msgstr "Postinumero"
 
-#: dynamicweb.py:272
+#: DynamicWeb//dynamicweb.py:276
 msgid "Country"
 msgstr "Valtio tai Liittovaltio"
 
-#: dynamicweb.py:273
+#: DynamicWeb//dynamicweb.py:277
 msgid "Phone"
 msgstr "Puhelin"
 
-#: dynamicweb.py:279
+#: DynamicWeb//dynamicweb.py:283
 msgid "Home Page"
 msgstr "Kotisivu"
 
-#: dynamicweb.py:280
+#: DynamicWeb//dynamicweb.py:284
 msgid "SVG graphical tree"
 msgstr "SVG graafinen sukupuu"
 
-#: dynamicweb.py:283
+#: DynamicWeb//dynamicweb.py:287
 msgid "Indexes pages"
 msgstr "Hakemistosivut"
 
-#: dynamicweb.py:287 dynamicweb.py:4238
+#: DynamicWeb//dynamicweb.py:291 DynamicWeb//dynamicweb.py:4252
 #, python-format
 msgid "Custom page %(index)i"
 msgstr "Mukautettu sivu %(index)i"
 
-#: dynamicweb.py:305
+#: DynamicWeb//dynamicweb.py:309
 msgid "Ascending tree"
 msgstr "Esivanhempien sukupuu"
 
-#: dynamicweb.py:306
+#: DynamicWeb//dynamicweb.py:310
 msgid "Descending tree"
 msgstr "Jälkeläisten sukupuu"
 
-#: dynamicweb.py:307
+#: DynamicWeb//dynamicweb.py:311
 msgid "Descending tree with spouses"
 msgstr "Jälkeläisten sukupuu puolisot mukana"
 
-#: dynamicweb.py:308
+#: DynamicWeb//dynamicweb.py:312
 msgid "Ascending and descending tree"
 msgstr "Jälkeläisten ja esivanhempien sukupuu"
 
-#: dynamicweb.py:309
+#: DynamicWeb//dynamicweb.py:313
 msgid "Ascending and descending tree with spouses"
 msgstr "Jälkeläisten ja esivanhempien sukupuu puolisoiden kanssa"
 
-#: dynamicweb.py:321
+#: DynamicWeb//dynamicweb.py:325
 msgid "Vertical (↓)"
 msgstr "Alaspäin (↓)"
 
-#: dynamicweb.py:322
+#: DynamicWeb//dynamicweb.py:326
 msgid "Vertical (↑)"
 msgstr "Ylöspäin (↑)"
 
-#: dynamicweb.py:323
+#: DynamicWeb//dynamicweb.py:327
 msgid "Horizontal (→)"
 msgstr "Oikealle (→)"
 
-#: dynamicweb.py:324
+#: DynamicWeb//dynamicweb.py:328
 msgid "Horizontal (←)"
 msgstr "Vasemmalle (←)"
 
-#: dynamicweb.py:325
+#: DynamicWeb//dynamicweb.py:329
 msgid "Full Circle"
 msgstr "Ympyrä"
 
-#: dynamicweb.py:326
+#: DynamicWeb//dynamicweb.py:330
 msgid "Half Circle"
 msgstr "Puoliympyrä"
 
-#: dynamicweb.py:327
+#: DynamicWeb//dynamicweb.py:331
 msgid "Quadrant"
 msgstr "Sektori"
 
-#: dynamicweb.py:339
+#: DynamicWeb//dynamicweb.py:343
 msgid "Size proportional to number of ancestors"
 msgstr "Koko suhteessa esivanhempien määrään"
 
-#: dynamicweb.py:340
+#: DynamicWeb//dynamicweb.py:344
 msgid "Homogeneous parents distribution"
 msgstr "Tasainen vanhempien jakautuma"
 
-#: dynamicweb.py:343
+#: DynamicWeb//dynamicweb.py:347
 msgid "Size proportional to number of descendants"
 msgstr "Koko suhteessa jälkeläisten määrään"
 
-#: dynamicweb.py:344
+#: DynamicWeb//dynamicweb.py:348
 msgid "Homogeneous children distribution"
 msgstr "Tasainen lasten jakautuma"
 
-#: dynamicweb.py:351 dynamicweb.py:374
+#: DynamicWeb//dynamicweb.py:355 DynamicWeb//dynamicweb.py:378
 msgid "Gender colors"
 msgstr "Sukupuolivärit"
 
-#: dynamicweb.py:352
+#: DynamicWeb//dynamicweb.py:356
 msgid "Generation based gradient"
 msgstr "Sukupolviin perustuva liukuväri"
 
-#: dynamicweb.py:353
+#: DynamicWeb//dynamicweb.py:357
 msgid "Age based gradient"
 msgstr "Ikäperusteinen liukuväri (0-100)"
 
-#: dynamicweb.py:354 dynamicweb.py:373
+#: DynamicWeb//dynamicweb.py:358 DynamicWeb//dynamicweb.py:377
 msgid "Single main (filter) color"
 msgstr "Yksivärinen (suodin)"
 
-#: dynamicweb.py:355
+#: DynamicWeb//dynamicweb.py:359
 msgid "Time period based gradient"
 msgstr "Aikaväliin perustuva liukuväri"
 
-#: dynamicweb.py:356 dynamicweb.py:378
+#: DynamicWeb//dynamicweb.py:360 DynamicWeb//dynamicweb.py:382
 msgid "White"
 msgstr "Valkoinen"
 
-#: dynamicweb.py:357 dynamicweb.py:376
+#: DynamicWeb//dynamicweb.py:361 DynamicWeb//dynamicweb.py:380
 msgid "Color scheme classic report"
 msgstr "Väriteema klassinen raportti"
 
-#: dynamicweb.py:358 dynamicweb.py:377
+#: DynamicWeb//dynamicweb.py:362 DynamicWeb//dynamicweb.py:381
 msgid "Color scheme classic view"
 msgstr "Väriteema perinteinen näkymä"
 
-#: dynamicweb.py:375
+#: DynamicWeb//dynamicweb.py:379
 msgid "Gradient"
 msgstr "Liukuväri"
 
-#: dynamicweb.py:394
+#: DynamicWeb//dynamicweb.py:398
 msgid "Default"
 msgstr "Oletus"
 
-#: dynamicweb.py:395
+#: DynamicWeb//dynamicweb.py:399
 msgid "Mainz"
 msgstr "Mainz"
 
-#: dynamicweb.py:703
+#: DynamicWeb//dynamicweb.py:707
 #, python-format
 msgid "Neither %(current)s nor %(parent)s are directories"
 msgstr "%(current)s ja %(parent)s eivät ole hakemistoja"
 
-#: dynamicweb.py:711 dynamicweb.py:716
+#: DynamicWeb//dynamicweb.py:715 DynamicWeb//dynamicweb.py:720
 #, python-format
 msgid "Could not create the directory: %(path)s"
 msgstr "Ei voitu luoda hakemistoa: %(path)s"
 
-#: dynamicweb.py:742 dynamicweb.py:3372
+#: DynamicWeb//dynamicweb.py:746 DynamicWeb//dynamicweb.py:3385
 msgid "Dynamic Web Site Report"
 msgstr "Dynaaminen nettiraportti"
 
-#: dynamicweb.py:742
+#: DynamicWeb//dynamicweb.py:746
 msgid "Exporting family tree data ..."
 msgstr "Viedään sukupuun tietoja ..."
 
-#: dynamicweb.py:1232 dynamicweb.py:2456
+#: DynamicWeb//dynamicweb.py:1237 DynamicWeb//dynamicweb.py:2461
 msgid "Author"
 msgstr "Tekijä"
 
-#: dynamicweb.py:1233 dynamicweb.py:2446
+#: DynamicWeb//dynamicweb.py:1238 DynamicWeb//dynamicweb.py:2451
 msgid "Abbreviation"
 msgstr "Lyhennys"
 
-#: dynamicweb.py:1234 dynamicweb.py:2542
+#: DynamicWeb//dynamicweb.py:1239 DynamicWeb//dynamicweb.py:2548
 msgid "Publication information"
 msgstr "Julkaisutiedot"
 
-#: dynamicweb.py:1304 dynamicweb.py:2474
+#: DynamicWeb//dynamicweb.py:1309 DynamicWeb//dynamicweb.py:2479
 msgid "Date"
 msgstr "Päivämäärä"
 
-#: dynamicweb.py:1305
+#: DynamicWeb//dynamicweb.py:1310
 msgid "Page"
 msgstr "Sivu"
 
-#: dynamicweb.py:1306
+#: DynamicWeb//dynamicweb.py:1311
 msgid "Confidence"
 msgstr "Luotettavuus"
 
-#: dynamicweb.py:1625
+#: DynamicWeb//dynamicweb.py:1630
 #, python-format
 msgid "%(type)s: %(value)s"
 msgstr "%(type)s: %(value)s"
 
-#: dynamicweb.py:1872
+#: DynamicWeb//dynamicweb.py:1877
 #, python-format
 msgid "Impossible to convert \"%(path)s\" to a relative path."
 msgstr "Polkua \"%(path)s\" ei ole mahdollista muuntaa suhteelliseksi."
 
-#: dynamicweb.py:2178
+#: DynamicWeb//dynamicweb.py:2183
 msgid ""
 "The pages configuration is not valid: several pages have the same content"
 msgstr "Sivujen kokoonpano ei ole voimassa: useilla sivuilla on sama sisältö"
 
-#: dynamicweb.py:2189
-msgid "Html|Home"
-msgstr "Koti"
+#: DynamicWeb//dynamicweb.py:2194
+msgid "DynWeb|Home"
+msgstr "Kotisivu"
 
-#: dynamicweb.py:2190 dynamicweb.py:2203 dynamicweb.py:2204 dynamicweb.py:2205
+#: DynamicWeb//dynamicweb.py:2195 DynamicWeb//dynamicweb.py:2208
+#: DynamicWeb//dynamicweb.py:2209 DynamicWeb//dynamicweb.py:2210
 msgid "Tree"
 msgstr "Sukupuu"
 
-#: dynamicweb.py:2191 dynamicweb.py:2206 dynamicweb.py:2207 dynamicweb.py:2208
+#: DynamicWeb//dynamicweb.py:2196 DynamicWeb//dynamicweb.py:2211
+#: DynamicWeb//dynamicweb.py:2212 DynamicWeb//dynamicweb.py:2213
 msgid "Statistics"
 msgstr "Tilasto"
 
-#: dynamicweb.py:2194 dynamicweb.py:2470
+#: DynamicWeb//dynamicweb.py:2199 DynamicWeb//dynamicweb.py:2475
 msgid "Configuration"
 msgstr "Asetukset"
 
-#: dynamicweb.py:2196 dynamicweb.py:2534
+#: DynamicWeb//dynamicweb.py:2201 DynamicWeb//dynamicweb.py:2540
 msgid "Person"
 msgstr "Henkilö"
 
-#: dynamicweb.py:2197
+#: DynamicWeb//dynamicweb.py:2202
 msgid "Family"
 msgstr "Perhe"
 
-#: dynamicweb.py:2198 dynamicweb.py:2572
+#: DynamicWeb//dynamicweb.py:2203 DynamicWeb//dynamicweb.py:2580
 msgid "Source"
 msgstr "Lähde"
 
-#: dynamicweb.py:2199 dynamicweb.py:2218 dynamicweb.py:2518
+#: DynamicWeb//dynamicweb.py:2204 DynamicWeb//dynamicweb.py:2223
+#: DynamicWeb//dynamicweb.py:2523
 msgid "Media"
 msgstr "Media"
 
-#: dynamicweb.py:2200 dynamicweb.py:2537
+#: DynamicWeb//dynamicweb.py:2205 DynamicWeb//dynamicweb.py:2543
 msgid "Place"
 msgstr "Paikka"
 
-#: dynamicweb.py:2201 dynamicweb.py:2548
+#: DynamicWeb//dynamicweb.py:2206 DynamicWeb//dynamicweb.py:2555
 msgid "Repository"
 msgstr "Arkisto"
 
-#: dynamicweb.py:2202
+#: DynamicWeb//dynamicweb.py:2207
 msgid "Search results"
 msgstr "Hakutulokset"
 
-#: dynamicweb.py:2213 dynamicweb.py:2214 dynamicweb.py:2579
+#: DynamicWeb//dynamicweb.py:2218 DynamicWeb//dynamicweb.py:2219
+#: DynamicWeb//dynamicweb.py:2587
 msgid "Surnames"
 msgstr "Sukunimet"
 
-#: dynamicweb.py:2215 dynamicweb.py:2503
+#: DynamicWeb//dynamicweb.py:2220 DynamicWeb//dynamicweb.py:2508
 msgid "Individuals"
 msgstr "Yksilöt"
 
-#: dynamicweb.py:2216 dynamicweb.py:2486
+#: DynamicWeb//dynamicweb.py:2221 DynamicWeb//dynamicweb.py:2491
 msgid "Families"
 msgstr "Perheet"
 
-#: dynamicweb.py:2217 dynamicweb.py:2574
+#: DynamicWeb//dynamicweb.py:2222 DynamicWeb//dynamicweb.py:2582
 msgid "Sources"
 msgstr "Lähteet"
 
-#: dynamicweb.py:2219 dynamicweb.py:2539
+#: DynamicWeb//dynamicweb.py:2224 DynamicWeb//dynamicweb.py:2545
 msgid "Places"
 msgstr "Paikat"
 
-#: dynamicweb.py:2220 dynamicweb.py:2448
+#: DynamicWeb//dynamicweb.py:2225 DynamicWeb//dynamicweb.py:2453
 msgid "Addresses"
 msgstr "Osoitteet"
 
-#: dynamicweb.py:2221 dynamicweb.py:2547
+#: DynamicWeb//dynamicweb.py:2226 DynamicWeb//dynamicweb.py:2554
 msgid "Repositories"
 msgstr "Arkistot"
 
-#: dynamicweb.py:2272 dynamicweb.py:2502 dynamicweb.py:4112
+#: DynamicWeb//dynamicweb.py:2277 DynamicWeb//dynamicweb.py:2507
+#: DynamicWeb//dynamicweb.py:4126
 msgid "Indexes"
 msgstr "Hakemistot"
 
-#: dynamicweb.py:2436
+#: DynamicWeb//dynamicweb.py:2441
 #, python-format
 msgid "(b. %(birthdate)s, d. %(deathdate)s)"
 msgstr "(s. %(birthdate)s, k. %(deathdate)s)"
 
-#: dynamicweb.py:2437
+#: DynamicWeb//dynamicweb.py:2442
 #, python-format
 msgid "(b. %s)"
 msgstr "(s. %s)"
 
-#: dynamicweb.py:2438
+#: DynamicWeb//dynamicweb.py:2443
 #, python-format
 msgid "(d. %s)"
 msgstr "(k. %s)"
 
-#: dynamicweb.py:2439
+#: DynamicWeb//dynamicweb.py:2444
 msgid "(filtered from _MAX_ total entries)"
 msgstr "(suodatettu _MAX_ kokonaismäärästä)"
 
-#: dynamicweb.py:2440
+#: DynamicWeb//dynamicweb.py:2445
 #, python-format
 msgid "(m. %s)"
 msgstr "(∞ %s)"
 
-#: dynamicweb.py:2441
+#: DynamicWeb//dynamicweb.py:2446
 msgid "(sort by name)"
 msgstr "(lajittele nimen mukaan)"
 
-#: dynamicweb.py:2442
+#: DynamicWeb//dynamicweb.py:2447
 msgid "(sort by quantity)"
 msgstr "(lajittele määrän mukaan)"
 
-#: dynamicweb.py:2443
+#: DynamicWeb//dynamicweb.py:2448
 msgid ": activate to sort column ascending"
 msgstr ": aktivoi lajittelu sarake nousevaksi"
 
-#: dynamicweb.py:2444
+#: DynamicWeb//dynamicweb.py:2449
 msgid ": activate to sort column descending"
 msgstr ": aktivoi lajittelu sarake laskevaksi"
 
-#: dynamicweb.py:2445
+#: DynamicWeb//dynamicweb.py:2450
 msgid ""
 "<p>This page provides the SVG raw code.<br>Copy the contents into a text "
 "editor and save as an SVG file.<br>Make sure that the text editor encoding "
@@ -370,528 +375,567 @@ msgstr ""
 "tallenna se SVG-tiedostoksi.<br>Varmista, että tekstieditorin koodaus on "
 "UTF-8.</p>"
 
-#: dynamicweb.py:2447
+#: DynamicWeb//dynamicweb.py:2452
 msgid "Address"
 msgstr "Osoite"
 
-#: dynamicweb.py:2449
+#: DynamicWeb//dynamicweb.py:2454
 msgid "Age at death"
 msgstr "Kuolinikä"
 
-#: dynamicweb.py:2450
+#: DynamicWeb//dynamicweb.py:2455
 msgid "Alternate Marriage"
 msgstr "Vaihtoehtoinen avioliitto"
 
-#: dynamicweb.py:2451
+#: DynamicWeb//dynamicweb.py:2456
 msgid "Alternate Name"
 msgstr "Vaihtoehtoinen nimi"
 
-#: dynamicweb.py:2452
+#: DynamicWeb//dynamicweb.py:2457
 msgid "Ancestors"
 msgstr "Esivanhemmat"
 
-#: dynamicweb.py:2453
+#: DynamicWeb//dynamicweb.py:2458
 msgid "Associations"
 msgstr "Liitokset"
 
-#: dynamicweb.py:2454
+#: DynamicWeb//dynamicweb.py:2459
 msgid "Attribute"
 msgstr "Ominaisuus"
 
-#: dynamicweb.py:2455
+#: DynamicWeb//dynamicweb.py:2460
 msgid "Attributes"
 msgstr "Ominaisuudet"
 
-#: dynamicweb.py:2457 dynamicweb.py:4195
+#: DynamicWeb//dynamicweb.py:2462 DynamicWeb//dynamicweb.py:4209
 msgid "Background"
 msgstr "Taustaväri"
 
-#: dynamicweb.py:2458
+#: DynamicWeb//dynamicweb.py:2463
 msgid "Baptism"
 msgstr "Kaste"
 
-#: dynamicweb.py:2459
+#: DynamicWeb//dynamicweb.py:2464
 msgid "Birth"
 msgstr "Syntymä"
 
-#: dynamicweb.py:2460
+#: DynamicWeb//dynamicweb.py:2465
 msgid "Burial"
 msgstr "Hautaus"
 
-#: dynamicweb.py:2461
+#: DynamicWeb//dynamicweb.py:2466
 msgid "Call Name"
 msgstr "Kutsumanimi"
 
-#: dynamicweb.py:2462
+#: DynamicWeb//dynamicweb.py:2467
 msgid "Call Number"
 msgstr "Hakuavain"
 
-#: dynamicweb.py:2463
+#: DynamicWeb//dynamicweb.py:2468
 msgid "Cause Of Death"
 msgstr "Kuolinsyy"
 
-#: dynamicweb.py:2464
+#: DynamicWeb//dynamicweb.py:2469
 msgid "Children"
 msgstr "Lapset"
 
-#: dynamicweb.py:2465
+#: DynamicWeb//dynamicweb.py:2470
 msgid "Christening"
 msgstr "Ristiäiset"
 
-#: dynamicweb.py:2466
+#: DynamicWeb//dynamicweb.py:2471
 msgid "Citation"
 msgstr "Lainaus"
 
-#: dynamicweb.py:2467
+#: DynamicWeb//dynamicweb.py:2472
 msgid "Citations"
 msgstr "Lainaukset"
 
-#: dynamicweb.py:2468
+#: DynamicWeb//dynamicweb.py:2473
 msgid "Click on the map to show it full-screen"
 msgstr "Napsauta karttaa näyttääksesi sen koko näytöllä"
 
-#: dynamicweb.py:2469
+#: DynamicWeb//dynamicweb.py:2474
 msgid "Code"
 msgstr "Koodi"
 
-#: dynamicweb.py:2471
+#: DynamicWeb//dynamicweb.py:2476
 msgid "Configure"
 msgstr "Asetukset"
 
-#: dynamicweb.py:2472
+#: DynamicWeb//dynamicweb.py:2477
 msgid "Count"
 msgstr "Lukumäärä"
 
-#: dynamicweb.py:2473
+#: DynamicWeb//dynamicweb.py:2478
 msgid "Cremation"
 msgstr "Tuhkaus"
 
-#: dynamicweb.py:2475
+#: DynamicWeb//dynamicweb.py:2480
 msgid "Death"
 msgstr "Kuolema"
 
-#: dynamicweb.py:2476
+#: DynamicWeb//dynamicweb.py:2481
 msgid "Descendants"
 msgstr "Jälkeläiset"
 
-#: dynamicweb.py:2477
+#: DynamicWeb//dynamicweb.py:2482
 msgid "Description"
 msgstr "Kuvaus"
 
-#: dynamicweb.py:2478
+#: DynamicWeb//dynamicweb.py:2483
 msgid "DynamicWeb_report#Help"
 msgstr "Dynaaminen_nettiraportti#Ohje"
 
-#: dynamicweb.py:2479
+#: DynamicWeb//dynamicweb.py:2484
 msgid "Enclosed By"
 msgstr "Ympärillä"
 
-#: dynamicweb.py:2480
+#: DynamicWeb//dynamicweb.py:2485
 msgid "Engagement"
 msgstr "Kihlaus"
 
-#: dynamicweb.py:2481
+#: DynamicWeb//dynamicweb.py:2486
 msgid "Event"
 msgstr "Tapahtuma"
 
-#: dynamicweb.py:2482
+#: DynamicWeb//dynamicweb.py:2487
 msgid "Events"
 msgstr "Tapahtumat"
 
-#: dynamicweb.py:2483
+#: DynamicWeb//dynamicweb.py:2488
 msgid "Examples"
 msgstr "Esimerkkejä"
 
-#: dynamicweb.py:2484
+#: DynamicWeb//dynamicweb.py:2489
 msgid "F"
 msgstr "F"
 
-#: dynamicweb.py:2485
+#: DynamicWeb//dynamicweb.py:2490
 msgid "Families Index"
 msgstr "Perhehakemisto"
 
-#: dynamicweb.py:2487
+#: DynamicWeb//dynamicweb.py:2492
 msgid "Family Nick Name"
 msgstr "Perheen lempinimi"
 
-#: dynamicweb.py:2488
+#: DynamicWeb//dynamicweb.py:2493
 msgid "Father"
 msgstr "Isä"
 
-#: dynamicweb.py:2489
+#: DynamicWeb//dynamicweb.py:2494
 msgid "Female"
 msgstr "Nainen"
 
-#: dynamicweb.py:2490
+#: DynamicWeb//dynamicweb.py:2495
 msgid "File ready"
 msgstr "Tiedosto valmis"
 
-#: dynamicweb.py:2491
+#: DynamicWeb//dynamicweb.py:2496
 msgid "Gender"
 msgstr "Sukupuoli"
 
-#: dynamicweb.py:2492
+#: DynamicWeb//dynamicweb.py:2497
 msgid "Help"
 msgstr "Ohje"
 
-#: dynamicweb.py:2493
+#: DynamicWeb//dynamicweb.py:2498
 msgid "ID"
 msgstr "ID"
 
-#: dynamicweb.py:2494 dynamicweb.py:4027
+#: DynamicWeb//dynamicweb.py:2499 DynamicWeb//dynamicweb.py:4041
 msgid "Include Place map on Place Pages"
 msgstr "Lisää paikkakartta paikkasivuille"
 
-#: dynamicweb.py:2495 dynamicweb.py:4132
+#: DynamicWeb//dynamicweb.py:2500 DynamicWeb//dynamicweb.py:4146
 msgid "Include dates columns on the index pages"
 msgstr "Lisää päivämääräsarakkeet hakemistosivulle"
 
-#: dynamicweb.py:2496 dynamicweb.py:4140
+#: DynamicWeb//dynamicweb.py:2501 DynamicWeb//dynamicweb.py:4154
 msgid "Include a column for parents on the index pages"
 msgstr "Lisää hakemistosivuille sarake vanhemmista"
 
-#: dynamicweb.py:2497 dynamicweb.py:4148
+#: DynamicWeb//dynamicweb.py:2502 DynamicWeb//dynamicweb.py:4162
 msgid "Include a column for media path on the index pages"
 msgstr "Lisää hakemistosivuille mediapolun sarake"
 
-#: dynamicweb.py:2498 dynamicweb.py:4136
+#: DynamicWeb//dynamicweb.py:2503 DynamicWeb//dynamicweb.py:4150
 msgid "Include a column for partners on the index pages"
 msgstr "Lisää hakemistosivuille sarake kumppaneista"
 
-#: dynamicweb.py:2499 dynamicweb.py:4035
+#: DynamicWeb//dynamicweb.py:2504 DynamicWeb//dynamicweb.py:4049
 msgid "Include a map in the individuals and family pages"
 msgstr "Lisää kartta henkilö- ja perhesivuihin"
 
-#: dynamicweb.py:2500 dynamicweb.py:4082
+#: DynamicWeb//dynamicweb.py:2505 DynamicWeb//dynamicweb.py:4096
 msgid "Include half and/ or step-siblings on the individual pages"
 msgstr "Lisää henkilösivuille sarake sisarpuolille"
 
-#: dynamicweb.py:2501 dynamicweb.py:4152
+#: DynamicWeb//dynamicweb.py:2506 DynamicWeb//dynamicweb.py:4166
 msgid "Include references in indexes"
 msgstr "Lisää lähdeviitteet hakemistoihin"
 
-#: dynamicweb.py:2504 dynamicweb.py:4102
+#: DynamicWeb//dynamicweb.py:2509 DynamicWeb//dynamicweb.py:4116
 msgid "Insert sources author in the sources title"
 msgstr "Lisää lähdeaineiston tekijä lähteen otsikkoon"
 
-#: dynamicweb.py:2505
+#: DynamicWeb//dynamicweb.py:2510
 msgid "Last Modified"
 msgstr "Viimeisin muutos"
 
-#: dynamicweb.py:2506
+#: DynamicWeb//dynamicweb.py:2511
 msgid "Latitude"
 msgstr "Leveysaste"
 
-#: dynamicweb.py:2507
+#: DynamicWeb//dynamicweb.py:2512
 msgid "Link"
 msgstr "Linkki"
 
-#: dynamicweb.py:2508
+#: DynamicWeb//dynamicweb.py:2513
 msgid "Loading..."
 msgstr "Ladataan..."
 
-#: dynamicweb.py:2509
+#: DynamicWeb//dynamicweb.py:2514
 msgid "Location"
 msgstr "Sijainti"
 
-#: dynamicweb.py:2510
+#: DynamicWeb//dynamicweb.py:2515
 msgid "Longitude"
 msgstr "Pituusaste"
 
-#: dynamicweb.py:2511
+#: DynamicWeb//dynamicweb.py:2516
 msgid "M"
 msgstr "M"
 
-#: dynamicweb.py:2512
+#: DynamicWeb//dynamicweb.py:2517
 msgid "Male"
 msgstr "Mies"
 
-#: dynamicweb.py:2513
+#: DynamicWeb//dynamicweb.py:2518
 msgid "Map"
 msgstr "Kartta"
 
-#: dynamicweb.py:2514
+#: DynamicWeb//dynamicweb.py:2519
 msgid "Marriage"
 msgstr "Avioliitto"
 
-#: dynamicweb.py:2515
+#: DynamicWeb//dynamicweb.py:2520
 msgid "Maximize"
 msgstr "Maksimoi"
 
-#: dynamicweb.py:2516
+#: DynamicWeb//dynamicweb.py:2521
 msgid "Media Index"
 msgstr "Mediahakemisto"
 
-#: dynamicweb.py:2517
+#: DynamicWeb//dynamicweb.py:2522
 msgid "Media Type"
 msgstr "Mediatyyppi"
 
-#: dynamicweb.py:2519
+#: DynamicWeb//dynamicweb.py:2524
 msgid "Mother"
 msgstr "Äiti"
 
-#: dynamicweb.py:2520
+#: DynamicWeb//dynamicweb.py:2525
 msgid "Name"
 msgstr "Nimi"
 
-#: dynamicweb.py:2521
+#: DynamicWeb//dynamicweb.py:2526
 msgid "Nick Name"
 msgstr "Lempinimi"
 
-#: dynamicweb.py:2522
+#: DynamicWeb//dynamicweb.py:2527
 msgid "No data available in table"
 msgstr "Taulukon tietoja ei ole saatavilla"
 
-#: dynamicweb.py:2523
+#: DynamicWeb//dynamicweb.py:2528
 msgid "No matches found"
 msgstr "Vastaavuuksia ei löydy"
 
-#: dynamicweb.py:2524
+#: DynamicWeb//dynamicweb.py:2529
 msgid "No matching records found"
 msgstr "Vastaavia merkintöjä ei löydy"
 
-#: dynamicweb.py:2525
+#: DynamicWeb//dynamicweb.py:2530
 msgid "No matching surname."
 msgstr "Vastaavia sukunimiä ei löydy"
 
-#: dynamicweb.py:2526
+#: DynamicWeb//dynamicweb.py:2531
 msgid "None"
 msgstr "Tyhjä"
 
-#: dynamicweb.py:2527
+#: DynamicWeb//dynamicweb.py:2532
 msgid "Notes"
 msgstr "Lisätiedot"
 
-#: dynamicweb.py:2528
+#: DynamicWeb//dynamicweb.py:2533
+#, fuzzy
+msgid "Number"
+msgstr "Hakuavain"
+
+#: DynamicWeb//dynamicweb.py:2534
 msgid "OK"
 msgstr "OK"
 
-#: dynamicweb.py:2529
+#: DynamicWeb//dynamicweb.py:2535
 msgid "Other participants"
 msgstr "Muut osallistujat"
 
-#: dynamicweb.py:2530
+#: DynamicWeb//dynamicweb.py:2536
 msgid "Parents"
 msgstr "Vanhemmat"
 
-#: dynamicweb.py:2531
+#: DynamicWeb//dynamicweb.py:2537
 msgid "Path"
 msgstr "Polku"
 
-#: dynamicweb.py:2532
+#: DynamicWeb//dynamicweb.py:2538
 msgid "Person page"
 msgstr "Henkilösivu"
 
-#: dynamicweb.py:2533
+#: DynamicWeb//dynamicweb.py:2539
 msgid "Person to search for"
 msgstr "Henkilöhaku"
 
-#: dynamicweb.py:2535
+#: DynamicWeb//dynamicweb.py:2541
 msgid "Persons Index"
 msgstr "Henkilöhakemisto"
 
-#: dynamicweb.py:2536
+#: DynamicWeb//dynamicweb.py:2542
 msgid "Persons"
 msgstr "Henkilöt"
 
-#: dynamicweb.py:2538
+#: DynamicWeb//dynamicweb.py:2544
 msgid "Places Index"
 msgstr "Paikkahakemisto"
 
-#: dynamicweb.py:2540
+#: DynamicWeb//dynamicweb.py:2546
 msgid "Preparing file ..."
 msgstr "Tiedoston valmistelu ..."
 
-#: dynamicweb.py:2541
+#: DynamicWeb//dynamicweb.py:2547
 msgid "Processing..."
 msgstr "Käsitellään..."
 
-#: dynamicweb.py:2543
+#: DynamicWeb//dynamicweb.py:2549
 msgid "References"
 msgstr "Viitteet"
 
-#: dynamicweb.py:2544
+#: DynamicWeb//dynamicweb.py:2550
 msgid "Relationship to Father"
 msgstr "Suhde isään"
 
-#: dynamicweb.py:2545
+#: DynamicWeb//dynamicweb.py:2551
 msgid "Relationship to Mother"
 msgstr "Suhde äitiin"
 
-#: dynamicweb.py:2546
+#: DynamicWeb//dynamicweb.py:2552
 msgid "Relationship"
 msgstr "Suhde"
 
-#: dynamicweb.py:2549
+#: DynamicWeb//dynamicweb.py:2553
+#, fuzzy
+msgid "Repositories Index"
+msgstr "Arkistot"
+
+#: DynamicWeb//dynamicweb.py:2556
 msgid "Restore"
 msgstr "Palauta"
 
-#: dynamicweb.py:2550
+#: DynamicWeb//dynamicweb.py:2557
 msgid "Restore default settings"
 msgstr "Palauta oletusasetukset"
 
-#: dynamicweb.py:2551 dynamicweb.py:4098
+#: DynamicWeb//dynamicweb.py:2558 DynamicWeb//dynamicweb.py:4112
 msgid "Show last modification time"
 msgstr "Näytä viimeinen muutosaika"
 
-#: dynamicweb.py:2552 dynamicweb.py:4189
+#: DynamicWeb//dynamicweb.py:2559 DynamicWeb//dynamicweb.py:4203
 msgid "SVG tree children distribution"
 msgstr "SVG-puun lasten jakauma"
 
-#: dynamicweb.py:2553
+#: DynamicWeb//dynamicweb.py:2560
 msgid "SVG tree configuration"
 msgstr "SVG-puun kokoonpano"
 
-#: dynamicweb.py:2554 dynamicweb.py:4177
+#: DynamicWeb//dynamicweb.py:2561 DynamicWeb//dynamicweb.py:4191
 msgid "SVG tree graph shape"
 msgstr "SVG-puun kaavion muoto"
 
-#: dynamicweb.py:2555 dynamicweb.py:4171
+#: DynamicWeb//dynamicweb.py:2562 DynamicWeb//dynamicweb.py:4185
 msgid "SVG tree graph type"
 msgstr "SVG-puun kaaviotyyppi"
 
-#: dynamicweb.py:2556 dynamicweb.py:4183
+#: DynamicWeb//dynamicweb.py:2563 DynamicWeb//dynamicweb.py:4197
 msgid "SVG tree parents distribution"
 msgstr "SVG-puun vanhempien jakauma"
 
-#: dynamicweb.py:2557
+#: DynamicWeb//dynamicweb.py:2564
 msgid "Save tree as file"
 msgstr "Tallenna puu tiedostona"
 
-#: dynamicweb.py:2558
+#: DynamicWeb//dynamicweb.py:2565
 msgid "Search:"
 msgstr "Etsi:"
 
-#: dynamicweb.py:2559
+#: DynamicWeb//dynamicweb.py:2566
 msgid "Select the background color scheme"
 msgstr "Valitse taustan värijärjestelmä"
 
-#: dynamicweb.py:2560
+#: DynamicWeb//dynamicweb.py:2567
 msgid "Select the children distribution (fan charts only)"
 msgstr "Valitse lasten jakautuma (vain viuhkamallit)"
 
-#: dynamicweb.py:2561
+#: DynamicWeb//dynamicweb.py:2568
 msgid "Select the number of ascending generations"
 msgstr "Valitse esivanhempien sukupolvien lukumäärä"
 
-#: dynamicweb.py:2562
+#: DynamicWeb//dynamicweb.py:2569
 msgid "Select the number of descending generations"
 msgstr "Valitse jälkeläisten sukupolvien lukumäärä"
 
-#: dynamicweb.py:2563
+#: DynamicWeb//dynamicweb.py:2570
 msgid "Select the parents distribution (fan charts only)"
 msgstr "Valitse SVG-sukupuun vanhempien jakautuma (vain viuhkamallit)"
 
-#: dynamicweb.py:2564
+#: DynamicWeb//dynamicweb.py:2571
 msgid "Select the shape of graph"
 msgstr "Valitse kaavion muoto"
 
-#: dynamicweb.py:2565
+#: DynamicWeb//dynamicweb.py:2572
 msgid "Select the type of graph"
 msgstr "Valitse kaavion tyyppi"
 
-#: dynamicweb.py:2566
+#: DynamicWeb//dynamicweb.py:2573
 msgid "Several matches.<br>Precise your search or choose in the lists below."
 msgstr ""
 "Löydetty useita.<br>Tarkenna hakuasi tai valitse alla olevista listoista."
 
-#: dynamicweb.py:2567
+#: DynamicWeb//dynamicweb.py:2574
 msgid "Show _MENU_ entries"
 msgstr "Näytä _MENU_ merkinnät"
 
-#: dynamicweb.py:2568 dynamicweb.py:4207
+#: DynamicWeb//dynamicweb.py:2575 DynamicWeb//dynamicweb.py:4221
 msgid "Show duplicates"
 msgstr "Näytä kaksoiskappaleet"
 
-#: dynamicweb.py:2569
+#: DynamicWeb//dynamicweb.py:2576
 msgid "Showing 0 to 0 of 0 entries"
 msgstr "Näytetään 0-0 0 merkinnästä"
 
-#: dynamicweb.py:2570
+#: DynamicWeb//dynamicweb.py:2577
 msgid "Showing _START_ to _END_ of _TOTAL_ entries"
 msgstr "Näytetään _START_ - _END_ / _TOTAL_ merkinnöille"
 
-#: dynamicweb.py:2571
+#: DynamicWeb//dynamicweb.py:2578
 msgid "Siblings"
 msgstr "Sisarukset"
 
-#: dynamicweb.py:2573
+#: DynamicWeb//dynamicweb.py:2579
+msgid "Sort by:"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:2581
 msgid "Sources Index"
 msgstr "Lähteet valikko"
 
-#: dynamicweb.py:2575
+#: DynamicWeb//dynamicweb.py:2583
 msgid "Spouses"
 msgstr "Puolisot"
 
-#: dynamicweb.py:2576 dynamicweb.py:4106
+#: DynamicWeb//dynamicweb.py:2584 DynamicWeb//dynamicweb.py:4120
 msgid "Suppress Gramps ID"
 msgstr "Jätä pois Gramps ID"
 
-#: dynamicweb.py:2577
+#: DynamicWeb//dynamicweb.py:2585
 msgid "Surname"
 msgstr "sukunimi"
 
-#: dynamicweb.py:2578
+#: DynamicWeb//dynamicweb.py:2586
 msgid "Surnames Index"
 msgstr "Sukunimihakemisto"
 
-#: dynamicweb.py:2580
+#: DynamicWeb//dynamicweb.py:2588
 msgid "Title"
 msgstr "Nimike"
 
-#: dynamicweb.py:2581
+#: DynamicWeb//dynamicweb.py:2589
 msgid "Type"
 msgstr "Tyyppi"
 
-#: dynamicweb.py:2582
+#: DynamicWeb//dynamicweb.py:2590
 msgid "U"
 msgstr "U"
 
-#: dynamicweb.py:2583
+#: DynamicWeb//dynamicweb.py:2591
 msgid "Unknown"
 msgstr "Tuntematon"
 
-#: dynamicweb.py:2584 dynamicweb.py:4094
+#: DynamicWeb//dynamicweb.py:2592 DynamicWeb//dynamicweb.py:4108
 msgid "Use tabbed panels instead of sections"
 msgstr "Käytä välilehtiä paneeleiden sijaan"
 
-#: dynamicweb.py:2585
+#: DynamicWeb//dynamicweb.py:2593
 msgid "Use the search box above in order to find a person."
 msgstr "Käytä hakukenttää yllä löytääksesi henkilön."
 
-#: dynamicweb.py:2586
+#: DynamicWeb//dynamicweb.py:2594
+#, fuzzy
+msgid "Use a table format for the surnames index"
+msgstr "Sukunimihakemiston oletusmuoto"
+
+#: DynamicWeb//dynamicweb.py:2595
+#, fuzzy
+msgid "Use a table format for the persons index"
+msgstr "Henkilöhakemiston oletusmuoto"
+
+#: DynamicWeb//dynamicweb.py:2596
+#, fuzzy
+msgid "Use a table format for the families index"
+msgstr "Perheluettelon oletusmuoto"
+
+#: DynamicWeb//dynamicweb.py:2597
+#, fuzzy
+msgid "Use a table format for the sources index"
+msgstr "Lähdeluettelon oletusmuoto"
+
+#: DynamicWeb//dynamicweb.py:2598
+#, fuzzy
+msgid "Use a table format for the places index"
+msgstr "Paikkaluettelon oletusmuoto"
+
+#: DynamicWeb//dynamicweb.py:2599
 msgid "Used for family"
 msgstr "Käytetään perheelle"
 
-#: dynamicweb.py:2587
+#: DynamicWeb//dynamicweb.py:2600
 msgid "Used for media"
 msgstr "Käytetään medialle"
 
-#: dynamicweb.py:2588
+#: DynamicWeb//dynamicweb.py:2601
 msgid "Used for person"
 msgstr "Käytetään henkilölle"
 
-#: dynamicweb.py:2589
+#: DynamicWeb//dynamicweb.py:2602
 msgid "Used for place"
 msgstr "Käytä paikalle"
 
-#: dynamicweb.py:2590
+#: DynamicWeb//dynamicweb.py:2603
 msgid "Used for source"
 msgstr "Käytä lähteelle"
 
-#: dynamicweb.py:2591
+#: DynamicWeb//dynamicweb.py:2604
 msgid "Value"
 msgstr "Arvo"
 
-#: dynamicweb.py:2592
+#: DynamicWeb//dynamicweb.py:2605
 msgid "Web Link"
 msgstr "Nettilinkki"
 
-#: dynamicweb.py:2593
+#: DynamicWeb//dynamicweb.py:2606
 msgid "Web Links"
 msgstr "Nettilinkit"
 
-#: dynamicweb.py:2594 dynamicweb.py:4208
+#: DynamicWeb//dynamicweb.py:2607 DynamicWeb//dynamicweb.py:4222
 msgid ""
 "Whether to use a special color for the persons that appear several times in "
 "the SVG tree"
@@ -899,49 +943,49 @@ msgstr ""
 "Käytetäänkö erityistä väriä henkilöille, jotka näkyvät useita kertoja SVG-"
 "sukupuussa"
 
-#: dynamicweb.py:2595
+#: DynamicWeb//dynamicweb.py:2608
 msgid "Without name"
 msgstr "Ilman nimeä"
 
-#: dynamicweb.py:2596
+#: DynamicWeb//dynamicweb.py:2609
 msgid "Without surname"
 msgstr "Sukunimi puuttuu"
 
-#: dynamicweb.py:2597
+#: DynamicWeb//dynamicweb.py:2610
 msgid "Without title"
 msgstr "Ilman nimikettä"
 
-#: dynamicweb.py:2598
+#: DynamicWeb//dynamicweb.py:2611
 msgid "Zoom in"
 msgstr "Lähennä"
 
-#: dynamicweb.py:2599
+#: DynamicWeb//dynamicweb.py:2612
 msgid "Zoom out"
 msgstr "Loitonna"
 
-#: dynamicweb.py:2600
+#: DynamicWeb//dynamicweb.py:2613
 msgid "all"
 msgstr "kaikki"
 
-#: dynamicweb.py:2803
+#: DynamicWeb//dynamicweb.py:2816
 msgid "No Home Person"
 msgstr "Ei kotihenkilöä"
 
-#: dynamicweb.py:2944
+#: DynamicWeb//dynamicweb.py:2957
 #, python-format
 msgid "Copying error: %(error)s"
 msgstr "Kopiointivirhe: %(error)s"
 
-#: dynamicweb.py:2945
+#: DynamicWeb//dynamicweb.py:2958
 #, python-format
 msgid "Impossible to copy \"%(src)s\" to \"%(dst)s\""
 msgstr "Mahdotonta kopioida \"%(src)s\" - \"%(dst)s\""
 
-#: dynamicweb.py:2948
+#: DynamicWeb//dynamicweb.py:2961
 msgid "Possible destination error"
 msgstr "Mahdollinen kohdevirhe"
 
-#: dynamicweb.py:2949
+#: DynamicWeb//dynamicweb.py:2962
 msgid ""
 "You appear to have set your target directory to a directory used for data "
 "storage. This could create problems with file management. It is recommended "
@@ -952,64 +996,64 @@ msgstr ""
 "säilytykseen. Tästä saattaa tulla ongelmia tiedostojenhallinnassa. On "
 "suositeltavaa, että luot nettisivusi johonkin toiseen hakemistoon."
 
-#: dynamicweb.py:2976
+#: DynamicWeb//dynamicweb.py:2989
 #, python-format
 msgid "Unable to copy web site template files from \"%(path)s\""
 msgstr "Sivustojen mallitiedostoja ei voi kopioida \"%(path)s\""
 
-#: dynamicweb.py:3020
+#: DynamicWeb//dynamicweb.py:3033
 #, python-format
 msgid "Keeping \"%(dst)s\" (newer than \"%(src)s\")"
 msgstr "Pidä \"%(dst)s\" (uudempi kuin \"%(src)s\")"
 
-#: dynamicweb.py:3023
+#: DynamicWeb//dynamicweb.py:3036
 #, python-format
 msgid "Copying \"%(src)s\" to \"%(dst)s\""
 msgstr "Kopioidaan \"%(src)s\" - \"%(dst)s\""
 
-#: dynamicweb.py:3041
+#: DynamicWeb//dynamicweb.py:3054
 msgid "Invalid file name"
 msgstr "Virheellinen tiedostonimi"
 
-#: dynamicweb.py:3042
+#: DynamicWeb//dynamicweb.py:3055
 msgid "The archive file must be a file, not a directory"
 msgstr "Arkistotiedosto ei voi olla hakemisto"
 
-#: dynamicweb.py:3052 dynamicweb.py:3070
+#: DynamicWeb//dynamicweb.py:3065 DynamicWeb//dynamicweb.py:3083
 #, python-format
 msgid "Unable to overwrite archive file \"%(path)s\""
 msgstr "Arkistotiedostoa \"%(path)s\" ei voi korvata"
 
-#: dynamicweb.py:3062 dynamicweb.py:3077
+#: DynamicWeb//dynamicweb.py:3075 DynamicWeb//dynamicweb.py:3090
 #, python-format
 msgid "Unable to add file \"%(file)s\" to archive \"%(archive)s\""
 msgstr "Tiedoston \"%(file)s\" lisääminen ei onnistu arkistoon \"%(archive)s\""
 
-#: dynamicweb.py:3130
+#: DynamicWeb//dynamicweb.py:3143
 #, python-format
 msgid "DynamicWebReport ignoring link type '%(class)s'"
 msgstr "DynaaminenNettiraportti ohittaa linkki tyyppi '%(class)s'"
 
-#: dynamicweb.py:3373
+#: DynamicWeb//dynamicweb.py:3386
 msgid "Constructing list of other objects..."
 msgstr "Kerätään muiden kohteiden listaa..."
 
-#: dynamicweb.py:3508
+#: DynamicWeb//dynamicweb.py:3521
 #, python-format
 msgid "Family of %(husband)s and %(spouse)s"
 msgstr "%(husband)s ja %(spouse)s muodostama perhe"
 
-#: dynamicweb.py:3514
+#: DynamicWeb//dynamicweb.py:3527
 #, python-format
 msgid "Family of %(father)s"
 msgstr "Perhe isälle %(father)s"
 
-#: dynamicweb.py:3518
+#: DynamicWeb//dynamicweb.py:3531
 #, python-format
 msgid "Family of %(mother)s"
 msgstr "Perhe äidille %(mother)s"
 
-#: dynamicweb.py:3833
+#: DynamicWeb//dynamicweb.py:3846
 msgid ""
 "In this note, the following special words are processed:\n"
 "__SEARCH_FORM__ is replaced by a search form.\n"
@@ -1044,140 +1088,140 @@ msgstr ""
 "URL-osoite, joka alkaa suhteessa://suhteellinen <linkki>, korvataan "
 "suhteellisella URL-osoitteella \"<linkki>\".\n"
 
-#: dynamicweb.py:3872
+#: DynamicWeb//dynamicweb.py:3886
 msgid "Report"
 msgstr "Raportti"
 
-#: dynamicweb.py:3877
+#: DynamicWeb//dynamicweb.py:3891
 msgid "Destination"
 msgstr "Kohde"
 
-#: dynamicweb.py:3879
+#: DynamicWeb//dynamicweb.py:3893
 msgid "The destination directory for the web files"
 msgstr "Netti-tiedostojen kohdehakemisto"
 
-#: dynamicweb.py:3883
+#: DynamicWeb//dynamicweb.py:3897
 msgid "Store web pages in archive"
 msgstr "Tallenna verkkosivut arkistoon"
 
-#: dynamicweb.py:3884
+#: DynamicWeb//dynamicweb.py:3898
 msgid ""
 "Whether to create an archive file (in ZIP or TGZ format) containing the web "
 "site"
 msgstr ""
 "Luodaanko arkistotiedosto (ZIP- tai TGZ-muodossa), joka sisältää verkkosivun"
 
-#: dynamicweb.py:3888
+#: DynamicWeb//dynamicweb.py:3902
 msgid "Archive file"
 msgstr "Arkistotiedosto"
 
-#: dynamicweb.py:3890
+#: DynamicWeb//dynamicweb.py:3904
 msgid "The archive file name (with \".zip\" or \".tgz\" extension)"
 msgstr "Arkistotiedoston nimi (\".zip\" tai \".tgz\" -laajennuksella)"
 
-#: dynamicweb.py:3896
+#: DynamicWeb//dynamicweb.py:3910
 msgid "Web site title"
 msgstr "Nettisivuston otsikko"
 
-#: dynamicweb.py:3896
+#: DynamicWeb//dynamicweb.py:3910
 msgid "My Family Tree"
 msgstr "Sukupuuni"
 
-#: dynamicweb.py:3897
+#: DynamicWeb//dynamicweb.py:3911
 msgid "The title of the web site"
 msgstr "Sivuston otsikko"
 
-#: dynamicweb.py:3900
+#: DynamicWeb//dynamicweb.py:3914
 msgid "Filter"
 msgstr "Suodatin"
 
-#: dynamicweb.py:3902
+#: DynamicWeb//dynamicweb.py:3916
 msgid "Select filter to restrict people that appear on web site"
 msgstr "Valitse suodin rajoittamaan henkilöitä jotka näkyvät nettisivustossa"
 
-#: dynamicweb.py:3906
+#: DynamicWeb//dynamicweb.py:3920
 msgid "Filter Person"
 msgstr "Suodinhenkilö"
 
-#: dynamicweb.py:3907
+#: DynamicWeb//dynamicweb.py:3921
 msgid "The center person for the filter"
 msgstr "Suotimen keskushenkilö"
 
-#: dynamicweb.py:3915 dynamicweb.py:3935
+#: DynamicWeb//dynamicweb.py:3929 DynamicWeb//dynamicweb.py:3949
 msgid "Name format (short)"
 msgstr "Nimen muoto (lyhyt)"
 
-#: dynamicweb.py:3916 dynamicweb.py:3938
+#: DynamicWeb//dynamicweb.py:3930 DynamicWeb//dynamicweb.py:3952
 msgid "Select the format to display a shorter version of the names"
 msgstr "Valitse muoto, joka näyttää lyhyemmän version nimistä"
 
-#: dynamicweb.py:3930
+#: DynamicWeb//dynamicweb.py:3944
 msgid "Name format"
 msgstr "Nimen muoto"
 
-#: dynamicweb.py:3933
+#: DynamicWeb//dynamicweb.py:3947
 msgid "Select the format to display names"
 msgstr "Valitse nimien näyttömuoto"
 
-#: dynamicweb.py:3941
+#: DynamicWeb//dynamicweb.py:3955
 msgid "Web site template"
 msgstr "Sivuston mallipohja"
 
-#: dynamicweb.py:3944
+#: DynamicWeb//dynamicweb.py:3958
 msgid "Select the template of the web site"
 msgstr "Valitse verkkosivuston malli"
 
-#: dynamicweb.py:3947
+#: DynamicWeb//dynamicweb.py:3961
 msgid "Copyright"
 msgstr "Tekijänoikeudet"
 
-#: dynamicweb.py:3950
+#: DynamicWeb//dynamicweb.py:3964
 msgid "The copyright to be used for the web files"
 msgstr "Nettisivujen tekijänoikeudet"
 
-#: dynamicweb.py:3958
+#: DynamicWeb//dynamicweb.py:3972
 msgid "Privacy"
 msgstr "Yksityisyys"
 
-#: dynamicweb.py:3966
+#: DynamicWeb//dynamicweb.py:3980
 msgid "Include records marked private"
 msgstr "Lisää yksityisiksi merkityt tiedot"
 
-#: dynamicweb.py:3967
+#: DynamicWeb//dynamicweb.py:3981
 msgid "Whether to include private objects"
 msgstr "Lisätäänkö yksityiset tiedot"
 
-#: dynamicweb.py:3969
+#: DynamicWeb//dynamicweb.py:3983
 msgid "Living People"
 msgstr "Elävät henkilöt"
 
-#: dynamicweb.py:3970
+#: DynamicWeb//dynamicweb.py:3984
 msgid "Exclude"
 msgstr "Jätä pois"
 
-#: dynamicweb.py:3971
+#: DynamicWeb//dynamicweb.py:3985
 msgid "Include Last Name Only"
 msgstr "Lisää vain sukunimi"
 
-#: dynamicweb.py:3972
+#: DynamicWeb//dynamicweb.py:3986
 msgid "Include Full Name Only"
 msgstr "Lisää vain koko nimi"
 
-#: dynamicweb.py:3973
+#: DynamicWeb//dynamicweb.py:3987
 msgid "Include"
 msgstr "Ota mukaan"
 
-#: dynamicweb.py:3974
+#: DynamicWeb//dynamicweb.py:3988
 msgid "How to handle living people"
 msgstr "Miten käsitellään elossa olevat henkilöt"
 
-#: dynamicweb.py:3977
+#: DynamicWeb//dynamicweb.py:3991
 msgid "Years from death to consider living"
 msgstr ""
 "Vuosien määrä kuolemasta, jolloin henkilöä pidetään tietosuojan kannalta "
 "elävänä"
 
-#: dynamicweb.py:3978
+#: DynamicWeb//dynamicweb.py:3992
 msgid ""
 "This allows you to restrict information on people who have not been dead for "
 "very long"
@@ -1185,87 +1229,87 @@ msgstr ""
 "Tällä voit rajoittaa tietoja henkilöistä, jotka eivät ole olleet kuolleina "
 "kovin pitkään"
 
-#: dynamicweb.py:3982
+#: DynamicWeb//dynamicweb.py:3996
 msgid "Export notes"
 msgstr "Viedään lisätiedot"
 
-#: dynamicweb.py:3983
+#: DynamicWeb//dynamicweb.py:3997
 msgid "Whether to export notes in the web pages"
 msgstr "Viedäänkö lisätiedot nettisivulle"
 
-#: dynamicweb.py:3986
+#: DynamicWeb//dynamicweb.py:4000
 msgid "Export sources"
 msgstr "Viedään lähteet"
 
-#: dynamicweb.py:3987
+#: DynamicWeb//dynamicweb.py:4001
 msgid "Whether to export sources and citations in the web pages"
 msgstr "Viedäänkö lähteet ja lainaukset nettisivulle"
 
-#: dynamicweb.py:3990
+#: DynamicWeb//dynamicweb.py:4004
 msgid "Export addresses"
 msgstr "Viedään osoitteet"
 
-#: dynamicweb.py:3991
+#: DynamicWeb//dynamicweb.py:4005
 msgid "Whether to export addresses in the web pages"
 msgstr "Viedäänkö osoitteet nettisivulle"
 
-#: dynamicweb.py:3996
+#: DynamicWeb//dynamicweb.py:4010
 msgid "Options"
 msgstr "Valinnat"
 
-#: dynamicweb.py:3999
+#: DynamicWeb//dynamicweb.py:4013
 msgid "Include repository pages"
 msgstr "Lisää arkistosivut"
 
-#: dynamicweb.py:4000
+#: DynamicWeb//dynamicweb.py:4014
 msgid "Whether or not to include the Repository Pages."
 msgstr "Lisätäänkö arkistosivut"
 
-#: dynamicweb.py:4003
+#: DynamicWeb//dynamicweb.py:4017
 msgid "Include images and media"
 msgstr "Lisää kuvat ja muut mediatiedostot"
 
-#: dynamicweb.py:4004
+#: DynamicWeb//dynamicweb.py:4018
 msgid "Whether to include images and media in the web pages"
 msgstr "Lisätäänkö kuvat ja media nettisivulle"
 
-#: dynamicweb.py:4008
+#: DynamicWeb//dynamicweb.py:4022
 msgid "Copy, rename files with an internal Gramps identifier"
 msgstr "Kopioi ja nimeä uudelleen tiedostot, joilla on sisäinen Gramps ID"
 
-#: dynamicweb.py:4009
+#: DynamicWeb//dynamicweb.py:4023
 msgid "Copy, keep file names unchanged"
 msgstr "Kopioi, säilytä tiedostonimet ennallaan"
 
-#: dynamicweb.py:4010
+#: DynamicWeb//dynamicweb.py:4024
 msgid "Do not copy, reference existing files"
 msgstr "Älä kopioi olemassa olevia tiedostoja"
 
-#: dynamicweb.py:4012
+#: DynamicWeb//dynamicweb.py:4026
 msgid "Images and media"
 msgstr "Kuvat ja media"
 
-#: dynamicweb.py:4015
+#: DynamicWeb//dynamicweb.py:4029
 msgid "Whether to make a copy of the media"
 msgstr "Kopioidaanko media"
 
-#: dynamicweb.py:4018
+#: DynamicWeb//dynamicweb.py:4032
 msgid "Print the notes type"
 msgstr "Tulosta lisätiedon tyyppi"
 
-#: dynamicweb.py:4019
+#: DynamicWeb//dynamicweb.py:4033
 msgid "Whether to print the notes type in the notes text"
 msgstr "Tulostetaanko muistiinpanoja kirjoittamalla lisätietoja tekstinä"
 
-#: dynamicweb.py:4022
+#: DynamicWeb//dynamicweb.py:4036
 msgid "Print place pages"
 msgstr "Tulosta paikkasivut"
 
-#: dynamicweb.py:4023
+#: DynamicWeb//dynamicweb.py:4037
 msgid "Whether to show pages for the places"
 msgstr "Näytetäänkö paikkasivut"
 
-#: dynamicweb.py:4029
+#: DynamicWeb//dynamicweb.py:4043
 msgid ""
 "Whether to include a place map on the Place Pages, where Latitude/ Longitude "
 "are available."
@@ -1273,7 +1317,7 @@ msgstr ""
 "Lisätäänkö mukaan paikkasivuille paikkakartta, jossa on leveys- ja "
 "pituuspiiritiedot."
 
-#: dynamicweb.py:4037
+#: DynamicWeb//dynamicweb.py:4051
 msgid ""
 "Whether or not to add an individual page map showing all the places on this "
 "page. This will allow you to see how your family traveled around the country."
@@ -1281,165 +1325,165 @@ msgstr ""
 "Lisätäänkö erillinen sivu karttaa varten. Siitä näkisi kuinka sukusi on "
 "liikkunut maassa ja maailmalla."
 
-#: dynamicweb.py:4045
+#: DynamicWeb//dynamicweb.py:4059
 msgid "Google"
 msgstr "Google"
 
-#: dynamicweb.py:4046
+#: DynamicWeb//dynamicweb.py:4060
 msgid "OpenStreetMap"
 msgstr "OpenStreetMap"
 
-#: dynamicweb.py:4048
+#: DynamicWeb//dynamicweb.py:4062
 msgid "Map Service"
 msgstr "Karttapalvelu"
 
-#: dynamicweb.py:4051
+#: DynamicWeb//dynamicweb.py:4065
 msgid "Choose your choice of map service for creating the Place Map Pages"
 msgstr "Valitse karttapalvelu, jota haluat käyttää paikkakarttasivuilla."
 
-#: dynamicweb.py:4055
+#: DynamicWeb//dynamicweb.py:4069
 msgid "Google map API key"
 msgstr "Google kartat API-avain"
 
-#: dynamicweb.py:4056
+#: DynamicWeb//dynamicweb.py:4070
 msgid "The API key used for the Google map"
 msgstr "Käytetään Google kartat API-avainta"
 
-#: dynamicweb.py:4063
+#: DynamicWeb//dynamicweb.py:4077
 msgid "Advanced"
 msgstr "Lisäasetukset"
 
-#: dynamicweb.py:4066
+#: DynamicWeb//dynamicweb.py:4080
 msgid "Character set encoding"
 msgstr "Merkistön koodaus"
 
-#: dynamicweb.py:4069
+#: DynamicWeb//dynamicweb.py:4083
 msgid "The encoding to be used for the web files"
 msgstr "Nettisivuilla käytettävä merkistökoodaus"
 
-#: dynamicweb.py:4072
+#: DynamicWeb//dynamicweb.py:4086
 msgid "Include family pages"
 msgstr "Lisää perhesivut"
 
-#: dynamicweb.py:4073
+#: DynamicWeb//dynamicweb.py:4087
 msgid "Whether or not to include family pages"
 msgstr "Lisätäänkö perhesivut."
 
-#: dynamicweb.py:4083
+#: DynamicWeb//dynamicweb.py:4097
 msgid ""
 "Whether to include half and/ or step-siblings with the parents and siblings"
 msgstr ""
 "Lisätäänkö hakemistosivuille sarake sisaruspuolille, vanhempineen ja "
 "sisaruksineen"
 
-#: dynamicweb.py:4086
+#: DynamicWeb//dynamicweb.py:4100
 msgid "Include GENDEX file (/gendex.txt)"
 msgstr "Ota mukaan GENDEX tiedosto (/gendex.txt)"
 
-#: dynamicweb.py:4087
+#: DynamicWeb//dynamicweb.py:4101
 msgid "Whether to include a GENDEX file or not"
 msgstr "Lisätäänkö GENDEX tiedosto vai ei"
 
-#: dynamicweb.py:4090
+#: DynamicWeb//dynamicweb.py:4104
 msgid "Enable page configuration"
 msgstr "Ota sivun kokoonpano käyttöön"
 
-#: dynamicweb.py:4091
+#: DynamicWeb//dynamicweb.py:4105
 msgid "Whether to enable page configuration"
 msgstr "Otetaanko sivun kokoonpano"
 
-#: dynamicweb.py:4095
+#: DynamicWeb//dynamicweb.py:4109
 msgid "Whether to use tabbed panels for the different sections of the pages."
 msgstr "Käytetäänkö välilehtipaneeleja sivujen eri osiin."
 
-#: dynamicweb.py:4099
+#: DynamicWeb//dynamicweb.py:4113
 msgid "Whether to show the last modification time in the pages footer"
 msgstr "Näytetäänkö muokkausaika sivun alatunnisteessa"
 
-#: dynamicweb.py:4103
+#: DynamicWeb//dynamicweb.py:4117
 msgid "Whether to insert sources author in the sources title"
 msgstr "Lisätäänkö lähteiden tekijä lähteet otsikkoon"
 
-#: dynamicweb.py:4107
+#: DynamicWeb//dynamicweb.py:4121
 msgid "Whether to hide the Gramps ID"
 msgstr "Piilotetaanko Gramps ID"
 
-#: dynamicweb.py:4116
+#: DynamicWeb//dynamicweb.py:4130
 msgid "List"
 msgstr "Lista"
 
-#: dynamicweb.py:4117
+#: DynamicWeb//dynamicweb.py:4131
 msgid "Table"
 msgstr "Taulukko"
 
-#: dynamicweb.py:4120
+#: DynamicWeb//dynamicweb.py:4134
 msgid "Default format for the surnames index"
 msgstr "Sukunimihakemiston oletusmuoto"
 
-#: dynamicweb.py:4120
+#: DynamicWeb//dynamicweb.py:4134
 msgid "The default format for the surnames index"
 msgstr "Sukunimihakemiston oletusmuoto"
 
-#: dynamicweb.py:4121
+#: DynamicWeb//dynamicweb.py:4135
 msgid "Default format for the persons index"
 msgstr "Henkilöhakemiston oletusmuoto"
 
-#: dynamicweb.py:4121
+#: DynamicWeb//dynamicweb.py:4135
 msgid "The default format for the persons index"
 msgstr "Henkilöhakemiston oletusmuoto"
 
-#: dynamicweb.py:4122
+#: DynamicWeb//dynamicweb.py:4136
 msgid "Default format for the families index"
 msgstr "Perheluettelon oletusmuoto"
 
-#: dynamicweb.py:4122
+#: DynamicWeb//dynamicweb.py:4136
 msgid "The default format for the families index"
 msgstr "Perheluettelon oletusmuoto"
 
-#: dynamicweb.py:4123
+#: DynamicWeb//dynamicweb.py:4137
 msgid "Default format for the sources index"
 msgstr "Lähdeluettelon oletusmuoto"
 
-#: dynamicweb.py:4123
+#: DynamicWeb//dynamicweb.py:4137
 msgid "The default format for the sources index"
 msgstr "Lähdeluettelon oletusmuoto"
 
-#: dynamicweb.py:4124
+#: DynamicWeb//dynamicweb.py:4138
 msgid "Default format for the places index"
 msgstr "Paikkaluettelon oletusmuoto"
 
-#: dynamicweb.py:4124
+#: DynamicWeb//dynamicweb.py:4138
 msgid "The default format for the places index"
 msgstr "Paikkaluettelon oletusmuoto"
 
-#: dynamicweb.py:4133
+#: DynamicWeb//dynamicweb.py:4147
 msgid ""
 "Whether to include dates columns (birth, death, marriage) on the index pages"
 msgstr ""
 "Lisätäänkö hakemistosivuihin päivämääräsarakkeet (syntymälle, kuolemalle ja "
 "avioliitolle)"
 
-#: dynamicweb.py:4137
+#: DynamicWeb//dynamicweb.py:4151
 msgid "Whether to include a partners column"
 msgstr "Lisätäänkö kumppanisarake"
 
-#: dynamicweb.py:4141
+#: DynamicWeb//dynamicweb.py:4155
 msgid "Whether to include a parents column"
 msgstr "Lisätäänkö vanhempien sarake"
 
-#: dynamicweb.py:4144
+#: DynamicWeb//dynamicweb.py:4158
 msgid "Generate a families index page"
 msgstr "Luo perheiden hakemistosivu"
 
-#: dynamicweb.py:4145
+#: DynamicWeb//dynamicweb.py:4159
 msgid "Whether to generate an index page for families"
 msgstr "Luodaanko perheille hakemistosivu"
 
-#: dynamicweb.py:4149
+#: DynamicWeb//dynamicweb.py:4163
 msgid "Whether to include a column showing the media path"
 msgstr "Lisätäänkö sarake, joka näyttää mediapolun"
 
-#: dynamicweb.py:4153
+#: DynamicWeb//dynamicweb.py:4167
 msgid ""
 "Whether to include the references to the items in the index pages. For "
 "example, in the media index page, the names of the individuals, families, "
@@ -1449,23 +1493,23 @@ msgstr ""
 "hakemistosivulla henkilöden, perheiden ja paikkojen lähteet, jotka "
 "viittaavat mediaan."
 
-#: dynamicweb.py:4156
+#: DynamicWeb//dynamicweb.py:4170
 msgid "Default number of entries in the indexes"
 msgstr "Hakemiston merkintöjen oletusmäärä"
 
-#: dynamicweb.py:4159
+#: DynamicWeb//dynamicweb.py:4173
 msgid "The default number of entries shown in one index page"
 msgstr "Yhdellä hakemistosivulla näkyvien merkintöjen oletusmäärä"
 
-#: dynamicweb.py:4164
+#: DynamicWeb//dynamicweb.py:4178
 msgid "Trees"
 msgstr "Sukupuut"
 
-#: dynamicweb.py:4167
+#: DynamicWeb//dynamicweb.py:4181
 msgid "Maximum number of generations"
 msgstr "Sukupolvien enimmäismäärä"
 
-#: dynamicweb.py:4168
+#: DynamicWeb//dynamicweb.py:4182
 msgid ""
 "The maximum number of generations to include in the ancestor and descendant "
 "trees and graphs"
@@ -1473,116 +1517,119 @@ msgstr ""
 "Sukupolvien enimmäismäärä, jotka lisätään esivanhempien ja jälkeläisten "
 "sukupuihin ja kaavioihin"
 
-#: dynamicweb.py:4174
+#: DynamicWeb//dynamicweb.py:4188
 msgid "Choose the default SVG tree graph type"
 msgstr "Valitse SVG-sukupuukaavion oletustyyppi"
 
-#: dynamicweb.py:4180
+#: DynamicWeb//dynamicweb.py:4194
 msgid "Choose the default SVG tree graph shape"
 msgstr "Valitse SVG-sukupuukaavion oletusmuoto"
 
-#: dynamicweb.py:4186
+#: DynamicWeb//dynamicweb.py:4200
 msgid "Choose the default SVG tree parents distribution (for fan charts only)"
 msgstr "Valitse vanhempien oletusjakautuma SVG-sukupuuhun (vain viuhkamallit)"
 
-#: dynamicweb.py:4192
+#: DynamicWeb//dynamicweb.py:4206
 msgid "Choose the default SVG tree children distribution (for fan charts only)"
 msgstr "Valitse lasten oletusjakautuma SVG-sukupuuhun (vain viuhkamallit)"
 
-#: dynamicweb.py:4198
+#: DynamicWeb//dynamicweb.py:4212
 msgid ""
 "Choose the background color scheme for the persons in the SVG tree graph"
 msgstr "Valitse henkilöiden taustaväri SVG-sukupuu kaaviolle"
 
-#: dynamicweb.py:4201
+#: DynamicWeb//dynamicweb.py:4215
 msgid "Start gradient/Main color"
 msgstr "Väriliu'un lähtöväri"
 
-#: dynamicweb.py:4204
+#: DynamicWeb//dynamicweb.py:4218
 msgid "End gradient/2nd color"
 msgstr "Väriliu'un pääteväri"
 
-#: dynamicweb.py:4212
+#: DynamicWeb//dynamicweb.py:4226
 msgid "Color for duplicates"
 msgstr "Henkilökahdennusten väri"
 
-#: dynamicweb.py:4217
+#: DynamicWeb//dynamicweb.py:4231
 msgid "Pages"
 msgstr "Sivut"
 
-#: dynamicweb.py:4220
+#: DynamicWeb//dynamicweb.py:4234
 msgid "HTML user header"
 msgstr "HTML ylätunniste"
 
-#: dynamicweb.py:4221
+#: DynamicWeb//dynamicweb.py:4235
 msgid "A note to be used as the page header"
 msgstr "Sivun ylätunnisteena käytettävä lisätieto"
 
-#: dynamicweb.py:4224
+#: DynamicWeb//dynamicweb.py:4238
 msgid "HTML user brand name / icon"
 msgstr "HTML käyttäjän tuotemerkki / kuvake"
 
-#: dynamicweb.py:4225
+#: DynamicWeb//dynamicweb.py:4239
 msgid "A note to be used as the brand name or image in the menu"
 msgstr "Merkki, jota käytetään valikossa tuotemerkkinä tai kuvana"
 
-#: dynamicweb.py:4228
+#: DynamicWeb//dynamicweb.py:4242
 msgid "HTML user footer"
 msgstr "HTML alatunniste"
 
-#: dynamicweb.py:4229
+#: DynamicWeb//dynamicweb.py:4243
 msgid "A note to be used as the page footer"
 msgstr "Sivun alatunnisteena käytettävä lisätieto"
 
-#: dynamicweb.py:4234
+#: DynamicWeb//dynamicweb.py:4248
 msgid "Custom pages"
 msgstr "Mukautetut sivut"
 
-#: dynamicweb.py:4238
+#: DynamicWeb//dynamicweb.py:4252
 #, python-format
 msgid "Title for the custom page %(index)i"
 msgstr "Mukautetun sivun otsikko %(index)i"
 
-#: dynamicweb.py:4239
+#: DynamicWeb//dynamicweb.py:4253
 #, python-format
 msgid "Name for the custom page %(index)i"
 msgstr "Mukautetun sivun nimi %(index)i"
 
-#: dynamicweb.py:4242
+#: DynamicWeb//dynamicweb.py:4256
 #, python-format
 msgid "Note for custom page %(index)i"
 msgstr "Lisätieto mukautetulle sivulle %(index)i"
 
-#: dynamicweb.py:4243
+#: DynamicWeb//dynamicweb.py:4257
 msgid "A note to be used for the custom page content.\n"
 msgstr "Mukautetun sivun sisältöä koskeva lisätieto.\n"
 
-#: dynamicweb.py:4246
+#: DynamicWeb//dynamicweb.py:4260
 #, python-format
 msgid "Menu for the custom page %(index)i"
 msgstr "Mukautetun sivun valikko %(index)i"
 
-#: dynamicweb.py:4247
+#: DynamicWeb//dynamicweb.py:4261
 msgid "Whether to print a menu for the custom page"
 msgstr "Tulostetaanko valikko muokatulle sivulle"
 
-#: dynamicweb.py:4252
+#: DynamicWeb//dynamicweb.py:4266
 msgid "Pages selection"
 msgstr "Sivujen valinta"
 
-#: dynamicweb.py:4255
+#: DynamicWeb//dynamicweb.py:4269
 msgid "Number of pages"
 msgstr "Sivujen määrä"
 
-#: dynamicweb.py:4256
+#: DynamicWeb//dynamicweb.py:4270
 msgid "Number pages in the web site menu."
 msgstr "Sivunumerot verkkosivun valikossa."
 
-#: dynamicweb.py:4272
+#: DynamicWeb//dynamicweb.py:4286
 #, python-format
 msgid "Contents of page %(index)i"
 msgstr "Sivun sisältö %(index)i"
 
-#: dynamicweb.py:4275
+#: DynamicWeb//dynamicweb.py:4289
 msgid "Contents of the page"
 msgstr "Sivun sisältö"
+
+#~ msgid "Html|Home"
+#~ msgstr "Koti"

--- a/DynamicWeb/po/fr-local.po
+++ b/DynamicWeb/po/fr-local.po
@@ -25,7 +25,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 5.0.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-09-12 19:46+0000\n"
+"POT-Creation-Date: 2020-07-24 17:33+0200\n"
 "PO-Revision-Date: 2016-08-22 15:53+0100\n"
 "Last-Translator: \n"
 "Language-Team: French <traduc@traduc.org>\n"
@@ -36,331 +36,370 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 1.5.4\n"
 
-#: DynamicWeb/dynamicweb.gpr.py:15
+#: DynamicWeb//dynamicweb.gpr.py:15
 msgid "Dynamic Web Report"
 msgstr "Rapport Web Dynamique"
 
-#: DynamicWeb/dynamicweb.gpr.py:16
+#: DynamicWeb//dynamicweb.gpr.py:16
 msgid "Produces dynamic web pages for the database"
 msgstr "Produit des pages web dynamiques pour la base de données"
 
-#: DynamicWeb/dynamicweb.py:276
+#: DynamicWeb//dynamicweb.py:269
+#, fuzzy
+msgid "Street"
+msgstr "OpenStreetMap"
+
+#: DynamicWeb//dynamicweb.py:270
+#, fuzzy
+msgid "Locality"
+msgstr "Emplacement"
+
+#: DynamicWeb//dynamicweb.py:271
+msgid "City"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:272
+msgid "Church Parish"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:273
+#, fuzzy
+msgid "County"
+msgstr "Nombre"
+
+#: DynamicWeb//dynamicweb.py:274
+msgid "State/ Province"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:275
+msgid "Postal Code"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:276
+#, fuzzy
+msgid "Country"
+msgstr "Nombre"
+
+#: DynamicWeb//dynamicweb.py:277
+msgid "Phone"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:283
 msgid "Home Page"
 msgstr "Page d'accueil"
 
-#: DynamicWeb/dynamicweb.py:277
+#: DynamicWeb//dynamicweb.py:284
 msgid "SVG graphical tree"
 msgstr "Arbre graphique SVG"
 
-#: DynamicWeb/dynamicweb.py:280
+#: DynamicWeb//dynamicweb.py:287
 msgid "Indexes pages"
 msgstr "Pages d'index"
 
-#: DynamicWeb/dynamicweb.py:284 DynamicWeb/dynamicweb.py:4240
+#: DynamicWeb//dynamicweb.py:291 DynamicWeb//dynamicweb.py:4252
 #, python-format
 msgid "Custom page %(index)i"
 msgstr "Page personnalisée %(index)i"
 
-#: DynamicWeb/dynamicweb.py:302
+#: DynamicWeb//dynamicweb.py:309
 msgid "Ascending tree"
 msgstr "Arbre ascendant"
 
-#: DynamicWeb/dynamicweb.py:303
+#: DynamicWeb//dynamicweb.py:310
 msgid "Descending tree"
 msgstr "Arbre descendant"
 
-#: DynamicWeb/dynamicweb.py:304
+#: DynamicWeb//dynamicweb.py:311
 msgid "Descending tree with spouses"
 msgstr "Arbre descendant avec conjoints"
 
-#: DynamicWeb/dynamicweb.py:305
+#: DynamicWeb//dynamicweb.py:312
 msgid "Ascending and descending tree"
 msgstr "Arbre ascendant et descendant"
 
-#: DynamicWeb/dynamicweb.py:306
+#: DynamicWeb//dynamicweb.py:313
 msgid "Ascending and descending tree with spouses"
 msgstr "Arbre ascendant et descendant avec conjoints"
 
-#: DynamicWeb/dynamicweb.py:318
+#: DynamicWeb//dynamicweb.py:325
 msgid "Vertical (↓)"
 msgstr "Vertical (↓)"
 
-#: DynamicWeb/dynamicweb.py:319
+#: DynamicWeb//dynamicweb.py:326
 msgid "Vertical (↑)"
 msgstr "Vertical (↑)"
 
-#: DynamicWeb/dynamicweb.py:320
+#: DynamicWeb//dynamicweb.py:327
 msgid "Horizontal (→)"
 msgstr "Horizontal (→)"
 
-#: DynamicWeb/dynamicweb.py:321
+#: DynamicWeb//dynamicweb.py:328
 msgid "Horizontal (←)"
 msgstr "Horizontal (←)"
 
-#: DynamicWeb/dynamicweb.py:322
+#: DynamicWeb//dynamicweb.py:329
 msgid "Full Circle"
 msgstr "Cercle complet"
 
-#: DynamicWeb/dynamicweb.py:323
+#: DynamicWeb//dynamicweb.py:330
 msgid "Half Circle"
 msgstr "Demi-cercle"
 
-#: DynamicWeb/dynamicweb.py:324
+#: DynamicWeb//dynamicweb.py:331
 msgid "Quadrant"
 msgstr "Quadrant"
 
-#: DynamicWeb/dynamicweb.py:336
+#: DynamicWeb//dynamicweb.py:343
 msgid "Size proportional to number of ancestors"
 msgstr "Taille proportionnelle au nombre d'ascendants"
 
-#: DynamicWeb/dynamicweb.py:337
+#: DynamicWeb//dynamicweb.py:344
 msgid "Homogeneous parents distribution"
 msgstr "Distribution homogène des parents"
 
-#: DynamicWeb/dynamicweb.py:340
+#: DynamicWeb//dynamicweb.py:347
 msgid "Size proportional to number of descendants"
 msgstr "Taille proportionnelle au nombre de descendants"
 
-#: DynamicWeb/dynamicweb.py:341
+#: DynamicWeb//dynamicweb.py:348
 msgid "Homogeneous children distribution"
 msgstr "Distribution homogène des enfants"
 
-#: DynamicWeb/dynamicweb.py:348 DynamicWeb/dynamicweb.py:371
+#: DynamicWeb//dynamicweb.py:355 DynamicWeb//dynamicweb.py:378
 msgid "Gender colors"
 msgstr "Couleurs du genre"
 
-#: DynamicWeb/dynamicweb.py:349
+#: DynamicWeb//dynamicweb.py:356
 msgid "Generation based gradient"
 msgstr "Gradient basé sur la génération"
 
-#: DynamicWeb/dynamicweb.py:350
+#: DynamicWeb//dynamicweb.py:357
 msgid "Age based gradient"
 msgstr "Gradient basé sur l'âge"
 
-#: DynamicWeb/dynamicweb.py:351 DynamicWeb/dynamicweb.py:370
+#: DynamicWeb//dynamicweb.py:358 DynamicWeb//dynamicweb.py:377
 msgid "Single main (filter) color"
 msgstr "Couleur unique de filtrage"
 
-#: DynamicWeb/dynamicweb.py:352
+#: DynamicWeb//dynamicweb.py:359
 msgid "Time period based gradient"
 msgstr "Gradient basé sur une période temporelle"
 
-#: DynamicWeb/dynamicweb.py:353 DynamicWeb/dynamicweb.py:375
+#: DynamicWeb//dynamicweb.py:360 DynamicWeb//dynamicweb.py:382
 msgid "White"
 msgstr "Blanc"
 
-#: DynamicWeb/dynamicweb.py:354 DynamicWeb/dynamicweb.py:373
+#: DynamicWeb//dynamicweb.py:361 DynamicWeb//dynamicweb.py:380
 msgid "Color scheme classic report"
 msgstr "Schéma de couleur classique pour le rapport"
 
-#: DynamicWeb/dynamicweb.py:355 DynamicWeb/dynamicweb.py:374
+#: DynamicWeb//dynamicweb.py:362 DynamicWeb//dynamicweb.py:381
 msgid "Color scheme classic view"
 msgstr "Schéma de couleur classique pour la vue"
 
-#: DynamicWeb/dynamicweb.py:372
+#: DynamicWeb//dynamicweb.py:379
 msgid "Gradient"
 msgstr "Gradient"
 
-#: DynamicWeb/dynamicweb.py:391
+#: DynamicWeb//dynamicweb.py:398
 msgid "Default"
 msgstr "Défaut"
 
-#: DynamicWeb/dynamicweb.py:392
+#: DynamicWeb//dynamicweb.py:399
 msgid "Mainz"
 msgstr "Mayence"
 
-#: DynamicWeb/dynamicweb.py:709
+#: DynamicWeb//dynamicweb.py:707
 #, python-format
 msgid "Neither %(current)s nor %(parent)s are directories"
 msgstr "Ni %(current)s ni %(parent)s ne sont des répertoires"
 
-#: DynamicWeb/dynamicweb.py:717 DynamicWeb/dynamicweb.py:722
+#: DynamicWeb//dynamicweb.py:715 DynamicWeb//dynamicweb.py:720
 #, python-format
 msgid "Could not create the directory: %(path)s"
 msgstr "Impossible de créer le répertoire: %(path)s"
 
-#: DynamicWeb/dynamicweb.py:748 DynamicWeb/dynamicweb.py:3366
-#: DynamicWeb/dynamicweb.py:3372
+#: DynamicWeb//dynamicweb.py:746 DynamicWeb//dynamicweb.py:3385
 msgid "Dynamic Web Site Report"
 msgstr "Rapport en site web dynamique"
 
-#: DynamicWeb/dynamicweb.py:748
+#: DynamicWeb//dynamicweb.py:746
 msgid "Exporting family tree data ..."
 msgstr "Export des données de l'arbre familial ..."
 
-#: DynamicWeb/dynamicweb.py:1238 DynamicWeb/dynamicweb.py:2456
+#: DynamicWeb//dynamicweb.py:1237 DynamicWeb//dynamicweb.py:2461
 msgid "Author"
 msgstr "Auteur"
 
-#: DynamicWeb/dynamicweb.py:1239 DynamicWeb/dynamicweb.py:2446
+#: DynamicWeb//dynamicweb.py:1238 DynamicWeb//dynamicweb.py:2451
 msgid "Abbreviation"
 msgstr "Abréviation"
 
-#: DynamicWeb/dynamicweb.py:1240 DynamicWeb/dynamicweb.py:2542
+#: DynamicWeb//dynamicweb.py:1239 DynamicWeb//dynamicweb.py:2548
 msgid "Publication information"
 msgstr "Informations de publication"
 
-#: DynamicWeb/dynamicweb.py:1310 DynamicWeb/dynamicweb.py:2474
+#: DynamicWeb//dynamicweb.py:1309 DynamicWeb//dynamicweb.py:2479
 msgid "Date"
 msgstr "Date "
 
-#: DynamicWeb/dynamicweb.py:1311
+#: DynamicWeb//dynamicweb.py:1310
 msgid "Page"
 msgstr "Page"
 
-#: DynamicWeb/dynamicweb.py:1312
+#: DynamicWeb//dynamicweb.py:1311
 msgid "Confidence"
 msgstr "Niveau de confiance"
 
-#: DynamicWeb/dynamicweb.py:1626
+#: DynamicWeb//dynamicweb.py:1630
 #, python-format
 msgid "%(type)s: %(value)s"
 msgstr "%(type)s : %(value)s"
 
-#: DynamicWeb/dynamicweb.py:1873
+#: DynamicWeb//dynamicweb.py:1877
 #, python-format
 msgid "Impossible to convert \"%(path)s\" to a relative path."
 msgstr "Impossible de convertir \"%(path)s\" en chemin relatif."
 
-#: DynamicWeb/dynamicweb.py:2179
+#: DynamicWeb//dynamicweb.py:2183
 msgid ""
 "The pages configuration is not valid: several pages have the same content"
 msgstr ""
 "La configuration des pages n'est pas valide: Il y a plusieurs pages avec le "
 "même contenu"
 
-#: DynamicWeb/dynamicweb.py:2190
-msgid "Html|Home"
-msgstr "Accueil"
+#: DynamicWeb//dynamicweb.py:2194
+msgid "DynWeb|Home"
+msgstr "Acceuil"
 
-#: DynamicWeb/dynamicweb.py:2191 DynamicWeb/dynamicweb.py:2204
-#: DynamicWeb/dynamicweb.py:2205 DynamicWeb/dynamicweb.py:2206
+#: DynamicWeb//dynamicweb.py:2195 DynamicWeb//dynamicweb.py:2208
+#: DynamicWeb//dynamicweb.py:2209 DynamicWeb//dynamicweb.py:2210
 msgid "Tree"
 msgstr "Arbre"
 
-#: DynamicWeb/dynamicweb.py:2192 DynamicWeb/dynamicweb.py:2207
-#: DynamicWeb/dynamicweb.py:2208 DynamicWeb/dynamicweb.py:2209
+#: DynamicWeb//dynamicweb.py:2196 DynamicWeb//dynamicweb.py:2211
+#: DynamicWeb//dynamicweb.py:2212 DynamicWeb//dynamicweb.py:2213
 msgid "Statistics"
 msgstr "Statistiques"
 
-#: DynamicWeb/dynamicweb.py:2195 DynamicWeb/dynamicweb.py:2470
+#: DynamicWeb//dynamicweb.py:2199 DynamicWeb//dynamicweb.py:2475
 msgid "Configuration"
 msgstr "Configuration"
 
 # L'espace finale est pour précéder le « : » codé en dur dans certains contextes.
 # /!\ vérifier double espace avec search bar "%(titre colonne)s contient"
-#: DynamicWeb/dynamicweb.py:2197 DynamicWeb/dynamicweb.py:2534
+#: DynamicWeb//dynamicweb.py:2201 DynamicWeb//dynamicweb.py:2540
 msgid "Person"
 msgstr "Individu "
 
 # L'espace finale est pour précéder le « : » codé en dur dans certains contextes.
 # /!\ vérifier double espace avec search bar "%(titre colonne)s contient"
-#: DynamicWeb/dynamicweb.py:2198
+#: DynamicWeb//dynamicweb.py:2202
 msgid "Family"
 msgstr "Famille "
 
 # L'espace finale est pour précéder le « : » codé en dur dans certains contextes.
 # /!\ vérifier double espace avec search bar "%(titre colonne)s contient"
-#: DynamicWeb/dynamicweb.py:2199 DynamicWeb/dynamicweb.py:2572
+#: DynamicWeb//dynamicweb.py:2203 DynamicWeb//dynamicweb.py:2580
 msgid "Source"
 msgstr "Source "
 
-#: DynamicWeb/dynamicweb.py:2200 DynamicWeb/dynamicweb.py:2219
-#: DynamicWeb/dynamicweb.py:2518
+#: DynamicWeb//dynamicweb.py:2204 DynamicWeb//dynamicweb.py:2223
+#: DynamicWeb//dynamicweb.py:2523
 msgid "Media"
 msgstr "Media"
 
 # L'espace finale est pour précéder le « : » codé en dur dans certains contextes.
 # /!\ vérifier double espace avec search bar "%(titre colonne)s contient"
-#: DynamicWeb/dynamicweb.py:2201 DynamicWeb/dynamicweb.py:2537
+#: DynamicWeb//dynamicweb.py:2205 DynamicWeb//dynamicweb.py:2543
 msgid "Place"
 msgstr "Lieu "
 
 # L'espace finale est pour précéder le « : » codé en dur dans certains contextes.
 # /!\ vérifier double espace avec search bar "%(titre colonne)s contient"
-#: DynamicWeb/dynamicweb.py:2202 DynamicWeb/dynamicweb.py:2548
+#: DynamicWeb//dynamicweb.py:2206 DynamicWeb//dynamicweb.py:2555
 msgid "Repository"
 msgstr "Dépôt "
 
-#: DynamicWeb/dynamicweb.py:2203
+#: DynamicWeb//dynamicweb.py:2207
 msgid "Search results"
 msgstr "Résultats de la recherche"
 
-#: DynamicWeb/dynamicweb.py:2214 DynamicWeb/dynamicweb.py:2215
-#: DynamicWeb/dynamicweb.py:2579
+#: DynamicWeb//dynamicweb.py:2218 DynamicWeb//dynamicweb.py:2219
+#: DynamicWeb//dynamicweb.py:2587
 msgid "Surnames"
 msgstr "Noms de famille"
 
-#: DynamicWeb/dynamicweb.py:2216 DynamicWeb/dynamicweb.py:2503
+#: DynamicWeb//dynamicweb.py:2220 DynamicWeb//dynamicweb.py:2508
 msgid "Individuals"
 msgstr "Individus"
 
-#: DynamicWeb/dynamicweb.py:2217 DynamicWeb/dynamicweb.py:2486
+#: DynamicWeb//dynamicweb.py:2221 DynamicWeb//dynamicweb.py:2491
 msgid "Families"
 msgstr "Familles"
 
-#: DynamicWeb/dynamicweb.py:2218 DynamicWeb/dynamicweb.py:2574
+#: DynamicWeb//dynamicweb.py:2222 DynamicWeb//dynamicweb.py:2582
 msgid "Sources"
 msgstr "Sources"
 
-#: DynamicWeb/dynamicweb.py:2220 DynamicWeb/dynamicweb.py:2539
+#: DynamicWeb//dynamicweb.py:2224 DynamicWeb//dynamicweb.py:2545
 msgid "Places"
 msgstr "Lieux"
 
-#: DynamicWeb/dynamicweb.py:2221 DynamicWeb/dynamicweb.py:2448
+#: DynamicWeb//dynamicweb.py:2225 DynamicWeb//dynamicweb.py:2453
 msgid "Addresses"
 msgstr "Adresses"
 
-#: DynamicWeb/dynamicweb.py:2222 DynamicWeb/dynamicweb.py:2547
+#: DynamicWeb//dynamicweb.py:2226 DynamicWeb//dynamicweb.py:2554
 msgid "Repositories"
 msgstr "Dépôts"
 
-#: DynamicWeb/dynamicweb.py:2273 DynamicWeb/dynamicweb.py:2502
-#: DynamicWeb/dynamicweb.py:4114
+#: DynamicWeb//dynamicweb.py:2277 DynamicWeb//dynamicweb.py:2507
+#: DynamicWeb//dynamicweb.py:4126
 msgid "Indexes"
 msgstr "Index"
 
-#: DynamicWeb/dynamicweb.py:2436
+#: DynamicWeb//dynamicweb.py:2441
 #, python-format
 msgid "(b. %(birthdate)s, d. %(deathdate)s)"
 msgstr "(n. %(birthdate)s, d. %(deathdate)s)"
 
-#: DynamicWeb/dynamicweb.py:2437
+#: DynamicWeb//dynamicweb.py:2442
 #, python-format
 msgid "(b. %s)"
 msgstr "(n. %s)"
 
-#: DynamicWeb/dynamicweb.py:2438
+#: DynamicWeb//dynamicweb.py:2443
 #, python-format
 msgid "(d. %s)"
 msgstr "(d. %s)"
 
-#: DynamicWeb/dynamicweb.py:2439
+#: DynamicWeb//dynamicweb.py:2444
 msgid "(filtered from _MAX_ total entries)"
 msgstr "(filtrées parmi un total de _MAX_ éléments)"
 
-#: DynamicWeb/dynamicweb.py:2440
+#: DynamicWeb//dynamicweb.py:2445
 #, python-format
 msgid "(m. %s)"
 msgstr "(m. %s)"
 
-#: DynamicWeb/dynamicweb.py:2441
+#: DynamicWeb//dynamicweb.py:2446
 msgid "(sort by name)"
 msgstr "(tri par nom)"
 
-#: DynamicWeb/dynamicweb.py:2442
+#: DynamicWeb//dynamicweb.py:2447
 msgid "(sort by quantity)"
 msgstr "(tri par nombre)"
 
-#: DynamicWeb/dynamicweb.py:2443
+#: DynamicWeb//dynamicweb.py:2448
 msgid ": activate to sort column ascending"
 msgstr ": activer pour trier la colonne dans l'ordre croissant"
 
-#: DynamicWeb/dynamicweb.py:2444
+#: DynamicWeb//dynamicweb.py:2449
 msgid ": activate to sort column descending"
 msgstr ": activer pour trier la colonne dans l'ordre décroissant"
 
-#: DynamicWeb/dynamicweb.py:2445
+#: DynamicWeb//dynamicweb.py:2450
 msgid ""
 "<p>This page provides the SVG raw code.<br>Copy the contents into a text "
 "editor and save as an SVG file.<br>Make sure that the text editor encoding "
@@ -371,543 +410,582 @@ msgstr ""
 "l'éditeur de texte est UTF-8.</p>"
 
 # L'espace finale est pour précéder le « : » codé en dur dans certains contextes.
-#: DynamicWeb/dynamicweb.py:2447
+#: DynamicWeb//dynamicweb.py:2452
 msgid "Address"
 msgstr "Adresse "
 
-#: DynamicWeb/dynamicweb.py:2449
+#: DynamicWeb//dynamicweb.py:2454
 msgid "Age at death"
 msgstr "Âge au décès"
 
 # peut être mariage de remplacement...
-#: DynamicWeb/dynamicweb.py:2450
+#: DynamicWeb//dynamicweb.py:2455
 msgid "Alternate Marriage"
 msgstr "Mariage alternatif"
 
-#: DynamicWeb/dynamicweb.py:2451
+#: DynamicWeb//dynamicweb.py:2456
 msgid "Alternate Name"
 msgstr "Nom alternatif"
 
-#: DynamicWeb/dynamicweb.py:2452
+#: DynamicWeb//dynamicweb.py:2457
 msgid "Ancestors"
 msgstr "Ascendants"
 
-#: DynamicWeb/dynamicweb.py:2453
+#: DynamicWeb//dynamicweb.py:2458
 msgid "Associations"
 msgstr "Associations"
 
-#: DynamicWeb/dynamicweb.py:2454
+#: DynamicWeb//dynamicweb.py:2459
 msgid "Attribute"
 msgstr "Attribut"
 
-#: DynamicWeb/dynamicweb.py:2455
+#: DynamicWeb//dynamicweb.py:2460
 msgid "Attributes"
 msgstr "Attributs"
 
-#: DynamicWeb/dynamicweb.py:2457 DynamicWeb/dynamicweb.py:4197
+#: DynamicWeb//dynamicweb.py:2462 DynamicWeb//dynamicweb.py:4209
 msgid "Background"
 msgstr "Fond"
 
-#: DynamicWeb/dynamicweb.py:2458
+#: DynamicWeb//dynamicweb.py:2463
 msgid "Baptism"
 msgstr "Baptême"
 
-#: DynamicWeb/dynamicweb.py:2459
+#: DynamicWeb//dynamicweb.py:2464
 msgid "Birth"
 msgstr "Naissance"
 
-#: DynamicWeb/dynamicweb.py:2460
+#: DynamicWeb//dynamicweb.py:2465
 msgid "Burial"
 msgstr "Inhumation"
 
 # call name = prénom dans le context !
-#: DynamicWeb/dynamicweb.py:2461
+#: DynamicWeb//dynamicweb.py:2466
 msgid "Call Name"
 msgstr "Prénom usuel"
 
-#: DynamicWeb/dynamicweb.py:2462
+#: DynamicWeb//dynamicweb.py:2467
 msgid "Call Number"
 msgstr "Numéro d'identifiant"
 
-#: DynamicWeb/dynamicweb.py:2463
+#: DynamicWeb//dynamicweb.py:2468
 msgid "Cause Of Death"
 msgstr "Cause de décès"
 
-#: DynamicWeb/dynamicweb.py:2464
+#: DynamicWeb//dynamicweb.py:2469
 msgid "Children"
 msgstr "Enfants "
 
-#: DynamicWeb/dynamicweb.py:2465
+#: DynamicWeb//dynamicweb.py:2470
 msgid "Christening"
 msgstr "Baptême religieux"
 
 # L'espace finale est pour précéder le « : » codé en dur dans certains contextes.
 # /!\ vérifier double espace avec search bar "%(titre colonne)s contient"
-#: DynamicWeb/dynamicweb.py:2466
+#: DynamicWeb//dynamicweb.py:2471
 msgid "Citation"
 msgstr "Citation "
 
 # trunk
-#: DynamicWeb/dynamicweb.py:2467
+#: DynamicWeb//dynamicweb.py:2472
 msgid "Citations"
 msgstr "Citations"
 
-#: DynamicWeb/dynamicweb.py:2468
+#: DynamicWeb//dynamicweb.py:2473
 msgid "Click on the map to show it full-screen"
 msgstr "Cliquer sur la carte pour l'afficher en plein écran"
 
 # trunk
-#: DynamicWeb/dynamicweb.py:2469
+#: DynamicWeb//dynamicweb.py:2474
 msgid "Code"
 msgstr "Code"
 
-#: DynamicWeb/dynamicweb.py:2471
+#: DynamicWeb//dynamicweb.py:2476
 msgid "Configure"
 msgstr "Configuration"
 
-#: DynamicWeb/dynamicweb.py:2472
+#: DynamicWeb//dynamicweb.py:2477
 msgid "Count"
 msgstr "Nombre"
 
-#: DynamicWeb/dynamicweb.py:2473
+#: DynamicWeb//dynamicweb.py:2478
 msgid "Cremation"
 msgstr "Incinération"
 
-#: DynamicWeb/dynamicweb.py:2475
+#: DynamicWeb//dynamicweb.py:2480
 msgid "Death"
 msgstr "Décès"
 
-#: DynamicWeb/dynamicweb.py:2476
+#: DynamicWeb//dynamicweb.py:2481
 msgid "Descendants"
 msgstr "Descendants"
 
-#: DynamicWeb/dynamicweb.py:2477
+#: DynamicWeb//dynamicweb.py:2482
 msgid "Description"
 msgstr "Description"
 
-#: DynamicWeb/dynamicweb.py:2478
+#: DynamicWeb//dynamicweb.py:2483
 msgid "DynamicWeb_report#Help"
 msgstr "DynamicWeb_report#Help"
 
 # trunk
-#: DynamicWeb/dynamicweb.py:2479
+#: DynamicWeb//dynamicweb.py:2484
 msgid "Enclosed By"
 msgstr "Partie de"
 
-#: DynamicWeb/dynamicweb.py:2480
+#: DynamicWeb//dynamicweb.py:2485
 msgid "Engagement"
 msgstr "Fiançailles"
 
 # L'espace finale est pour précéder le « : » codé en dur dans certains contextes.
 # /!\ vérifier double espace avec search bar "%(titre colonne)s contient"
-#: DynamicWeb/dynamicweb.py:2481
+#: DynamicWeb//dynamicweb.py:2486
 msgid "Event"
 msgstr "Événement "
 
-#: DynamicWeb/dynamicweb.py:2482
+#: DynamicWeb//dynamicweb.py:2487
 msgid "Events"
 msgstr "Événements"
 
-#: DynamicWeb/dynamicweb.py:2483
+#: DynamicWeb//dynamicweb.py:2488
 msgid "Examples"
 msgstr "Exemples"
 
-#: DynamicWeb/dynamicweb.py:2484
+#: DynamicWeb//dynamicweb.py:2489
 msgid "F"
 msgstr "F"
 
-#: DynamicWeb/dynamicweb.py:2485
+#: DynamicWeb//dynamicweb.py:2490
 msgid "Families Index"
 msgstr "Index des familles"
 
-#: DynamicWeb/dynamicweb.py:2487
+#: DynamicWeb//dynamicweb.py:2492
 msgid "Family Nick Name"
 msgstr "Surnom de la famille"
 
-#: DynamicWeb/dynamicweb.py:2488
+#: DynamicWeb//dynamicweb.py:2493
 msgid "Father"
 msgstr "Père "
 
-#: DynamicWeb/dynamicweb.py:2489
+#: DynamicWeb//dynamicweb.py:2494
 msgid "Female"
 msgstr "Féminin"
 
-#: DynamicWeb/dynamicweb.py:2490
+#: DynamicWeb//dynamicweb.py:2495
 msgid "File ready"
 msgstr "Fichier prêt"
 
-#: DynamicWeb/dynamicweb.py:2491
+#: DynamicWeb//dynamicweb.py:2496
 msgid "Gender"
 msgstr "Genre"
 
-#: DynamicWeb/dynamicweb.py:2492
+#: DynamicWeb//dynamicweb.py:2497
 msgid "Help"
 msgstr "Aide"
 
-#: DynamicWeb/dynamicweb.py:2493
+#: DynamicWeb//dynamicweb.py:2498
 msgid "ID"
 msgstr "ID"
 
-#: DynamicWeb/dynamicweb.py:2494 DynamicWeb/dynamicweb.py:4029
+#: DynamicWeb//dynamicweb.py:2499 DynamicWeb//dynamicweb.py:4041
 msgid "Include Place map on Place Pages"
 msgstr "Inclure une carte dans les pages du lieu"
 
-#: DynamicWeb/dynamicweb.py:2495 DynamicWeb/dynamicweb.py:4134
+#: DynamicWeb//dynamicweb.py:2500 DynamicWeb//dynamicweb.py:4146
 msgid "Include dates columns on the index pages"
 msgstr "Inclure des colonnes de date dans les pages index"
 
-#: DynamicWeb/dynamicweb.py:2496 DynamicWeb/dynamicweb.py:4142
+#: DynamicWeb//dynamicweb.py:2501 DynamicWeb//dynamicweb.py:4154
 msgid "Include a column for parents on the index pages"
 msgstr "Inclure une colonne pour les parents dans les pages index"
 
-#: DynamicWeb/dynamicweb.py:2497 DynamicWeb/dynamicweb.py:4150
+#: DynamicWeb//dynamicweb.py:2502 DynamicWeb//dynamicweb.py:4162
 msgid "Include a column for media path on the index pages"
 msgstr "Inclure une colonne pour les chemins des media dans les pages index"
 
-#: DynamicWeb/dynamicweb.py:2498 DynamicWeb/dynamicweb.py:4138
+#: DynamicWeb//dynamicweb.py:2503 DynamicWeb//dynamicweb.py:4150
 msgid "Include a column for partners on the index pages"
 msgstr "Inclure une colonne pour les conjoints dans les pages index"
 
-#: DynamicWeb/dynamicweb.py:2499 DynamicWeb/dynamicweb.py:4037
+#: DynamicWeb//dynamicweb.py:2504 DynamicWeb//dynamicweb.py:4049
 msgid "Include a map in the individuals and family pages"
 msgstr "Inclure une carte dans les pages des individus et des familles"
 
-#: DynamicWeb/dynamicweb.py:2500 DynamicWeb/dynamicweb.py:4084
+#: DynamicWeb//dynamicweb.py:2505 DynamicWeb//dynamicweb.py:4096
 msgid "Include half and/ or step-siblings on the individual pages"
 msgstr "Inclure les demi-frères et demi-sœurs sur la page de l'individu"
 
-#: DynamicWeb/dynamicweb.py:2501 DynamicWeb/dynamicweb.py:4154
+#: DynamicWeb//dynamicweb.py:2506 DynamicWeb//dynamicweb.py:4166
 msgid "Include references in indexes"
 msgstr "Inclure les références dans les index"
 
-#: DynamicWeb/dynamicweb.py:2504 DynamicWeb/dynamicweb.py:4104
+#: DynamicWeb//dynamicweb.py:2509 DynamicWeb//dynamicweb.py:4116
 msgid "Insert sources author in the sources title"
 msgstr "Insérer l'auteur des sources dans le titre des sources"
 
-#: DynamicWeb/dynamicweb.py:2505
+#: DynamicWeb//dynamicweb.py:2510
 msgid "Last Modified"
 msgstr "Dernière modification"
 
-#: DynamicWeb/dynamicweb.py:2506
+#: DynamicWeb//dynamicweb.py:2511
 msgid "Latitude"
 msgstr "Latitude"
 
-#: DynamicWeb/dynamicweb.py:2507
+#: DynamicWeb//dynamicweb.py:2512
 msgid "Link"
 msgstr "Lien"
 
 # Substantif (GNOME fr)
-#: DynamicWeb/dynamicweb.py:2508
+#: DynamicWeb//dynamicweb.py:2513
 msgid "Loading..."
 msgstr "En charge..."
 
-#: DynamicWeb/dynamicweb.py:2509
+#: DynamicWeb//dynamicweb.py:2514
 msgid "Location"
 msgstr "Emplacement"
 
-#: DynamicWeb/dynamicweb.py:2510
+#: DynamicWeb//dynamicweb.py:2515
 msgid "Longitude"
 msgstr "Longitude"
 
-#: DynamicWeb/dynamicweb.py:2511
+#: DynamicWeb//dynamicweb.py:2516
 msgid "M"
 msgstr "M"
 
-#: DynamicWeb/dynamicweb.py:2512
+#: DynamicWeb//dynamicweb.py:2517
 msgid "Male"
 msgstr "Masculin"
 
-#: DynamicWeb/dynamicweb.py:2513
+#: DynamicWeb//dynamicweb.py:2518
 msgid "Map"
 msgstr "Plan"
 
-#: DynamicWeb/dynamicweb.py:2514
+#: DynamicWeb//dynamicweb.py:2519
 msgid "Marriage"
 msgstr "Mariage"
 
-#: DynamicWeb/dynamicweb.py:2515
+#: DynamicWeb//dynamicweb.py:2520
 msgid "Maximize"
 msgstr "Agrandir"
 
-#: DynamicWeb/dynamicweb.py:2516
+#: DynamicWeb//dynamicweb.py:2521
 msgid "Media Index"
 msgstr "Index des media"
 
-#: DynamicWeb/dynamicweb.py:2517
+#: DynamicWeb//dynamicweb.py:2522
 msgid "Media Type"
 msgstr "Type du media"
 
-#: DynamicWeb/dynamicweb.py:2519
+#: DynamicWeb//dynamicweb.py:2524
 msgid "Mother"
 msgstr "Mère "
 
 # L'espace finale est pour précéder le « : » codé en dur dans certains contextes.
-#: DynamicWeb/dynamicweb.py:2520
+#: DynamicWeb//dynamicweb.py:2525
 msgid "Name"
 msgstr "Nom "
 
-#: DynamicWeb/dynamicweb.py:2521
+#: DynamicWeb//dynamicweb.py:2526
 msgid "Nick Name"
 msgstr "Surnom"
 
-#: DynamicWeb/dynamicweb.py:2522
+#: DynamicWeb//dynamicweb.py:2527
 msgid "No data available in table"
 msgstr "Pas de données disponible dans la table"
 
-#: DynamicWeb/dynamicweb.py:2523
+#: DynamicWeb//dynamicweb.py:2528
 msgid "No matches found"
 msgstr "Aucune correspondance trouvée"
 
-#: DynamicWeb/dynamicweb.py:2524
+#: DynamicWeb//dynamicweb.py:2529
 msgid "No matching records found"
 msgstr "Pas d'objets correspondant trouvés"
 
-#: DynamicWeb/dynamicweb.py:2525
+#: DynamicWeb//dynamicweb.py:2530
 msgid "No matching surname."
 msgstr "Il n'y a pas de nom correspondant."
 
-#: DynamicWeb/dynamicweb.py:2526
+#: DynamicWeb//dynamicweb.py:2531
 msgid "None"
 msgstr "Aucun"
 
-#: DynamicWeb/dynamicweb.py:2527
+#: DynamicWeb//dynamicweb.py:2532
 msgid "Notes"
 msgstr "Notes"
 
-#: DynamicWeb/dynamicweb.py:2528
+#: DynamicWeb//dynamicweb.py:2533
+#, fuzzy
+msgid "Number"
+msgstr "Numéro d'identifiant"
+
+#: DynamicWeb//dynamicweb.py:2534
 msgid "OK"
 msgstr "OK"
 
-#: DynamicWeb/dynamicweb.py:2529
+#: DynamicWeb//dynamicweb.py:2535
 msgid "Other participants"
 msgstr "Autres participants"
 
-#: DynamicWeb/dynamicweb.py:2530
+#: DynamicWeb//dynamicweb.py:2536
 msgid "Parents"
 msgstr "Parents "
 
-#: DynamicWeb/dynamicweb.py:2531
+#: DynamicWeb//dynamicweb.py:2537
 msgid "Path"
 msgstr "Chemin"
 
-#: DynamicWeb/dynamicweb.py:2532
+#: DynamicWeb//dynamicweb.py:2538
 msgid "Person page"
 msgstr "Page d'individu"
 
-#: DynamicWeb/dynamicweb.py:2533
+#: DynamicWeb//dynamicweb.py:2539
 msgid "Person to search for"
 msgstr "Personne à rechercher"
 
-#: DynamicWeb/dynamicweb.py:2535
+#: DynamicWeb//dynamicweb.py:2541
 msgid "Persons Index"
 msgstr "Index des personnes"
 
-#: DynamicWeb/dynamicweb.py:2536
+#: DynamicWeb//dynamicweb.py:2542
 msgid "Persons"
 msgstr "Personnes"
 
-#: DynamicWeb/dynamicweb.py:2538
+#: DynamicWeb//dynamicweb.py:2544
 msgid "Places Index"
 msgstr "Index des lieux"
 
-#: DynamicWeb/dynamicweb.py:2540
+#: DynamicWeb//dynamicweb.py:2546
 msgid "Preparing file ..."
 msgstr "Préparation du fichier ..."
 
-#: DynamicWeb/dynamicweb.py:2541
+#: DynamicWeb//dynamicweb.py:2547
 msgid "Processing..."
 msgstr "Traitement en cours..."
 
-#: DynamicWeb/dynamicweb.py:2543
+#: DynamicWeb//dynamicweb.py:2549
 msgid "References"
 msgstr "Références"
 
-#: DynamicWeb/dynamicweb.py:2544
+#: DynamicWeb//dynamicweb.py:2550
 msgid "Relationship to Father"
 msgstr "Relation au père"
 
-#: DynamicWeb/dynamicweb.py:2545
+#: DynamicWeb//dynamicweb.py:2551
 msgid "Relationship to Mother"
 msgstr "Relation à la mère"
 
-#: DynamicWeb/dynamicweb.py:2546
+#: DynamicWeb//dynamicweb.py:2552
 msgid "Relationship"
 msgstr "Relation "
 
-#: DynamicWeb/dynamicweb.py:2549
+#: DynamicWeb//dynamicweb.py:2553
+#, fuzzy
+msgid "Repositories Index"
+msgstr "Dépôts"
+
+#: DynamicWeb//dynamicweb.py:2556
 msgid "Restore"
 msgstr "Restaurer"
 
-#: DynamicWeb/dynamicweb.py:2550
+#: DynamicWeb//dynamicweb.py:2557
 msgid "Restore default settings"
 msgstr "Restaurer les paramètres par défaut"
 
-#: DynamicWeb/dynamicweb.py:2551 DynamicWeb/dynamicweb.py:4100
+#: DynamicWeb//dynamicweb.py:2558 DynamicWeb//dynamicweb.py:4112
 msgid "Show last modification time"
 msgstr "Affiche la date de dernière modification"
 
-#: DynamicWeb/dynamicweb.py:2552 DynamicWeb/dynamicweb.py:4191
+#: DynamicWeb//dynamicweb.py:2559 DynamicWeb//dynamicweb.py:4203
 msgid "SVG tree children distribution"
 msgstr "Répartition des enfants dans l'arbre SVG"
 
-#: DynamicWeb/dynamicweb.py:2553
+#: DynamicWeb//dynamicweb.py:2560
 msgid "SVG tree configuration"
 msgstr "Configuration de l'arbre SVG"
 
-#: DynamicWeb/dynamicweb.py:2554 DynamicWeb/dynamicweb.py:4179
+#: DynamicWeb//dynamicweb.py:2561 DynamicWeb//dynamicweb.py:4191
 msgid "SVG tree graph shape"
 msgstr "Forme de l'arbre SVG"
 
-#: DynamicWeb/dynamicweb.py:2555 DynamicWeb/dynamicweb.py:4173
+#: DynamicWeb//dynamicweb.py:2562 DynamicWeb//dynamicweb.py:4185
 msgid "SVG tree graph type"
 msgstr "Type d'arbre graphique SVG"
 
-#: DynamicWeb/dynamicweb.py:2556 DynamicWeb/dynamicweb.py:4185
+#: DynamicWeb//dynamicweb.py:2563 DynamicWeb//dynamicweb.py:4197
 msgid "SVG tree parents distribution"
 msgstr "Répartition des parents dans l'arbre SVG"
 
-#: DynamicWeb/dynamicweb.py:2557
+#: DynamicWeb//dynamicweb.py:2564
 msgid "Save tree as file"
 msgstr "Enregistrer l'arbre dans un fichier"
 
-#: DynamicWeb/dynamicweb.py:2558
+#: DynamicWeb//dynamicweb.py:2565
 msgid "Search:"
 msgstr "Recherche:"
 
-#: DynamicWeb/dynamicweb.py:2559
+#: DynamicWeb//dynamicweb.py:2566
 msgid "Select the background color scheme"
 msgstr "Sélection de la trame de fond"
 
-#: DynamicWeb/dynamicweb.py:2560
+#: DynamicWeb//dynamicweb.py:2567
 msgid "Select the children distribution (fan charts only)"
 msgstr ""
 "Sélection de la répartition des enfants (pour les graphiques circulaires)"
 
-#: DynamicWeb/dynamicweb.py:2561
+#: DynamicWeb//dynamicweb.py:2568
 msgid "Select the number of ascending generations"
 msgstr "Sélection du nombre de générations ascendantes"
 
-#: DynamicWeb/dynamicweb.py:2562
+#: DynamicWeb//dynamicweb.py:2569
 msgid "Select the number of descending generations"
 msgstr "Sélection du nombre de générations descendantes"
 
-#: DynamicWeb/dynamicweb.py:2563
+#: DynamicWeb//dynamicweb.py:2570
 msgid "Select the parents distribution (fan charts only)"
 msgstr ""
 "Sélection de la répartition des parents (pour les graphiques circulaires)"
 
-#: DynamicWeb/dynamicweb.py:2564
+#: DynamicWeb//dynamicweb.py:2571
 msgid "Select the shape of graph"
 msgstr "Sélection de la forme du graphique"
 
-#: DynamicWeb/dynamicweb.py:2565
+#: DynamicWeb//dynamicweb.py:2572
 msgid "Select the type of graph"
 msgstr "Sélection du type de graphe"
 
-#: DynamicWeb/dynamicweb.py:2566
+#: DynamicWeb//dynamicweb.py:2573
 msgid "Several matches.<br>Precise your search or choose in the lists below."
 msgstr ""
 "Plusieurs correspondances.<br>Précisez votre recherche ou choisissez dans "
 "les listes ci-dessous."
 
-#: DynamicWeb/dynamicweb.py:2567
+#: DynamicWeb//dynamicweb.py:2574
 msgid "Show _MENU_ entries"
 msgstr "Afficher _MENU_ éléments"
 
-#: DynamicWeb/dynamicweb.py:2568 DynamicWeb/dynamicweb.py:4209
+#: DynamicWeb//dynamicweb.py:2575 DynamicWeb//dynamicweb.py:4221
 msgid "Show duplicates"
 msgstr "Affiche les doublons"
 
-#: DynamicWeb/dynamicweb.py:2569
+#: DynamicWeb//dynamicweb.py:2576
 msgid "Showing 0 to 0 of 0 entries"
 msgstr "Eléments 0 à 0 affichés parmi 0"
 
-#: DynamicWeb/dynamicweb.py:2570
+#: DynamicWeb//dynamicweb.py:2577
 msgid "Showing _START_ to _END_ of _TOTAL_ entries"
 msgstr "Eléments _START_ à _END_ affichés parmi _TOTAL_"
 
-#: DynamicWeb/dynamicweb.py:2571
+#: DynamicWeb//dynamicweb.py:2578
 msgid "Siblings"
 msgstr "Frères et sœurs "
 
-#: DynamicWeb/dynamicweb.py:2573
+#: DynamicWeb//dynamicweb.py:2579
+msgid "Sort by:"
+msgstr ""
+
+#: DynamicWeb//dynamicweb.py:2581
 msgid "Sources Index"
 msgstr "Index des sources"
 
-#: DynamicWeb/dynamicweb.py:2575
+#: DynamicWeb//dynamicweb.py:2583
 msgid "Spouses"
 msgstr "Conjoints"
 
-#: DynamicWeb/dynamicweb.py:2576 DynamicWeb/dynamicweb.py:4108
+#: DynamicWeb//dynamicweb.py:2584 DynamicWeb//dynamicweb.py:4120
 msgid "Suppress Gramps ID"
 msgstr "Supprimer les identifiants Gramps"
 
-#: DynamicWeb/dynamicweb.py:2577
+#: DynamicWeb//dynamicweb.py:2585
 msgid "Surname"
 msgstr "Nom"
 
-#: DynamicWeb/dynamicweb.py:2578
+#: DynamicWeb//dynamicweb.py:2586
 msgid "Surnames Index"
 msgstr "Index des patronymes"
 
-#: DynamicWeb/dynamicweb.py:2580
+#: DynamicWeb//dynamicweb.py:2588
 msgid "Title"
 msgstr "Titre"
 
-#: DynamicWeb/dynamicweb.py:2581
+#: DynamicWeb//dynamicweb.py:2589
 msgid "Type"
 msgstr "Type "
 
-#: DynamicWeb/dynamicweb.py:2582
+#: DynamicWeb//dynamicweb.py:2590
 msgid "U"
 msgstr "?"
 
-#: DynamicWeb/dynamicweb.py:2583
+#: DynamicWeb//dynamicweb.py:2591
 msgid "Unknown"
 msgstr "Inconnu"
 
-#: DynamicWeb/dynamicweb.py:2584 DynamicWeb/dynamicweb.py:4096
+#: DynamicWeb//dynamicweb.py:2592 DynamicWeb//dynamicweb.py:4108
 msgid "Use tabbed panels instead of sections"
 msgstr "Utiliser des onglets à la place des paragraphes"
 
-#: DynamicWeb/dynamicweb.py:2585
+#: DynamicWeb//dynamicweb.py:2593
 msgid "Use the search box above in order to find a person."
 msgstr ""
 "Utilisez le formulaire de recherche ci-dessus pour trouver un individu."
 
-#: DynamicWeb/dynamicweb.py:2586
+#: DynamicWeb//dynamicweb.py:2594
+#, fuzzy
+msgid "Use a table format for the surnames index"
+msgstr "Format par défaut de l'index des nom de famille"
+
+#: DynamicWeb//dynamicweb.py:2595
+#, fuzzy
+msgid "Use a table format for the persons index"
+msgstr "Format par défaut de l'index des personnes"
+
+#: DynamicWeb//dynamicweb.py:2596
+#, fuzzy
+msgid "Use a table format for the families index"
+msgstr "Format par défaut de l'index des familles"
+
+#: DynamicWeb//dynamicweb.py:2597
+#, fuzzy
+msgid "Use a table format for the sources index"
+msgstr "Format par défaut de l'index des sources"
+
+#: DynamicWeb//dynamicweb.py:2598
+#, fuzzy
+msgid "Use a table format for the places index"
+msgstr "Format par défaut de l'index des lieux"
+
+#: DynamicWeb//dynamicweb.py:2599
 msgid "Used for family"
 msgstr "Référencé par les familles"
 
-#: DynamicWeb/dynamicweb.py:2587
+#: DynamicWeb//dynamicweb.py:2600
 msgid "Used for media"
 msgstr "Référencé par les médias"
 
-#: DynamicWeb/dynamicweb.py:2588
+#: DynamicWeb//dynamicweb.py:2601
 msgid "Used for person"
 msgstr "Référencé par les personnes"
 
-#: DynamicWeb/dynamicweb.py:2589
+#: DynamicWeb//dynamicweb.py:2602
 msgid "Used for place"
 msgstr "Référencé par les lieux"
 
-#: DynamicWeb/dynamicweb.py:2590
+#: DynamicWeb//dynamicweb.py:2603
 msgid "Used for source"
 msgstr "Référencé par les sources"
 
-#: DynamicWeb/dynamicweb.py:2591
+#: DynamicWeb//dynamicweb.py:2604
 msgid "Value"
 msgstr "Valeur"
 
-#: DynamicWeb/dynamicweb.py:2592
+#: DynamicWeb//dynamicweb.py:2605
 msgid "Web Link"
 msgstr "Lien internet"
 
-#: DynamicWeb/dynamicweb.py:2593
+#: DynamicWeb//dynamicweb.py:2606
 msgid "Web Links"
 msgstr "Liens internet"
 
-#: DynamicWeb/dynamicweb.py:2594 DynamicWeb/dynamicweb.py:4210
+#: DynamicWeb//dynamicweb.py:2607 DynamicWeb//dynamicweb.py:4222
 msgid ""
 "Whether to use a special color for the persons that appear several times in "
 "the SVG tree"
@@ -915,45 +993,50 @@ msgstr ""
 "Utiliser ou non une couleur spéciale pour les individus qui apparaissent "
 "plusieurs fois dans l'arbre SVG"
 
-#: DynamicWeb/dynamicweb.py:2595
+#: DynamicWeb//dynamicweb.py:2608
 msgid "Without name"
 msgstr "Sans nom"
 
-#: DynamicWeb/dynamicweb.py:2596
+#: DynamicWeb//dynamicweb.py:2609
 msgid "Without surname"
 msgstr "Sans patronyme"
 
-#: DynamicWeb/dynamicweb.py:2597
+#: DynamicWeb//dynamicweb.py:2610
 msgid "Without title"
 msgstr "Sans titre"
 
-#: DynamicWeb/dynamicweb.py:2598
+#: DynamicWeb//dynamicweb.py:2611
 msgid "Zoom in"
 msgstr "Zoom avant"
 
-#: DynamicWeb/dynamicweb.py:2599
+#: DynamicWeb//dynamicweb.py:2612
 msgid "Zoom out"
 msgstr "Zoom arrière"
 
-#: DynamicWeb/dynamicweb.py:2600
+#: DynamicWeb//dynamicweb.py:2613
 msgid "all"
 msgstr "tout"
 
-#: DynamicWeb/dynamicweb.py:2941
+#: DynamicWeb//dynamicweb.py:2816
+#, fuzzy
+msgid "No Home Person"
+msgstr "Page d'accueil"
+
+#: DynamicWeb//dynamicweb.py:2957
 #, python-format
 msgid "Copying error: %(error)s"
 msgstr "Erreur de copie: %(error)s"
 
-#: DynamicWeb/dynamicweb.py:2942
+#: DynamicWeb//dynamicweb.py:2958
 #, python-format
 msgid "Impossible to copy \"%(src)s\" to \"%(dst)s\""
 msgstr "Échec de la copie de \"%(src)s\" vers \"%(dst)s\""
 
-#: DynamicWeb/dynamicweb.py:2945
+#: DynamicWeb//dynamicweb.py:2961
 msgid "Possible destination error"
 msgstr "Possible erreur de destination"
 
-#: DynamicWeb/dynamicweb.py:2946
+#: DynamicWeb//dynamicweb.py:2962
 msgid ""
 "You appear to have set your target directory to a directory used for data "
 "storage. This could create problems with file management. It is recommended "
@@ -965,71 +1048,66 @@ msgstr ""
 "recommandé d'utiliser un répertoire différent pour stocker les pages "
 "internet générées."
 
-#: DynamicWeb/dynamicweb.py:2973
+#: DynamicWeb//dynamicweb.py:2989
 #, python-format
 msgid "Unable to copy web site template files from \"%(path)s\""
 msgstr "Impossible de copier le modèle de site web depuis \"%(path)s\""
 
-#: DynamicWeb/dynamicweb.py:3017
+#: DynamicWeb//dynamicweb.py:3033
 #, python-format
 msgid "Keeping \"%(dst)s\" (newer than \"%(src)s\")"
 msgstr "Conserve \"%(dst)s\" (plus récent que \"%(src)s\")"
 
-#: DynamicWeb/dynamicweb.py:3020
+#: DynamicWeb//dynamicweb.py:3036
 #, python-format
 msgid "Copying \"%(src)s\" to \"%(dst)s\""
 msgstr "Copie de \"%(src)s\" vers \"%(dst)s\""
 
-#: DynamicWeb/dynamicweb.py:3038
+#: DynamicWeb//dynamicweb.py:3054
 msgid "Invalid file name"
 msgstr "Nom de fichier invalide"
 
-#: DynamicWeb/dynamicweb.py:3039
+#: DynamicWeb//dynamicweb.py:3055
 msgid "The archive file must be a file, not a directory"
 msgstr "L'archive doit être un fichier, pas un répertoire"
 
-#: DynamicWeb/dynamicweb.py:3049 DynamicWeb/dynamicweb.py:3067
+#: DynamicWeb//dynamicweb.py:3065 DynamicWeb//dynamicweb.py:3083
 #, python-format
 msgid "Unable to overwrite archive file \"%(path)s\""
 msgstr "Impossible de créer le fichier d'archive \"%(path)s\""
 
-#: DynamicWeb/dynamicweb.py:3059 DynamicWeb/dynamicweb.py:3074
+#: DynamicWeb//dynamicweb.py:3075 DynamicWeb//dynamicweb.py:3090
 #, python-format
 msgid "Unable to add file \"%(file)s\" to archive \"%(archive)s\""
 msgstr ""
 "Impossible d'ajouter le fichier \"%(file)s\" à l'archive \"%(archive)s\""
 
-#: DynamicWeb/dynamicweb.py:3126
+#: DynamicWeb//dynamicweb.py:3143
 #, python-format
 msgid "DynamicWebReport ignoring link type '%(class)s'"
 msgstr "DynamicWebReport ignore le type de lien '%(class)s'"
 
-# Substantif (GNOME fr)
-#: DynamicWeb/dynamicweb.py:3367
-msgid "Applying Person Filter..."
-msgstr "Application du filtre individu..."
-
-#: DynamicWeb/dynamicweb.py:3373
+#: DynamicWeb//dynamicweb.py:3386
 msgid "Constructing list of other objects..."
 msgstr "Construction d'une liste d'autres objets..."
 
 # trunk
-#: DynamicWeb/dynamicweb.py:3512
+#: DynamicWeb//dynamicweb.py:3521
 #, python-format
 msgid "Family of %(husband)s and %(spouse)s"
 msgstr "Famille de %(husband)s et %(spouse)s"
 
-#: DynamicWeb/dynamicweb.py:3518
+#: DynamicWeb//dynamicweb.py:3527
 #, python-format
 msgid "Family of %(father)s"
 msgstr "Famille de %(father)s"
 
-#: DynamicWeb/dynamicweb.py:3522
+#: DynamicWeb//dynamicweb.py:3531
 #, python-format
 msgid "Family of %(mother)s"
 msgstr "Famille de %(mother)s"
 
-#: DynamicWeb/dynamicweb.py:3835
+#: DynamicWeb//dynamicweb.py:3846
 msgid ""
 "In this note, the following special words are processed:\n"
 "__SEARCH_FORM__ is replaced by a search form.\n"
@@ -1066,142 +1144,142 @@ msgstr ""
 "Les URL commençant par \"relative://relative.<link>\" sont remplacées par "
 "l'URL relative \"<link>\".\n"
 
-#: DynamicWeb/dynamicweb.py:3874
+#: DynamicWeb//dynamicweb.py:3886
 msgid "Report"
 msgstr "Rapport"
 
-#: DynamicWeb/dynamicweb.py:3879
+#: DynamicWeb//dynamicweb.py:3891
 msgid "Destination"
 msgstr "Destination"
 
-#: DynamicWeb/dynamicweb.py:3881
+#: DynamicWeb//dynamicweb.py:3893
 msgid "The destination directory for the web files"
 msgstr "Le répertoire de destination pour les fichiers internet"
 
-#: DynamicWeb/dynamicweb.py:3885
+#: DynamicWeb//dynamicweb.py:3897
 msgid "Store web pages in archive"
 msgstr "Enregistre les pages web dans un fichier archive"
 
-#: DynamicWeb/dynamicweb.py:3886
+#: DynamicWeb//dynamicweb.py:3898
 msgid ""
 "Whether to create an archive file (in ZIP or TGZ format) containing the web "
 "site"
 msgstr ""
 "Créer ou non un fichier archive (au format ZIP ou TGZ) contenant le site web"
 
-#: DynamicWeb/dynamicweb.py:3890
+#: DynamicWeb//dynamicweb.py:3902
 msgid "Archive file"
 msgstr "Fichier d'archive"
 
-#: DynamicWeb/dynamicweb.py:3892
+#: DynamicWeb//dynamicweb.py:3904
 msgid "The archive file name (with \".zip\" or \".tgz\" extension)"
 msgstr "Le nom du fichier archive (avec l'extension \".zip\" ou \".tgz\")"
 
-#: DynamicWeb/dynamicweb.py:3898
+#: DynamicWeb//dynamicweb.py:3910
 msgid "Web site title"
 msgstr "Titre du site"
 
-#: DynamicWeb/dynamicweb.py:3898
+#: DynamicWeb//dynamicweb.py:3910
 msgid "My Family Tree"
 msgstr "Mon arbre généalogique"
 
-#: DynamicWeb/dynamicweb.py:3899
+#: DynamicWeb//dynamicweb.py:3911
 msgid "The title of the web site"
 msgstr "Le titre du site internet"
 
-#: DynamicWeb/dynamicweb.py:3902
+#: DynamicWeb//dynamicweb.py:3914
 msgid "Filter"
 msgstr "Filtre"
 
-#: DynamicWeb/dynamicweb.py:3904
+#: DynamicWeb//dynamicweb.py:3916
 msgid "Select filter to restrict people that appear on web site"
 msgstr ""
 "Sélectionnez un filtre pour restreindre les individus qui apparaîtront dans "
 "le site web"
 
-#: DynamicWeb/dynamicweb.py:3908
+#: DynamicWeb//dynamicweb.py:3920
 msgid "Filter Person"
 msgstr "Filtre sur l'individu"
 
-#: DynamicWeb/dynamicweb.py:3909
+#: DynamicWeb//dynamicweb.py:3921
 msgid "The center person for the filter"
 msgstr "L'individu central pour ce filtre"
 
-#: DynamicWeb/dynamicweb.py:3917 DynamicWeb/dynamicweb.py:3937
+#: DynamicWeb//dynamicweb.py:3929 DynamicWeb//dynamicweb.py:3949
 msgid "Name format (short)"
 msgstr "Format de nom (court)"
 
-#: DynamicWeb/dynamicweb.py:3918 DynamicWeb/dynamicweb.py:3940
+#: DynamicWeb//dynamicweb.py:3930 DynamicWeb//dynamicweb.py:3952
 msgid "Select the format to display a shorter version of the names"
 msgstr "Sélectionner le format d'affichage des versions courtes des noms"
 
 # L'espace finale est pour précéder le « : » codé en dur.
-#: DynamicWeb/dynamicweb.py:3932
+#: DynamicWeb//dynamicweb.py:3944
 msgid "Name format"
 msgstr "Format des noms "
 
-#: DynamicWeb/dynamicweb.py:3935
+#: DynamicWeb//dynamicweb.py:3947
 msgid "Select the format to display names"
 msgstr "Sélection du format d'affichage pour le nom"
 
-#: DynamicWeb/dynamicweb.py:3943
+#: DynamicWeb//dynamicweb.py:3955
 msgid "Web site template"
 msgstr "Modèle de site web"
 
-#: DynamicWeb/dynamicweb.py:3946
+#: DynamicWeb//dynamicweb.py:3958
 msgid "Select the template of the web site"
 msgstr "Sélectionner le modèle de site web"
 
-#: DynamicWeb/dynamicweb.py:3949
+#: DynamicWeb//dynamicweb.py:3961
 msgid "Copyright"
 msgstr "Licence"
 
-#: DynamicWeb/dynamicweb.py:3952
+#: DynamicWeb//dynamicweb.py:3964
 msgid "The copyright to be used for the web files"
 msgstr "Le droit d'auteur utilisé pour les fichiers internet"
 
-#: DynamicWeb/dynamicweb.py:3960
+#: DynamicWeb//dynamicweb.py:3972
 msgid "Privacy"
 msgstr "Vie privée"
 
-#: DynamicWeb/dynamicweb.py:3968
+#: DynamicWeb//dynamicweb.py:3980
 msgid "Include records marked private"
 msgstr "Inclure les données privées"
 
-#: DynamicWeb/dynamicweb.py:3969
+#: DynamicWeb//dynamicweb.py:3981
 msgid "Whether to include private objects"
 msgstr "Inclure ou non les objets privés"
 
-#: DynamicWeb/dynamicweb.py:3971
+#: DynamicWeb//dynamicweb.py:3983
 msgid "Living People"
 msgstr "Individus vivants"
 
-#: DynamicWeb/dynamicweb.py:3972
+#: DynamicWeb//dynamicweb.py:3984
 msgid "Exclude"
 msgstr "Exclure"
 
-#: DynamicWeb/dynamicweb.py:3973
+#: DynamicWeb//dynamicweb.py:3985
 msgid "Include Last Name Only"
 msgstr "N'inclure que le nom"
 
-#: DynamicWeb/dynamicweb.py:3974
+#: DynamicWeb//dynamicweb.py:3986
 msgid "Include Full Name Only"
 msgstr "Inclure le nom complet"
 
-#: DynamicWeb/dynamicweb.py:3975
+#: DynamicWeb//dynamicweb.py:3987
 msgid "Include"
 msgstr "Inclure"
 
 # Substantif (GNOME fr)
-#: DynamicWeb/dynamicweb.py:3976
+#: DynamicWeb//dynamicweb.py:3988
 msgid "How to handle living people"
 msgstr "Gestion des individus vivants"
 
-#: DynamicWeb/dynamicweb.py:3979
+#: DynamicWeb//dynamicweb.py:3991
 msgid "Years from death to consider living"
 msgstr "Années depuis le décès"
 
-#: DynamicWeb/dynamicweb.py:3980
+#: DynamicWeb//dynamicweb.py:3992
 msgid ""
 "This allows you to restrict information on people who have not been dead for "
 "very long"
@@ -1209,87 +1287,87 @@ msgstr ""
 "Ceci vous permet de restreindre l'information sur les individus décédés il y "
 "a peu de temps"
 
-#: DynamicWeb/dynamicweb.py:3984
+#: DynamicWeb//dynamicweb.py:3996
 msgid "Export notes"
 msgstr "Exporter les notes"
 
-#: DynamicWeb/dynamicweb.py:3985
+#: DynamicWeb//dynamicweb.py:3997
 msgid "Whether to export notes in the web pages"
 msgstr "Exporter ou non les notes dans les pages web"
 
-#: DynamicWeb/dynamicweb.py:3988
+#: DynamicWeb//dynamicweb.py:4000
 msgid "Export sources"
 msgstr "Exporter les sources"
 
-#: DynamicWeb/dynamicweb.py:3989
+#: DynamicWeb//dynamicweb.py:4001
 msgid "Whether to export sources and citations in the web pages"
 msgstr "Exporter ou non les sources et citations dans les pages web"
 
-#: DynamicWeb/dynamicweb.py:3992
+#: DynamicWeb//dynamicweb.py:4004
 msgid "Export addresses"
 msgstr "Exporter les addresses"
 
-#: DynamicWeb/dynamicweb.py:3993
+#: DynamicWeb//dynamicweb.py:4005
 msgid "Whether to export addresses in the web pages"
 msgstr "Exporter ou non les addresses dans les pages web"
 
-#: DynamicWeb/dynamicweb.py:3998
+#: DynamicWeb//dynamicweb.py:4010
 msgid "Options"
 msgstr "Options"
 
-#: DynamicWeb/dynamicweb.py:4001
+#: DynamicWeb//dynamicweb.py:4013
 msgid "Include repository pages"
 msgstr "Inclure les pages dépôt"
 
-#: DynamicWeb/dynamicweb.py:4002
+#: DynamicWeb//dynamicweb.py:4014
 msgid "Whether or not to include the Repository Pages."
 msgstr "Inclure ou non des pages dépôt."
 
-#: DynamicWeb/dynamicweb.py:4005
+#: DynamicWeb//dynamicweb.py:4017
 msgid "Include images and media"
 msgstr "Inclure image et media"
 
-#: DynamicWeb/dynamicweb.py:4006
+#: DynamicWeb//dynamicweb.py:4018
 msgid "Whether to include images and media in the web pages"
 msgstr "Inclure ou non les images et media dans les pages web"
 
-#: DynamicWeb/dynamicweb.py:4010
+#: DynamicWeb//dynamicweb.py:4022
 msgid "Copy, rename files with an internal Gramps identifier"
 msgstr "Copie, renomme les fichiers avec un identifiant interne Gramps"
 
-#: DynamicWeb/dynamicweb.py:4011
+#: DynamicWeb//dynamicweb.py:4023
 msgid "Copy, keep file names unchanged"
 msgstr "Copie, conserve les noms de fichier"
 
-#: DynamicWeb/dynamicweb.py:4012
+#: DynamicWeb//dynamicweb.py:4024
 msgid "Do not copy, reference existing files"
 msgstr "Ne copie pas, référence les fichiers existants"
 
-#: DynamicWeb/dynamicweb.py:4014
+#: DynamicWeb//dynamicweb.py:4026
 msgid "Images and media"
 msgstr "Images et media"
 
-#: DynamicWeb/dynamicweb.py:4017
+#: DynamicWeb//dynamicweb.py:4029
 msgid "Whether to make a copy of the media"
 msgstr "Copier on non les media"
 
-#: DynamicWeb/dynamicweb.py:4020
+#: DynamicWeb//dynamicweb.py:4032
 msgid "Print the notes type"
 msgstr "Imprimer le type des notes"
 
-#: DynamicWeb/dynamicweb.py:4021
+#: DynamicWeb//dynamicweb.py:4033
 msgid "Whether to print the notes type in the notes text"
 msgstr "Imprimer ou non le type des notes dans le texte des notes"
 
-#: DynamicWeb/dynamicweb.py:4024
+#: DynamicWeb//dynamicweb.py:4036
 msgid "Print place pages"
 msgstr "Afficher des pages pour les lieux"
 
-#: DynamicWeb/dynamicweb.py:4025
+#: DynamicWeb//dynamicweb.py:4037
 msgid "Whether to show pages for the places"
 msgstr "Affiche ou non les pages pour les lieux"
 
-#: DynamicWeb/dynamicweb.py:4031
+#: DynamicWeb//dynamicweb.py:4043
 msgid ""
 "Whether to include a place map on the Place Pages, where Latitude/ Longitude "
 "are available."
@@ -1298,7 +1376,7 @@ msgstr ""
 "Longitude est disponible."
 
 # traduction qui tient compte du résultat généré ...
-#: DynamicWeb/dynamicweb.py:4039
+#: DynamicWeb//dynamicweb.py:4051
 msgid ""
 "Whether or not to add an individual page map showing all the places on this "
 "page. This will allow you to see how your family traveled around the country."
@@ -1307,168 +1385,168 @@ msgstr ""
 "page de l'individu. Ceci vous permettra de voir votre famille à travers ses "
 "lieux."
 
-#: DynamicWeb/dynamicweb.py:4047
+#: DynamicWeb//dynamicweb.py:4059
 msgid "Google"
 msgstr "Google"
 
-#: DynamicWeb/dynamicweb.py:4048
+#: DynamicWeb//dynamicweb.py:4060
 msgid "OpenStreetMap"
 msgstr "OpenStreetMap"
 
-#: DynamicWeb/dynamicweb.py:4050
+#: DynamicWeb//dynamicweb.py:4062
 msgid "Map Service"
 msgstr "Service cartographique"
 
-#: DynamicWeb/dynamicweb.py:4053
+#: DynamicWeb//dynamicweb.py:4065
 msgid "Choose your choice of map service for creating the Place Map Pages"
 msgstr ""
 "Choisissez votre service cartographique pour la création des pages Carte du "
 "lieu"
 
-#: DynamicWeb/dynamicweb.py:4057
+#: DynamicWeb//dynamicweb.py:4069
 msgid "Google map API key"
 msgstr "Clé de l'API Google Map"
 
-#: DynamicWeb/dynamicweb.py:4058
+#: DynamicWeb//dynamicweb.py:4070
 msgid "The API key used for the Google map"
 msgstr "La clé utilisée pour l'API Google Map"
 
 # trunk
-#: DynamicWeb/dynamicweb.py:4065
+#: DynamicWeb//dynamicweb.py:4077
 msgid "Advanced"
 msgstr "Avancé"
 
-#: DynamicWeb/dynamicweb.py:4068
+#: DynamicWeb//dynamicweb.py:4080
 msgid "Character set encoding"
 msgstr "Encodage de caractères"
 
-#: DynamicWeb/dynamicweb.py:4071
+#: DynamicWeb//dynamicweb.py:4083
 msgid "The encoding to be used for the web files"
 msgstr "L'encodage utilisé pour les fichiers internet"
 
-#: DynamicWeb/dynamicweb.py:4074
+#: DynamicWeb//dynamicweb.py:4086
 msgid "Include family pages"
 msgstr "Inclure les pages de la famille"
 
-#: DynamicWeb/dynamicweb.py:4075
+#: DynamicWeb//dynamicweb.py:4087
 msgid "Whether or not to include family pages"
 msgstr "Inclure ou non des pages de la famille"
 
-#: DynamicWeb/dynamicweb.py:4085
+#: DynamicWeb//dynamicweb.py:4097
 msgid ""
 "Whether to include half and/ or step-siblings with the parents and siblings"
 msgstr ""
 "Inclure ou non les demi-frères et demi-sœurs avec les parents, frères et "
 "sœurs."
 
-#: DynamicWeb/dynamicweb.py:4088
+#: DynamicWeb//dynamicweb.py:4100
 msgid "Include GENDEX file (/gendex.txt)"
 msgstr "Inclure un fichier GENDEX (gendex.txt)"
 
-#: DynamicWeb/dynamicweb.py:4089
+#: DynamicWeb//dynamicweb.py:4101
 msgid "Whether to include a GENDEX file or not"
 msgstr "Inclure ou non un fichier GENDEX"
 
-#: DynamicWeb/dynamicweb.py:4092
+#: DynamicWeb//dynamicweb.py:4104
 msgid "Enable page configuration"
 msgstr "Activer la configuration des pages"
 
-#: DynamicWeb/dynamicweb.py:4093
+#: DynamicWeb//dynamicweb.py:4105
 msgid "Whether to enable page configuration"
 msgstr "Activer ou non la configuration des pages"
 
-#: DynamicWeb/dynamicweb.py:4097
+#: DynamicWeb//dynamicweb.py:4109
 msgid "Whether to use tabbed panels for the different sections of the pages."
 msgstr "Utiliser ou non des onglets à la place des paragraphes."
 
-#: DynamicWeb/dynamicweb.py:4101
+#: DynamicWeb//dynamicweb.py:4113
 msgid "Whether to show the last modification time in the pages footer"
 msgstr "Afficher ou non la date de dernière modification dans le pied de page"
 
-#: DynamicWeb/dynamicweb.py:4105
+#: DynamicWeb//dynamicweb.py:4117
 msgid "Whether to insert sources author in the sources title"
 msgstr "Insérer ou non l'auteur des sources dans le titre des sources"
 
-#: DynamicWeb/dynamicweb.py:4109
+#: DynamicWeb//dynamicweb.py:4121
 msgid "Whether to hide the Gramps ID"
 msgstr "Cacher ou no l'ID Gramps"
 
-#: DynamicWeb/dynamicweb.py:4118
+#: DynamicWeb//dynamicweb.py:4130
 msgid "List"
 msgstr "Liste"
 
-#: DynamicWeb/dynamicweb.py:4119
+#: DynamicWeb//dynamicweb.py:4131
 msgid "Table"
 msgstr "Tableau"
 
-#: DynamicWeb/dynamicweb.py:4122
+#: DynamicWeb//dynamicweb.py:4134
 msgid "Default format for the surnames index"
 msgstr "Format par défaut de l'index des nom de famille"
 
-#: DynamicWeb/dynamicweb.py:4122
+#: DynamicWeb//dynamicweb.py:4134
 msgid "The default format for the surnames index"
 msgstr "Le format par défaut de l'index des nom de famille"
 
-#: DynamicWeb/dynamicweb.py:4123
+#: DynamicWeb//dynamicweb.py:4135
 msgid "Default format for the persons index"
 msgstr "Format par défaut de l'index des personnes"
 
-#: DynamicWeb/dynamicweb.py:4123
+#: DynamicWeb//dynamicweb.py:4135
 msgid "The default format for the persons index"
 msgstr "Le format par défaut de l'index des personnes"
 
-#: DynamicWeb/dynamicweb.py:4124
+#: DynamicWeb//dynamicweb.py:4136
 msgid "Default format for the families index"
 msgstr "Format par défaut de l'index des familles"
 
-#: DynamicWeb/dynamicweb.py:4124
+#: DynamicWeb//dynamicweb.py:4136
 msgid "The default format for the families index"
 msgstr "Le format par défaut de l'index des familles"
 
-#: DynamicWeb/dynamicweb.py:4125
+#: DynamicWeb//dynamicweb.py:4137
 msgid "Default format for the sources index"
 msgstr "Format par défaut de l'index des sources"
 
-#: DynamicWeb/dynamicweb.py:4125
+#: DynamicWeb//dynamicweb.py:4137
 msgid "The default format for the sources index"
 msgstr "Le format par défaut de l'index des sources"
 
-#: DynamicWeb/dynamicweb.py:4126
+#: DynamicWeb//dynamicweb.py:4138
 msgid "Default format for the places index"
 msgstr "Format par défaut de l'index des lieux"
 
-#: DynamicWeb/dynamicweb.py:4126
+#: DynamicWeb//dynamicweb.py:4138
 msgid "The default format for the places index"
 msgstr "Le format par défaut de l'index des lieux"
 
-#: DynamicWeb/dynamicweb.py:4135
+#: DynamicWeb//dynamicweb.py:4147
 msgid ""
 "Whether to include dates columns (birth, death, marriage) on the index pages"
 msgstr ""
 "Inclure ou non des colonnes de date (naissance, décès, marriage) dans les "
 "pages index"
 
-#: DynamicWeb/dynamicweb.py:4139
+#: DynamicWeb//dynamicweb.py:4151
 msgid "Whether to include a partners column"
 msgstr "Inclure ou non une colonne conjoints"
 
-#: DynamicWeb/dynamicweb.py:4143
+#: DynamicWeb//dynamicweb.py:4155
 msgid "Whether to include a parents column"
 msgstr "Inclure ou non une colonne parents"
 
-#: DynamicWeb/dynamicweb.py:4146
+#: DynamicWeb//dynamicweb.py:4158
 msgid "Generate a families index page"
 msgstr "Générer un index des familles"
 
-#: DynamicWeb/dynamicweb.py:4147
+#: DynamicWeb//dynamicweb.py:4159
 msgid "Whether to generate an index page for families"
 msgstr "Générer ou pas un index des familles"
 
-#: DynamicWeb/dynamicweb.py:4151
+#: DynamicWeb//dynamicweb.py:4163
 msgid "Whether to include a column showing the media path"
 msgstr "Inclure ou non une colonne montrant les chemins des media"
 
-#: DynamicWeb/dynamicweb.py:4155
+#: DynamicWeb//dynamicweb.py:4167
 msgid ""
 "Whether to include the references to the items in the index pages. For "
 "example, in the media index page, the names of the individuals, families, "
@@ -1478,23 +1556,23 @@ msgstr ""
 "dans la page d'index des média, les noms des individus, familles, lieux, "
 "sources qui référencent chaque média."
 
-#: DynamicWeb/dynamicweb.py:4158
+#: DynamicWeb//dynamicweb.py:4170
 msgid "Default number of entries in the indexes"
 msgstr "Nombre de lignes par défaut dans les index"
 
-#: DynamicWeb/dynamicweb.py:4161
+#: DynamicWeb//dynamicweb.py:4173
 msgid "The default number of entries shown in one index page"
 msgstr "Nombre par défaut de lignes affichées dans les index"
 
-#: DynamicWeb/dynamicweb.py:4166
+#: DynamicWeb//dynamicweb.py:4178
 msgid "Trees"
 msgstr "Arbres"
 
-#: DynamicWeb/dynamicweb.py:4169
+#: DynamicWeb//dynamicweb.py:4181
 msgid "Maximum number of generations"
 msgstr "Nombre maximal de générations"
 
-#: DynamicWeb/dynamicweb.py:4170
+#: DynamicWeb//dynamicweb.py:4182
 msgid ""
 "The maximum number of generations to include in the ancestor and descendant "
 "trees and graphs"
@@ -1502,123 +1580,130 @@ msgstr ""
 "Le nombre mawimal de générations à inclure dans les arbres et graphiques, "
 "ascendants et descendants"
 
-#: DynamicWeb/dynamicweb.py:4176
+#: DynamicWeb//dynamicweb.py:4188
 msgid "Choose the default SVG tree graph type"
 msgstr "Sélection du type d'arbre SVG par défaut"
 
-#: DynamicWeb/dynamicweb.py:4182
+#: DynamicWeb//dynamicweb.py:4194
 msgid "Choose the default SVG tree graph shape"
 msgstr "Sélection de la forme d'arbre SVG par défaut"
 
-#: DynamicWeb/dynamicweb.py:4188
+#: DynamicWeb//dynamicweb.py:4200
 msgid "Choose the default SVG tree parents distribution (for fan charts only)"
 msgstr ""
 "Sélection de la répartition par défaut des parents dans l'arbre SVG (pour "
 "les graphiques circulaires)"
 
-#: DynamicWeb/dynamicweb.py:4194
+#: DynamicWeb//dynamicweb.py:4206
 msgid "Choose the default SVG tree children distribution (for fan charts only)"
 msgstr ""
 "Sélection de la répartition par défaut des enfants dans l'arbre SVG (pour "
 "les graphiques circulaires)"
 
-#: DynamicWeb/dynamicweb.py:4200
+#: DynamicWeb//dynamicweb.py:4212
 msgid ""
 "Choose the background color scheme for the persons in the SVG tree graph"
 msgstr ""
 "Sélection de la trame de fond par défaut des individus dans l'arbre SVG"
 
-#: DynamicWeb/dynamicweb.py:4203
+#: DynamicWeb//dynamicweb.py:4215
 msgid "Start gradient/Main color"
 msgstr "Gradient de départ/couleur principale"
 
-#: DynamicWeb/dynamicweb.py:4206
+#: DynamicWeb//dynamicweb.py:4218
 msgid "End gradient/2nd color"
 msgstr "Gradient de fin/deuxième couleur"
 
-#: DynamicWeb/dynamicweb.py:4214
+#: DynamicWeb//dynamicweb.py:4226
 msgid "Color for duplicates"
 msgstr "Couleur des doublons"
 
-#: DynamicWeb/dynamicweb.py:4219
+#: DynamicWeb//dynamicweb.py:4231
 msgid "Pages"
 msgstr "Pages"
 
 # espace limité dans la fenêtre, bug #3596
-#: DynamicWeb/dynamicweb.py:4222
+#: DynamicWeb//dynamicweb.py:4234
 msgid "HTML user header"
 msgstr "En-tête HTML"
 
-#: DynamicWeb/dynamicweb.py:4223
+#: DynamicWeb//dynamicweb.py:4235
 msgid "A note to be used as the page header"
 msgstr "La note utilisée pour l'en-tête de la page"
 
-#: DynamicWeb/dynamicweb.py:4226
+#: DynamicWeb//dynamicweb.py:4238
 msgid "HTML user brand name / icon"
 msgstr "Nom de compagnie / icône HTML"
 
-#: DynamicWeb/dynamicweb.py:4227
+#: DynamicWeb//dynamicweb.py:4239
 msgid "A note to be used as the brand name or image in the menu"
 msgstr "Une note à utiliser comme nom de marque ou comme image dans le menu"
 
 # espace limité dans la fenêtre, bug #3596
-#: DynamicWeb/dynamicweb.py:4230
+#: DynamicWeb//dynamicweb.py:4242
 msgid "HTML user footer"
 msgstr "Pied de page HTML"
 
-#: DynamicWeb/dynamicweb.py:4231
+#: DynamicWeb//dynamicweb.py:4243
 msgid "A note to be used as the page footer"
 msgstr "La note utilisée pour le pied de page"
 
-#: DynamicWeb/dynamicweb.py:4236
+#: DynamicWeb//dynamicweb.py:4248
 msgid "Custom pages"
 msgstr "Pages personnalisées"
 
-#: DynamicWeb/dynamicweb.py:4240
+#: DynamicWeb//dynamicweb.py:4252
 #, python-format
 msgid "Title for the custom page %(index)i"
 msgstr "Titre de la page personnalisée %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4241
+#: DynamicWeb//dynamicweb.py:4253
 #, python-format
 msgid "Name for the custom page %(index)i"
 msgstr "Nom de la page personnalisée %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4244
+#: DynamicWeb//dynamicweb.py:4256
 #, python-format
 msgid "Note for custom page %(index)i"
 msgstr "Note pour la page personnalisée %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4245
+#: DynamicWeb//dynamicweb.py:4257
 msgid "A note to be used for the custom page content.\n"
 msgstr "Une note à utiliser pour le contenu de la page personnalisée.\n"
 
-#: DynamicWeb/dynamicweb.py:4248
+#: DynamicWeb//dynamicweb.py:4260
 #, python-format
 msgid "Menu for the custom page %(index)i"
 msgstr "Menu de la page personnalisée %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4249
+#: DynamicWeb//dynamicweb.py:4261
 msgid "Whether to print a menu for the custom page"
 msgstr "Afficher ou non un menu pour la page personnalisée"
 
-#: DynamicWeb/dynamicweb.py:4254
+#: DynamicWeb//dynamicweb.py:4266
 msgid "Pages selection"
 msgstr "Sélection des pages"
 
-#: DynamicWeb/dynamicweb.py:4257
+#: DynamicWeb//dynamicweb.py:4269
 msgid "Number of pages"
 msgstr "Nombre de pages"
 
-#: DynamicWeb/dynamicweb.py:4258
+#: DynamicWeb//dynamicweb.py:4270
 msgid "Number pages in the web site menu."
 msgstr "Nombre de pages dans le menu du site web."
 
-#: DynamicWeb/dynamicweb.py:4274
+#: DynamicWeb//dynamicweb.py:4286
 #, python-format
 msgid "Contents of page %(index)i"
 msgstr "Contenu de la page %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4277
+#: DynamicWeb//dynamicweb.py:4289
 msgid "Contents of the page"
 msgstr "Contenu de la page"
+
+#~ msgid "Html|Home"
+#~ msgstr "Accueil"
+
+# Substantif (GNOME fr)
+#~ msgid "Applying Person Filter..."
+#~ msgstr "Application du filtre individu..."

--- a/DynamicWeb/po/hr-local.po
+++ b/DynamicWeb/po/hr-local.po
@@ -7,366 +7,366 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Gramps 5.x\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"POT-Creation-Date: 2020-07-24 17:33+0200\n"
 "PO-Revision-Date: 2019-03-08 01:48+0100\n"
+"Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: \n"
+"Language: hr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.2.1\n"
-"Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
-"Language: hr\n"
 
-#: DynamicWeb/dynamicweb.gpr.py:15
+#: DynamicWeb//dynamicweb.gpr.py:15
 msgid "Dynamic Web Report"
 msgstr "Dinamični web izvještaj"
 
-#: DynamicWeb/dynamicweb.gpr.py:16
+#: DynamicWeb//dynamicweb.gpr.py:16
 msgid "Produces dynamic web pages for the database"
 msgstr "Stvara dinamične web stranice za bazu podataka"
 
-#: DynamicWeb/dynamicweb.py:265
+#: DynamicWeb//dynamicweb.py:269
 msgid "Street"
 msgstr "Ulica"
 
-#: DynamicWeb/dynamicweb.py:266
+#: DynamicWeb//dynamicweb.py:270
 msgid "Locality"
 msgstr "Lokalitet"
 
-#: DynamicWeb/dynamicweb.py:267
+#: DynamicWeb//dynamicweb.py:271
 msgid "City"
 msgstr "Grad"
 
-#: DynamicWeb/dynamicweb.py:268
+#: DynamicWeb//dynamicweb.py:272
 msgid "Church Parish"
 msgstr "Župa"
 
-#: DynamicWeb/dynamicweb.py:269
+#: DynamicWeb//dynamicweb.py:273
 msgid "County"
 msgstr "Županija"
 
-#: DynamicWeb/dynamicweb.py:270
+#: DynamicWeb//dynamicweb.py:274
 msgid "State/ Province"
 msgstr "Savezna država/Pokrajina"
 
-#: DynamicWeb/dynamicweb.py:271
+#: DynamicWeb//dynamicweb.py:275
 msgid "Postal Code"
 msgstr "Poštanski broj"
 
-#: DynamicWeb/dynamicweb.py:272
+#: DynamicWeb//dynamicweb.py:276
 msgid "Country"
 msgstr "Država"
 
-#: DynamicWeb/dynamicweb.py:273
+#: DynamicWeb//dynamicweb.py:277
 msgid "Phone"
 msgstr "Telefon"
 
-#: DynamicWeb/dynamicweb.py:279
+#: DynamicWeb//dynamicweb.py:283
 msgid "Home Page"
 msgstr "Početna stranica"
 
-#: DynamicWeb/dynamicweb.py:280
+#: DynamicWeb//dynamicweb.py:284
 msgid "SVG graphical tree"
 msgstr "SVG grafičko stablo"
 
-#: DynamicWeb/dynamicweb.py:283
+#: DynamicWeb//dynamicweb.py:287
 msgid "Indexes pages"
 msgstr "Stranice indeksa"
 
-#: DynamicWeb/dynamicweb.py:287 DynamicWeb/dynamicweb.py:4246
+#: DynamicWeb//dynamicweb.py:291 DynamicWeb//dynamicweb.py:4252
 #, python-format
 msgid "Custom page %(index)i"
 msgstr "Prilagođena stranica %(index)i"
 
-#: DynamicWeb/dynamicweb.py:305
+#: DynamicWeb//dynamicweb.py:309
 msgid "Ascending tree"
 msgstr "Uzlazno stablo"
 
-#: DynamicWeb/dynamicweb.py:306
+#: DynamicWeb//dynamicweb.py:310
 msgid "Descending tree"
 msgstr "Silazno stablo"
 
-#: DynamicWeb/dynamicweb.py:307
+#: DynamicWeb//dynamicweb.py:311
 msgid "Descending tree with spouses"
 msgstr "Silazno stablo sa supružnicima"
 
-#: DynamicWeb/dynamicweb.py:308
+#: DynamicWeb//dynamicweb.py:312
 msgid "Ascending and descending tree"
 msgstr "Uzlazno i silazno stablo"
 
-#: DynamicWeb/dynamicweb.py:309
+#: DynamicWeb//dynamicweb.py:313
 msgid "Ascending and descending tree with spouses"
 msgstr "Uzlazno i silazno stablo sa supružnicima"
 
-#: DynamicWeb/dynamicweb.py:321
+#: DynamicWeb//dynamicweb.py:325
 msgid "Vertical (↓)"
 msgstr "Uspravno (↓)"
 
-#: DynamicWeb/dynamicweb.py:322
+#: DynamicWeb//dynamicweb.py:326
 msgid "Vertical (↑)"
 msgstr "Uspravno (↑)"
 
-#: DynamicWeb/dynamicweb.py:323
+#: DynamicWeb//dynamicweb.py:327
 msgid "Horizontal (→)"
 msgstr "Vodoravno (→)"
 
-#: DynamicWeb/dynamicweb.py:324
+#: DynamicWeb//dynamicweb.py:328
 msgid "Horizontal (←)"
 msgstr "Vodoravno (←)"
 
-#: DynamicWeb/dynamicweb.py:325
+#: DynamicWeb//dynamicweb.py:329
 msgid "Full Circle"
 msgstr "Puni krug"
 
-#: DynamicWeb/dynamicweb.py:326
+#: DynamicWeb//dynamicweb.py:330
 msgid "Half Circle"
 msgstr "Polukrug"
 
-#: DynamicWeb/dynamicweb.py:327
+#: DynamicWeb//dynamicweb.py:331
 msgid "Quadrant"
 msgstr "Četvrt kruga"
 
-#: DynamicWeb/dynamicweb.py:339
+#: DynamicWeb//dynamicweb.py:343
 msgid "Size proportional to number of ancestors"
 msgstr "Veličina polja proporcionalna broju predaka"
 
-#: DynamicWeb/dynamicweb.py:340
+#: DynamicWeb//dynamicweb.py:344
 msgid "Homogeneous parents distribution"
 msgstr "Jednolična distribucija roditelja"
 
-#: DynamicWeb/dynamicweb.py:343
+#: DynamicWeb//dynamicweb.py:347
 msgid "Size proportional to number of descendants"
 msgstr "Veličina polja proporcionalna broju potomaka"
 
-#: DynamicWeb/dynamicweb.py:344
+#: DynamicWeb//dynamicweb.py:348
 msgid "Homogeneous children distribution"
 msgstr "Jednolična distribucija djece"
 
-#: DynamicWeb/dynamicweb.py:351 DynamicWeb/dynamicweb.py:374
+#: DynamicWeb//dynamicweb.py:355 DynamicWeb//dynamicweb.py:378
 msgid "Gender colors"
 msgstr "Boje spolova"
 
-#: DynamicWeb/dynamicweb.py:352
+#: DynamicWeb//dynamicweb.py:356
 msgid "Generation based gradient"
 msgstr "Generacijski gradijent"
 
-#: DynamicWeb/dynamicweb.py:353
+#: DynamicWeb//dynamicweb.py:357
 msgid "Age based gradient"
 msgstr "Gradijent na osnovi starosti"
 
-#: DynamicWeb/dynamicweb.py:354 DynamicWeb/dynamicweb.py:373
+#: DynamicWeb//dynamicweb.py:358 DynamicWeb//dynamicweb.py:377
 msgid "Single main (filter) color"
 msgstr "Glavna boja (filtar)"
 
-#: DynamicWeb/dynamicweb.py:355
+#: DynamicWeb//dynamicweb.py:359
 msgid "Time period based gradient"
 msgstr "Vremenski gradijent"
 
-#: DynamicWeb/dynamicweb.py:356 DynamicWeb/dynamicweb.py:378
+#: DynamicWeb//dynamicweb.py:360 DynamicWeb//dynamicweb.py:382
 msgid "White"
 msgstr "Bijela"
 
-#: DynamicWeb/dynamicweb.py:357 DynamicWeb/dynamicweb.py:376
+#: DynamicWeb//dynamicweb.py:361 DynamicWeb//dynamicweb.py:380
 msgid "Color scheme classic report"
 msgstr "Sistem boje klasičnog izvještaja"
 
-#: DynamicWeb/dynamicweb.py:358 DynamicWeb/dynamicweb.py:377
+#: DynamicWeb//dynamicweb.py:362 DynamicWeb//dynamicweb.py:381
 msgid "Color scheme classic view"
 msgstr "Sistem boje klasičnog pogleda"
 
-#: DynamicWeb/dynamicweb.py:375
+#: DynamicWeb//dynamicweb.py:379
 msgid "Gradient"
 msgstr "Gradient"
 
-#: DynamicWeb/dynamicweb.py:394
+#: DynamicWeb//dynamicweb.py:398
 msgid "Default"
 msgstr "Zadano"
 
-#: DynamicWeb/dynamicweb.py:395
+#: DynamicWeb//dynamicweb.py:399
 msgid "Mainz"
 msgstr "Mainz"
 
-#: DynamicWeb/dynamicweb.py:703
+#: DynamicWeb//dynamicweb.py:707
 #, python-format
 msgid "Neither %(current)s nor %(parent)s are directories"
 msgstr "%(current)s i %(parent)s nisu direktoriji"
 
-#: DynamicWeb/dynamicweb.py:711 DynamicWeb/dynamicweb.py:716
+#: DynamicWeb//dynamicweb.py:715 DynamicWeb//dynamicweb.py:720
 #, python-format
 msgid "Could not create the directory: %(path)s"
 msgstr "Nije bilo moguće stvoriti stazu: %(path)s"
 
-#: DynamicWeb/dynamicweb.py:742 DynamicWeb/dynamicweb.py:3380
+#: DynamicWeb//dynamicweb.py:746 DynamicWeb//dynamicweb.py:3385
 msgid "Dynamic Web Site Report"
 msgstr "Dinamična web stranica"
 
-#: DynamicWeb/dynamicweb.py:742
+#: DynamicWeb//dynamicweb.py:746
 msgid "Exporting family tree data ..."
 msgstr "Izvoz rodoslovnih podataka …"
 
-#: DynamicWeb/dynamicweb.py:1232 DynamicWeb/dynamicweb.py:2456
+#: DynamicWeb//dynamicweb.py:1237 DynamicWeb//dynamicweb.py:2461
 msgid "Author"
 msgstr "Autor"
 
-#: DynamicWeb/dynamicweb.py:1233 DynamicWeb/dynamicweb.py:2446
+#: DynamicWeb//dynamicweb.py:1238 DynamicWeb//dynamicweb.py:2451
 msgid "Abbreviation"
 msgstr "Kratica"
 
-#: DynamicWeb/dynamicweb.py:1234 DynamicWeb/dynamicweb.py:2543
+#: DynamicWeb//dynamicweb.py:1239 DynamicWeb//dynamicweb.py:2548
 msgid "Publication information"
 msgstr "Podaci o publikaciji"
 
-#: DynamicWeb/dynamicweb.py:1304 DynamicWeb/dynamicweb.py:2474
+#: DynamicWeb//dynamicweb.py:1309 DynamicWeb//dynamicweb.py:2479
 msgid "Date"
 msgstr "Datum"
 
-#: DynamicWeb/dynamicweb.py:1305
+#: DynamicWeb//dynamicweb.py:1310
 msgid "Page"
 msgstr "Stranica"
 
-#: DynamicWeb/dynamicweb.py:1306
+#: DynamicWeb//dynamicweb.py:1311
 msgid "Confidence"
 msgstr "Pouzdanost"
 
-#: DynamicWeb/dynamicweb.py:1625
+#: DynamicWeb//dynamicweb.py:1630
 #, python-format
 msgid "%(type)s: %(value)s"
 msgstr "%(type)s: %(value)s"
 
-#: DynamicWeb/dynamicweb.py:1872
+#: DynamicWeb//dynamicweb.py:1877
 #, python-format
 msgid "Impossible to convert \"%(path)s\" to a relative path."
 msgstr "Nije bilo moguće konvertirati stazu „%(path)s” u relativnu stazu."
 
-#: DynamicWeb/dynamicweb.py:2178
+#: DynamicWeb//dynamicweb.py:2183
 msgid ""
 "The pages configuration is not valid: several pages have the same content"
 msgstr "Konfiguracija stranice nije važeća: više stranica imaju isti sadržaj"
 
-#: DynamicWeb/dynamicweb.py:2189
-msgid "Html|Home"
+#: DynamicWeb//dynamicweb.py:2194
+msgid "DynWeb|Home"
 msgstr "Početna"
 
-#: DynamicWeb/dynamicweb.py:2190 DynamicWeb/dynamicweb.py:2203
-#: DynamicWeb/dynamicweb.py:2204 DynamicWeb/dynamicweb.py:2205
+#: DynamicWeb//dynamicweb.py:2195 DynamicWeb//dynamicweb.py:2208
+#: DynamicWeb//dynamicweb.py:2209 DynamicWeb//dynamicweb.py:2210
 msgid "Tree"
 msgstr "Stablo"
 
-#: DynamicWeb/dynamicweb.py:2191 DynamicWeb/dynamicweb.py:2206
-#: DynamicWeb/dynamicweb.py:2207 DynamicWeb/dynamicweb.py:2208
+#: DynamicWeb//dynamicweb.py:2196 DynamicWeb//dynamicweb.py:2211
+#: DynamicWeb//dynamicweb.py:2212 DynamicWeb//dynamicweb.py:2213
 msgid "Statistics"
 msgstr "Statistike"
 
-#: DynamicWeb/dynamicweb.py:2194 DynamicWeb/dynamicweb.py:2470
+#: DynamicWeb//dynamicweb.py:2199 DynamicWeb//dynamicweb.py:2475
 msgid "Configuration"
 msgstr "Konfiguracija"
 
-#: DynamicWeb/dynamicweb.py:2196 DynamicWeb/dynamicweb.py:2535
+#: DynamicWeb//dynamicweb.py:2201 DynamicWeb//dynamicweb.py:2540
 msgid "Person"
 msgstr "Osoba"
 
-#: DynamicWeb/dynamicweb.py:2197
+#: DynamicWeb//dynamicweb.py:2202
 msgid "Family"
 msgstr "Obitelj"
 
-#: DynamicWeb/dynamicweb.py:2198 DynamicWeb/dynamicweb.py:2575
+#: DynamicWeb//dynamicweb.py:2203 DynamicWeb//dynamicweb.py:2580
 msgid "Source"
 msgstr "Izvor"
 
-#: DynamicWeb/dynamicweb.py:2199 DynamicWeb/dynamicweb.py:2218
-#: DynamicWeb/dynamicweb.py:2518
+#: DynamicWeb//dynamicweb.py:2204 DynamicWeb//dynamicweb.py:2223
+#: DynamicWeb//dynamicweb.py:2523
 msgid "Media"
 msgstr "Mediji"
 
-#: DynamicWeb/dynamicweb.py:2200 DynamicWeb/dynamicweb.py:2538
+#: DynamicWeb//dynamicweb.py:2205 DynamicWeb//dynamicweb.py:2543
 msgid "Place"
 msgstr "Mjesto"
 
-#: DynamicWeb/dynamicweb.py:2201 DynamicWeb/dynamicweb.py:2550
+#: DynamicWeb//dynamicweb.py:2206 DynamicWeb//dynamicweb.py:2555
 msgid "Repository"
 msgstr "Spremište"
 
-#: DynamicWeb/dynamicweb.py:2202
+#: DynamicWeb//dynamicweb.py:2207
 msgid "Search results"
 msgstr "Rezultati traženja"
 
-#: DynamicWeb/dynamicweb.py:2213 DynamicWeb/dynamicweb.py:2214
-#: DynamicWeb/dynamicweb.py:2582
+#: DynamicWeb//dynamicweb.py:2218 DynamicWeb//dynamicweb.py:2219
+#: DynamicWeb//dynamicweb.py:2587
 msgid "Surnames"
 msgstr "Prezimena"
 
-#: DynamicWeb/dynamicweb.py:2215 DynamicWeb/dynamicweb.py:2503
+#: DynamicWeb//dynamicweb.py:2220 DynamicWeb//dynamicweb.py:2508
 msgid "Individuals"
 msgstr "Pojedinci"
 
-#: DynamicWeb/dynamicweb.py:2216 DynamicWeb/dynamicweb.py:2486
+#: DynamicWeb//dynamicweb.py:2221 DynamicWeb//dynamicweb.py:2491
 msgid "Families"
 msgstr "Obitelji"
 
-#: DynamicWeb/dynamicweb.py:2217 DynamicWeb/dynamicweb.py:2577
+#: DynamicWeb//dynamicweb.py:2222 DynamicWeb//dynamicweb.py:2582
 msgid "Sources"
 msgstr "Izvori"
 
-#: DynamicWeb/dynamicweb.py:2219 DynamicWeb/dynamicweb.py:2540
+#: DynamicWeb//dynamicweb.py:2224 DynamicWeb//dynamicweb.py:2545
 msgid "Places"
 msgstr "Mjesta"
 
-#: DynamicWeb/dynamicweb.py:2220 DynamicWeb/dynamicweb.py:2448
+#: DynamicWeb//dynamicweb.py:2225 DynamicWeb//dynamicweb.py:2453
 msgid "Addresses"
 msgstr "Adrese"
 
-#: DynamicWeb/dynamicweb.py:2221 DynamicWeb/dynamicweb.py:2549
+#: DynamicWeb//dynamicweb.py:2226 DynamicWeb//dynamicweb.py:2554
 msgid "Repositories"
 msgstr "Spremišta"
 
-#: DynamicWeb/dynamicweb.py:2272 DynamicWeb/dynamicweb.py:2502
-#: DynamicWeb/dynamicweb.py:4120
+#: DynamicWeb//dynamicweb.py:2277 DynamicWeb//dynamicweb.py:2507
+#: DynamicWeb//dynamicweb.py:4126
 msgid "Indexes"
 msgstr "Indeksi"
 
-#: DynamicWeb/dynamicweb.py:2436
+#: DynamicWeb//dynamicweb.py:2441
 #, python-format
 msgid "(b. %(birthdate)s, d. %(deathdate)s)"
 msgstr "(r. %(birthdate)s, u. %(deathdate)s)"
 
-#: DynamicWeb/dynamicweb.py:2437
+#: DynamicWeb//dynamicweb.py:2442
 #, python-format
 msgid "(b. %s)"
 msgstr "(r. %s)"
 
-#: DynamicWeb/dynamicweb.py:2438
+#: DynamicWeb//dynamicweb.py:2443
 #, python-format
 msgid "(d. %s)"
 msgstr "(u. %s)"
 
-#: DynamicWeb/dynamicweb.py:2439
+#: DynamicWeb//dynamicweb.py:2444
 msgid "(filtered from _MAX_ total entries)"
 msgstr "(filtrirano iz _MAKS_ ukupno unosa)"
 
-#: DynamicWeb/dynamicweb.py:2440
+#: DynamicWeb//dynamicweb.py:2445
 #, python-format
 msgid "(m. %s)"
 msgstr "(b. %s)"
 
-#: DynamicWeb/dynamicweb.py:2441
+#: DynamicWeb//dynamicweb.py:2446
 msgid "(sort by name)"
 msgstr "(sortiraj po imenu)"
 
-#: DynamicWeb/dynamicweb.py:2442
+#: DynamicWeb//dynamicweb.py:2447
 msgid "(sort by quantity)"
 msgstr "(sortiraj po količini)"
 
-#: DynamicWeb/dynamicweb.py:2443
+#: DynamicWeb//dynamicweb.py:2448
 msgid ": activate to sort column ascending"
 msgstr ": aktiviraj za uzlazno razvrstavanje stupca"
 
-#: DynamicWeb/dynamicweb.py:2444
+#: DynamicWeb//dynamicweb.py:2449
 msgid ": activate to sort column descending"
 msgstr ": aktiviraj za silazno razvrstavanje stupca"
 
-#: DynamicWeb/dynamicweb.py:2445
+#: DynamicWeb//dynamicweb.py:2450
 msgid ""
 "<p>This page provides the SVG raw code.<br>Copy the contents into a text "
 "editor and save as an SVG file.<br>Make sure that the text editor encoding "
@@ -376,560 +376,560 @@ msgstr ""
 "uređivač teksta i spremi ga kao SVG datoteku.<br>Provjeri, da je kodiranje "
 "uređivača postavljeno na UTF-8.</p>"
 
-#: DynamicWeb/dynamicweb.py:2447
+#: DynamicWeb//dynamicweb.py:2452
 msgid "Address"
 msgstr "Adresa"
 
-#: DynamicWeb/dynamicweb.py:2449
+#: DynamicWeb//dynamicweb.py:2454
 msgid "Age at death"
 msgstr "Starost pri smrti"
 
-#: DynamicWeb/dynamicweb.py:2450
+#: DynamicWeb//dynamicweb.py:2455
 msgid "Alternate Marriage"
 msgstr "Alternativni brak"
 
-#: DynamicWeb/dynamicweb.py:2451
+#: DynamicWeb//dynamicweb.py:2456
 msgid "Alternate Name"
 msgstr "Alternativno ime"
 
-#: DynamicWeb/dynamicweb.py:2452
+#: DynamicWeb//dynamicweb.py:2457
 msgid "Ancestors"
 msgstr "Preci"
 
-#: DynamicWeb/dynamicweb.py:2453
+#: DynamicWeb//dynamicweb.py:2458
 msgid "Associations"
 msgstr "Veze"
 
-#: DynamicWeb/dynamicweb.py:2454
+#: DynamicWeb//dynamicweb.py:2459
 msgid "Attribute"
 msgstr "Svojstvo"
 
-#: DynamicWeb/dynamicweb.py:2455
+#: DynamicWeb//dynamicweb.py:2460
 msgid "Attributes"
 msgstr "Svojstva"
 
-#: DynamicWeb/dynamicweb.py:2457 DynamicWeb/dynamicweb.py:4203
+#: DynamicWeb//dynamicweb.py:2462 DynamicWeb//dynamicweb.py:4209
 msgid "Background"
 msgstr "Pozadina"
 
-#: DynamicWeb/dynamicweb.py:2458
+#: DynamicWeb//dynamicweb.py:2463
 msgid "Baptism"
 msgstr "Krštenje"
 
-#: DynamicWeb/dynamicweb.py:2459
+#: DynamicWeb//dynamicweb.py:2464
 msgid "Birth"
 msgstr "Rođenje"
 
-#: DynamicWeb/dynamicweb.py:2460
+#: DynamicWeb//dynamicweb.py:2465
 msgid "Burial"
 msgstr "Pogreb"
 
-#: DynamicWeb/dynamicweb.py:2461
+#: DynamicWeb//dynamicweb.py:2466
 msgid "Call Name"
 msgstr "Upotrebno ime"
 
-#: DynamicWeb/dynamicweb.py:2462
+#: DynamicWeb//dynamicweb.py:2467
 msgid "Call Number"
 msgstr "Pozivni broj"
 
-#: DynamicWeb/dynamicweb.py:2463
+#: DynamicWeb//dynamicweb.py:2468
 msgid "Cause Of Death"
 msgstr "Uzrok smrti"
 
-#: DynamicWeb/dynamicweb.py:2464
+#: DynamicWeb//dynamicweb.py:2469
 msgid "Children"
 msgstr "Djeca"
 
-#: DynamicWeb/dynamicweb.py:2465
+#: DynamicWeb//dynamicweb.py:2470
 msgid "Christening"
 msgstr "Krštenje"
 
-#: DynamicWeb/dynamicweb.py:2466
+#: DynamicWeb//dynamicweb.py:2471
 msgid "Citation"
 msgstr "Citat"
 
-#: DynamicWeb/dynamicweb.py:2467
+#: DynamicWeb//dynamicweb.py:2472
 msgid "Citations"
 msgstr "Citati"
 
-#: DynamicWeb/dynamicweb.py:2468
+#: DynamicWeb//dynamicweb.py:2473
 msgid "Click on the map to show it full-screen"
 msgstr "Klikni na kartu za prikaz u cijelom zaslonu"
 
-#: DynamicWeb/dynamicweb.py:2469
+#: DynamicWeb//dynamicweb.py:2474
 msgid "Code"
 msgstr "Kôd"
 
-#: DynamicWeb/dynamicweb.py:2471
+#: DynamicWeb//dynamicweb.py:2476
 msgid "Configure"
 msgstr "Konfiguriraj"
 
-#: DynamicWeb/dynamicweb.py:2472
+#: DynamicWeb//dynamicweb.py:2477
 msgid "Count"
 msgstr "Broj"
 
-#: DynamicWeb/dynamicweb.py:2473
+#: DynamicWeb//dynamicweb.py:2478
 msgid "Cremation"
 msgstr "Kremiranje"
 
-#: DynamicWeb/dynamicweb.py:2475
+#: DynamicWeb//dynamicweb.py:2480
 msgid "Death"
 msgstr "Smrt"
 
-#: DynamicWeb/dynamicweb.py:2476
+#: DynamicWeb//dynamicweb.py:2481
 msgid "Descendants"
 msgstr "Potomci"
 
-#: DynamicWeb/dynamicweb.py:2477
+#: DynamicWeb//dynamicweb.py:2482
 msgid "Description"
 msgstr "Opis"
 
-#: DynamicWeb/dynamicweb.py:2478
+#: DynamicWeb//dynamicweb.py:2483
 msgid "DynamicWeb_report#Help"
 msgstr "Dinamični_web_izvještaj#Pomoć"
 
-#: DynamicWeb/dynamicweb.py:2479
+#: DynamicWeb//dynamicweb.py:2484
 msgid "Enclosed By"
 msgstr "Obuhvaćeno"
 
-#: DynamicWeb/dynamicweb.py:2480
+#: DynamicWeb//dynamicweb.py:2485
 msgid "Engagement"
 msgstr "Zaruke"
 
-#: DynamicWeb/dynamicweb.py:2481
+#: DynamicWeb//dynamicweb.py:2486
 msgid "Event"
 msgstr "Događaj"
 
-#: DynamicWeb/dynamicweb.py:2482
+#: DynamicWeb//dynamicweb.py:2487
 msgid "Events"
 msgstr "Događaji"
 
-#: DynamicWeb/dynamicweb.py:2483
+#: DynamicWeb//dynamicweb.py:2488
 msgid "Examples"
 msgstr "Primjeri"
 
-#: DynamicWeb/dynamicweb.py:2484
+#: DynamicWeb//dynamicweb.py:2489
 msgid "F"
 msgstr "Ž"
 
-#: DynamicWeb/dynamicweb.py:2485
+#: DynamicWeb//dynamicweb.py:2490
 msgid "Families Index"
 msgstr "Indeks obitelji"
 
-#: DynamicWeb/dynamicweb.py:2487
+#: DynamicWeb//dynamicweb.py:2492
 msgid "Family Nick Name"
 msgstr "Obiteljski nadimak"
 
-#: DynamicWeb/dynamicweb.py:2488
+#: DynamicWeb//dynamicweb.py:2493
 msgid "Father"
 msgstr "Otac"
 
-#: DynamicWeb/dynamicweb.py:2489
+#: DynamicWeb//dynamicweb.py:2494
 msgid "Female"
 msgstr "Žensko"
 
-#: DynamicWeb/dynamicweb.py:2490
+#: DynamicWeb//dynamicweb.py:2495
 msgid "File ready"
 msgstr "Datoteka je premna"
 
-#: DynamicWeb/dynamicweb.py:2491
+#: DynamicWeb//dynamicweb.py:2496
 msgid "Gender"
 msgstr "Spol"
 
-#: DynamicWeb/dynamicweb.py:2492
+#: DynamicWeb//dynamicweb.py:2497
 msgid "Help"
 msgstr "Pomoć"
 
-#: DynamicWeb/dynamicweb.py:2493
+#: DynamicWeb//dynamicweb.py:2498
 msgid "ID"
 msgstr "ID"
 
-#: DynamicWeb/dynamicweb.py:2494 DynamicWeb/dynamicweb.py:4035
+#: DynamicWeb//dynamicweb.py:2499 DynamicWeb//dynamicweb.py:4041
 msgid "Include Place map on Place Pages"
 msgstr "Uključi kartu mjesta na stranicama mjesta"
 
-#: DynamicWeb/dynamicweb.py:2495 DynamicWeb/dynamicweb.py:4140
+#: DynamicWeb//dynamicweb.py:2500 DynamicWeb//dynamicweb.py:4146
 msgid "Include dates columns on the index pages"
 msgstr "Uključi stupce s datumima na stranicama indeksa"
 
-#: DynamicWeb/dynamicweb.py:2496 DynamicWeb/dynamicweb.py:4148
+#: DynamicWeb//dynamicweb.py:2501 DynamicWeb//dynamicweb.py:4154
 msgid "Include a column for parents on the index pages"
 msgstr "Uključi stupac s roditeljima na indeksnoj stranici"
 
-#: DynamicWeb/dynamicweb.py:2497 DynamicWeb/dynamicweb.py:4156
+#: DynamicWeb//dynamicweb.py:2502 DynamicWeb//dynamicweb.py:4162
 msgid "Include a column for media path on the index pages"
 msgstr "Uključi stupac s stazama medija na indeksnoj stranici"
 
-#: DynamicWeb/dynamicweb.py:2498 DynamicWeb/dynamicweb.py:4144
+#: DynamicWeb//dynamicweb.py:2503 DynamicWeb//dynamicweb.py:4150
 msgid "Include a column for partners on the index pages"
 msgstr "Uključi stupac s partnerima na indeksnoj stranici"
 
-#: DynamicWeb/dynamicweb.py:2499 DynamicWeb/dynamicweb.py:4043
+#: DynamicWeb//dynamicweb.py:2504 DynamicWeb//dynamicweb.py:4049
 msgid "Include a map in the individuals and family pages"
 msgstr "Uključi kartu na stranicama pojedinaca i obitelji"
 
-#: DynamicWeb/dynamicweb.py:2500 DynamicWeb/dynamicweb.py:4090
+#: DynamicWeb//dynamicweb.py:2505 DynamicWeb//dynamicweb.py:4096
 msgid "Include half and/ or step-siblings on the individual pages"
 msgstr "Uključi polubraću na osobnim stranicama"
 
-#: DynamicWeb/dynamicweb.py:2501 DynamicWeb/dynamicweb.py:4160
+#: DynamicWeb//dynamicweb.py:2506 DynamicWeb//dynamicweb.py:4166
 msgid "Include references in indexes"
 msgstr "Uključi reference u indeksima"
 
-#: DynamicWeb/dynamicweb.py:2504 DynamicWeb/dynamicweb.py:4110
+#: DynamicWeb//dynamicweb.py:2509 DynamicWeb//dynamicweb.py:4116
 msgid "Insert sources author in the sources title"
 msgstr "Uključi autora izvora u nazivu izvora"
 
-#: DynamicWeb/dynamicweb.py:2505
+#: DynamicWeb//dynamicweb.py:2510
 msgid "Last Modified"
 msgstr "Zadnja izmjena"
 
-#: DynamicWeb/dynamicweb.py:2506
+#: DynamicWeb//dynamicweb.py:2511
 msgid "Latitude"
 msgstr "Zemljopisna širina"
 
-#: DynamicWeb/dynamicweb.py:2507
+#: DynamicWeb//dynamicweb.py:2512
 msgid "Link"
 msgstr "Poveznica"
 
-#: DynamicWeb/dynamicweb.py:2508
+#: DynamicWeb//dynamicweb.py:2513
 msgid "Loading..."
 msgstr "Učitavanje ..."
 
-#: DynamicWeb/dynamicweb.py:2509
+#: DynamicWeb//dynamicweb.py:2514
 msgid "Location"
 msgstr "Lokacija"
 
-#: DynamicWeb/dynamicweb.py:2510
+#: DynamicWeb//dynamicweb.py:2515
 msgid "Longitude"
 msgstr "Zemljopisna dužina"
 
-#: DynamicWeb/dynamicweb.py:2511
+#: DynamicWeb//dynamicweb.py:2516
 msgid "M"
 msgstr "M"
 
-#: DynamicWeb/dynamicweb.py:2512
+#: DynamicWeb//dynamicweb.py:2517
 msgid "Male"
 msgstr "Muško"
 
-#: DynamicWeb/dynamicweb.py:2513
+#: DynamicWeb//dynamicweb.py:2518
 msgid "Map"
 msgstr "Karta"
 
-#: DynamicWeb/dynamicweb.py:2514
+#: DynamicWeb//dynamicweb.py:2519
 msgid "Marriage"
 msgstr "Brak"
 
-#: DynamicWeb/dynamicweb.py:2515
+#: DynamicWeb//dynamicweb.py:2520
 msgid "Maximize"
 msgstr "Maksimiraj"
 
-#: DynamicWeb/dynamicweb.py:2516
+#: DynamicWeb//dynamicweb.py:2521
 msgid "Media Index"
 msgstr "Indeks medija"
 
-#: DynamicWeb/dynamicweb.py:2517
+#: DynamicWeb//dynamicweb.py:2522
 msgid "Media Type"
 msgstr "Vrsta medija"
 
-#: DynamicWeb/dynamicweb.py:2519
+#: DynamicWeb//dynamicweb.py:2524
 msgid "Mother"
 msgstr "Majka"
 
-#: DynamicWeb/dynamicweb.py:2520
+#: DynamicWeb//dynamicweb.py:2525
 msgid "Name"
 msgstr "Ime"
 
-#: DynamicWeb/dynamicweb.py:2521
+#: DynamicWeb//dynamicweb.py:2526
 msgid "Nick Name"
 msgstr "Nadimak"
 
-#: DynamicWeb/dynamicweb.py:2522
+#: DynamicWeb//dynamicweb.py:2527
 msgid "No data available in table"
 msgstr "Nema podataka u tablici"
 
-#: DynamicWeb/dynamicweb.py:2523
+#: DynamicWeb//dynamicweb.py:2528
 msgid "No matches found"
 msgstr "Nema podudarnosti"
 
-#: DynamicWeb/dynamicweb.py:2524
+#: DynamicWeb//dynamicweb.py:2529
 msgid "No matching records found"
 msgstr "Nema odgovarajućih zapisa"
 
-#: DynamicWeb/dynamicweb.py:2525
+#: DynamicWeb//dynamicweb.py:2530
 msgid "No matching surname."
 msgstr "Nema odgovarajućih prezimena."
 
-#: DynamicWeb/dynamicweb.py:2526
+#: DynamicWeb//dynamicweb.py:2531
 msgid "None"
 msgstr "Bez"
 
-#: DynamicWeb/dynamicweb.py:2527
+#: DynamicWeb//dynamicweb.py:2532
 msgid "Notes"
 msgstr "Zabilješke"
 
-#: DynamicWeb/dynamicweb.py:2528
+#: DynamicWeb//dynamicweb.py:2533
 msgid "Number"
 msgstr "Broj"
 
-#: DynamicWeb/dynamicweb.py:2529
+#: DynamicWeb//dynamicweb.py:2534
 msgid "OK"
 msgstr "U redu"
 
-#: DynamicWeb/dynamicweb.py:2530
+#: DynamicWeb//dynamicweb.py:2535
 msgid "Other participants"
 msgstr "Ostali sudionici"
 
-#: DynamicWeb/dynamicweb.py:2531
+#: DynamicWeb//dynamicweb.py:2536
 msgid "Parents"
 msgstr "Roditelji"
 
-#: DynamicWeb/dynamicweb.py:2532
+#: DynamicWeb//dynamicweb.py:2537
 msgid "Path"
 msgstr "Staza"
 
-#: DynamicWeb/dynamicweb.py:2533
+#: DynamicWeb//dynamicweb.py:2538
 msgid "Person page"
 msgstr "Stranica osobe"
 
-#: DynamicWeb/dynamicweb.py:2534
+#: DynamicWeb//dynamicweb.py:2539
 msgid "Person to search for"
 msgstr "Tražena osoba"
 
-#: DynamicWeb/dynamicweb.py:2536
+#: DynamicWeb//dynamicweb.py:2541
 msgid "Persons Index"
 msgstr "Indeks osoba"
 
-#: DynamicWeb/dynamicweb.py:2537
+#: DynamicWeb//dynamicweb.py:2542
 msgid "Persons"
 msgstr "Osobe"
 
-#: DynamicWeb/dynamicweb.py:2539
+#: DynamicWeb//dynamicweb.py:2544
 msgid "Places Index"
 msgstr "Indeks mjesta"
 
-#: DynamicWeb/dynamicweb.py:2541
+#: DynamicWeb//dynamicweb.py:2546
 msgid "Preparing file ..."
 msgstr "Pripremanje datoteke …"
 
-#: DynamicWeb/dynamicweb.py:2542
+#: DynamicWeb//dynamicweb.py:2547
 msgid "Processing..."
 msgstr "Obrada ..."
 
-#: DynamicWeb/dynamicweb.py:2544
+#: DynamicWeb//dynamicweb.py:2549
 msgid "References"
 msgstr "Reference"
 
-#: DynamicWeb/dynamicweb.py:2545
+#: DynamicWeb//dynamicweb.py:2550
 msgid "Relationship to Father"
 msgstr "Srodstvo s ocem"
 
-#: DynamicWeb/dynamicweb.py:2546
+#: DynamicWeb//dynamicweb.py:2551
 msgid "Relationship to Mother"
 msgstr "Srodstvo s majkom"
 
-#: DynamicWeb/dynamicweb.py:2547
+#: DynamicWeb//dynamicweb.py:2552
 msgid "Relationship"
 msgstr "Srodstvo"
 
-#: DynamicWeb/dynamicweb.py:2548
+#: DynamicWeb//dynamicweb.py:2553
 msgid "Repositories Index"
 msgstr "Index spremišta"
 
-#: DynamicWeb/dynamicweb.py:2551
+#: DynamicWeb//dynamicweb.py:2556
 msgid "Restore"
 msgstr "Obnovi"
 
-#: DynamicWeb/dynamicweb.py:2552
+#: DynamicWeb//dynamicweb.py:2557
 msgid "Restore default settings"
 msgstr "Vrati zadane postavke"
 
-#: DynamicWeb/dynamicweb.py:2553 DynamicWeb/dynamicweb.py:4106
+#: DynamicWeb//dynamicweb.py:2558 DynamicWeb//dynamicweb.py:4112
 msgid "Show last modification time"
 msgstr "Prikaži vrijeme zadnje promjene"
 
-#: DynamicWeb/dynamicweb.py:2554 DynamicWeb/dynamicweb.py:4197
+#: DynamicWeb//dynamicweb.py:2559 DynamicWeb//dynamicweb.py:4203
 msgid "SVG tree children distribution"
 msgstr "Distribucija djece u SVG stablu"
 
-#: DynamicWeb/dynamicweb.py:2555
+#: DynamicWeb//dynamicweb.py:2560
 msgid "SVG tree configuration"
 msgstr "Konfiguracija SVG stabla"
 
-#: DynamicWeb/dynamicweb.py:2556 DynamicWeb/dynamicweb.py:4185
+#: DynamicWeb//dynamicweb.py:2561 DynamicWeb//dynamicweb.py:4191
 msgid "SVG tree graph shape"
 msgstr "Oblik dijagrama SVG stabla"
 
-#: DynamicWeb/dynamicweb.py:2557 DynamicWeb/dynamicweb.py:4179
+#: DynamicWeb//dynamicweb.py:2562 DynamicWeb//dynamicweb.py:4185
 msgid "SVG tree graph type"
 msgstr "Vrsta dijagrama SVG stabla"
 
-#: DynamicWeb/dynamicweb.py:2558 DynamicWeb/dynamicweb.py:4191
+#: DynamicWeb//dynamicweb.py:2563 DynamicWeb//dynamicweb.py:4197
 msgid "SVG tree parents distribution"
 msgstr "Distribucija roditelja u SVG stablu"
 
-#: DynamicWeb/dynamicweb.py:2559
+#: DynamicWeb//dynamicweb.py:2564
 msgid "Save tree as file"
 msgstr "Spremi stablo kao"
 
-#: DynamicWeb/dynamicweb.py:2560
+#: DynamicWeb//dynamicweb.py:2565
 msgid "Search:"
 msgstr "Traži:"
 
-#: DynamicWeb/dynamicweb.py:2561
+#: DynamicWeb//dynamicweb.py:2566
 msgid "Select the background color scheme"
 msgstr "Odaberi sistem boje za pozadinu"
 
-#: DynamicWeb/dynamicweb.py:2562
+#: DynamicWeb//dynamicweb.py:2567
 msgid "Select the children distribution (fan charts only)"
 msgstr "Odaberi distribuciju djece (samo za lepezaste dijagrame)"
 
-#: DynamicWeb/dynamicweb.py:2563
+#: DynamicWeb//dynamicweb.py:2568
 msgid "Select the number of ascending generations"
 msgstr "Odaberi broj uzlaznih generacija"
 
-#: DynamicWeb/dynamicweb.py:2564
+#: DynamicWeb//dynamicweb.py:2569
 msgid "Select the number of descending generations"
 msgstr "Odaberi broj silaznih generacija"
 
-#: DynamicWeb/dynamicweb.py:2565
+#: DynamicWeb//dynamicweb.py:2570
 msgid "Select the parents distribution (fan charts only)"
 msgstr "Odaberi distribuciju roditelja (samo za lepezaste dijagrame)"
 
-#: DynamicWeb/dynamicweb.py:2566
+#: DynamicWeb//dynamicweb.py:2571
 msgid "Select the shape of graph"
 msgstr "Odaberi oblik grafikona"
 
-#: DynamicWeb/dynamicweb.py:2567
+#: DynamicWeb//dynamicweb.py:2572
 msgid "Select the type of graph"
 msgstr "Odaberi vrstu grafikona"
 
-#: DynamicWeb/dynamicweb.py:2568
+#: DynamicWeb//dynamicweb.py:2573
 msgid "Several matches.<br>Precise your search or choose in the lists below."
 msgstr ""
 "Višestruka poklapanja.<br>Preciziraj pretragu ili odaberi iz doljnjeg popisa."
 
-#: DynamicWeb/dynamicweb.py:2569
+#: DynamicWeb//dynamicweb.py:2574
 msgid "Show _MENU_ entries"
 msgstr "Prikaži _MENU_ unose"
 
-#: DynamicWeb/dynamicweb.py:2570 DynamicWeb/dynamicweb.py:4215
+#: DynamicWeb//dynamicweb.py:2575 DynamicWeb//dynamicweb.py:4221
 msgid "Show duplicates"
 msgstr "Prikaži duplikate"
 
-#: DynamicWeb/dynamicweb.py:2571
+#: DynamicWeb//dynamicweb.py:2576
 msgid "Showing 0 to 0 of 0 entries"
 msgstr "Prikaz 0 do 0 od 0 unosa"
 
-#: DynamicWeb/dynamicweb.py:2572
+#: DynamicWeb//dynamicweb.py:2577
 msgid "Showing _START_ to _END_ of _TOTAL_ entries"
 msgstr "Prikaz _START_ do _END_ od _TOTAL_ unosa"
 
-#: DynamicWeb/dynamicweb.py:2573
+#: DynamicWeb//dynamicweb.py:2578
 msgid "Siblings"
 msgstr "Braća/sestre"
 
-#: DynamicWeb/dynamicweb.py:2574
+#: DynamicWeb//dynamicweb.py:2579
 msgid "Sort by:"
 msgstr "Razvrstaj po:"
 
-#: DynamicWeb/dynamicweb.py:2576
+#: DynamicWeb//dynamicweb.py:2581
 msgid "Sources Index"
 msgstr "Indeks izvora"
 
-#: DynamicWeb/dynamicweb.py:2578
+#: DynamicWeb//dynamicweb.py:2583
 msgid "Spouses"
 msgstr "Supružnici"
 
-#: DynamicWeb/dynamicweb.py:2579 DynamicWeb/dynamicweb.py:4114
+#: DynamicWeb//dynamicweb.py:2584 DynamicWeb//dynamicweb.py:4120
 msgid "Suppress Gramps ID"
 msgstr "Ne prikazuj Gramps ID"
 
-#: DynamicWeb/dynamicweb.py:2580
+#: DynamicWeb//dynamicweb.py:2585
 msgid "Surname"
 msgstr "Prezime"
 
-#: DynamicWeb/dynamicweb.py:2581
+#: DynamicWeb//dynamicweb.py:2586
 msgid "Surnames Index"
 msgstr "Indeks prezimena"
 
-#: DynamicWeb/dynamicweb.py:2583
+#: DynamicWeb//dynamicweb.py:2588
 msgid "Title"
 msgstr "Naslov"
 
-#: DynamicWeb/dynamicweb.py:2584
+#: DynamicWeb//dynamicweb.py:2589
 msgid "Type"
 msgstr "Vrsta"
 
-#: DynamicWeb/dynamicweb.py:2585
+#: DynamicWeb//dynamicweb.py:2590
 msgid "U"
 msgstr "N"
 
-#: DynamicWeb/dynamicweb.py:2586
+#: DynamicWeb//dynamicweb.py:2591
 msgid "Unknown"
 msgstr "Nepoznato"
 
-#: DynamicWeb/dynamicweb.py:2587 DynamicWeb/dynamicweb.py:4102
+#: DynamicWeb//dynamicweb.py:2592 DynamicWeb//dynamicweb.py:4108
 msgid "Use tabbed panels instead of sections"
 msgstr "Koristi registarske kartice umjesto odjeljaka"
 
-#: DynamicWeb/dynamicweb.py:2588
+#: DynamicWeb//dynamicweb.py:2593
 msgid "Use the search box above in order to find a person."
 msgstr "Koristi gornju tražilicu za pronalaženje osobe"
 
-#: DynamicWeb/dynamicweb.py:2589
+#: DynamicWeb//dynamicweb.py:2594
 msgid "Use a table format for the surnames index"
 msgstr "Koristi tablični format za indeks prezimena"
 
-#: DynamicWeb/dynamicweb.py:2590
+#: DynamicWeb//dynamicweb.py:2595
 msgid "Use a table format for the persons index"
 msgstr "Koristi tablični format za indeks osoba"
 
-#: DynamicWeb/dynamicweb.py:2591
+#: DynamicWeb//dynamicweb.py:2596
 msgid "Use a table format for the families index"
 msgstr "Koristi tablični format za indeks ogitelji"
 
-#: DynamicWeb/dynamicweb.py:2592
+#: DynamicWeb//dynamicweb.py:2597
 msgid "Use a table format for the sources index"
 msgstr "Koristi tablični format za indeks izvora"
 
-#: DynamicWeb/dynamicweb.py:2593
+#: DynamicWeb//dynamicweb.py:2598
 msgid "Use a table format for the places index"
 msgstr "Koristi tablični format za indeks mjesta"
 
-#: DynamicWeb/dynamicweb.py:2594
+#: DynamicWeb//dynamicweb.py:2599
 msgid "Used for family"
 msgstr "Korišteno za obitelj"
 
-#: DynamicWeb/dynamicweb.py:2595
+#: DynamicWeb//dynamicweb.py:2600
 msgid "Used for media"
 msgstr "Korišteno za medij"
 
-#: DynamicWeb/dynamicweb.py:2596
+#: DynamicWeb//dynamicweb.py:2601
 msgid "Used for person"
 msgstr "Korišteno za osobu"
 
-#: DynamicWeb/dynamicweb.py:2597
+#: DynamicWeb//dynamicweb.py:2602
 msgid "Used for place"
 msgstr "Korišteno za mjesto"
 
-#: DynamicWeb/dynamicweb.py:2598
+#: DynamicWeb//dynamicweb.py:2603
 msgid "Used for source"
 msgstr "Korišteno za izvor"
 
-#: DynamicWeb/dynamicweb.py:2599
+#: DynamicWeb//dynamicweb.py:2604
 msgid "Value"
 msgstr "Vrijednost"
 
-#: DynamicWeb/dynamicweb.py:2600
+#: DynamicWeb//dynamicweb.py:2605
 msgid "Web Link"
 msgstr "Web poveznica"
 
-#: DynamicWeb/dynamicweb.py:2601
+#: DynamicWeb//dynamicweb.py:2606
 msgid "Web Links"
 msgstr "Web poveznice"
 
-#: DynamicWeb/dynamicweb.py:2602 DynamicWeb/dynamicweb.py:4216
+#: DynamicWeb//dynamicweb.py:2607 DynamicWeb//dynamicweb.py:4222
 msgid ""
 "Whether to use a special color for the persons that appear several times in "
 "the SVG tree"
@@ -937,49 +937,49 @@ msgstr ""
 "Da li koristiti posebnu boju za osobe, koje se pojavljuju nekoliko puta u "
 "SVG stablu"
 
-#: DynamicWeb/dynamicweb.py:2603
+#: DynamicWeb//dynamicweb.py:2608
 msgid "Without name"
 msgstr "Bez imena"
 
-#: DynamicWeb/dynamicweb.py:2604
+#: DynamicWeb//dynamicweb.py:2609
 msgid "Without surname"
 msgstr "Bez prezimena"
 
-#: DynamicWeb/dynamicweb.py:2605
+#: DynamicWeb//dynamicweb.py:2610
 msgid "Without title"
 msgstr "Bez naslova"
 
-#: DynamicWeb/dynamicweb.py:2606
+#: DynamicWeb//dynamicweb.py:2611
 msgid "Zoom in"
 msgstr "Uvećaj"
 
-#: DynamicWeb/dynamicweb.py:2607
+#: DynamicWeb//dynamicweb.py:2612
 msgid "Zoom out"
 msgstr "Umanji"
 
-#: DynamicWeb/dynamicweb.py:2608
+#: DynamicWeb//dynamicweb.py:2613
 msgid "all"
 msgstr "sve"
 
-#: DynamicWeb/dynamicweb.py:2811
+#: DynamicWeb//dynamicweb.py:2816
 msgid "No Home Person"
 msgstr "Nema početne osobe"
 
-#: DynamicWeb/dynamicweb.py:2952
+#: DynamicWeb//dynamicweb.py:2957
 #, python-format
 msgid "Copying error: %(error)s"
 msgstr "Greška prilikom kopiranja: %(error)s"
 
-#: DynamicWeb/dynamicweb.py:2953
+#: DynamicWeb//dynamicweb.py:2958
 #, python-format
 msgid "Impossible to copy \"%(src)s\" to \"%(dst)s\""
 msgstr "Nije moguće kopirati „%(src)s” prema „%(dst)s”"
 
-#: DynamicWeb/dynamicweb.py:2956
+#: DynamicWeb//dynamicweb.py:2961
 msgid "Possible destination error"
 msgstr "Moguća greška u odredištu"
 
-#: DynamicWeb/dynamicweb.py:2957
+#: DynamicWeb//dynamicweb.py:2962
 msgid ""
 "You appear to have set your target directory to a directory used for data "
 "storage. This could create problems with file management. It is recommended "
@@ -990,64 +990,64 @@ msgstr ""
 "podataka, što može dovesti do problema u upravljanju datotekama. Preporučuje "
 "se odabir nekog drugog direktorija, za spremanje izrađenih web stranica."
 
-#: DynamicWeb/dynamicweb.py:2984
+#: DynamicWeb//dynamicweb.py:2989
 #, python-format
 msgid "Unable to copy web site template files from \"%(path)s\""
 msgstr "Nije moguće kopirati predloške web stranice „%(path)s”"
 
-#: DynamicWeb/dynamicweb.py:3028
+#: DynamicWeb//dynamicweb.py:3033
 #, python-format
 msgid "Keeping \"%(dst)s\" (newer than \"%(src)s\")"
 msgstr "Zadži „%(dst)s” (novije od „%(src)s”)"
 
-#: DynamicWeb/dynamicweb.py:3031
+#: DynamicWeb//dynamicweb.py:3036
 #, python-format
 msgid "Copying \"%(src)s\" to \"%(dst)s\""
 msgstr "Kopiraj „%(src)s” prema „%(dst)s”"
 
-#: DynamicWeb/dynamicweb.py:3049
+#: DynamicWeb//dynamicweb.py:3054
 msgid "Invalid file name"
 msgstr "Nevažeće ime datoteke"
 
-#: DynamicWeb/dynamicweb.py:3050
+#: DynamicWeb//dynamicweb.py:3055
 msgid "The archive file must be a file, not a directory"
 msgstr "Arhiva mora biti datoteka, a ne direktorij"
 
-#: DynamicWeb/dynamicweb.py:3060 DynamicWeb/dynamicweb.py:3078
+#: DynamicWeb//dynamicweb.py:3065 DynamicWeb//dynamicweb.py:3083
 #, python-format
 msgid "Unable to overwrite archive file \"%(path)s\""
 msgstr "Nije moguće prepisati datoteku arhive „%(path)s”"
 
-#: DynamicWeb/dynamicweb.py:3070 DynamicWeb/dynamicweb.py:3085
+#: DynamicWeb//dynamicweb.py:3075 DynamicWeb//dynamicweb.py:3090
 #, python-format
 msgid "Unable to add file \"%(file)s\" to archive \"%(archive)s\""
 msgstr "Nije moguće dodati datoteku „%(file)s” u arhivu „%(archive)s”"
 
-#: DynamicWeb/dynamicweb.py:3138
+#: DynamicWeb//dynamicweb.py:3143
 #, python-format
 msgid "DynamicWebReport ignoring link type '%(class)s'"
 msgstr "Dinamični web izvještaj zanemaruje vrstu poveznica „%(class)s”"
 
-#: DynamicWeb/dynamicweb.py:3381
+#: DynamicWeb//dynamicweb.py:3386
 msgid "Constructing list of other objects..."
 msgstr "Stvaranje popisa ostalih objekata ..."
 
-#: DynamicWeb/dynamicweb.py:3516
+#: DynamicWeb//dynamicweb.py:3521
 #, python-format
 msgid "Family of %(husband)s and %(spouse)s"
 msgstr "Obitelj od %(husband)s i %(spouse)s"
 
-#: DynamicWeb/dynamicweb.py:3522
+#: DynamicWeb//dynamicweb.py:3527
 #, python-format
 msgid "Family of %(father)s"
 msgstr "Obitelj od %(father)s"
 
-#: DynamicWeb/dynamicweb.py:3526
+#: DynamicWeb//dynamicweb.py:3531
 #, python-format
 msgid "Family of %(mother)s"
 msgstr "Obitelj od %(mother)s"
 
-#: DynamicWeb/dynamicweb.py:3841
+#: DynamicWeb//dynamicweb.py:3846
 msgid ""
 "In this note, the following special words are processed:\n"
 "__SEARCH_FORM__ is replaced by a search form.\n"
@@ -1083,23 +1083,23 @@ msgstr ""
 "URL, koji započinju s \"relative://relative.<link>\" se zamijenjuje s "
 "relativnim URL-om \"<link>\".\n"
 
-#: DynamicWeb/dynamicweb.py:3880
+#: DynamicWeb//dynamicweb.py:3886
 msgid "Report"
 msgstr "Izvještaj"
 
-#: DynamicWeb/dynamicweb.py:3885
+#: DynamicWeb//dynamicweb.py:3891
 msgid "Destination"
 msgstr "Odredište"
 
-#: DynamicWeb/dynamicweb.py:3887
+#: DynamicWeb//dynamicweb.py:3893
 msgid "The destination directory for the web files"
 msgstr "Mapa za spremanje web datoteka"
 
-#: DynamicWeb/dynamicweb.py:3891
+#: DynamicWeb//dynamicweb.py:3897
 msgid "Store web pages in archive"
 msgstr "Spremi web stranicu u arhivu"
 
-#: DynamicWeb/dynamicweb.py:3892
+#: DynamicWeb//dynamicweb.py:3898
 msgid ""
 "Whether to create an archive file (in ZIP or TGZ format) containing the web "
 "site"
@@ -1107,204 +1107,204 @@ msgstr ""
 "Da li stvoriti arhivsku datoteku (u ZIP ili TGZ formatu), koja sadrži web "
 "stranicu"
 
-#: DynamicWeb/dynamicweb.py:3896
+#: DynamicWeb//dynamicweb.py:3902
 msgid "Archive file"
 msgstr "Arhivna datoteka"
 
-#: DynamicWeb/dynamicweb.py:3898
+#: DynamicWeb//dynamicweb.py:3904
 msgid "The archive file name (with \".zip\" or \".tgz\" extension)"
 msgstr "Ime arhivne datoteke (s dodacima „.zip” ili „.tgz”)"
 
-#: DynamicWeb/dynamicweb.py:3904
+#: DynamicWeb//dynamicweb.py:3910
 msgid "Web site title"
 msgstr "Naslov web stranice"
 
-#: DynamicWeb/dynamicweb.py:3904
+#: DynamicWeb//dynamicweb.py:3910
 msgid "My Family Tree"
 msgstr "Moj rodoslov"
 
-#: DynamicWeb/dynamicweb.py:3905
+#: DynamicWeb//dynamicweb.py:3911
 msgid "The title of the web site"
 msgstr "Naslov za web stranicu"
 
-#: DynamicWeb/dynamicweb.py:3908
+#: DynamicWeb//dynamicweb.py:3914
 msgid "Filter"
 msgstr "Filtar"
 
-#: DynamicWeb/dynamicweb.py:3910
+#: DynamicWeb//dynamicweb.py:3916
 msgid "Select filter to restrict people that appear on web site"
 msgstr ""
 "Odaberi filtar za ograničavanje osoba, koje će biti prikazane na web "
 "stranicama"
 
-#: DynamicWeb/dynamicweb.py:3914
+#: DynamicWeb//dynamicweb.py:3920
 msgid "Filter Person"
 msgstr "Osoba filtra"
 
-#: DynamicWeb/dynamicweb.py:3915
+#: DynamicWeb//dynamicweb.py:3921
 msgid "The center person for the filter"
 msgstr "Središnja osoba ovog filtra"
 
-#: DynamicWeb/dynamicweb.py:3923 DynamicWeb/dynamicweb.py:3943
+#: DynamicWeb//dynamicweb.py:3929 DynamicWeb//dynamicweb.py:3949
 msgid "Name format (short)"
 msgstr "Format imena (skraćeno)"
 
-#: DynamicWeb/dynamicweb.py:3924 DynamicWeb/dynamicweb.py:3946
+#: DynamicWeb//dynamicweb.py:3930 DynamicWeb//dynamicweb.py:3952
 msgid "Select the format to display a shorter version of the names"
 msgstr "Odaberi format za skraćeni prikaz imena"
 
-#: DynamicWeb/dynamicweb.py:3938
+#: DynamicWeb//dynamicweb.py:3944
 msgid "Name format"
 msgstr "Format za imena"
 
-#: DynamicWeb/dynamicweb.py:3941
+#: DynamicWeb//dynamicweb.py:3947
 msgid "Select the format to display names"
 msgstr "Odaberi format za prikaz imena"
 
-#: DynamicWeb/dynamicweb.py:3949
+#: DynamicWeb//dynamicweb.py:3955
 msgid "Web site template"
 msgstr "Predložak za web stranicu"
 
-#: DynamicWeb/dynamicweb.py:3952
+#: DynamicWeb//dynamicweb.py:3958
 msgid "Select the template of the web site"
 msgstr "Odaberi predložak za web stranicu"
 
-#: DynamicWeb/dynamicweb.py:3955
+#: DynamicWeb//dynamicweb.py:3961
 msgid "Copyright"
 msgstr "Autorska prava"
 
-#: DynamicWeb/dynamicweb.py:3958
+#: DynamicWeb//dynamicweb.py:3964
 msgid "The copyright to be used for the web files"
 msgstr "Autorsko pravo korišteno na web stranicama"
 
-#: DynamicWeb/dynamicweb.py:3966
+#: DynamicWeb//dynamicweb.py:3972
 msgid "Privacy"
 msgstr "Privatnost"
 
-#: DynamicWeb/dynamicweb.py:3974
+#: DynamicWeb//dynamicweb.py:3980
 msgid "Include records marked private"
 msgstr "Uključi zapise, označene kao privatne"
 
-#: DynamicWeb/dynamicweb.py:3975
+#: DynamicWeb//dynamicweb.py:3981
 msgid "Whether to include private objects"
 msgstr "Da li uključiti privatne objekte"
 
-#: DynamicWeb/dynamicweb.py:3977
+#: DynamicWeb//dynamicweb.py:3983
 msgid "Living People"
 msgstr "Žive osobe"
 
-#: DynamicWeb/dynamicweb.py:3978
+#: DynamicWeb//dynamicweb.py:3984
 msgid "Exclude"
 msgstr "Isključi"
 
-#: DynamicWeb/dynamicweb.py:3979
+#: DynamicWeb//dynamicweb.py:3985
 msgid "Include Last Name Only"
 msgstr "Uključi samo prezimena"
 
-#: DynamicWeb/dynamicweb.py:3980
+#: DynamicWeb//dynamicweb.py:3986
 msgid "Include Full Name Only"
 msgstr "Uključi samo potpuna imena"
 
-#: DynamicWeb/dynamicweb.py:3981
+#: DynamicWeb//dynamicweb.py:3987
 msgid "Include"
 msgstr "Uključi"
 
-#: DynamicWeb/dynamicweb.py:3982
+#: DynamicWeb//dynamicweb.py:3988
 msgid "How to handle living people"
 msgstr "Kako postupati sa živim osobama"
 
-#: DynamicWeb/dynamicweb.py:3985
+#: DynamicWeb//dynamicweb.py:3991
 msgid "Years from death to consider living"
 msgstr "Broj godina nakon smrti, za određivanje 'živih' osoba"
 
-#: DynamicWeb/dynamicweb.py:3986
+#: DynamicWeb//dynamicweb.py:3992
 msgid ""
 "This allows you to restrict information on people who have not been dead for "
 "very long"
 msgstr ""
 "Ovime se ograničava prikaz informacija osoba, koje su tek nedavno preminule"
 
-#: DynamicWeb/dynamicweb.py:3990
+#: DynamicWeb//dynamicweb.py:3996
 msgid "Export notes"
 msgstr "Izvezi zabilješke"
 
-#: DynamicWeb/dynamicweb.py:3991
+#: DynamicWeb//dynamicweb.py:3997
 msgid "Whether to export notes in the web pages"
 msgstr "Da li izvesti zabilješke u web stranicu"
 
-#: DynamicWeb/dynamicweb.py:3994
+#: DynamicWeb//dynamicweb.py:4000
 msgid "Export sources"
 msgstr "Izvezi izvore"
 
-#: DynamicWeb/dynamicweb.py:3995
+#: DynamicWeb//dynamicweb.py:4001
 msgid "Whether to export sources and citations in the web pages"
 msgstr "Da li izvesti izvore i citate u web stranicu"
 
-#: DynamicWeb/dynamicweb.py:3998
+#: DynamicWeb//dynamicweb.py:4004
 msgid "Export addresses"
 msgstr "Izvezi adrese"
 
-#: DynamicWeb/dynamicweb.py:3999
+#: DynamicWeb//dynamicweb.py:4005
 msgid "Whether to export addresses in the web pages"
 msgstr "Da li izvesti adrese u web stranicu"
 
-#: DynamicWeb/dynamicweb.py:4004
+#: DynamicWeb//dynamicweb.py:4010
 msgid "Options"
 msgstr "Opcije"
 
-#: DynamicWeb/dynamicweb.py:4007
+#: DynamicWeb//dynamicweb.py:4013
 msgid "Include repository pages"
 msgstr "Uključi stranice sa spremištima"
 
-#: DynamicWeb/dynamicweb.py:4008
+#: DynamicWeb//dynamicweb.py:4014
 msgid "Whether or not to include the Repository Pages."
 msgstr "Da li uključiti stranice sa spremištima."
 
-#: DynamicWeb/dynamicweb.py:4011
+#: DynamicWeb//dynamicweb.py:4017
 msgid "Include images and media"
 msgstr "Uključi slike i medijske objekte"
 
-#: DynamicWeb/dynamicweb.py:4012
+#: DynamicWeb//dynamicweb.py:4018
 msgid "Whether to include images and media in the web pages"
 msgstr "Da li uključiti slike i medije u web stranice"
 
-#: DynamicWeb/dynamicweb.py:4016
+#: DynamicWeb//dynamicweb.py:4022
 msgid "Copy, rename files with an internal Gramps identifier"
 msgstr "Kopiraj, preimenuj datoteke s internom Gramps oznakom"
 
-#: DynamicWeb/dynamicweb.py:4017
+#: DynamicWeb//dynamicweb.py:4023
 msgid "Copy, keep file names unchanged"
 msgstr "Kopiraj, zadrži imena datoteka"
 
-#: DynamicWeb/dynamicweb.py:4018
+#: DynamicWeb//dynamicweb.py:4024
 msgid "Do not copy, reference existing files"
 msgstr "Ne kopiraj, referenciraj postojeću datoteku"
 
-#: DynamicWeb/dynamicweb.py:4020
+#: DynamicWeb//dynamicweb.py:4026
 msgid "Images and media"
 msgstr "Slike i mediji"
 
-#: DynamicWeb/dynamicweb.py:4023
+#: DynamicWeb//dynamicweb.py:4029
 msgid "Whether to make a copy of the media"
 msgstr "Da li stvoriti kopije medija"
 
-#: DynamicWeb/dynamicweb.py:4026
+#: DynamicWeb//dynamicweb.py:4032
 msgid "Print the notes type"
 msgstr "Ispiši vrstu zabilježaka"
 
-#: DynamicWeb/dynamicweb.py:4027
+#: DynamicWeb//dynamicweb.py:4033
 msgid "Whether to print the notes type in the notes text"
 msgstr "Da li ispisati vrstu zabilješke u tekstu zabilješke"
 
-#: DynamicWeb/dynamicweb.py:4030
+#: DynamicWeb//dynamicweb.py:4036
 msgid "Print place pages"
 msgstr "Ispiši stranice mjesta"
 
-#: DynamicWeb/dynamicweb.py:4031
+#: DynamicWeb//dynamicweb.py:4037
 msgid "Whether to show pages for the places"
 msgstr "Da li prikazati stranice za mjesta"
 
-#: DynamicWeb/dynamicweb.py:4037
+#: DynamicWeb//dynamicweb.py:4043
 msgid ""
 "Whether to include a place map on the Place Pages, where Latitude/ Longitude "
 "are available."
@@ -1312,7 +1312,7 @@ msgstr ""
 "Da li uključiti kartu mjesta na stranicama mjesta, gdje su dostupne i "
 "zemljopisne širine/dužine."
 
-#: DynamicWeb/dynamicweb.py:4045
+#: DynamicWeb//dynamicweb.py:4051
 msgid ""
 "Whether or not to add an individual page map showing all the places on this "
 "page. This will allow you to see how your family traveled around the country."
@@ -1320,164 +1320,164 @@ msgstr ""
 "Da li uključiti zasebnu stranicu s kartom svih mjesta. Na taj način možeš "
 "vidjeti, kuda se tvoja obitelj svuda kretala."
 
-#: DynamicWeb/dynamicweb.py:4053
+#: DynamicWeb//dynamicweb.py:4059
 msgid "Google"
 msgstr "Google"
 
-#: DynamicWeb/dynamicweb.py:4054
+#: DynamicWeb//dynamicweb.py:4060
 msgid "OpenStreetMap"
 msgstr "OpenStreetMap"
 
-#: DynamicWeb/dynamicweb.py:4056
+#: DynamicWeb//dynamicweb.py:4062
 msgid "Map Service"
 msgstr "Kartografska usluga"
 
-#: DynamicWeb/dynamicweb.py:4059
+#: DynamicWeb//dynamicweb.py:4065
 msgid "Choose your choice of map service for creating the Place Map Pages"
 msgstr ""
 "Odaberi svoju kartografsku uslugu za stvaranje kartografskih stranica mjesta"
 
-#: DynamicWeb/dynamicweb.py:4063
+#: DynamicWeb//dynamicweb.py:4069
 msgid "Google map API key"
 msgstr "Google karta API ključ"
 
-#: DynamicWeb/dynamicweb.py:4064
+#: DynamicWeb//dynamicweb.py:4070
 msgid "The API key used for the Google map"
 msgstr "API ključ za Google kartu"
 
-#: DynamicWeb/dynamicweb.py:4071
+#: DynamicWeb//dynamicweb.py:4077
 msgid "Advanced"
 msgstr "Napredno"
 
-#: DynamicWeb/dynamicweb.py:4074
+#: DynamicWeb//dynamicweb.py:4080
 msgid "Character set encoding"
 msgstr "Kodiranje znakovnog skupa"
 
-#: DynamicWeb/dynamicweb.py:4077
+#: DynamicWeb//dynamicweb.py:4083
 msgid "The encoding to be used for the web files"
 msgstr "Kodiranje korišteno u web datotekama"
 
-#: DynamicWeb/dynamicweb.py:4080
+#: DynamicWeb//dynamicweb.py:4086
 msgid "Include family pages"
 msgstr "Uključi obiteljske stranice"
 
-#: DynamicWeb/dynamicweb.py:4081
+#: DynamicWeb//dynamicweb.py:4087
 msgid "Whether or not to include family pages"
 msgstr "Da li uključiti obiteljske stranice"
 
-#: DynamicWeb/dynamicweb.py:4091
+#: DynamicWeb//dynamicweb.py:4097
 msgid ""
 "Whether to include half and/ or step-siblings with the parents and siblings"
 msgstr "Da li uključiti polubraću s roditeljima i braću/sestre"
 
-#: DynamicWeb/dynamicweb.py:4094
+#: DynamicWeb//dynamicweb.py:4100
 msgid "Include GENDEX file (/gendex.txt)"
 msgstr "Uključi GENDEX datoteku (/gendex.txt)"
 
-#: DynamicWeb/dynamicweb.py:4095
+#: DynamicWeb//dynamicweb.py:4101
 msgid "Whether to include a GENDEX file or not"
 msgstr "Da li uključiti GENDEX datoteku"
 
-#: DynamicWeb/dynamicweb.py:4098
+#: DynamicWeb//dynamicweb.py:4104
 msgid "Enable page configuration"
 msgstr "Omogući konfiguraciju stranice"
 
-#: DynamicWeb/dynamicweb.py:4099
+#: DynamicWeb//dynamicweb.py:4105
 msgid "Whether to enable page configuration"
 msgstr "Da li omogućiti konfiguraciju stranice"
 
-#: DynamicWeb/dynamicweb.py:4103
+#: DynamicWeb//dynamicweb.py:4109
 msgid "Whether to use tabbed panels for the different sections of the pages."
 msgstr "Da li koristiti registarske kartice za različite odjeljke stranice."
 
-#: DynamicWeb/dynamicweb.py:4107
+#: DynamicWeb//dynamicweb.py:4113
 msgid "Whether to show the last modification time in the pages footer"
 msgstr "Da li prikazati vrijeme zadnje promjene u podnožju stranice"
 
-#: DynamicWeb/dynamicweb.py:4111
+#: DynamicWeb//dynamicweb.py:4117
 msgid "Whether to insert sources author in the sources title"
 msgstr "Da li uključiti autora izvora u nazivu izvora"
 
-#: DynamicWeb/dynamicweb.py:4115
+#: DynamicWeb//dynamicweb.py:4121
 msgid "Whether to hide the Gramps ID"
 msgstr "Da li sakriti Gramps ID oznake"
 
-#: DynamicWeb/dynamicweb.py:4124
+#: DynamicWeb//dynamicweb.py:4130
 msgid "List"
 msgstr "Popis"
 
-#: DynamicWeb/dynamicweb.py:4125
+#: DynamicWeb//dynamicweb.py:4131
 msgid "Table"
 msgstr "Tablica"
 
-#: DynamicWeb/dynamicweb.py:4128
+#: DynamicWeb//dynamicweb.py:4134
 msgid "Default format for the surnames index"
 msgstr "Zadani format za indeks prezimena"
 
-#: DynamicWeb/dynamicweb.py:4128
+#: DynamicWeb//dynamicweb.py:4134
 msgid "The default format for the surnames index"
 msgstr "Ovo je zadani format za indeks prezimena"
 
-#: DynamicWeb/dynamicweb.py:4129
+#: DynamicWeb//dynamicweb.py:4135
 msgid "Default format for the persons index"
 msgstr "Zadani format za indeks osoba"
 
-#: DynamicWeb/dynamicweb.py:4129
+#: DynamicWeb//dynamicweb.py:4135
 msgid "The default format for the persons index"
 msgstr "Ovo je zadani format za indeks osoba"
 
-#: DynamicWeb/dynamicweb.py:4130
+#: DynamicWeb//dynamicweb.py:4136
 msgid "Default format for the families index"
 msgstr "Zadani format za indeks obitelji"
 
-#: DynamicWeb/dynamicweb.py:4130
+#: DynamicWeb//dynamicweb.py:4136
 msgid "The default format for the families index"
 msgstr "Ovo je zadani format za indeks obitelji"
 
-#: DynamicWeb/dynamicweb.py:4131
+#: DynamicWeb//dynamicweb.py:4137
 msgid "Default format for the sources index"
 msgstr "Zadani format za indeks izvora"
 
-#: DynamicWeb/dynamicweb.py:4131
+#: DynamicWeb//dynamicweb.py:4137
 msgid "The default format for the sources index"
 msgstr "Ovo je zadani format za indeks izvora"
 
-#: DynamicWeb/dynamicweb.py:4132
+#: DynamicWeb//dynamicweb.py:4138
 msgid "Default format for the places index"
 msgstr "Zadani format za indeks mjesta"
 
-#: DynamicWeb/dynamicweb.py:4132
+#: DynamicWeb//dynamicweb.py:4138
 msgid "The default format for the places index"
 msgstr "Ovo je zadani format za indeks mjesta"
 
-#: DynamicWeb/dynamicweb.py:4141
+#: DynamicWeb//dynamicweb.py:4147
 msgid ""
 "Whether to include dates columns (birth, death, marriage) on the index pages"
 msgstr ""
 "Da li uključiti stupac s datumima (rođenje, smrt, sklapanje braka) na "
 "stranicama indeksa"
 
-#: DynamicWeb/dynamicweb.py:4145
+#: DynamicWeb//dynamicweb.py:4151
 msgid "Whether to include a partners column"
 msgstr "Da li uključiti stupac s partnerima"
 
-#: DynamicWeb/dynamicweb.py:4149
+#: DynamicWeb//dynamicweb.py:4155
 msgid "Whether to include a parents column"
 msgstr "Da li uključiti stupac s roditeljima"
 
-#: DynamicWeb/dynamicweb.py:4152
+#: DynamicWeb//dynamicweb.py:4158
 msgid "Generate a families index page"
 msgstr "Stvori stranicu indeksa za obitelji"
 
-#: DynamicWeb/dynamicweb.py:4153
+#: DynamicWeb//dynamicweb.py:4159
 msgid "Whether to generate an index page for families"
 msgstr "Da li stvoriti stranicu indeksa za obitelji"
 
-#: DynamicWeb/dynamicweb.py:4157
+#: DynamicWeb//dynamicweb.py:4163
 msgid "Whether to include a column showing the media path"
 msgstr "Da li uključiti stupac sa stazom medija"
 
-#: DynamicWeb/dynamicweb.py:4161
+#: DynamicWeb//dynamicweb.py:4167
 msgid ""
 "Whether to include the references to the items in the index pages. For "
 "example, in the media index page, the names of the individuals, families, "
@@ -1487,23 +1487,23 @@ msgstr ""
 "stranici indeksa medija, to mogu biti imena osoba, obitelji, mjesta ili "
 "izvora, koji imaju referencu na medij."
 
-#: DynamicWeb/dynamicweb.py:4164
+#: DynamicWeb//dynamicweb.py:4170
 msgid "Default number of entries in the indexes"
 msgstr "Zadani broj unosa u indeksu"
 
-#: DynamicWeb/dynamicweb.py:4167
+#: DynamicWeb//dynamicweb.py:4173
 msgid "The default number of entries shown in one index page"
 msgstr "Zadani broj unosa, prikazanih na jednoj stranici indeksa"
 
-#: DynamicWeb/dynamicweb.py:4172
+#: DynamicWeb//dynamicweb.py:4178
 msgid "Trees"
 msgstr "Stabla"
 
-#: DynamicWeb/dynamicweb.py:4175
+#: DynamicWeb//dynamicweb.py:4181
 msgid "Maximum number of generations"
 msgstr "Najveći broj generacija"
 
-#: DynamicWeb/dynamicweb.py:4176
+#: DynamicWeb//dynamicweb.py:4182
 msgid ""
 "The maximum number of generations to include in the ancestor and descendant "
 "trees and graphs"
@@ -1511,120 +1511,123 @@ msgstr ""
 "Maksimalni broj uključenih generacija u stabla predaka i potomaka, kao i u "
 "dijagramima"
 
-#: DynamicWeb/dynamicweb.py:4182
+#: DynamicWeb//dynamicweb.py:4188
 msgid "Choose the default SVG tree graph type"
 msgstr "Odaberi standardnu vrstu dijagrama SVG stabla"
 
-#: DynamicWeb/dynamicweb.py:4188
+#: DynamicWeb//dynamicweb.py:4194
 msgid "Choose the default SVG tree graph shape"
 msgstr "Odaberi standardni oblik dijagrama SVG stabla"
 
-#: DynamicWeb/dynamicweb.py:4194
+#: DynamicWeb//dynamicweb.py:4200
 msgid "Choose the default SVG tree parents distribution (for fan charts only)"
 msgstr ""
 "Odaberi standardnu distribuciju roditelja u SVG stablu (samo za lepezaste "
 "dijagrame)"
 
-#: DynamicWeb/dynamicweb.py:4200
+#: DynamicWeb//dynamicweb.py:4206
 msgid "Choose the default SVG tree children distribution (for fan charts only)"
 msgstr ""
 "Odaberi standardnu distribuciju djece u SVG stablu (samo za lepezaste "
 "dijagrame)"
 
-#: DynamicWeb/dynamicweb.py:4206
+#: DynamicWeb//dynamicweb.py:4212
 msgid ""
 "Choose the background color scheme for the persons in the SVG tree graph"
 msgstr "Odaberi sistem boje pozadine za osobe u dijagramu SVG stabla"
 
-#: DynamicWeb/dynamicweb.py:4209
+#: DynamicWeb//dynamicweb.py:4215
 msgid "Start gradient/Main color"
 msgstr "Početak gradijenta/glavna boja"
 
-#: DynamicWeb/dynamicweb.py:4212
+#: DynamicWeb//dynamicweb.py:4218
 msgid "End gradient/2nd color"
 msgstr "Kraj gradijenta/druga boja"
 
-#: DynamicWeb/dynamicweb.py:4220
+#: DynamicWeb//dynamicweb.py:4226
 msgid "Color for duplicates"
 msgstr "Boja duplikata"
 
-#: DynamicWeb/dynamicweb.py:4225
+#: DynamicWeb//dynamicweb.py:4231
 msgid "Pages"
 msgstr "Stranice"
 
-#: DynamicWeb/dynamicweb.py:4228
+#: DynamicWeb//dynamicweb.py:4234
 msgid "HTML user header"
 msgstr "HTML korisničko zaglavlje"
 
-#: DynamicWeb/dynamicweb.py:4229
+#: DynamicWeb//dynamicweb.py:4235
 msgid "A note to be used as the page header"
 msgstr "Zabilješka korištena u zaglavlju stranice"
 
-#: DynamicWeb/dynamicweb.py:4232
+#: DynamicWeb//dynamicweb.py:4238
 msgid "HTML user brand name / icon"
 msgstr "HTML korisnička marka / ikona"
 
-#: DynamicWeb/dynamicweb.py:4233
+#: DynamicWeb//dynamicweb.py:4239
 msgid "A note to be used as the brand name or image in the menu"
 msgstr "Zabilješka u izborniku, koja se koristi kao marka ili slika"
 
-#: DynamicWeb/dynamicweb.py:4236
+#: DynamicWeb//dynamicweb.py:4242
 msgid "HTML user footer"
 msgstr "HTML korisničko podnožje"
 
-#: DynamicWeb/dynamicweb.py:4237
+#: DynamicWeb//dynamicweb.py:4243
 msgid "A note to be used as the page footer"
 msgstr "Bilješka korištena u podnožju stranice"
 
-#: DynamicWeb/dynamicweb.py:4242
+#: DynamicWeb//dynamicweb.py:4248
 msgid "Custom pages"
 msgstr "Prilagođene stranice"
 
-#: DynamicWeb/dynamicweb.py:4246
+#: DynamicWeb//dynamicweb.py:4252
 #, python-format
 msgid "Title for the custom page %(index)i"
 msgstr "Naslov za prilagođenu stranicu %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4247
+#: DynamicWeb//dynamicweb.py:4253
 #, python-format
 msgid "Name for the custom page %(index)i"
 msgstr "Ime za prilagođenu stranicu %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4250
+#: DynamicWeb//dynamicweb.py:4256
 #, python-format
 msgid "Note for custom page %(index)i"
 msgstr "Zabilješka za prilagođenu stranicu %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4251
+#: DynamicWeb//dynamicweb.py:4257
 msgid "A note to be used for the custom page content.\n"
 msgstr "Bilješka korištena za sadržaj prilagođene stranice.\n"
 
-#: DynamicWeb/dynamicweb.py:4254
+#: DynamicWeb//dynamicweb.py:4260
 #, python-format
 msgid "Menu for the custom page %(index)i"
 msgstr "Izbornik za prilagođenu stranicu %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4255
+#: DynamicWeb//dynamicweb.py:4261
 msgid "Whether to print a menu for the custom page"
 msgstr "Da li prikazati izbornik za prilagođenu stranicu"
 
-#: DynamicWeb/dynamicweb.py:4260
+#: DynamicWeb//dynamicweb.py:4266
 msgid "Pages selection"
 msgstr "Odabir stranica"
 
-#: DynamicWeb/dynamicweb.py:4263
+#: DynamicWeb//dynamicweb.py:4269
 msgid "Number of pages"
 msgstr "Broj stranica"
 
-#: DynamicWeb/dynamicweb.py:4264
+#: DynamicWeb//dynamicweb.py:4270
 msgid "Number pages in the web site menu."
 msgstr "Pobroji stranice u izborniku web stranice."
 
-#: DynamicWeb/dynamicweb.py:4280
+#: DynamicWeb//dynamicweb.py:4286
 #, python-format
 msgid "Contents of page %(index)i"
 msgstr "Sadržaj stranice %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4283
+#: DynamicWeb//dynamicweb.py:4289
 msgid "Contents of the page"
 msgstr "Sadržaj stranice"
+
+#~ msgid "Html|Home"
+#~ msgstr "Početna"

--- a/DynamicWeb/po/nl-local.po
+++ b/DynamicWeb/po/nl-local.po
@@ -1,0 +1,1637 @@
+# Dutch translation of addon DynamicWeb.
+# Copyright (C) 2020 Gramps project
+# This file is distributed under the same license as the DynamicWeb package.
+# Jan Sparreboom <jan@sparreboom.net>, 2020.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: DynamicWeb 5.x\n"
+"Report-Msgid-Bugs-To: https://www.gramps-project.org/bugs\n"
+"POT-Creation-Date: 2020-07-24 17:33+0200\n"
+"PO-Revision-Date: 2020-07-24 17:26+0200\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
+"Language-Team: Dutch <gramps-users@lists.sourceforge.net>\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.3\n"
+
+#: DynamicWeb//dynamicweb.gpr.py:15
+msgid "Dynamic Web Report"
+msgstr "Dynamisch webverslag"
+
+#: DynamicWeb//dynamicweb.gpr.py:16
+msgid "Produces dynamic web pages for the database"
+msgstr "Produceert dynamische webpagina's voor de database"
+
+#: DynamicWeb//dynamicweb.py:269
+msgid "Street"
+msgstr "Straat"
+
+#: DynamicWeb//dynamicweb.py:270
+msgid "Locality"
+msgstr "Streek"
+
+#: DynamicWeb//dynamicweb.py:271
+msgid "City"
+msgstr "Stad"
+
+#: DynamicWeb//dynamicweb.py:272
+msgid "Church Parish"
+msgstr "Kerkparochie"
+
+#: DynamicWeb//dynamicweb.py:273
+msgid "County"
+msgstr "Streek"
+
+#: DynamicWeb//dynamicweb.py:274
+msgid "State/ Province"
+msgstr "Staat/ Provincie"
+
+#: DynamicWeb//dynamicweb.py:275
+msgid "Postal Code"
+msgstr "Postcode"
+
+#: DynamicWeb//dynamicweb.py:276
+msgid "Country"
+msgstr "Land"
+
+#: DynamicWeb//dynamicweb.py:277
+msgid "Phone"
+msgstr "Telefoon"
+
+#: DynamicWeb//dynamicweb.py:283
+msgid "Home Page"
+msgstr "Startpagina"
+
+#: DynamicWeb//dynamicweb.py:284
+msgid "SVG graphical tree"
+msgstr "SVG grafische boom"
+
+#: DynamicWeb//dynamicweb.py:287
+msgid "Indexes pages"
+msgstr "Indexeert pagina's"
+
+#: DynamicWeb//dynamicweb.py:291 DynamicWeb//dynamicweb.py:4252
+#, python-format
+msgid "Custom page %(index)i"
+msgstr "Aangepaste pagina %(index)i"
+
+#: DynamicWeb//dynamicweb.py:309
+msgid "Ascending tree"
+msgstr "Stijgende boom"
+
+#: DynamicWeb//dynamicweb.py:310
+msgid "Descending tree"
+msgstr "Dalende boom"
+
+#: DynamicWeb//dynamicweb.py:311
+msgid "Descending tree with spouses"
+msgstr "Dalende boom met echtgenoten"
+
+#: DynamicWeb//dynamicweb.py:312
+msgid "Ascending and descending tree"
+msgstr "Stijgende en dalende boom"
+
+#: DynamicWeb//dynamicweb.py:313
+msgid "Ascending and descending tree with spouses"
+msgstr "Stijgende en dalende boom met echtgenoten"
+
+#: DynamicWeb//dynamicweb.py:325
+msgid "Vertical (↓)"
+msgstr "Verticaal (↓)"
+
+#: DynamicWeb//dynamicweb.py:326
+msgid "Vertical (↑)"
+msgstr "Verticaal (↑)"
+
+#: DynamicWeb//dynamicweb.py:327
+msgid "Horizontal (→)"
+msgstr "Horizontaal (→)"
+
+#: DynamicWeb//dynamicweb.py:328
+msgid "Horizontal (←)"
+msgstr "Horizontaal (←)"
+
+#: DynamicWeb//dynamicweb.py:329
+msgid "Full Circle"
+msgstr "Volledige cirkel"
+
+#: DynamicWeb//dynamicweb.py:330
+msgid "Half Circle"
+msgstr "Halve cirkel"
+
+#: DynamicWeb//dynamicweb.py:331
+msgid "Quadrant"
+msgstr "Kwart cirkel"
+
+#: DynamicWeb//dynamicweb.py:343
+msgid "Size proportional to number of ancestors"
+msgstr "Grootte evenredig met het aantal voorouders"
+
+#: DynamicWeb//dynamicweb.py:344
+msgid "Homogeneous parents distribution"
+msgstr "Homogene verdeling van ouders"
+
+#: DynamicWeb//dynamicweb.py:347
+msgid "Size proportional to number of descendants"
+msgstr "Grootte evenredig met het aantal afstammelingen"
+
+#: DynamicWeb//dynamicweb.py:348
+msgid "Homogeneous children distribution"
+msgstr "Homogene verdeling van kinderen"
+
+#: DynamicWeb//dynamicweb.py:355 DynamicWeb//dynamicweb.py:378
+msgid "Gender colors"
+msgstr "Kleuren geslacht"
+
+#: DynamicWeb//dynamicweb.py:356
+msgid "Generation based gradient"
+msgstr "Op generatie gebaseerd kleurverloop"
+
+#: DynamicWeb//dynamicweb.py:357
+msgid "Age based gradient"
+msgstr "Op leeftijd gebaseerd kleurverloop"
+
+#: DynamicWeb//dynamicweb.py:358 DynamicWeb//dynamicweb.py:377
+msgid "Single main (filter) color"
+msgstr "Enkele hoofdkleur (filter)"
+
+#: DynamicWeb//dynamicweb.py:359
+msgid "Time period based gradient"
+msgstr "Op tijdsperiode gebaseerd kleurverloop"
+
+#: DynamicWeb//dynamicweb.py:360 DynamicWeb//dynamicweb.py:382
+msgid "White"
+msgstr "Wit"
+
+#: DynamicWeb//dynamicweb.py:361 DynamicWeb//dynamicweb.py:380
+msgid "Color scheme classic report"
+msgstr "Kleurenschema klassiek verslag"
+
+#: DynamicWeb//dynamicweb.py:362 DynamicWeb//dynamicweb.py:381
+msgid "Color scheme classic view"
+msgstr "Kleurenschema klassieke weergave"
+
+#: DynamicWeb//dynamicweb.py:379
+msgid "Gradient"
+msgstr "Kleurverloop"
+
+#: DynamicWeb//dynamicweb.py:398
+msgid "Default"
+msgstr "Standaard"
+
+#: DynamicWeb//dynamicweb.py:399
+msgid "Mainz"
+msgstr "Mainz"
+
+#: DynamicWeb//dynamicweb.py:707
+#, python-format
+msgid "Neither %(current)s nor %(parent)s are directories"
+msgstr "Noch %(current)s noch %(parent)s zijn directories"
+
+#: DynamicWeb//dynamicweb.py:715 DynamicWeb//dynamicweb.py:720
+#, python-format
+msgid "Could not create the directory: %(path)s"
+msgstr "Kan de directory niet maken: %(path)s"
+
+#: DynamicWeb//dynamicweb.py:746 DynamicWeb//dynamicweb.py:3385
+msgid "Dynamic Web Site Report"
+msgstr "Dynamisch websiteverslag"
+
+#: DynamicWeb//dynamicweb.py:746
+msgid "Exporting family tree data ..."
+msgstr "Stamboomgegevens exporteren ..."
+
+#: DynamicWeb//dynamicweb.py:1237 DynamicWeb//dynamicweb.py:2461
+msgid "Author"
+msgstr "Auteur"
+
+#: DynamicWeb//dynamicweb.py:1238 DynamicWeb//dynamicweb.py:2451
+msgid "Abbreviation"
+msgstr "Afkorting"
+
+#: DynamicWeb//dynamicweb.py:1239 DynamicWeb//dynamicweb.py:2548
+msgid "Publication information"
+msgstr "Publicatie-informatie"
+
+#: DynamicWeb//dynamicweb.py:1309 DynamicWeb//dynamicweb.py:2479
+msgid "Date"
+msgstr "Datum"
+
+#: DynamicWeb//dynamicweb.py:1310
+msgid "Page"
+msgstr "Bladzijde"
+
+#: DynamicWeb//dynamicweb.py:1311
+msgid "Confidence"
+msgstr "Betrouwbaarheid"
+
+#: DynamicWeb//dynamicweb.py:1630
+#, python-format
+msgid "%(type)s: %(value)s"
+msgstr "%(type)s: %(value)s"
+
+#: DynamicWeb//dynamicweb.py:1877
+#, python-format
+msgid "Impossible to convert \"%(path)s\" to a relative path."
+msgstr "Onmogelijk om \"%(path)s\" naar een relatief pad te converteren."
+
+#: DynamicWeb//dynamicweb.py:2183
+msgid ""
+"The pages configuration is not valid: several pages have the same content"
+msgstr ""
+"De paginaconfiguratie is niet geldig: meerdere pagina's hebben dezelfde "
+"inhoud"
+
+#: DynamicWeb//dynamicweb.py:2194
+msgid "DynWeb|Home"
+msgstr "Start"
+
+#: DynamicWeb//dynamicweb.py:2195 DynamicWeb//dynamicweb.py:2208
+#: DynamicWeb//dynamicweb.py:2209 DynamicWeb//dynamicweb.py:2210
+msgid "Tree"
+msgstr "Boom"
+
+#: DynamicWeb//dynamicweb.py:2196 DynamicWeb//dynamicweb.py:2211
+#: DynamicWeb//dynamicweb.py:2212 DynamicWeb//dynamicweb.py:2213
+msgid "Statistics"
+msgstr "Statistieken"
+
+#: DynamicWeb//dynamicweb.py:2199 DynamicWeb//dynamicweb.py:2475
+msgid "Configuration"
+msgstr "Configuratie"
+
+#: DynamicWeb//dynamicweb.py:2201 DynamicWeb//dynamicweb.py:2540
+msgid "Person"
+msgstr "Persoon"
+
+#: DynamicWeb//dynamicweb.py:2202
+msgid "Family"
+msgstr "Gezin"
+
+#: DynamicWeb//dynamicweb.py:2203 DynamicWeb//dynamicweb.py:2580
+msgid "Source"
+msgstr "Bron"
+
+#: DynamicWeb//dynamicweb.py:2204 DynamicWeb//dynamicweb.py:2223
+#: DynamicWeb//dynamicweb.py:2523
+msgid "Media"
+msgstr "Media"
+
+#: DynamicWeb//dynamicweb.py:2205 DynamicWeb//dynamicweb.py:2543
+msgid "Place"
+msgstr "Locatie"
+
+#: DynamicWeb//dynamicweb.py:2206 DynamicWeb//dynamicweb.py:2555
+msgid "Repository"
+msgstr "Bibliotheek"
+
+#: DynamicWeb//dynamicweb.py:2207
+msgid "Search results"
+msgstr "Zoekresultaten"
+
+#: DynamicWeb//dynamicweb.py:2218 DynamicWeb//dynamicweb.py:2219
+#: DynamicWeb//dynamicweb.py:2587
+msgid "Surnames"
+msgstr "Achternamen"
+
+#: DynamicWeb//dynamicweb.py:2220 DynamicWeb//dynamicweb.py:2508
+msgid "Individuals"
+msgstr "Individuen"
+
+#: DynamicWeb//dynamicweb.py:2221 DynamicWeb//dynamicweb.py:2491
+msgid "Families"
+msgstr "Gezinnen"
+
+#: DynamicWeb//dynamicweb.py:2222 DynamicWeb//dynamicweb.py:2582
+msgid "Sources"
+msgstr "Bronnen"
+
+#: DynamicWeb//dynamicweb.py:2224 DynamicWeb//dynamicweb.py:2545
+msgid "Places"
+msgstr "Locaties"
+
+#: DynamicWeb//dynamicweb.py:2225 DynamicWeb//dynamicweb.py:2453
+msgid "Addresses"
+msgstr "Adressen"
+
+#: DynamicWeb//dynamicweb.py:2226 DynamicWeb//dynamicweb.py:2554
+msgid "Repositories"
+msgstr "Bibliotheken"
+
+#: DynamicWeb//dynamicweb.py:2277 DynamicWeb//dynamicweb.py:2507
+#: DynamicWeb//dynamicweb.py:4126
+msgid "Indexes"
+msgstr "Indexen"
+
+#: DynamicWeb//dynamicweb.py:2441
+#, python-format
+msgid "(b. %(birthdate)s, d. %(deathdate)s)"
+msgstr "(g. %(birthdate)s, o. %(deathdate)s)"
+
+#: DynamicWeb//dynamicweb.py:2442
+#, python-format
+msgid "(b. %s)"
+msgstr "(g. %s)"
+
+#: DynamicWeb//dynamicweb.py:2443
+#, python-format
+msgid "(d. %s)"
+msgstr "(o. %s)"
+
+#: DynamicWeb//dynamicweb.py:2444
+msgid "(filtered from _MAX_ total entries)"
+msgstr "(gefilterd uit in totaal _MAX_ items)"
+
+#: DynamicWeb//dynamicweb.py:2445
+#, python-format
+msgid "(m. %s)"
+msgstr "(m. %s)"
+
+#: DynamicWeb//dynamicweb.py:2446
+msgid "(sort by name)"
+msgstr "(sorteren op naam)"
+
+#: DynamicWeb//dynamicweb.py:2447
+msgid "(sort by quantity)"
+msgstr "(sorteer op hoeveelheid)"
+
+#: DynamicWeb//dynamicweb.py:2448
+msgid ": activate to sort column ascending"
+msgstr ": activeer om de kolom oplopend te sorteren"
+
+#: DynamicWeb//dynamicweb.py:2449
+msgid ": activate to sort column descending"
+msgstr ": activeer om de kolom aflopend te sorteren"
+
+#: DynamicWeb//dynamicweb.py:2450
+msgid ""
+"<p>This page provides the SVG raw code.<br>Copy the contents into a text "
+"editor and save as an SVG file.<br>Make sure that the text editor encoding "
+"is UTF-8.</p>"
+msgstr ""
+"<p> Deze pagina bevat de onbewerkte SVG-code. <br> Kopieer de inhoud naar "
+"een teksteditor en sla deze op als een SVG-bestand. <br> Zorg ervoor dat de "
+"codering van de teksteditor UTF-8 is. </p>"
+
+#: DynamicWeb//dynamicweb.py:2452
+msgid "Address"
+msgstr "Adres"
+
+#: DynamicWeb//dynamicweb.py:2454
+msgid "Age at death"
+msgstr "Leeftijd bij overlijden"
+
+#: DynamicWeb//dynamicweb.py:2455
+msgid "Alternate Marriage"
+msgstr "Alternatief huwelijk"
+
+#: DynamicWeb//dynamicweb.py:2456
+msgid "Alternate Name"
+msgstr "Bijnaam"
+
+#: DynamicWeb//dynamicweb.py:2457
+msgid "Ancestors"
+msgstr "Voorouders"
+
+#: DynamicWeb//dynamicweb.py:2458
+msgid "Associations"
+msgstr "Associaties"
+
+#: DynamicWeb//dynamicweb.py:2459
+msgid "Attribute"
+msgstr "Kenmerk"
+
+#: DynamicWeb//dynamicweb.py:2460
+msgid "Attributes"
+msgstr "Kenmerken"
+
+#: DynamicWeb//dynamicweb.py:2462 DynamicWeb//dynamicweb.py:4209
+msgid "Background"
+msgstr "Achtergrond"
+
+#: DynamicWeb//dynamicweb.py:2463
+msgid "Baptism"
+msgstr "Doop"
+
+#: DynamicWeb//dynamicweb.py:2464
+msgid "Birth"
+msgstr "Geboorte"
+
+#: DynamicWeb//dynamicweb.py:2465
+msgid "Burial"
+msgstr "Begrafenis"
+
+#: DynamicWeb//dynamicweb.py:2466
+msgid "Call Name"
+msgstr "Roepnaam"
+
+#: DynamicWeb//dynamicweb.py:2467
+msgid "Call Number"
+msgstr "Inventarisnummer"
+
+#: DynamicWeb//dynamicweb.py:2468
+msgid "Cause Of Death"
+msgstr "Doodsoorzaak"
+
+#: DynamicWeb//dynamicweb.py:2469
+msgid "Children"
+msgstr "Kinderen"
+
+#: DynamicWeb//dynamicweb.py:2470
+msgid "Christening"
+msgstr "Doopnaam (chr)"
+
+#: DynamicWeb//dynamicweb.py:2471
+msgid "Citation"
+msgstr "Citaat"
+
+#: DynamicWeb//dynamicweb.py:2472
+msgid "Citations"
+msgstr "Citaten"
+
+#: DynamicWeb//dynamicweb.py:2473
+msgid "Click on the map to show it full-screen"
+msgstr "Klik op de kaart om deze op volledig scherm weer te geven"
+
+#: DynamicWeb//dynamicweb.py:2474
+msgid "Code"
+msgstr "Code"
+
+#: DynamicWeb//dynamicweb.py:2476
+msgid "Configure"
+msgstr "Configureer"
+
+#: DynamicWeb//dynamicweb.py:2477
+msgid "Count"
+msgstr "Tellen"
+
+#: DynamicWeb//dynamicweb.py:2478
+msgid "Cremation"
+msgstr "Crematie"
+
+#: DynamicWeb//dynamicweb.py:2480
+msgid "Death"
+msgstr "Overlijden"
+
+#: DynamicWeb//dynamicweb.py:2481
+msgid "Descendants"
+msgstr "Afstammelingen"
+
+#: DynamicWeb//dynamicweb.py:2482
+msgid "Description"
+msgstr "Beschrijving"
+
+#: DynamicWeb//dynamicweb.py:2483
+msgid "DynamicWeb_report#Help"
+msgstr "DynamicWeb_report#Help"
+
+#: DynamicWeb//dynamicweb.py:2484
+msgid "Enclosed By"
+msgstr "Omsloten door"
+
+#: DynamicWeb//dynamicweb.py:2485
+msgid "Engagement"
+msgstr "Verloving"
+
+#: DynamicWeb//dynamicweb.py:2486
+msgid "Event"
+msgstr "Gebeurtenis"
+
+#: DynamicWeb//dynamicweb.py:2487
+msgid "Events"
+msgstr "Gebeurtenissen"
+
+#: DynamicWeb//dynamicweb.py:2488
+msgid "Examples"
+msgstr "Voorbeelden"
+
+#: DynamicWeb//dynamicweb.py:2489
+msgid "F"
+msgstr "V"
+
+#: DynamicWeb//dynamicweb.py:2490
+msgid "Families Index"
+msgstr "Index van gezinnen"
+
+#: DynamicWeb//dynamicweb.py:2492
+msgid "Family Nick Name"
+msgstr "Familiebijnaam"
+
+#: DynamicWeb//dynamicweb.py:2493
+msgid "Father"
+msgstr "Vader"
+
+#: DynamicWeb//dynamicweb.py:2494
+msgid "Female"
+msgstr "Vrouwelijk"
+
+#: DynamicWeb//dynamicweb.py:2495
+msgid "File ready"
+msgstr "Bestand klaar"
+
+#: DynamicWeb//dynamicweb.py:2496
+msgid "Gender"
+msgstr "Geslacht"
+
+#: DynamicWeb//dynamicweb.py:2497
+msgid "Help"
+msgstr "Help"
+
+#: DynamicWeb//dynamicweb.py:2498
+msgid "ID"
+msgstr "ID"
+
+#: DynamicWeb//dynamicweb.py:2499 DynamicWeb//dynamicweb.py:4041
+msgid "Include Place map on Place Pages"
+msgstr "Voeg Locatiekaart op Locatiepagina's toe"
+
+#: DynamicWeb//dynamicweb.py:2500 DynamicWeb//dynamicweb.py:4146
+msgid "Include dates columns on the index pages"
+msgstr "Neem kolommen met datums op de indexpagina's op"
+
+#: DynamicWeb//dynamicweb.py:2501 DynamicWeb//dynamicweb.py:4154
+msgid "Include a column for parents on the index pages"
+msgstr "Voeg een kolom voor ouders toe op de indexpagina's"
+
+#: DynamicWeb//dynamicweb.py:2502 DynamicWeb//dynamicweb.py:4162
+msgid "Include a column for media path on the index pages"
+msgstr "Voeg een kolom toe voor het mediapad op de indexpagina's"
+
+#: DynamicWeb//dynamicweb.py:2503 DynamicWeb//dynamicweb.py:4150
+msgid "Include a column for partners on the index pages"
+msgstr "Voeg een kolom voor partners toe op de indexpagina's"
+
+#: DynamicWeb//dynamicweb.py:2504 DynamicWeb//dynamicweb.py:4049
+msgid "Include a map in the individuals and family pages"
+msgstr "Voeg een kaart toe aan de individuele en gezinpagina's"
+
+#: DynamicWeb//dynamicweb.py:2505 DynamicWeb//dynamicweb.py:4096
+msgid "Include half and/ or step-siblings on the individual pages"
+msgstr "Neem half- en/of stiefbroers/-zussen op de afzonderlijke pagina's op"
+
+#: DynamicWeb//dynamicweb.py:2506 DynamicWeb//dynamicweb.py:4166
+msgid "Include references in indexes"
+msgstr "Verwijzingen opnemen in indexen"
+
+#: DynamicWeb//dynamicweb.py:2509 DynamicWeb//dynamicweb.py:4116
+msgid "Insert sources author in the sources title"
+msgstr "Voeg bronnenauteur in de brontitel in"
+
+#: DynamicWeb//dynamicweb.py:2510
+msgid "Last Modified"
+msgstr "Laatst gewijzigd"
+
+#: DynamicWeb//dynamicweb.py:2511
+msgid "Latitude"
+msgstr "Breedtegraad"
+
+#: DynamicWeb//dynamicweb.py:2512
+msgid "Link"
+msgstr "Koppeling"
+
+#: DynamicWeb//dynamicweb.py:2513
+msgid "Loading..."
+msgstr "Bezig met laden..."
+
+#: DynamicWeb//dynamicweb.py:2514
+msgid "Location"
+msgstr "Locatie"
+
+#: DynamicWeb//dynamicweb.py:2515
+msgid "Longitude"
+msgstr "Lengtegraad"
+
+#: DynamicWeb//dynamicweb.py:2516
+msgid "M"
+msgstr "M"
+
+#: DynamicWeb//dynamicweb.py:2517
+msgid "Male"
+msgstr "Mannelijk"
+
+#: DynamicWeb//dynamicweb.py:2518
+msgid "Map"
+msgstr "Landkaart"
+
+#: DynamicWeb//dynamicweb.py:2519
+msgid "Marriage"
+msgstr "Huwelijk"
+
+#: DynamicWeb//dynamicweb.py:2520
+msgid "Maximize"
+msgstr "Maximaliseren"
+
+#: DynamicWeb//dynamicweb.py:2521
+msgid "Media Index"
+msgstr "Media-index"
+
+#: DynamicWeb//dynamicweb.py:2522
+msgid "Media Type"
+msgstr "Mediatype"
+
+#: DynamicWeb//dynamicweb.py:2524
+msgid "Mother"
+msgstr "Moeder"
+
+#: DynamicWeb//dynamicweb.py:2525
+msgid "Name"
+msgstr "Naam"
+
+#: DynamicWeb//dynamicweb.py:2526
+msgid "Nick Name"
+msgstr "Bijnaam"
+
+#: DynamicWeb//dynamicweb.py:2527
+msgid "No data available in table"
+msgstr "Geen data beschikbaar in de tabel"
+
+#: DynamicWeb//dynamicweb.py:2528
+msgid "No matches found"
+msgstr "Geen overeenkomsten gevonden"
+
+#: DynamicWeb//dynamicweb.py:2529
+msgid "No matching records found"
+msgstr "Geen overeenkomende gegevens gevonden"
+
+#: DynamicWeb//dynamicweb.py:2530
+msgid "No matching surname."
+msgstr "Geen overeenkomende achternaam."
+
+#: DynamicWeb//dynamicweb.py:2531
+msgid "None"
+msgstr "Geen"
+
+#: DynamicWeb//dynamicweb.py:2532
+msgid "Notes"
+msgstr "Notities"
+
+#: DynamicWeb//dynamicweb.py:2533
+msgid "Number"
+msgstr "Nummer"
+
+#: DynamicWeb//dynamicweb.py:2534
+msgid "OK"
+msgstr "OK"
+
+#: DynamicWeb//dynamicweb.py:2535
+msgid "Other participants"
+msgstr "Andere deelnemers"
+
+#: DynamicWeb//dynamicweb.py:2536
+msgid "Parents"
+msgstr "Ouders"
+
+#: DynamicWeb//dynamicweb.py:2537
+msgid "Path"
+msgstr "Pad"
+
+#: DynamicWeb//dynamicweb.py:2538
+msgid "Person page"
+msgstr "Persoonspagina"
+
+#: DynamicWeb//dynamicweb.py:2539
+msgid "Person to search for"
+msgstr "Persoon om naar te zoeken"
+
+#: DynamicWeb//dynamicweb.py:2541
+msgid "Persons Index"
+msgstr "Personenindex"
+
+#: DynamicWeb//dynamicweb.py:2542
+msgid "Persons"
+msgstr "Personen"
+
+#: DynamicWeb//dynamicweb.py:2544
+msgid "Places Index"
+msgstr "Plaatsenindex"
+
+#: DynamicWeb//dynamicweb.py:2546
+msgid "Preparing file ..."
+msgstr "Bestand voorbereiden ..."
+
+#: DynamicWeb//dynamicweb.py:2547
+msgid "Processing..."
+msgstr "Verwerken..."
+
+#: DynamicWeb//dynamicweb.py:2549
+msgid "References"
+msgstr "Referenties"
+
+#: DynamicWeb//dynamicweb.py:2550
+msgid "Relationship to Father"
+msgstr "Verwantschap met vader"
+
+#: DynamicWeb//dynamicweb.py:2551
+msgid "Relationship to Mother"
+msgstr "Verwantschap met moeder"
+
+#: DynamicWeb//dynamicweb.py:2552
+msgid "Relationship"
+msgstr "Verwantschap"
+
+#: DynamicWeb//dynamicweb.py:2553
+msgid "Repositories Index"
+msgstr "Bibliothekenindex"
+
+#: DynamicWeb//dynamicweb.py:2556
+msgid "Restore"
+msgstr "Herstellen"
+
+#: DynamicWeb//dynamicweb.py:2557
+msgid "Restore default settings"
+msgstr "Standaard instellingen terugzetten"
+
+#: DynamicWeb//dynamicweb.py:2558 DynamicWeb//dynamicweb.py:4112
+msgid "Show last modification time"
+msgstr "Tijd van laatste wijziging weergeven"
+
+#: DynamicWeb//dynamicweb.py:2559 DynamicWeb//dynamicweb.py:4203
+msgid "SVG tree children distribution"
+msgstr "SVG-boom kinderenverdeling"
+
+#: DynamicWeb//dynamicweb.py:2560
+msgid "SVG tree configuration"
+msgstr "SVG-boomconfiguratie"
+
+#: DynamicWeb//dynamicweb.py:2561 DynamicWeb//dynamicweb.py:4191
+msgid "SVG tree graph shape"
+msgstr "SVG-boom grafiekvorm"
+
+#: DynamicWeb//dynamicweb.py:2562 DynamicWeb//dynamicweb.py:4185
+msgid "SVG tree graph type"
+msgstr "SVG-boom grafiektype"
+
+#: DynamicWeb//dynamicweb.py:2563 DynamicWeb//dynamicweb.py:4197
+msgid "SVG tree parents distribution"
+msgstr "SVG-boom oudersverdeling"
+
+#: DynamicWeb//dynamicweb.py:2564
+msgid "Save tree as file"
+msgstr "Boom opslaan als bestand"
+
+#: DynamicWeb//dynamicweb.py:2565
+msgid "Search:"
+msgstr "Zoek:"
+
+#: DynamicWeb//dynamicweb.py:2566
+msgid "Select the background color scheme"
+msgstr "Selecteer het achtergrondkleurenschema"
+
+#: DynamicWeb//dynamicweb.py:2567
+msgid "Select the children distribution (fan charts only)"
+msgstr "Selecteer de kinderverdeling (alleen waaierdiagrammen)"
+
+#: DynamicWeb//dynamicweb.py:2568
+msgid "Select the number of ascending generations"
+msgstr "Selecteer het aantal oplopende generaties"
+
+#: DynamicWeb//dynamicweb.py:2569
+msgid "Select the number of descending generations"
+msgstr "Selecteer het aantal aflopende generaties"
+
+#: DynamicWeb//dynamicweb.py:2570
+msgid "Select the parents distribution (fan charts only)"
+msgstr "Selecteer de oudersverdeling (alleen waaierdiagrammen)"
+
+#: DynamicWeb//dynamicweb.py:2571
+msgid "Select the shape of graph"
+msgstr "Selecteer de vorm van de grafiek"
+
+#: DynamicWeb//dynamicweb.py:2572
+msgid "Select the type of graph"
+msgstr "Selecteer het type grafiek"
+
+#: DynamicWeb//dynamicweb.py:2573
+msgid "Several matches.<br>Precise your search or choose in the lists below."
+msgstr ""
+"Meerdere overeenkomsten. <br> Preciseer uw zoekopdracht of kies in de "
+"onderstaande lijsten."
+
+#: DynamicWeb//dynamicweb.py:2574
+msgid "Show _MENU_ entries"
+msgstr "Toon _MENU_-vermeldingen"
+
+#: DynamicWeb//dynamicweb.py:2575 DynamicWeb//dynamicweb.py:4221
+msgid "Show duplicates"
+msgstr "Toon duplicaten"
+
+#: DynamicWeb//dynamicweb.py:2576
+msgid "Showing 0 to 0 of 0 entries"
+msgstr "Toont 0 tot 0 van 0 vermeldingen"
+
+#: DynamicWeb//dynamicweb.py:2577
+msgid "Showing _START_ to _END_ of _TOTAL_ entries"
+msgstr "Toont _START_ tot _END_ van _TOTAL_ vermeldingen"
+
+#: DynamicWeb//dynamicweb.py:2578
+msgid "Siblings"
+msgstr "Broers en zussen"
+
+#: DynamicWeb//dynamicweb.py:2579
+msgid "Sort by:"
+msgstr "Sorteer op:"
+
+#: DynamicWeb//dynamicweb.py:2581
+msgid "Sources Index"
+msgstr "Bronnenindex"
+
+#: DynamicWeb//dynamicweb.py:2583
+msgid "Spouses"
+msgstr "Echtgenoten"
+
+#: DynamicWeb//dynamicweb.py:2584 DynamicWeb//dynamicweb.py:4120
+msgid "Suppress Gramps ID"
+msgstr "Onderdruk Gramps-ID"
+
+#: DynamicWeb//dynamicweb.py:2585
+msgid "Surname"
+msgstr "Achternaam"
+
+#: DynamicWeb//dynamicweb.py:2586
+msgid "Surnames Index"
+msgstr "Achternamenindex"
+
+#: DynamicWeb//dynamicweb.py:2588
+msgid "Title"
+msgstr "Titel"
+
+#: DynamicWeb//dynamicweb.py:2589
+msgid "Type"
+msgstr "Type"
+
+#: DynamicWeb//dynamicweb.py:2590
+msgid "U"
+msgstr "U"
+
+#: DynamicWeb//dynamicweb.py:2591
+msgid "Unknown"
+msgstr "Onbekend"
+
+#: DynamicWeb//dynamicweb.py:2592 DynamicWeb//dynamicweb.py:4108
+msgid "Use tabbed panels instead of sections"
+msgstr "Gebruik tabbladen in plaats van secties"
+
+#: DynamicWeb//dynamicweb.py:2593
+msgid "Use the search box above in order to find a person."
+msgstr "Gebruik het zoekvak hierboven om een persoon te vinden."
+
+#: DynamicWeb//dynamicweb.py:2594
+msgid "Use a table format for the surnames index"
+msgstr "Gebruik een tabelindeling voor de achternamenindex"
+
+#: DynamicWeb//dynamicweb.py:2595
+msgid "Use a table format for the persons index"
+msgstr "Gebruik een tabelindeling voor de personenindex"
+
+#: DynamicWeb//dynamicweb.py:2596
+msgid "Use a table format for the families index"
+msgstr "Gebruik een tabelindeling voor de gezinsindex"
+
+#: DynamicWeb//dynamicweb.py:2597
+msgid "Use a table format for the sources index"
+msgstr "Gebruik een tabelindeling voor de bronnenindex"
+
+#: DynamicWeb//dynamicweb.py:2598
+msgid "Use a table format for the places index"
+msgstr "Gebruik een tabelindeling voor de plaatsenindex"
+
+#: DynamicWeb//dynamicweb.py:2599
+msgid "Used for family"
+msgstr "Gebruikt voor gezin"
+
+#: DynamicWeb//dynamicweb.py:2600
+msgid "Used for media"
+msgstr "Gebruikt voor media"
+
+#: DynamicWeb//dynamicweb.py:2601
+msgid "Used for person"
+msgstr "Gebruikt voor persoon"
+
+#: DynamicWeb//dynamicweb.py:2602
+msgid "Used for place"
+msgstr "Gebruikt voor locatie"
+
+#: DynamicWeb//dynamicweb.py:2603
+msgid "Used for source"
+msgstr "Gebruikt voor bron"
+
+#: DynamicWeb//dynamicweb.py:2604
+msgid "Value"
+msgstr "Waarde"
+
+#: DynamicWeb//dynamicweb.py:2605
+msgid "Web Link"
+msgstr "Web link"
+
+#: DynamicWeb//dynamicweb.py:2606
+msgid "Web Links"
+msgstr "Web links"
+
+#: DynamicWeb//dynamicweb.py:2607 DynamicWeb//dynamicweb.py:4222
+msgid ""
+"Whether to use a special color for the persons that appear several times in "
+"the SVG tree"
+msgstr ""
+"Of een speciale kleur moet worden gebruikt voor de personen die meerdere "
+"keren in de SVG-structuur voorkomen"
+
+#: DynamicWeb//dynamicweb.py:2608
+msgid "Without name"
+msgstr "Zonder naam"
+
+#: DynamicWeb//dynamicweb.py:2609
+msgid "Without surname"
+msgstr "Zonder achternaam"
+
+#: DynamicWeb//dynamicweb.py:2610
+msgid "Without title"
+msgstr "Zonder titel"
+
+#: DynamicWeb//dynamicweb.py:2611
+msgid "Zoom in"
+msgstr "Inzoomen"
+
+#: DynamicWeb//dynamicweb.py:2612
+msgid "Zoom out"
+msgstr "Uitzoomen"
+
+#: DynamicWeb//dynamicweb.py:2613
+msgid "all"
+msgstr "allemaal"
+
+#: DynamicWeb//dynamicweb.py:2816
+msgid "No Home Person"
+msgstr "Geen Beginpersoon"
+
+#: DynamicWeb//dynamicweb.py:2957
+#, python-format
+msgid "Copying error: %(error)s"
+msgstr "Kopieerfout: %(error)s"
+
+#: DynamicWeb//dynamicweb.py:2958
+#, python-format
+msgid "Impossible to copy \"%(src)s\" to \"%(dst)s\""
+msgstr "Onmogelijk om \"%(src)s\" naar \"%(dst)s\" te kopiëren"
+
+#: DynamicWeb//dynamicweb.py:2961
+msgid "Possible destination error"
+msgstr "Mogelijk fout in bestemming"
+
+#: DynamicWeb//dynamicweb.py:2962
+msgid ""
+"You appear to have set your target directory to a directory used for data "
+"storage. This could create problems with file management. It is recommended "
+"that you consider using a different directory to store your generated web "
+"pages."
+msgstr ""
+"Het lijkt erop dat u uw doelmap heeft ingesteld op een map die wordt "
+"gebruikt voor gegevensopslag. Dit kan problemen opleveren met "
+"bestandsbeheer. Het wordt aanbevolen om een andere directory te gebruiken om "
+"uw gegenereerde webpagina's op te slaan."
+
+#: DynamicWeb//dynamicweb.py:2989
+#, python-format
+msgid "Unable to copy web site template files from \"%(path)s\""
+msgstr "Kan websitesjabloonbestanden niet kopiëren van \"%(path)s\""
+
+#: DynamicWeb//dynamicweb.py:3033
+#, python-format
+msgid "Keeping \"%(dst)s\" (newer than \"%(src)s\")"
+msgstr "\"%(dst)s\" behouden (nieuwer dan \"%(src)s\")"
+
+#: DynamicWeb//dynamicweb.py:3036
+#, python-format
+msgid "Copying \"%(src)s\" to \"%(dst)s\""
+msgstr "\"%(src)s\" naar \"%(dst)s\" kopiëren"
+
+#: DynamicWeb//dynamicweb.py:3054
+msgid "Invalid file name"
+msgstr "Ongeldige bestandsnaam"
+
+#: DynamicWeb//dynamicweb.py:3055
+msgid "The archive file must be a file, not a directory"
+msgstr "Het archiefbestand moet een bestand zijn en geen directory"
+
+#: DynamicWeb//dynamicweb.py:3065 DynamicWeb//dynamicweb.py:3083
+#, python-format
+msgid "Unable to overwrite archive file \"%(path)s\""
+msgstr "Kan archiefbestand \"%(path)s\" niet overschrijven"
+
+#: DynamicWeb//dynamicweb.py:3075 DynamicWeb//dynamicweb.py:3090
+#, python-format
+msgid "Unable to add file \"%(file)s\" to archive \"%(archive)s\""
+msgstr "Kan bestand \"%(file)s\" niet toevoegen aan archief \"%(archive)s\""
+
+#: DynamicWeb//dynamicweb.py:3143
+#, python-format
+msgid "DynamicWebReport ignoring link type '%(class)s'"
+msgstr "DynamicWebReport negeert linktype '%(class)s'"
+
+#: DynamicWeb//dynamicweb.py:3386
+msgid "Constructing list of other objects..."
+msgstr "Lijst met andere objecten maken..."
+
+#: DynamicWeb//dynamicweb.py:3521
+#, python-format
+msgid "Family of %(husband)s and %(spouse)s"
+msgstr "Gezin van %(husband)s en %(spouse)s"
+
+#: DynamicWeb//dynamicweb.py:3527
+#, python-format
+msgid "Family of %(father)s"
+msgstr "Gezin van %(father)s"
+
+#: DynamicWeb//dynamicweb.py:3531
+#, python-format
+msgid "Family of %(mother)s"
+msgstr "Gezin van %(mother)s"
+
+#: DynamicWeb//dynamicweb.py:3846
+msgid ""
+"In this note, the following special words are processed:\n"
+"__SEARCH_FORM__ is replaced by a search form.\n"
+"__NB_INDIVIDUALS__ is replaced by the number of persons.\n"
+"__NB_FAMILIES__ is replaced by the number of families.\n"
+"__NB_MEDIA__ is replaced by the number of media.\n"
+"__NB_SOURCES__ is replaced by the number of sources.\n"
+"__NB_REPOSITORIES__ is replaced by the number of repositories.\n"
+"__NB_PLACES__ is replaced by the number of places.\n"
+"__MEDIA_<gid>__ is replaced by the media with Gramps ID <gid>.\n"
+"__THUMB_<gid>__ is replaced by the thumbnail of the media with Gramps ID "
+"<gid>.\n"
+"__EXPORT_DATE__ is replaced by the current date.\n"
+"__GRAMPS_VERSION__ is replaced by the Gramps version.\n"
+"__GRAMPS_HOMEPAGE__ is replaced by the Gramps homepage link.\n"
+"URL starting with \"relative://relative.<link>\" are replaced by the "
+"relative URL \"<link>\".\n"
+msgstr ""
+"In deze notitie worden de volgende speciale woorden gebruikt:\n"
+"__SEARCH_FORM__ wordt vervangen door een zoekformulier.\n"
+"__NB_INDIVIDUALS__ wordt vervangen door het aantal personen.\n"
+"__NB_FAMILIES__ wordt vervangen door het aantal gezinnen.\n"
+"__NB_MEDIA__ wordt vervangen door het aantal media.\n"
+"__NB_SOURCES__ wordt vervangen door het aantal bronnen.\n"
+"__NB_REPOSITORIES__ wordt vervangen door het aantal bibliotheken.\n"
+"__NB_PLACES__ wordt vervangen door het aantal locaties.\n"
+"__MEDIA_ <gid> __ wordt vervangen door media met Gramps-ID <gid>.\n"
+"__THUMB_ <gid> __ wordt vervangen door de miniatuurafbeelding van media met "
+"Gramps-ID <gid>.\n"
+"__EXPORT_DATE__ wordt vervangen door de huidige datum.\n"
+"__GRAMPS_VERSION__ wordt vervangen door de Gramps-versie.\n"
+"__GRAMPS_HOMEPAGE__ wordt vervangen door de Gramps-startpagina-link.\n"
+"URL die begint met \"relatief: // relatief. <link>\" wordt vervangen door de "
+"relatieve URL \"<link>\".\n"
+
+#: DynamicWeb//dynamicweb.py:3886
+msgid "Report"
+msgstr "Verslag"
+
+#: DynamicWeb//dynamicweb.py:3891
+msgid "Destination"
+msgstr "Bestemming"
+
+#: DynamicWeb//dynamicweb.py:3893
+msgid "The destination directory for the web files"
+msgstr "De bestemmingsmap voor de webbestanden"
+
+#: DynamicWeb//dynamicweb.py:3897
+msgid "Store web pages in archive"
+msgstr "Bewaar webpagina's in het archief"
+
+#: DynamicWeb//dynamicweb.py:3898
+msgid ""
+"Whether to create an archive file (in ZIP or TGZ format) containing the web "
+"site"
+msgstr ""
+"Of er een archiefbestand gemaakt moet worden (in ZIP- of TGZ-formaat) van de "
+"website"
+
+#: DynamicWeb//dynamicweb.py:3902
+msgid "Archive file"
+msgstr "Archiefbestand"
+
+#: DynamicWeb//dynamicweb.py:3904
+msgid "The archive file name (with \".zip\" or \".tgz\" extension)"
+msgstr "De archiefbestandsnaam (met extensie \".zip\" of \".tgz\")"
+
+#: DynamicWeb//dynamicweb.py:3910
+msgid "Web site title"
+msgstr "Website titel"
+
+#: DynamicWeb//dynamicweb.py:3910
+msgid "My Family Tree"
+msgstr "Mijn stamboom"
+
+#: DynamicWeb//dynamicweb.py:3911
+msgid "The title of the web site"
+msgstr "De titel van de website"
+
+#: DynamicWeb//dynamicweb.py:3914
+msgid "Filter"
+msgstr "Filter"
+
+#: DynamicWeb//dynamicweb.py:3916
+msgid "Select filter to restrict people that appear on web site"
+msgstr ""
+"Selecteer filter om het aantal personen te beperken die op de website "
+"verschijnen"
+
+#: DynamicWeb//dynamicweb.py:3920
+msgid "Filter Person"
+msgstr "Persoon filteren"
+
+#: DynamicWeb//dynamicweb.py:3921
+msgid "The center person for the filter"
+msgstr "De centrale persoon voor het filter"
+
+#: DynamicWeb//dynamicweb.py:3929 DynamicWeb//dynamicweb.py:3949
+msgid "Name format (short)"
+msgstr "Naamopmaak (kort)"
+
+#: DynamicWeb//dynamicweb.py:3930 DynamicWeb//dynamicweb.py:3952
+msgid "Select the format to display a shorter version of the names"
+msgstr "Selecteer de opmaak om een kortere versie van de namen weer te geven"
+
+#: DynamicWeb//dynamicweb.py:3944
+msgid "Name format"
+msgstr "Naamopmaak"
+
+#: DynamicWeb//dynamicweb.py:3947
+msgid "Select the format to display names"
+msgstr "Selecteer de indeling om namen weer te geven"
+
+#: DynamicWeb//dynamicweb.py:3955
+msgid "Web site template"
+msgstr "Website sjabloon"
+
+#: DynamicWeb//dynamicweb.py:3958
+msgid "Select the template of the web site"
+msgstr "Selecteer de sjabloon van de website"
+
+#: DynamicWeb//dynamicweb.py:3961
+msgid "Copyright"
+msgstr "Auteursrecht"
+
+#: DynamicWeb//dynamicweb.py:3964
+msgid "The copyright to be used for the web files"
+msgstr "Het auteursrecht dat voor de webbestanden moet worden gebruikt"
+
+#: DynamicWeb//dynamicweb.py:3972
+msgid "Privacy"
+msgstr "Privacy"
+
+#: DynamicWeb//dynamicweb.py:3980
+msgid "Include records marked private"
+msgstr "Neem records op die als privé zijn gemarkeerd"
+
+#: DynamicWeb//dynamicweb.py:3981
+msgid "Whether to include private objects"
+msgstr "Of privé-objecten moeten worden opgenomen"
+
+#: DynamicWeb//dynamicweb.py:3983
+msgid "Living People"
+msgstr "Levende mensen"
+
+#: DynamicWeb//dynamicweb.py:3984
+msgid "Exclude"
+msgstr "Uitsluiten"
+
+#: DynamicWeb//dynamicweb.py:3985
+msgid "Include Last Name Only"
+msgstr "Alleen achternaam opnemen"
+
+#: DynamicWeb//dynamicweb.py:3986
+msgid "Include Full Name Only"
+msgstr "Alleen volledige naam opnemen"
+
+#: DynamicWeb//dynamicweb.py:3987
+msgid "Include"
+msgstr "Bijsluiten"
+
+#: DynamicWeb//dynamicweb.py:3988
+msgid "How to handle living people"
+msgstr "Hoe om te gaan met levende personen"
+
+#: DynamicWeb//dynamicweb.py:3991
+msgid "Years from death to consider living"
+msgstr "Levensverwachting"
+
+#: DynamicWeb//dynamicweb.py:3992
+msgid ""
+"This allows you to restrict information on people who have not been dead for "
+"very long"
+msgstr ""
+"Hiermee kunt u informatie beperken over mensen die nog niet lang overleden "
+"zijn"
+
+#: DynamicWeb//dynamicweb.py:3996
+msgid "Export notes"
+msgstr "Exporteer notities"
+
+#: DynamicWeb//dynamicweb.py:3997
+msgid "Whether to export notes in the web pages"
+msgstr "Of notities naar de webpagina's moeten worden geëxporteerd"
+
+#: DynamicWeb//dynamicweb.py:4000
+msgid "Export sources"
+msgstr "Exporteer bronnen"
+
+#: DynamicWeb//dynamicweb.py:4001
+msgid "Whether to export sources and citations in the web pages"
+msgstr "Of bronnen en citaten naar de webpagina's moeten worden geëxporteerd"
+
+#: DynamicWeb//dynamicweb.py:4004
+msgid "Export addresses"
+msgstr "Adressen exporteren"
+
+#: DynamicWeb//dynamicweb.py:4005
+msgid "Whether to export addresses in the web pages"
+msgstr "Of adressen naar de webpagina's moeten worden geëxporteerd"
+
+#: DynamicWeb//dynamicweb.py:4010
+msgid "Options"
+msgstr "Opties"
+
+#: DynamicWeb//dynamicweb.py:4013
+msgid "Include repository pages"
+msgstr "Voeg bibliotheekpagina's toe"
+
+#: DynamicWeb//dynamicweb.py:4014
+msgid "Whether or not to include the Repository Pages."
+msgstr "Of de bibliotheekpagina's moeten worden opgenomen."
+
+#: DynamicWeb//dynamicweb.py:4017
+msgid "Include images and media"
+msgstr "Voeg afbeeldingen en media toe"
+
+#: DynamicWeb//dynamicweb.py:4018
+msgid "Whether to include images and media in the web pages"
+msgstr "Of afbeeldingen en media in de webpagina's moeten worden opgenomen"
+
+#: DynamicWeb//dynamicweb.py:4022
+msgid "Copy, rename files with an internal Gramps identifier"
+msgstr "Kopieer en hernoem bestanden met een interne Gramps-ID"
+
+#: DynamicWeb//dynamicweb.py:4023
+msgid "Copy, keep file names unchanged"
+msgstr "Kopieer, houd bestandsnamen ongewijzigd"
+
+#: DynamicWeb//dynamicweb.py:4024
+msgid "Do not copy, reference existing files"
+msgstr "Kopieer niet, verwijs naar bestaande bestanden"
+
+#: DynamicWeb//dynamicweb.py:4026
+msgid "Images and media"
+msgstr "Afbeeldingen en media"
+
+#: DynamicWeb//dynamicweb.py:4029
+msgid "Whether to make a copy of the media"
+msgstr "Of er een kopie van de media gemaakt moet worden"
+
+#: DynamicWeb//dynamicweb.py:4032
+msgid "Print the notes type"
+msgstr "Druk het notitietype af"
+
+#: DynamicWeb//dynamicweb.py:4033
+msgid "Whether to print the notes type in the notes text"
+msgstr "Of het notitietype afgedrukt moet worden in de notitietekst"
+
+#: DynamicWeb//dynamicweb.py:4036
+msgid "Print place pages"
+msgstr "Locatiepagina's afdrukken"
+
+#: DynamicWeb//dynamicweb.py:4037
+msgid "Whether to show pages for the places"
+msgstr "Of pagina's voor de locaties moeten worden weergegeven"
+
+#: DynamicWeb//dynamicweb.py:4043
+msgid ""
+"Whether to include a place map on the Place Pages, where Latitude/ Longitude "
+"are available."
+msgstr ""
+"Of een locatiekaart moet worden opgenomen op de locatiepagina's, waar de "
+"lengte- en breedtegraad beschikbaar is."
+
+#: DynamicWeb//dynamicweb.py:4051
+msgid ""
+"Whether or not to add an individual page map showing all the places on this "
+"page. This will allow you to see how your family traveled around the country."
+msgstr ""
+"Al dan niet een individuele paginakaart toevoegen die alle locaties toont op "
+"deze pagina. Zo kunt u zien hoe uw gezin door het land reisde."
+
+#: DynamicWeb//dynamicweb.py:4059
+msgid "Google"
+msgstr "Google"
+
+#: DynamicWeb//dynamicweb.py:4060
+msgid "OpenStreetMap"
+msgstr "OpenStreetMap"
+
+#: DynamicWeb//dynamicweb.py:4062
+msgid "Map Service"
+msgstr "Kaartservice"
+
+#: DynamicWeb//dynamicweb.py:4065
+msgid "Choose your choice of map service for creating the Place Map Pages"
+msgstr "Kies uw kaartservice voor het maken van de locatiekaartpagina's"
+
+#: DynamicWeb//dynamicweb.py:4069
+msgid "Google map API key"
+msgstr "Google-kaart API-sleutel"
+
+#: DynamicWeb//dynamicweb.py:4070
+msgid "The API key used for the Google map"
+msgstr "De API-sleutel die wordt gebruikt voor de Google-kaart"
+
+#: DynamicWeb//dynamicweb.py:4077
+msgid "Advanced"
+msgstr "Geavanceerd"
+
+#: DynamicWeb//dynamicweb.py:4080
+msgid "Character set encoding"
+msgstr "Tekenset codering"
+
+#: DynamicWeb//dynamicweb.py:4083
+msgid "The encoding to be used for the web files"
+msgstr "De codering die voor de webbestanden moet worden gebruikt"
+
+#: DynamicWeb//dynamicweb.py:4086
+msgid "Include family pages"
+msgstr "Voeg gezinspagina's toe"
+
+#: DynamicWeb//dynamicweb.py:4087
+msgid "Whether or not to include family pages"
+msgstr "Al dan niet gezinspagina's opnemen"
+
+#: DynamicWeb//dynamicweb.py:4097
+msgid ""
+"Whether to include half and/ or step-siblings with the parents and siblings"
+msgstr ""
+"Of half- en/of stiefbroers en -zussen met de ouders en broers en zussen "
+"moeten worden ogepnomen"
+
+#: DynamicWeb//dynamicweb.py:4100
+msgid "Include GENDEX file (/gendex.txt)"
+msgstr "Voeg GENDEX-bestand (/gendex.txt) toe"
+
+#: DynamicWeb//dynamicweb.py:4101
+msgid "Whether to include a GENDEX file or not"
+msgstr "Of een GENDEX-bestand moet worden opgenomen"
+
+#: DynamicWeb//dynamicweb.py:4104
+msgid "Enable page configuration"
+msgstr "Schakel paginaconfiguratie in"
+
+#: DynamicWeb//dynamicweb.py:4105
+msgid "Whether to enable page configuration"
+msgstr "Of pagina-configuratie moet worden ingeschakeld"
+
+#: DynamicWeb//dynamicweb.py:4109
+msgid "Whether to use tabbed panels for the different sections of the pages."
+msgstr ""
+"Of panelen met tabbladen moeten worden gebruikt voor de verschillende "
+"secties van de pagina's."
+
+#: DynamicWeb//dynamicweb.py:4113
+msgid "Whether to show the last modification time in the pages footer"
+msgstr ""
+"Of de laatste wijzigingstijd in de voettekst van de pagina moet worden "
+"weergegeven"
+
+#: DynamicWeb//dynamicweb.py:4117
+msgid "Whether to insert sources author in the sources title"
+msgstr "Of de bronauteur moet worden ingevoegd in de titel van de bron"
+
+#: DynamicWeb//dynamicweb.py:4121
+msgid "Whether to hide the Gramps ID"
+msgstr "Of het Gramps-ID verborgen moet worden"
+
+#: DynamicWeb//dynamicweb.py:4130
+msgid "List"
+msgstr "Lijst"
+
+#: DynamicWeb//dynamicweb.py:4131
+msgid "Table"
+msgstr "Tabel"
+
+#: DynamicWeb//dynamicweb.py:4134
+msgid "Default format for the surnames index"
+msgstr "Standaardopmaak voor de achternamenindex"
+
+#: DynamicWeb//dynamicweb.py:4134
+msgid "The default format for the surnames index"
+msgstr "De standaardindeling voor de achternamenindex"
+
+#: DynamicWeb//dynamicweb.py:4135
+msgid "Default format for the persons index"
+msgstr "Standaardopmaak voor de personenindex"
+
+#: DynamicWeb//dynamicweb.py:4135
+msgid "The default format for the persons index"
+msgstr "De standaardindeling voor de personenindex"
+
+#: DynamicWeb//dynamicweb.py:4136
+msgid "Default format for the families index"
+msgstr "Standaardopmaak voor de gezinsindex"
+
+#: DynamicWeb//dynamicweb.py:4136
+msgid "The default format for the families index"
+msgstr "De standaardindeling voor de gezinsindex"
+
+#: DynamicWeb//dynamicweb.py:4137
+msgid "Default format for the sources index"
+msgstr "Standaardopmaak voor de bronnenindex"
+
+#: DynamicWeb//dynamicweb.py:4137
+msgid "The default format for the sources index"
+msgstr "De standaardindeling voor de bronnenindex"
+
+#: DynamicWeb//dynamicweb.py:4138
+msgid "Default format for the places index"
+msgstr "Standaardopmaak voor de locatiesindex"
+
+#: DynamicWeb//dynamicweb.py:4138
+msgid "The default format for the places index"
+msgstr "De standaardindeling voor de locatiesindex"
+
+#: DynamicWeb//dynamicweb.py:4147
+msgid ""
+"Whether to include dates columns (birth, death, marriage) on the index pages"
+msgstr ""
+"Of kolommen met datums (geboorte, overlijden, huwelijk) op de indexpagina's "
+"moeten worden opgenomen"
+
+#: DynamicWeb//dynamicweb.py:4151
+msgid "Whether to include a partners column"
+msgstr "Of een kolom met partners moet worden opgenomen"
+
+#: DynamicWeb//dynamicweb.py:4155
+msgid "Whether to include a parents column"
+msgstr "Of een ouderkolom moet worden opgenomen"
+
+#: DynamicWeb//dynamicweb.py:4158
+msgid "Generate a families index page"
+msgstr "Genereer een gezinsindexpagina"
+
+#: DynamicWeb//dynamicweb.py:4159
+msgid "Whether to generate an index page for families"
+msgstr "Of er een indexpagina voor gezinnen moet worden gegenereerd"
+
+#: DynamicWeb//dynamicweb.py:4163
+msgid "Whether to include a column showing the media path"
+msgstr "Of een kolom met het mediapad moet worden opgenomen"
+
+#: DynamicWeb//dynamicweb.py:4167
+msgid ""
+"Whether to include the references to the items in the index pages. For "
+"example, in the media index page, the names of the individuals, families, "
+"places, sources that reference the media."
+msgstr ""
+"Of de verwijzingen naar de items in de indexpagina's moeten worden "
+"opgenomen. Op de media-indexpagina bijvoorbeeld de namen van de individuen, "
+"families, plaatsen, bronnen die naar de media verwijzen."
+
+#: DynamicWeb//dynamicweb.py:4170
+msgid "Default number of entries in the indexes"
+msgstr "Standaardaantal vermeldingen in de indexen"
+
+#: DynamicWeb//dynamicweb.py:4173
+msgid "The default number of entries shown in one index page"
+msgstr "Het standaardaantal items dat op één indexpagina wordt weergegeven"
+
+#: DynamicWeb//dynamicweb.py:4178
+msgid "Trees"
+msgstr "Bomen"
+
+#: DynamicWeb//dynamicweb.py:4181
+msgid "Maximum number of generations"
+msgstr "Maximaal aantal generaties"
+
+#: DynamicWeb//dynamicweb.py:4182
+msgid ""
+"The maximum number of generations to include in the ancestor and descendant "
+"trees and graphs"
+msgstr ""
+"Het maximale aantal generaties dat in de voorouder- en afstammelingsbomen en "
+"grafieken moet worden opgenomen"
+
+#: DynamicWeb//dynamicweb.py:4188
+msgid "Choose the default SVG tree graph type"
+msgstr "Kies het standaard SVG-boom grafiektype"
+
+#: DynamicWeb//dynamicweb.py:4194
+msgid "Choose the default SVG tree graph shape"
+msgstr "Kies de standaard SVG-boom grafiekvorm"
+
+#: DynamicWeb//dynamicweb.py:4200
+msgid "Choose the default SVG tree parents distribution (for fan charts only)"
+msgstr ""
+"Kies de standaard SVG-boom oudersverdeling (alleen voor waaierdiagrammen)"
+
+#: DynamicWeb//dynamicweb.py:4206
+msgid "Choose the default SVG tree children distribution (for fan charts only)"
+msgstr ""
+"Kies de standaard SVG-boom kinderenverdeling (alleen voor waaierdiagrammen)"
+
+#: DynamicWeb//dynamicweb.py:4212
+msgid ""
+"Choose the background color scheme for the persons in the SVG tree graph"
+msgstr ""
+"Kies het achtergrondkleurenschema voor de personen in de SVG-boomgrafiek"
+
+#: DynamicWeb//dynamicweb.py:4215
+msgid "Start gradient/Main color"
+msgstr "Start kleurverloop/hoofdkleur"
+
+#: DynamicWeb//dynamicweb.py:4218
+msgid "End gradient/2nd color"
+msgstr "Eind kleurverloop/2e kleur"
+
+#: DynamicWeb//dynamicweb.py:4226
+msgid "Color for duplicates"
+msgstr "Kleur voor duplicaten"
+
+#: DynamicWeb//dynamicweb.py:4231
+msgid "Pages"
+msgstr "Pagina's"
+
+#: DynamicWeb//dynamicweb.py:4234
+msgid "HTML user header"
+msgstr "HTML-gebruikerskop"
+
+#: DynamicWeb//dynamicweb.py:4235
+msgid "A note to be used as the page header"
+msgstr "Een notitie om te gebruiken als paginakoptekst"
+
+#: DynamicWeb//dynamicweb.py:4238
+msgid "HTML user brand name / icon"
+msgstr "Merknaam / pictogram van HTML-gebruiker"
+
+#: DynamicWeb//dynamicweb.py:4239
+msgid "A note to be used as the brand name or image in the menu"
+msgstr "Een notitie om te gebruiken als merknaam of afbeelding in het menu"
+
+#: DynamicWeb//dynamicweb.py:4242
+msgid "HTML user footer"
+msgstr "Voettekst HTML-gebruiker"
+
+#: DynamicWeb//dynamicweb.py:4243
+msgid "A note to be used as the page footer"
+msgstr "Een notitie die als voettekst van de pagina moet worden gebruikt"
+
+#: DynamicWeb//dynamicweb.py:4248
+msgid "Custom pages"
+msgstr "Aangepaste pagina's"
+
+#: DynamicWeb//dynamicweb.py:4252
+#, python-format
+msgid "Title for the custom page %(index)i"
+msgstr "Titel voor de aangepaste pagina %(index)i"
+
+#: DynamicWeb//dynamicweb.py:4253
+#, python-format
+msgid "Name for the custom page %(index)i"
+msgstr "Naam voor de aangepaste pagina %(index)i"
+
+#: DynamicWeb//dynamicweb.py:4256
+#, python-format
+msgid "Note for custom page %(index)i"
+msgstr "Notitie voor aangepaste pagina %(index)i"
+
+#: DynamicWeb//dynamicweb.py:4257
+msgid "A note to be used for the custom page content.\n"
+msgstr "Een notitie voor de aangepaste pagina-inhoud.\n"
+
+#: DynamicWeb//dynamicweb.py:4260
+#, python-format
+msgid "Menu for the custom page %(index)i"
+msgstr "Menu voor de aangepaste pagina %(index)i"
+
+#: DynamicWeb//dynamicweb.py:4261
+msgid "Whether to print a menu for the custom page"
+msgstr "Of er een menu afgedrukt moet worden voor de aangepaste pagina"
+
+#: DynamicWeb//dynamicweb.py:4266
+msgid "Pages selection"
+msgstr "Selectie van pagina's"
+
+#: DynamicWeb//dynamicweb.py:4269
+msgid "Number of pages"
+msgstr "Aantal pagina's"
+
+#: DynamicWeb//dynamicweb.py:4270
+msgid "Number pages in the web site menu."
+msgstr "Aantal pagina's in het website menu."
+
+#: DynamicWeb//dynamicweb.py:4286
+#, python-format
+msgid "Contents of page %(index)i"
+msgstr "Inhoud van pagina %(index)i"
+
+#: DynamicWeb//dynamicweb.py:4289
+msgid "Contents of the page"
+msgstr "Inhoud van de pagina"

--- a/DynamicWeb/po/pt_PT-local.po
+++ b/DynamicWeb/po/pt_PT-local.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gramps51\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"POT-Creation-Date: 2020-07-24 17:33+0200\n"
 "PO-Revision-Date: 2020-03-31 07:39Hora de Verão de GMT\n"
 "Last-Translator: Pedro Albuquerque <pmra@protonmail.com>\n"
 "Language-Team: Pedro Albuquerque\n"
@@ -17,356 +17,356 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Geany / PoHelper 1.36\n"
 
-#: DynamicWeb/dynamicweb.gpr.py:15
+#: DynamicWeb//dynamicweb.gpr.py:15
 msgid "Dynamic Web Report"
 msgstr "Relatório Web dinâmico"
 
-#: DynamicWeb/dynamicweb.gpr.py:16
+#: DynamicWeb//dynamicweb.gpr.py:16
 msgid "Produces dynamic web pages for the database"
 msgstr "Produz páginas web dinâmicas para a base de dados"
 
-#: DynamicWeb/dynamicweb.py:265
+#: DynamicWeb//dynamicweb.py:269
 msgid "Street"
 msgstr "Rua"
 
-#: DynamicWeb/dynamicweb.py:266
+#: DynamicWeb//dynamicweb.py:270
 msgid "Locality"
 msgstr "Localidade"
 
-#: DynamicWeb/dynamicweb.py:267
+#: DynamicWeb//dynamicweb.py:271
 msgid "City"
 msgstr "Cidade"
 
-#: DynamicWeb/dynamicweb.py:268
+#: DynamicWeb//dynamicweb.py:272
 msgid "Church Parish"
 msgstr "Paróquia"
 
-#: DynamicWeb/dynamicweb.py:269
+#: DynamicWeb//dynamicweb.py:273
 msgid "County"
 msgstr "Concelho"
 
-#: DynamicWeb/dynamicweb.py:270
+#: DynamicWeb//dynamicweb.py:274
 msgid "State/ Province"
 msgstr "Distrito"
 
-#: DynamicWeb/dynamicweb.py:271
+#: DynamicWeb//dynamicweb.py:275
 msgid "Postal Code"
 msgstr "Código postal"
 
-#: DynamicWeb/dynamicweb.py:272
+#: DynamicWeb//dynamicweb.py:276
 msgid "Country"
 msgstr "País"
 
-#: DynamicWeb/dynamicweb.py:273
+#: DynamicWeb//dynamicweb.py:277
 msgid "Phone"
 msgstr "Telefone"
 
-#: DynamicWeb/dynamicweb.py:279
+#: DynamicWeb//dynamicweb.py:283
 msgid "Home Page"
 msgstr "Página web"
 
-#: DynamicWeb/dynamicweb.py:280
+#: DynamicWeb//dynamicweb.py:284
 msgid "SVG graphical tree"
 msgstr "Árvore gráfica SVG"
 
-#: DynamicWeb/dynamicweb.py:283
+#: DynamicWeb//dynamicweb.py:287
 msgid "Indexes pages"
 msgstr "Páginas de índice"
 
-#: DynamicWeb/dynamicweb.py:287 DynamicWeb/dynamicweb.py:4246
+#: DynamicWeb//dynamicweb.py:291 DynamicWeb//dynamicweb.py:4252
 #, python-format
 msgid "Custom page %(index)i"
 msgstr "Página personalizada %(index)i"
 
-#: DynamicWeb/dynamicweb.py:305
+#: DynamicWeb//dynamicweb.py:309
 msgid "Ascending tree"
 msgstr "Árvore ascendente"
 
-#: DynamicWeb/dynamicweb.py:306
+#: DynamicWeb//dynamicweb.py:310
 msgid "Descending tree"
 msgstr "Árvore descendente"
 
-#: DynamicWeb/dynamicweb.py:307
+#: DynamicWeb//dynamicweb.py:311
 msgid "Descending tree with spouses"
 msgstr "Árvore descendente com cônjuges"
 
-#: DynamicWeb/dynamicweb.py:308
+#: DynamicWeb//dynamicweb.py:312
 msgid "Ascending and descending tree"
 msgstr "Árvore ascendente e descendente"
 
-#: DynamicWeb/dynamicweb.py:309
+#: DynamicWeb//dynamicweb.py:313
 msgid "Ascending and descending tree with spouses"
 msgstr "Árvore ascendente e descendente com cônjuges"
 
-#: DynamicWeb/dynamicweb.py:321
+#: DynamicWeb//dynamicweb.py:325
 msgid "Vertical (↓)"
 msgstr "Vertical (↓)"
 
-#: DynamicWeb/dynamicweb.py:322
+#: DynamicWeb//dynamicweb.py:326
 msgid "Vertical (↑)"
 msgstr "Vertical (↑)"
 
-#: DynamicWeb/dynamicweb.py:323
+#: DynamicWeb//dynamicweb.py:327
 msgid "Horizontal (→)"
 msgstr "Horizontal (→)"
 
-#: DynamicWeb/dynamicweb.py:324
+#: DynamicWeb//dynamicweb.py:328
 msgid "Horizontal (←)"
 msgstr "Horizontal (←)"
 
-#: DynamicWeb/dynamicweb.py:325
+#: DynamicWeb//dynamicweb.py:329
 msgid "Full Circle"
 msgstr "Círculo completo"
 
-#: DynamicWeb/dynamicweb.py:326
+#: DynamicWeb//dynamicweb.py:330
 msgid "Half Circle"
 msgstr "Meio círculo"
 
-#: DynamicWeb/dynamicweb.py:327
+#: DynamicWeb//dynamicweb.py:331
 msgid "Quadrant"
 msgstr "Quarto de círculo"
 
-#: DynamicWeb/dynamicweb.py:339
+#: DynamicWeb//dynamicweb.py:343
 msgid "Size proportional to number of ancestors"
 msgstr "Tamanho proporcional ao número de ascendentes"
 
-#: DynamicWeb/dynamicweb.py:340
+#: DynamicWeb//dynamicweb.py:344
 msgid "Homogeneous parents distribution"
 msgstr "Distribuição de pais homogénea"
 
-#: DynamicWeb/dynamicweb.py:343
+#: DynamicWeb//dynamicweb.py:347
 msgid "Size proportional to number of descendants"
 msgstr "Tamanho proporcional ao número de descendentes"
 
-#: DynamicWeb/dynamicweb.py:344
+#: DynamicWeb//dynamicweb.py:348
 msgid "Homogeneous children distribution"
 msgstr "Distribuição de filhos homogénea"
 
-#: DynamicWeb/dynamicweb.py:351 DynamicWeb/dynamicweb.py:374
+#: DynamicWeb//dynamicweb.py:355 DynamicWeb//dynamicweb.py:378
 msgid "Gender colors"
 msgstr "Cores dos sexos"
 
-#: DynamicWeb/dynamicweb.py:352
+#: DynamicWeb//dynamicweb.py:356
 msgid "Generation based gradient"
 msgstr "Gradação baseada em gerações"
 
-#: DynamicWeb/dynamicweb.py:353
+#: DynamicWeb//dynamicweb.py:357
 msgid "Age based gradient"
 msgstr "Gradação baseada em idade"
 
-#: DynamicWeb/dynamicweb.py:354 DynamicWeb/dynamicweb.py:373
+#: DynamicWeb//dynamicweb.py:358 DynamicWeb//dynamicweb.py:377
 msgid "Single main (filter) color"
 msgstr "Filtro (cor) principal único"
 
-#: DynamicWeb/dynamicweb.py:355
+#: DynamicWeb//dynamicweb.py:359
 msgid "Time period based gradient"
 msgstr "Gradação baseada em período de tempo"
 
-#: DynamicWeb/dynamicweb.py:356 DynamicWeb/dynamicweb.py:378
+#: DynamicWeb//dynamicweb.py:360 DynamicWeb//dynamicweb.py:382
 msgid "White"
 msgstr "Branco"
 
-#: DynamicWeb/dynamicweb.py:357 DynamicWeb/dynamicweb.py:376
+#: DynamicWeb//dynamicweb.py:361 DynamicWeb//dynamicweb.py:380
 msgid "Color scheme classic report"
 msgstr "Relatório clássico com esquema de cores"
 
-#: DynamicWeb/dynamicweb.py:358 DynamicWeb/dynamicweb.py:377
+#: DynamicWeb//dynamicweb.py:362 DynamicWeb//dynamicweb.py:381
 msgid "Color scheme classic view"
 msgstr "Vista clássica com esquema de cores"
 
-#: DynamicWeb/dynamicweb.py:375
+#: DynamicWeb//dynamicweb.py:379
 msgid "Gradient"
 msgstr "Gradação"
 
-#: DynamicWeb/dynamicweb.py:394
+#: DynamicWeb//dynamicweb.py:398
 msgid "Default"
 msgstr "Predefinição"
 
-#: DynamicWeb/dynamicweb.py:395
+#: DynamicWeb//dynamicweb.py:399
 msgid "Mainz"
 msgstr "Mainz"
 
-#: DynamicWeb/dynamicweb.py:703
+#: DynamicWeb//dynamicweb.py:707
 #, python-format
 msgid "Neither %(current)s nor %(parent)s are directories"
 msgstr "Nem %(current)s nem %(parent)s são pastas"
 
-#: DynamicWeb/dynamicweb.py:711 DynamicWeb/dynamicweb.py:716
+#: DynamicWeb//dynamicweb.py:715 DynamicWeb//dynamicweb.py:720
 #, python-format
 msgid "Could not create the directory: %(path)s"
 msgstr "Impossível criar a pasta: %(path)s"
 
-#: DynamicWeb/dynamicweb.py:742 DynamicWeb/dynamicweb.py:3380
+#: DynamicWeb//dynamicweb.py:746 DynamicWeb//dynamicweb.py:3385
 msgid "Dynamic Web Site Report"
 msgstr "Relatório Página Web dinâmica"
 
-#: DynamicWeb/dynamicweb.py:742
+#: DynamicWeb//dynamicweb.py:746
 msgid "Exporting family tree data ..."
 msgstr "A exportar dados da árvore de família..."
 
-#: DynamicWeb/dynamicweb.py:1232 DynamicWeb/dynamicweb.py:2456
+#: DynamicWeb//dynamicweb.py:1237 DynamicWeb//dynamicweb.py:2461
 msgid "Author"
 msgstr "Autor"
 
-#: DynamicWeb/dynamicweb.py:1233 DynamicWeb/dynamicweb.py:2446
+#: DynamicWeb//dynamicweb.py:1238 DynamicWeb//dynamicweb.py:2451
 msgid "Abbreviation"
 msgstr "Abreviatura"
 
-#: DynamicWeb/dynamicweb.py:1234 DynamicWeb/dynamicweb.py:2543
+#: DynamicWeb//dynamicweb.py:1239 DynamicWeb//dynamicweb.py:2548
 msgid "Publication information"
 msgstr "Informação de publicação"
 
-#: DynamicWeb/dynamicweb.py:1304 DynamicWeb/dynamicweb.py:2474
+#: DynamicWeb//dynamicweb.py:1309 DynamicWeb//dynamicweb.py:2479
 msgid "Date"
 msgstr "Data"
 
-#: DynamicWeb/dynamicweb.py:1305
+#: DynamicWeb//dynamicweb.py:1310
 msgid "Page"
 msgstr "Página"
 
-#: DynamicWeb/dynamicweb.py:1306
+#: DynamicWeb//dynamicweb.py:1311
 msgid "Confidence"
 msgstr "Confiança"
 
-#: DynamicWeb/dynamicweb.py:1625
+#: DynamicWeb//dynamicweb.py:1630
 #, python-format
 msgid "%(type)s: %(value)s"
 msgstr "%(type)s: %(value)s"
 
-#: DynamicWeb/dynamicweb.py:1872
+#: DynamicWeb//dynamicweb.py:1877
 #, python-format
 msgid "Impossible to convert \"%(path)s\" to a relative path."
 msgstr "Impossível converter \"%(path)s\" em caminho relativo."
 
-#: DynamicWeb/dynamicweb.py:2178
+#: DynamicWeb//dynamicweb.py:2183
 msgid ""
 "The pages configuration is not valid: several pages have the same content"
 msgstr ""
 "A configuração da página não é válida: há várias páginas com o mesmo "
 "comentário"
 
-#: DynamicWeb/dynamicweb.py:2189
-msgid "Html|Home"
+#: DynamicWeb//dynamicweb.py:2194
+msgid "DynWeb|Home"
 msgstr "Início"
 
-#: DynamicWeb/dynamicweb.py:2190 DynamicWeb/dynamicweb.py:2203
-#: DynamicWeb/dynamicweb.py:2204 DynamicWeb/dynamicweb.py:2205
+#: DynamicWeb//dynamicweb.py:2195 DynamicWeb//dynamicweb.py:2208
+#: DynamicWeb//dynamicweb.py:2209 DynamicWeb//dynamicweb.py:2210
 msgid "Tree"
 msgstr "Árvore"
 
-#: DynamicWeb/dynamicweb.py:2191 DynamicWeb/dynamicweb.py:2206
-#: DynamicWeb/dynamicweb.py:2207 DynamicWeb/dynamicweb.py:2208
+#: DynamicWeb//dynamicweb.py:2196 DynamicWeb//dynamicweb.py:2211
+#: DynamicWeb//dynamicweb.py:2212 DynamicWeb//dynamicweb.py:2213
 msgid "Statistics"
 msgstr "Estatísticas"
 
-#: DynamicWeb/dynamicweb.py:2194 DynamicWeb/dynamicweb.py:2470
+#: DynamicWeb//dynamicweb.py:2199 DynamicWeb//dynamicweb.py:2475
 msgid "Configuration"
 msgstr "Configuração"
 
-#: DynamicWeb/dynamicweb.py:2196 DynamicWeb/dynamicweb.py:2535
+#: DynamicWeb//dynamicweb.py:2201 DynamicWeb//dynamicweb.py:2540
 msgid "Person"
 msgstr "Indivíduo"
 
-#: DynamicWeb/dynamicweb.py:2197
+#: DynamicWeb//dynamicweb.py:2202
 msgid "Family"
 msgstr "Família"
 
-#: DynamicWeb/dynamicweb.py:2198 DynamicWeb/dynamicweb.py:2575
+#: DynamicWeb//dynamicweb.py:2203 DynamicWeb//dynamicweb.py:2580
 msgid "Source"
 msgstr "Fonte"
 
-#: DynamicWeb/dynamicweb.py:2199 DynamicWeb/dynamicweb.py:2218
-#: DynamicWeb/dynamicweb.py:2518
+#: DynamicWeb//dynamicweb.py:2204 DynamicWeb//dynamicweb.py:2223
+#: DynamicWeb//dynamicweb.py:2523
 msgid "Media"
 msgstr "Multimédia"
 
-#: DynamicWeb/dynamicweb.py:2200 DynamicWeb/dynamicweb.py:2538
+#: DynamicWeb//dynamicweb.py:2205 DynamicWeb//dynamicweb.py:2543
 msgid "Place"
 msgstr "Local"
 
-#: DynamicWeb/dynamicweb.py:2201 DynamicWeb/dynamicweb.py:2550
+#: DynamicWeb//dynamicweb.py:2206 DynamicWeb//dynamicweb.py:2555
 msgid "Repository"
 msgstr "Repositório"
 
-#: DynamicWeb/dynamicweb.py:2202
+#: DynamicWeb//dynamicweb.py:2207
 msgid "Search results"
 msgstr "Resultados da procura"
 
-#: DynamicWeb/dynamicweb.py:2213 DynamicWeb/dynamicweb.py:2214
-#: DynamicWeb/dynamicweb.py:2582
+#: DynamicWeb//dynamicweb.py:2218 DynamicWeb//dynamicweb.py:2219
+#: DynamicWeb//dynamicweb.py:2587
 msgid "Surnames"
 msgstr "Apelidos"
 
-#: DynamicWeb/dynamicweb.py:2215 DynamicWeb/dynamicweb.py:2503
+#: DynamicWeb//dynamicweb.py:2220 DynamicWeb//dynamicweb.py:2508
 msgid "Individuals"
 msgstr "Indivíduos"
 
-#: DynamicWeb/dynamicweb.py:2216 DynamicWeb/dynamicweb.py:2486
+#: DynamicWeb//dynamicweb.py:2221 DynamicWeb//dynamicweb.py:2491
 msgid "Families"
 msgstr "Famílias"
 
-#: DynamicWeb/dynamicweb.py:2217 DynamicWeb/dynamicweb.py:2577
+#: DynamicWeb//dynamicweb.py:2222 DynamicWeb//dynamicweb.py:2582
 msgid "Sources"
 msgstr "Fontes"
 
-#: DynamicWeb/dynamicweb.py:2219 DynamicWeb/dynamicweb.py:2540
+#: DynamicWeb//dynamicweb.py:2224 DynamicWeb//dynamicweb.py:2545
 msgid "Places"
 msgstr "Locais"
 
-#: DynamicWeb/dynamicweb.py:2220 DynamicWeb/dynamicweb.py:2448
+#: DynamicWeb//dynamicweb.py:2225 DynamicWeb//dynamicweb.py:2453
 msgid "Addresses"
 msgstr "Endereços"
 
-#: DynamicWeb/dynamicweb.py:2221 DynamicWeb/dynamicweb.py:2549
+#: DynamicWeb//dynamicweb.py:2226 DynamicWeb//dynamicweb.py:2554
 msgid "Repositories"
 msgstr "Repositórios"
 
-#: DynamicWeb/dynamicweb.py:2272 DynamicWeb/dynamicweb.py:2502
-#: DynamicWeb/dynamicweb.py:4120
+#: DynamicWeb//dynamicweb.py:2277 DynamicWeb//dynamicweb.py:2507
+#: DynamicWeb//dynamicweb.py:4126
 msgid "Indexes"
 msgstr "Índices"
 
-#: DynamicWeb/dynamicweb.py:2436
+#: DynamicWeb//dynamicweb.py:2441
 #, python-format
 msgid "(b. %(birthdate)s, d. %(deathdate)s)"
 msgstr "(b. %(birthdate)s, ó. %(deathdate)s)"
 
-#: DynamicWeb/dynamicweb.py:2437
+#: DynamicWeb//dynamicweb.py:2442
 #, python-format
 msgid "(b. %s)"
 msgstr "(b. %s)"
 
-#: DynamicWeb/dynamicweb.py:2438
+#: DynamicWeb//dynamicweb.py:2443
 #, python-format
 msgid "(d. %s)"
 msgstr "(ó. %s)"
 
-#: DynamicWeb/dynamicweb.py:2439
+#: DynamicWeb//dynamicweb.py:2444
 msgid "(filtered from _MAX_ total entries)"
 msgstr "(filtrado de _MAX_ total entradas)"
 
-#: DynamicWeb/dynamicweb.py:2440
+#: DynamicWeb//dynamicweb.py:2445
 #, python-format
 msgid "(m. %s)"
 msgstr "(c. %s)"
 
-#: DynamicWeb/dynamicweb.py:2441
+#: DynamicWeb//dynamicweb.py:2446
 msgid "(sort by name)"
 msgstr "(ordenar por nome)"
 
-#: DynamicWeb/dynamicweb.py:2442
+#: DynamicWeb//dynamicweb.py:2447
 msgid "(sort by quantity)"
 msgstr "(ordenar por quantidade)"
 
-#: DynamicWeb/dynamicweb.py:2443
+#: DynamicWeb//dynamicweb.py:2448
 msgid ": activate to sort column ascending"
 msgstr ": activar para coluna de ordem ascendente"
 
-#: DynamicWeb/dynamicweb.py:2444
+#: DynamicWeb//dynamicweb.py:2449
 msgid ": activate to sort column descending"
 msgstr ": activar para coluna de ordem descendente"
 
-#: DynamicWeb/dynamicweb.py:2445
+#: DynamicWeb//dynamicweb.py:2450
 msgid ""
 "<p>This page provides the SVG raw code.<br>Copy the contents into a text "
 "editor and save as an SVG file.<br>Make sure that the text editor encoding "
@@ -376,559 +376,559 @@ msgstr ""
 "de texto e grave como ficheiro SVG.<br>Certifique-se de que a codificação de "
 "caracteres é UTF-8.</p>"
 
-#: DynamicWeb/dynamicweb.py:2447
+#: DynamicWeb//dynamicweb.py:2452
 msgid "Address"
 msgstr "Endereço"
 
-#: DynamicWeb/dynamicweb.py:2449
+#: DynamicWeb//dynamicweb.py:2454
 msgid "Age at death"
 msgstr "Idade ao óbito"
 
-#: DynamicWeb/dynamicweb.py:2450
+#: DynamicWeb//dynamicweb.py:2455
 msgid "Alternate Marriage"
 msgstr "Casamento alternativo"
 
-#: DynamicWeb/dynamicweb.py:2451
+#: DynamicWeb//dynamicweb.py:2456
 msgid "Alternate Name"
 msgstr "Nome alternativo"
 
-#: DynamicWeb/dynamicweb.py:2452
+#: DynamicWeb//dynamicweb.py:2457
 msgid "Ancestors"
 msgstr "Ascendentes"
 
-#: DynamicWeb/dynamicweb.py:2453
+#: DynamicWeb//dynamicweb.py:2458
 msgid "Associations"
 msgstr "Associações"
 
-#: DynamicWeb/dynamicweb.py:2454
+#: DynamicWeb//dynamicweb.py:2459
 msgid "Attribute"
 msgstr "Atributo"
 
-#: DynamicWeb/dynamicweb.py:2455
+#: DynamicWeb//dynamicweb.py:2460
 msgid "Attributes"
 msgstr "Atributos"
 
-#: DynamicWeb/dynamicweb.py:2457 DynamicWeb/dynamicweb.py:4203
+#: DynamicWeb//dynamicweb.py:2462 DynamicWeb//dynamicweb.py:4209
 msgid "Background"
 msgstr "Fundo"
 
-#: DynamicWeb/dynamicweb.py:2458
+#: DynamicWeb//dynamicweb.py:2463
 msgid "Baptism"
 msgstr "Baptismo"
 
-#: DynamicWeb/dynamicweb.py:2459
+#: DynamicWeb//dynamicweb.py:2464
 msgid "Birth"
 msgstr "Nascimento"
 
-#: DynamicWeb/dynamicweb.py:2460
+#: DynamicWeb//dynamicweb.py:2465
 msgid "Burial"
 msgstr "Funeral"
 
-#: DynamicWeb/dynamicweb.py:2461
+#: DynamicWeb//dynamicweb.py:2466
 msgid "Call Name"
 msgstr "Nome usual"
 
-#: DynamicWeb/dynamicweb.py:2462
+#: DynamicWeb//dynamicweb.py:2467
 msgid "Call Number"
 msgstr "Número de catálogo"
 
-#: DynamicWeb/dynamicweb.py:2463
+#: DynamicWeb//dynamicweb.py:2468
 msgid "Cause Of Death"
 msgstr "Causa do óbito"
 
-#: DynamicWeb/dynamicweb.py:2464
+#: DynamicWeb//dynamicweb.py:2469
 msgid "Children"
 msgstr "Filhos"
 
-#: DynamicWeb/dynamicweb.py:2465
+#: DynamicWeb//dynamicweb.py:2470
 msgid "Christening"
 msgstr "Baptismo"
 
-#: DynamicWeb/dynamicweb.py:2466
+#: DynamicWeb//dynamicweb.py:2471
 msgid "Citation"
 msgstr "Citação"
 
-#: DynamicWeb/dynamicweb.py:2467
+#: DynamicWeb//dynamicweb.py:2472
 msgid "Citations"
 msgstr "Citações"
 
-#: DynamicWeb/dynamicweb.py:2468
+#: DynamicWeb//dynamicweb.py:2473
 msgid "Click on the map to show it full-screen"
 msgstr "Clique no mapa para ver em ecrã completo"
 
-#: DynamicWeb/dynamicweb.py:2469
+#: DynamicWeb//dynamicweb.py:2474
 msgid "Code"
 msgstr "Código"
 
-#: DynamicWeb/dynamicweb.py:2471
+#: DynamicWeb//dynamicweb.py:2476
 msgid "Configure"
 msgstr "Configurar"
 
-#: DynamicWeb/dynamicweb.py:2472
+#: DynamicWeb//dynamicweb.py:2477
 msgid "Count"
 msgstr "Total"
 
-#: DynamicWeb/dynamicweb.py:2473
+#: DynamicWeb//dynamicweb.py:2478
 msgid "Cremation"
 msgstr "Cremação"
 
-#: DynamicWeb/dynamicweb.py:2475
+#: DynamicWeb//dynamicweb.py:2480
 msgid "Death"
 msgstr "Óbito"
 
-#: DynamicWeb/dynamicweb.py:2476
+#: DynamicWeb//dynamicweb.py:2481
 msgid "Descendants"
 msgstr "Descendentes"
 
-#: DynamicWeb/dynamicweb.py:2477
+#: DynamicWeb//dynamicweb.py:2482
 msgid "Description"
 msgstr "Descrição"
 
-#: DynamicWeb/dynamicweb.py:2478
+#: DynamicWeb//dynamicweb.py:2483
 msgid "DynamicWeb_report#Help"
 msgstr "DynamicWeb_relatório#Ajuda"
 
-#: DynamicWeb/dynamicweb.py:2479
+#: DynamicWeb//dynamicweb.py:2484
 msgid "Enclosed By"
 msgstr "Confinado por"
 
-#: DynamicWeb/dynamicweb.py:2480
+#: DynamicWeb//dynamicweb.py:2485
 msgid "Engagement"
 msgstr "Noivado"
 
-#: DynamicWeb/dynamicweb.py:2481
+#: DynamicWeb//dynamicweb.py:2486
 msgid "Event"
 msgstr "Evento"
 
-#: DynamicWeb/dynamicweb.py:2482
+#: DynamicWeb//dynamicweb.py:2487
 msgid "Events"
 msgstr "Eventos"
 
-#: DynamicWeb/dynamicweb.py:2483
+#: DynamicWeb//dynamicweb.py:2488
 msgid "Examples"
 msgstr "Exemplos"
 
-#: DynamicWeb/dynamicweb.py:2484
+#: DynamicWeb//dynamicweb.py:2489
 msgid "F"
 msgstr "F"
 
-#: DynamicWeb/dynamicweb.py:2485
+#: DynamicWeb//dynamicweb.py:2490
 msgid "Families Index"
 msgstr "Índice de famílias"
 
-#: DynamicWeb/dynamicweb.py:2487
+#: DynamicWeb//dynamicweb.py:2492
 msgid "Family Nick Name"
 msgstr "Diminutivo familiar"
 
-#: DynamicWeb/dynamicweb.py:2488
+#: DynamicWeb//dynamicweb.py:2493
 msgid "Father"
 msgstr "Pai"
 
-#: DynamicWeb/dynamicweb.py:2489
+#: DynamicWeb//dynamicweb.py:2494
 msgid "Female"
 msgstr "Feminino"
 
-#: DynamicWeb/dynamicweb.py:2490
+#: DynamicWeb//dynamicweb.py:2495
 msgid "File ready"
 msgstr "Ficheiro pronto"
 
-#: DynamicWeb/dynamicweb.py:2491
+#: DynamicWeb//dynamicweb.py:2496
 msgid "Gender"
 msgstr "Sexo"
 
-#: DynamicWeb/dynamicweb.py:2492
+#: DynamicWeb//dynamicweb.py:2497
 msgid "Help"
 msgstr "Ajuda"
 
-#: DynamicWeb/dynamicweb.py:2493
+#: DynamicWeb//dynamicweb.py:2498
 msgid "ID"
 msgstr "Id"
 
-#: DynamicWeb/dynamicweb.py:2494 DynamicWeb/dynamicweb.py:4035
+#: DynamicWeb//dynamicweb.py:2499 DynamicWeb//dynamicweb.py:4041
 msgid "Include Place map on Place Pages"
 msgstr "Incluir mapa nas páginas de locais"
 
-#: DynamicWeb/dynamicweb.py:2495 DynamicWeb/dynamicweb.py:4140
+#: DynamicWeb//dynamicweb.py:2500 DynamicWeb//dynamicweb.py:4146
 msgid "Include dates columns on the index pages"
 msgstr "Incluir coluna de datas nas páginas de índice"
 
-#: DynamicWeb/dynamicweb.py:2496 DynamicWeb/dynamicweb.py:4148
+#: DynamicWeb//dynamicweb.py:2501 DynamicWeb//dynamicweb.py:4154
 msgid "Include a column for parents on the index pages"
 msgstr "Incluir coluna de pais nas páginas de índice"
 
-#: DynamicWeb/dynamicweb.py:2497 DynamicWeb/dynamicweb.py:4156
+#: DynamicWeb//dynamicweb.py:2502 DynamicWeb//dynamicweb.py:4162
 msgid "Include a column for media path on the index pages"
 msgstr "Incluir coluna de caminhos multimédia nas páginas de índice"
 
-#: DynamicWeb/dynamicweb.py:2498 DynamicWeb/dynamicweb.py:4144
+#: DynamicWeb//dynamicweb.py:2503 DynamicWeb//dynamicweb.py:4150
 msgid "Include a column for partners on the index pages"
 msgstr "Incluir coluna de companheiros nas páginas de índice"
 
-#: DynamicWeb/dynamicweb.py:2499 DynamicWeb/dynamicweb.py:4043
+#: DynamicWeb//dynamicweb.py:2504 DynamicWeb//dynamicweb.py:4049
 msgid "Include a map in the individuals and family pages"
 msgstr "Incluir mapa nas páginas individuais e familiares"
 
-#: DynamicWeb/dynamicweb.py:2500 DynamicWeb/dynamicweb.py:4090
+#: DynamicWeb//dynamicweb.py:2505 DynamicWeb//dynamicweb.py:4096
 msgid "Include half and/ or step-siblings on the individual pages"
 msgstr "Incluir meio-irmãos nas paǵinas individuais"
 
-#: DynamicWeb/dynamicweb.py:2501 DynamicWeb/dynamicweb.py:4160
+#: DynamicWeb//dynamicweb.py:2506 DynamicWeb//dynamicweb.py:4166
 msgid "Include references in indexes"
 msgstr "Incluir referências nos índices"
 
-#: DynamicWeb/dynamicweb.py:2504 DynamicWeb/dynamicweb.py:4110
+#: DynamicWeb//dynamicweb.py:2509 DynamicWeb//dynamicweb.py:4116
 msgid "Insert sources author in the sources title"
 msgstr "Inserir autor das fontes no título das fontes"
 
-#: DynamicWeb/dynamicweb.py:2505
+#: DynamicWeb//dynamicweb.py:2510
 msgid "Last Modified"
 msgstr "Última modificação"
 
-#: DynamicWeb/dynamicweb.py:2506
+#: DynamicWeb//dynamicweb.py:2511
 msgid "Latitude"
 msgstr "Latitude"
 
-#: DynamicWeb/dynamicweb.py:2507
+#: DynamicWeb//dynamicweb.py:2512
 msgid "Link"
 msgstr "Ligação"
 
-#: DynamicWeb/dynamicweb.py:2508
+#: DynamicWeb//dynamicweb.py:2513
 msgid "Loading..."
 msgstr "A carregar..."
 
-#: DynamicWeb/dynamicweb.py:2509
+#: DynamicWeb//dynamicweb.py:2514
 msgid "Location"
 msgstr "Localização"
 
-#: DynamicWeb/dynamicweb.py:2510
+#: DynamicWeb//dynamicweb.py:2515
 msgid "Longitude"
 msgstr "Longitude"
 
-#: DynamicWeb/dynamicweb.py:2511
+#: DynamicWeb//dynamicweb.py:2516
 msgid "M"
 msgstr "M"
 
-#: DynamicWeb/dynamicweb.py:2512
+#: DynamicWeb//dynamicweb.py:2517
 msgid "Male"
 msgstr "Masculino"
 
-#: DynamicWeb/dynamicweb.py:2513
+#: DynamicWeb//dynamicweb.py:2518
 msgid "Map"
 msgstr "Mapa"
 
-#: DynamicWeb/dynamicweb.py:2514
+#: DynamicWeb//dynamicweb.py:2519
 msgid "Marriage"
 msgstr "Casamento"
 
-#: DynamicWeb/dynamicweb.py:2515
+#: DynamicWeb//dynamicweb.py:2520
 msgid "Maximize"
 msgstr "Maximizar"
 
-#: DynamicWeb/dynamicweb.py:2516
+#: DynamicWeb//dynamicweb.py:2521
 msgid "Media Index"
 msgstr "Índice de multimédia"
 
-#: DynamicWeb/dynamicweb.py:2517
+#: DynamicWeb//dynamicweb.py:2522
 msgid "Media Type"
 msgstr "Tipo de multimédia"
 
-#: DynamicWeb/dynamicweb.py:2519
+#: DynamicWeb//dynamicweb.py:2524
 msgid "Mother"
 msgstr "Mãe"
 
-#: DynamicWeb/dynamicweb.py:2520
+#: DynamicWeb//dynamicweb.py:2525
 msgid "Name"
 msgstr "Nome"
 
-#: DynamicWeb/dynamicweb.py:2521
+#: DynamicWeb//dynamicweb.py:2526
 msgid "Nick Name"
 msgstr "Alcunha"
 
-#: DynamicWeb/dynamicweb.py:2522
+#: DynamicWeb//dynamicweb.py:2527
 msgid "No data available in table"
 msgstr "Sem dados disponíveis na tabela"
 
-#: DynamicWeb/dynamicweb.py:2523
+#: DynamicWeb//dynamicweb.py:2528
 msgid "No matches found"
 msgstr "Sem resultados"
 
-#: DynamicWeb/dynamicweb.py:2524
+#: DynamicWeb//dynamicweb.py:2529
 msgid "No matching records found"
 msgstr "Sem registos encontrados"
 
-#: DynamicWeb/dynamicweb.py:2525
+#: DynamicWeb//dynamicweb.py:2530
 msgid "No matching surname."
 msgstr "Sem apelido encontrado."
 
-#: DynamicWeb/dynamicweb.py:2526
+#: DynamicWeb//dynamicweb.py:2531
 msgid "None"
 msgstr "Nada"
 
-#: DynamicWeb/dynamicweb.py:2527
+#: DynamicWeb//dynamicweb.py:2532
 msgid "Notes"
 msgstr "Notas"
 
-#: DynamicWeb/dynamicweb.py:2528
+#: DynamicWeb//dynamicweb.py:2533
 msgid "Number"
 msgstr "Número"
 
-#: DynamicWeb/dynamicweb.py:2529
+#: DynamicWeb//dynamicweb.py:2534
 msgid "OK"
 msgstr "Aceitar"
 
-#: DynamicWeb/dynamicweb.py:2530
+#: DynamicWeb//dynamicweb.py:2535
 msgid "Other participants"
 msgstr "Outros participantes"
 
-#: DynamicWeb/dynamicweb.py:2531
+#: DynamicWeb//dynamicweb.py:2536
 msgid "Parents"
 msgstr "Pais"
 
-#: DynamicWeb/dynamicweb.py:2532
+#: DynamicWeb//dynamicweb.py:2537
 msgid "Path"
 msgstr "Caminho"
 
-#: DynamicWeb/dynamicweb.py:2533
+#: DynamicWeb//dynamicweb.py:2538
 msgid "Person page"
 msgstr "Página pessoal"
 
-#: DynamicWeb/dynamicweb.py:2534
+#: DynamicWeb//dynamicweb.py:2539
 msgid "Person to search for"
 msgstr "Indivíduo a procurar"
 
-#: DynamicWeb/dynamicweb.py:2536
+#: DynamicWeb//dynamicweb.py:2541
 msgid "Persons Index"
 msgstr "Índice de indivíduos"
 
-#: DynamicWeb/dynamicweb.py:2537
+#: DynamicWeb//dynamicweb.py:2542
 msgid "Persons"
 msgstr "Indivíduos"
 
-#: DynamicWeb/dynamicweb.py:2539
+#: DynamicWeb//dynamicweb.py:2544
 msgid "Places Index"
 msgstr "Índice de locais"
 
-#: DynamicWeb/dynamicweb.py:2541
+#: DynamicWeb//dynamicweb.py:2546
 msgid "Preparing file ..."
 msgstr "A preparar ficheiro..."
 
-#: DynamicWeb/dynamicweb.py:2542
+#: DynamicWeb//dynamicweb.py:2547
 msgid "Processing..."
 msgstr "A processar..."
 
-#: DynamicWeb/dynamicweb.py:2544
+#: DynamicWeb//dynamicweb.py:2549
 msgid "References"
 msgstr "Referências"
 
-#: DynamicWeb/dynamicweb.py:2545
+#: DynamicWeb//dynamicweb.py:2550
 msgid "Relationship to Father"
 msgstr "Relação com o pai"
 
-#: DynamicWeb/dynamicweb.py:2546
+#: DynamicWeb//dynamicweb.py:2551
 msgid "Relationship to Mother"
 msgstr "Relação com a mãe"
 
-#: DynamicWeb/dynamicweb.py:2547
+#: DynamicWeb//dynamicweb.py:2552
 msgid "Relationship"
 msgstr "Relação"
 
-#: DynamicWeb/dynamicweb.py:2548
+#: DynamicWeb//dynamicweb.py:2553
 msgid "Repositories Index"
 msgstr "Índice de repositórios"
 
-#: DynamicWeb/dynamicweb.py:2551
+#: DynamicWeb//dynamicweb.py:2556
 msgid "Restore"
 msgstr "Restaurar"
 
-#: DynamicWeb/dynamicweb.py:2552
+#: DynamicWeb//dynamicweb.py:2557
 msgid "Restore default settings"
 msgstr "Restaurar predefinições"
 
-#: DynamicWeb/dynamicweb.py:2553 DynamicWeb/dynamicweb.py:4106
+#: DynamicWeb//dynamicweb.py:2558 DynamicWeb//dynamicweb.py:4112
 msgid "Show last modification time"
 msgstr "Mostrar hora da última modificação"
 
-#: DynamicWeb/dynamicweb.py:2554 DynamicWeb/dynamicweb.py:4197
+#: DynamicWeb//dynamicweb.py:2559 DynamicWeb//dynamicweb.py:4203
 msgid "SVG tree children distribution"
 msgstr "Distribuição de filhos em SVG"
 
-#: DynamicWeb/dynamicweb.py:2555
+#: DynamicWeb//dynamicweb.py:2560
 msgid "SVG tree configuration"
 msgstr "Configuração da árvore SVG"
 
-#: DynamicWeb/dynamicweb.py:2556 DynamicWeb/dynamicweb.py:4185
+#: DynamicWeb//dynamicweb.py:2561 DynamicWeb//dynamicweb.py:4191
 msgid "SVG tree graph shape"
 msgstr "Forma da árvore SVG"
 
-#: DynamicWeb/dynamicweb.py:2557 DynamicWeb/dynamicweb.py:4179
+#: DynamicWeb//dynamicweb.py:2562 DynamicWeb//dynamicweb.py:4185
 msgid "SVG tree graph type"
 msgstr "Tipo da árvore SVG"
 
-#: DynamicWeb/dynamicweb.py:2558 DynamicWeb/dynamicweb.py:4191
+#: DynamicWeb//dynamicweb.py:2563 DynamicWeb//dynamicweb.py:4197
 msgid "SVG tree parents distribution"
 msgstr "Distribuição de pais em SVG"
 
-#: DynamicWeb/dynamicweb.py:2559
+#: DynamicWeb//dynamicweb.py:2564
 msgid "Save tree as file"
 msgstr "Gravar árvore como ficheiro"
 
-#: DynamicWeb/dynamicweb.py:2560
+#: DynamicWeb//dynamicweb.py:2565
 msgid "Search:"
 msgstr "Procurar:"
 
-#: DynamicWeb/dynamicweb.py:2561
+#: DynamicWeb//dynamicweb.py:2566
 msgid "Select the background color scheme"
 msgstr "Seleccionar o esquema de cor do fundo"
 
-#: DynamicWeb/dynamicweb.py:2562
+#: DynamicWeb//dynamicweb.py:2567
 msgid "Select the children distribution (fan charts only)"
 msgstr "Seleccione a distribuição dos filhos(só para leques)"
 
-#: DynamicWeb/dynamicweb.py:2563
+#: DynamicWeb//dynamicweb.py:2568
 msgid "Select the number of ascending generations"
 msgstr "Seleccione o número de gerações ascendentes"
 
-#: DynamicWeb/dynamicweb.py:2564
+#: DynamicWeb//dynamicweb.py:2569
 msgid "Select the number of descending generations"
 msgstr "Seleccione o número de gerações descendentes"
 
-#: DynamicWeb/dynamicweb.py:2565
+#: DynamicWeb//dynamicweb.py:2570
 msgid "Select the parents distribution (fan charts only)"
 msgstr "Seleccione a distribuição dos pais (só para leques)"
 
-#: DynamicWeb/dynamicweb.py:2566
+#: DynamicWeb//dynamicweb.py:2571
 msgid "Select the shape of graph"
 msgstr "Seleccione a forma do gráfico"
 
-#: DynamicWeb/dynamicweb.py:2567
+#: DynamicWeb//dynamicweb.py:2572
 msgid "Select the type of graph"
 msgstr "Seleccione o tipo do gráfico"
 
-#: DynamicWeb/dynamicweb.py:2568
+#: DynamicWeb//dynamicweb.py:2573
 msgid "Several matches.<br>Precise your search or choose in the lists below."
 msgstr "Vários resultados.<br>Refine a procura ou escolha na lista abaixo."
 
-#: DynamicWeb/dynamicweb.py:2569
+#: DynamicWeb//dynamicweb.py:2574
 msgid "Show _MENU_ entries"
 msgstr "Mostrar_entradas_de_MENU"
 
-#: DynamicWeb/dynamicweb.py:2570 DynamicWeb/dynamicweb.py:4215
+#: DynamicWeb//dynamicweb.py:2575 DynamicWeb//dynamicweb.py:4221
 msgid "Show duplicates"
 msgstr "Mostrar duplicados"
 
-#: DynamicWeb/dynamicweb.py:2571
+#: DynamicWeb//dynamicweb.py:2576
 msgid "Showing 0 to 0 of 0 entries"
 msgstr "A mostrar 0 a 0 de 0 entradas"
 
-#: DynamicWeb/dynamicweb.py:2572
+#: DynamicWeb//dynamicweb.py:2577
 msgid "Showing _START_ to _END_ of _TOTAL_ entries"
 msgstr "A mostrar _START_ a _END_ de _TOTAL_ entradas"
 
-#: DynamicWeb/dynamicweb.py:2573
+#: DynamicWeb//dynamicweb.py:2578
 msgid "Siblings"
 msgstr "Irmãos"
 
-#: DynamicWeb/dynamicweb.py:2574
+#: DynamicWeb//dynamicweb.py:2579
 msgid "Sort by:"
 msgstr "Ordenar por"
 
-#: DynamicWeb/dynamicweb.py:2576
+#: DynamicWeb//dynamicweb.py:2581
 msgid "Sources Index"
 msgstr "Índice de fontes"
 
-#: DynamicWeb/dynamicweb.py:2578
+#: DynamicWeb//dynamicweb.py:2583
 msgid "Spouses"
 msgstr "Cônjuges"
 
-#: DynamicWeb/dynamicweb.py:2579 DynamicWeb/dynamicweb.py:4114
+#: DynamicWeb//dynamicweb.py:2584 DynamicWeb//dynamicweb.py:4120
 msgid "Suppress Gramps ID"
 msgstr "Suprimir Id Gramps"
 
-#: DynamicWeb/dynamicweb.py:2580
+#: DynamicWeb//dynamicweb.py:2585
 msgid "Surname"
 msgstr "Apelido"
 
-#: DynamicWeb/dynamicweb.py:2581
+#: DynamicWeb//dynamicweb.py:2586
 msgid "Surnames Index"
 msgstr "Índice de apelidos"
 
-#: DynamicWeb/dynamicweb.py:2583
+#: DynamicWeb//dynamicweb.py:2588
 msgid "Title"
 msgstr "Título"
 
-#: DynamicWeb/dynamicweb.py:2584
+#: DynamicWeb//dynamicweb.py:2589
 msgid "Type"
 msgstr "Tipo"
 
-#: DynamicWeb/dynamicweb.py:2585
+#: DynamicWeb//dynamicweb.py:2590
 msgid "U"
 msgstr "D"
 
-#: DynamicWeb/dynamicweb.py:2586
+#: DynamicWeb//dynamicweb.py:2591
 msgid "Unknown"
 msgstr "Desconhecido"
 
-#: DynamicWeb/dynamicweb.py:2587 DynamicWeb/dynamicweb.py:4102
+#: DynamicWeb//dynamicweb.py:2592 DynamicWeb//dynamicweb.py:4108
 msgid "Use tabbed panels instead of sections"
 msgstr "Usar separadores em vez de secções"
 
-#: DynamicWeb/dynamicweb.py:2588
+#: DynamicWeb//dynamicweb.py:2593
 msgid "Use the search box above in order to find a person."
 msgstr "Usar a caixa de procura acima para encontrar um indivíduo."
 
-#: DynamicWeb/dynamicweb.py:2589
+#: DynamicWeb//dynamicweb.py:2594
 msgid "Use a table format for the surnames index"
 msgstr "Usar um formato de tabela para o índice de apelidos"
 
-#: DynamicWeb/dynamicweb.py:2590
+#: DynamicWeb//dynamicweb.py:2595
 msgid "Use a table format for the persons index"
 msgstr "Usar um formato de tabela para o índice de indivíduos"
 
-#: DynamicWeb/dynamicweb.py:2591
+#: DynamicWeb//dynamicweb.py:2596
 msgid "Use a table format for the families index"
 msgstr "Usar um formato de tabela para o índice de famílias"
 
-#: DynamicWeb/dynamicweb.py:2592
+#: DynamicWeb//dynamicweb.py:2597
 msgid "Use a table format for the sources index"
 msgstr "Usar um formato de tabela para o índice de fontes"
 
-#: DynamicWeb/dynamicweb.py:2593
+#: DynamicWeb//dynamicweb.py:2598
 msgid "Use a table format for the places index"
 msgstr "Usar um formato de tabela para o índice de locais"
 
-#: DynamicWeb/dynamicweb.py:2594
+#: DynamicWeb//dynamicweb.py:2599
 msgid "Used for family"
 msgstr "Usado para família"
 
-#: DynamicWeb/dynamicweb.py:2595
+#: DynamicWeb//dynamicweb.py:2600
 msgid "Used for media"
 msgstr "Usado para multimédia"
 
-#: DynamicWeb/dynamicweb.py:2596
+#: DynamicWeb//dynamicweb.py:2601
 msgid "Used for person"
 msgstr "Usado para indivíduo"
 
-#: DynamicWeb/dynamicweb.py:2597
+#: DynamicWeb//dynamicweb.py:2602
 msgid "Used for place"
 msgstr "Usado para local"
 
-#: DynamicWeb/dynamicweb.py:2598
+#: DynamicWeb//dynamicweb.py:2603
 msgid "Used for source"
 msgstr "Usado para fonte"
 
-#: DynamicWeb/dynamicweb.py:2599
+#: DynamicWeb//dynamicweb.py:2604
 msgid "Value"
 msgstr "Valor"
 
-#: DynamicWeb/dynamicweb.py:2600
+#: DynamicWeb//dynamicweb.py:2605
 msgid "Web Link"
 msgstr "Ligação web"
 
-#: DynamicWeb/dynamicweb.py:2601
+#: DynamicWeb//dynamicweb.py:2606
 msgid "Web Links"
 msgstr "Ligações web"
 
-#: DynamicWeb/dynamicweb.py:2602 DynamicWeb/dynamicweb.py:4216
+#: DynamicWeb//dynamicweb.py:2607 DynamicWeb//dynamicweb.py:4222
 msgid ""
 "Whether to use a special color for the persons that appear several times in "
 "the SVG tree"
@@ -936,49 +936,49 @@ msgstr ""
 "Se deve usar uma cor especial para o indivíduo que aparece várias vezes na "
 "árvore SVG"
 
-#: DynamicWeb/dynamicweb.py:2603
+#: DynamicWeb//dynamicweb.py:2608
 msgid "Without name"
 msgstr "Sem nome"
 
-#: DynamicWeb/dynamicweb.py:2604
+#: DynamicWeb//dynamicweb.py:2609
 msgid "Without surname"
 msgstr "Sem apelido"
 
-#: DynamicWeb/dynamicweb.py:2605
+#: DynamicWeb//dynamicweb.py:2610
 msgid "Without title"
 msgstr "Sem título"
 
-#: DynamicWeb/dynamicweb.py:2606
+#: DynamicWeb//dynamicweb.py:2611
 msgid "Zoom in"
 msgstr "Ampliar"
 
-#: DynamicWeb/dynamicweb.py:2607
+#: DynamicWeb//dynamicweb.py:2612
 msgid "Zoom out"
 msgstr "Reduzir"
 
-#: DynamicWeb/dynamicweb.py:2608
+#: DynamicWeb//dynamicweb.py:2613
 msgid "all"
 msgstr "tudo"
 
-#: DynamicWeb/dynamicweb.py:2811
+#: DynamicWeb//dynamicweb.py:2816
 msgid "No Home Person"
 msgstr "Sem indivíduo inicial"
 
-#: DynamicWeb/dynamicweb.py:2952
+#: DynamicWeb//dynamicweb.py:2957
 #, python-format
 msgid "Copying error: %(error)s"
 msgstr "Erro de cópia: %(error)s"
 
-#: DynamicWeb/dynamicweb.py:2953
+#: DynamicWeb//dynamicweb.py:2958
 #, python-format
 msgid "Impossible to copy \"%(src)s\" to \"%(dst)s\""
 msgstr "Impossível copiar \"%(src)s\" para \"%(dst)s\""
 
-#: DynamicWeb/dynamicweb.py:2956
+#: DynamicWeb//dynamicweb.py:2961
 msgid "Possible destination error"
 msgstr "Possível erro de destino"
 
-#: DynamicWeb/dynamicweb.py:2957
+#: DynamicWeb//dynamicweb.py:2962
 msgid ""
 "You appear to have set your target directory to a directory used for data "
 "storage. This could create problems with file management. It is recommended "
@@ -990,64 +990,64 @@ msgstr ""
 "considere usar uma pasta diferente para armazenar as suas páginas web "
 "geradas."
 
-#: DynamicWeb/dynamicweb.py:2984
+#: DynamicWeb//dynamicweb.py:2989
 #, python-format
 msgid "Unable to copy web site template files from \"%(path)s\""
 msgstr "Impossível copiar o modelo de página web de \"%(path)s\""
 
-#: DynamicWeb/dynamicweb.py:3028
+#: DynamicWeb//dynamicweb.py:3033
 #, python-format
 msgid "Keeping \"%(dst)s\" (newer than \"%(src)s\")"
 msgstr "A manter \"%(dst)s\" (mais recente que \"%(src)s\")"
 
-#: DynamicWeb/dynamicweb.py:3031
+#: DynamicWeb//dynamicweb.py:3036
 #, python-format
 msgid "Copying \"%(src)s\" to \"%(dst)s\""
 msgstr "A copiar \"%(src)s\" para \"%(dst)s\""
 
-#: DynamicWeb/dynamicweb.py:3049
+#: DynamicWeb//dynamicweb.py:3054
 msgid "Invalid file name"
 msgstr "Nome de ficheiro inválido"
 
-#: DynamicWeb/dynamicweb.py:3050
+#: DynamicWeb//dynamicweb.py:3055
 msgid "The archive file must be a file, not a directory"
 msgstr "O arquivo tem de ser um ficheiro, não uma pasta"
 
-#: DynamicWeb/dynamicweb.py:3060 DynamicWeb/dynamicweb.py:3078
+#: DynamicWeb//dynamicweb.py:3065 DynamicWeb//dynamicweb.py:3083
 #, python-format
 msgid "Unable to overwrite archive file \"%(path)s\""
 msgstr "Impossível sobrescrever o arquivo \"%(path)s\""
 
-#: DynamicWeb/dynamicweb.py:3070 DynamicWeb/dynamicweb.py:3085
+#: DynamicWeb//dynamicweb.py:3075 DynamicWeb//dynamicweb.py:3090
 #, python-format
 msgid "Unable to add file \"%(file)s\" to archive \"%(archive)s\""
 msgstr "Impossível adicionar \"%(file)s\" ao arquivo \"%(archive)s\""
 
-#: DynamicWeb/dynamicweb.py:3138
+#: DynamicWeb//dynamicweb.py:3143
 #, python-format
 msgid "DynamicWebReport ignoring link type '%(class)s'"
 msgstr "Relatório Web dinâmico a ignorar tipo de ligação \"%(class)s\""
 
-#: DynamicWeb/dynamicweb.py:3381
+#: DynamicWeb//dynamicweb.py:3386
 msgid "Constructing list of other objects..."
 msgstr "A construir lista de outros objectos..."
 
-#: DynamicWeb/dynamicweb.py:3516
+#: DynamicWeb//dynamicweb.py:3521
 #, python-format
 msgid "Family of %(husband)s and %(spouse)s"
 msgstr "Família de %(husband)s e %(spouse)s"
 
-#: DynamicWeb/dynamicweb.py:3522
+#: DynamicWeb//dynamicweb.py:3527
 #, python-format
 msgid "Family of %(father)s"
 msgstr "Família de %(father)s"
 
-#: DynamicWeb/dynamicweb.py:3526
+#: DynamicWeb//dynamicweb.py:3531
 #, python-format
 msgid "Family of %(mother)s"
 msgstr "Família de %(mother)s"
 
-#: DynamicWeb/dynamicweb.py:3841
+#: DynamicWeb//dynamicweb.py:3846
 msgid ""
 "In this note, the following special words are processed:\n"
 "__SEARCH_FORM__ is replaced by a search form.\n"
@@ -1083,138 +1083,138 @@ msgstr ""
 "URLs começado por \"relative://relative.<link>\" são subtituídos pelo URL "
 "relativo \"<link>\".\n"
 
-#: DynamicWeb/dynamicweb.py:3880
+#: DynamicWeb//dynamicweb.py:3886
 msgid "Report"
 msgstr "Relatório"
 
-#: DynamicWeb/dynamicweb.py:3885
+#: DynamicWeb//dynamicweb.py:3891
 msgid "Destination"
 msgstr "Destino"
 
-#: DynamicWeb/dynamicweb.py:3887
+#: DynamicWeb//dynamicweb.py:3893
 msgid "The destination directory for the web files"
 msgstr "A pasta destino dos ficheiros web"
 
-#: DynamicWeb/dynamicweb.py:3891
+#: DynamicWeb//dynamicweb.py:3897
 msgid "Store web pages in archive"
 msgstr "Armazenar páginas web num arquivo"
 
-#: DynamicWeb/dynamicweb.py:3892
+#: DynamicWeb//dynamicweb.py:3898
 msgid ""
 "Whether to create an archive file (in ZIP or TGZ format) containing the web "
 "site"
 msgstr "Se deve criar um arquivo (em formato ZIP ou TGZ) contendo a página web"
 
-#: DynamicWeb/dynamicweb.py:3896
+#: DynamicWeb//dynamicweb.py:3902
 msgid "Archive file"
 msgstr "Arquivo"
 
-#: DynamicWeb/dynamicweb.py:3898
+#: DynamicWeb//dynamicweb.py:3904
 msgid "The archive file name (with \".zip\" or \".tgz\" extension)"
 msgstr "O nome do arquivo (com extensão \".zip\" ou \".tgz\")"
 
-#: DynamicWeb/dynamicweb.py:3904
+#: DynamicWeb//dynamicweb.py:3910
 msgid "Web site title"
 msgstr "Título da página web"
 
-#: DynamicWeb/dynamicweb.py:3904
+#: DynamicWeb//dynamicweb.py:3910
 msgid "My Family Tree"
 msgstr "Minha árvore de família"
 
-#: DynamicWeb/dynamicweb.py:3905
+#: DynamicWeb//dynamicweb.py:3911
 msgid "The title of the web site"
 msgstr "O título da página web"
 
-#: DynamicWeb/dynamicweb.py:3908
+#: DynamicWeb//dynamicweb.py:3914
 msgid "Filter"
 msgstr "Filtro"
 
-#: DynamicWeb/dynamicweb.py:3910
+#: DynamicWeb//dynamicweb.py:3916
 msgid "Select filter to restrict people that appear on web site"
 msgstr ""
 "Seleccione o filtro para limitar os indivíduos que aparecem na página web"
 
-#: DynamicWeb/dynamicweb.py:3914
+#: DynamicWeb//dynamicweb.py:3920
 msgid "Filter Person"
 msgstr "Indivíduo filtro"
 
-#: DynamicWeb/dynamicweb.py:3915
+#: DynamicWeb//dynamicweb.py:3921
 msgid "The center person for the filter"
 msgstr "O indivíduo central do filtro"
 
-#: DynamicWeb/dynamicweb.py:3923 DynamicWeb/dynamicweb.py:3943
+#: DynamicWeb//dynamicweb.py:3929 DynamicWeb//dynamicweb.py:3949
 msgid "Name format (short)"
 msgstr "Formato de nome (curto)"
 
-#: DynamicWeb/dynamicweb.py:3924 DynamicWeb/dynamicweb.py:3946
+#: DynamicWeb//dynamicweb.py:3930 DynamicWeb//dynamicweb.py:3952
 msgid "Select the format to display a shorter version of the names"
 msgstr "Seleccione um formato para mostrar uma versão mais curta dos nomes"
 
-#: DynamicWeb/dynamicweb.py:3938
+#: DynamicWeb//dynamicweb.py:3944
 msgid "Name format"
 msgstr "Formato de nome"
 
-#: DynamicWeb/dynamicweb.py:3941
+#: DynamicWeb//dynamicweb.py:3947
 msgid "Select the format to display names"
 msgstr "Seleccione o formato para mostrar nomes"
 
-#: DynamicWeb/dynamicweb.py:3949
+#: DynamicWeb//dynamicweb.py:3955
 msgid "Web site template"
 msgstr "Modelo de página web"
 
-#: DynamicWeb/dynamicweb.py:3952
+#: DynamicWeb//dynamicweb.py:3958
 msgid "Select the template of the web site"
 msgstr "Seleccione o modelo de página web"
 
-#: DynamicWeb/dynamicweb.py:3955
+#: DynamicWeb//dynamicweb.py:3961
 msgid "Copyright"
 msgstr "Direitos de autor"
 
-#: DynamicWeb/dynamicweb.py:3958
+#: DynamicWeb//dynamicweb.py:3964
 msgid "The copyright to be used for the web files"
 msgstr "Os direitos de autor a serem usados para os ficheiros"
 
-#: DynamicWeb/dynamicweb.py:3966
+#: DynamicWeb//dynamicweb.py:3972
 msgid "Privacy"
 msgstr "Privacidade"
 
-#: DynamicWeb/dynamicweb.py:3974
+#: DynamicWeb//dynamicweb.py:3980
 msgid "Include records marked private"
 msgstr "Incluir registos marcados privados"
 
-#: DynamicWeb/dynamicweb.py:3975
+#: DynamicWeb//dynamicweb.py:3981
 msgid "Whether to include private objects"
 msgstr "Se deve incluir objectos provados"
 
-#: DynamicWeb/dynamicweb.py:3977
+#: DynamicWeb//dynamicweb.py:3983
 msgid "Living People"
 msgstr "Indivíduos vivos"
 
-#: DynamicWeb/dynamicweb.py:3978
+#: DynamicWeb//dynamicweb.py:3984
 msgid "Exclude"
 msgstr "Excluir"
 
-#: DynamicWeb/dynamicweb.py:3979
+#: DynamicWeb//dynamicweb.py:3985
 msgid "Include Last Name Only"
 msgstr "Incluir só apelido"
 
-#: DynamicWeb/dynamicweb.py:3980
+#: DynamicWeb//dynamicweb.py:3986
 msgid "Include Full Name Only"
 msgstr "Incluir só nome completo"
 
-#: DynamicWeb/dynamicweb.py:3981
+#: DynamicWeb//dynamicweb.py:3987
 msgid "Include"
 msgstr "Incluir"
 
-#: DynamicWeb/dynamicweb.py:3982
+#: DynamicWeb//dynamicweb.py:3988
 msgid "How to handle living people"
 msgstr "Como gerir indivíduos vivos"
 
-#: DynamicWeb/dynamicweb.py:3985
+#: DynamicWeb//dynamicweb.py:3991
 msgid "Years from death to consider living"
 msgstr "Anos após o óbito para considerar vivo"
 
-#: DynamicWeb/dynamicweb.py:3986
+#: DynamicWeb//dynamicweb.py:3992
 msgid ""
 "This allows you to restrict information on people who have not been dead for "
 "very long"
@@ -1222,87 +1222,87 @@ msgstr ""
 "Permite restringir informação sobre indivíduos que não tenham falecido há "
 "muito tempo"
 
-#: DynamicWeb/dynamicweb.py:3990
+#: DynamicWeb//dynamicweb.py:3996
 msgid "Export notes"
 msgstr "Exportar notas"
 
-#: DynamicWeb/dynamicweb.py:3991
+#: DynamicWeb//dynamicweb.py:3997
 msgid "Whether to export notes in the web pages"
 msgstr "Se deve exportar notas nas páginas web"
 
-#: DynamicWeb/dynamicweb.py:3994
+#: DynamicWeb//dynamicweb.py:4000
 msgid "Export sources"
 msgstr "Exportar fontes"
 
-#: DynamicWeb/dynamicweb.py:3995
+#: DynamicWeb//dynamicweb.py:4001
 msgid "Whether to export sources and citations in the web pages"
 msgstr "Se deve exportar fontes e citações nas páginas web"
 
-#: DynamicWeb/dynamicweb.py:3998
+#: DynamicWeb//dynamicweb.py:4004
 msgid "Export addresses"
 msgstr "Exportar endereços"
 
-#: DynamicWeb/dynamicweb.py:3999
+#: DynamicWeb//dynamicweb.py:4005
 msgid "Whether to export addresses in the web pages"
 msgstr "Se deve exportar endereços nas páginas web"
 
-#: DynamicWeb/dynamicweb.py:4004
+#: DynamicWeb//dynamicweb.py:4010
 msgid "Options"
 msgstr "Opções"
 
-#: DynamicWeb/dynamicweb.py:4007
+#: DynamicWeb//dynamicweb.py:4013
 msgid "Include repository pages"
 msgstr "Incluir páginas de repositórios"
 
-#: DynamicWeb/dynamicweb.py:4008
+#: DynamicWeb//dynamicweb.py:4014
 msgid "Whether or not to include the Repository Pages."
 msgstr "Se deve incluir as páginas dos repositórios."
 
-#: DynamicWeb/dynamicweb.py:4011
+#: DynamicWeb//dynamicweb.py:4017
 msgid "Include images and media"
 msgstr "Incluir multimédia"
 
-#: DynamicWeb/dynamicweb.py:4012
+#: DynamicWeb//dynamicweb.py:4018
 msgid "Whether to include images and media in the web pages"
 msgstr "Se deve incluir a multimédia nas páginas web."
 
-#: DynamicWeb/dynamicweb.py:4016
+#: DynamicWeb//dynamicweb.py:4022
 msgid "Copy, rename files with an internal Gramps identifier"
 msgstr "Copiar, renomear ficheiros com identificador Gramps interno"
 
-#: DynamicWeb/dynamicweb.py:4017
+#: DynamicWeb//dynamicweb.py:4023
 msgid "Copy, keep file names unchanged"
 msgstr "Copiar, manter nomes de ficheiros"
 
-#: DynamicWeb/dynamicweb.py:4018
+#: DynamicWeb//dynamicweb.py:4024
 msgid "Do not copy, reference existing files"
 msgstr "Não copiar, referenciar ficheiros existentes"
 
-#: DynamicWeb/dynamicweb.py:4020
+#: DynamicWeb//dynamicweb.py:4026
 msgid "Images and media"
 msgstr "Multimédia"
 
-#: DynamicWeb/dynamicweb.py:4023
+#: DynamicWeb//dynamicweb.py:4029
 msgid "Whether to make a copy of the media"
 msgstr "Se deve fazer cópias da multimédia."
 
-#: DynamicWeb/dynamicweb.py:4026
+#: DynamicWeb//dynamicweb.py:4032
 msgid "Print the notes type"
 msgstr "Imprimir o tipo das notas"
 
-#: DynamicWeb/dynamicweb.py:4027
+#: DynamicWeb//dynamicweb.py:4033
 msgid "Whether to print the notes type in the notes text"
 msgstr "Se deve imprimir o tipo das notas no texto das notas."
 
-#: DynamicWeb/dynamicweb.py:4030
+#: DynamicWeb//dynamicweb.py:4036
 msgid "Print place pages"
 msgstr "Imprimir páginas de locais"
 
-#: DynamicWeb/dynamicweb.py:4031
+#: DynamicWeb//dynamicweb.py:4037
 msgid "Whether to show pages for the places"
 msgstr "Se deve mostrar páginas dos locais."
 
-#: DynamicWeb/dynamicweb.py:4037
+#: DynamicWeb//dynamicweb.py:4043
 msgid ""
 "Whether to include a place map on the Place Pages, where Latitude/ Longitude "
 "are available."
@@ -1310,7 +1310,7 @@ msgstr ""
 "Se deve incluir um mapa nas páginas de locais onde Latitude/Longitude "
 "estejam disponíveis."
 
-#: DynamicWeb/dynamicweb.py:4045
+#: DynamicWeb//dynamicweb.py:4051
 msgid ""
 "Whether or not to add an individual page map showing all the places on this "
 "page. This will allow you to see how your family traveled around the country."
@@ -1318,163 +1318,163 @@ msgstr ""
 "Se deve adicionar uma página de mapa individual mostrando todos os locais "
 "nesta página. Permite ver como a família viajou pelo país."
 
-#: DynamicWeb/dynamicweb.py:4053
+#: DynamicWeb//dynamicweb.py:4059
 msgid "Google"
 msgstr "Google"
 
-#: DynamicWeb/dynamicweb.py:4054
+#: DynamicWeb//dynamicweb.py:4060
 msgid "OpenStreetMap"
 msgstr "OpenStreetMap"
 
-#: DynamicWeb/dynamicweb.py:4056
+#: DynamicWeb//dynamicweb.py:4062
 msgid "Map Service"
 msgstr "Serviço de mapas"
 
-#: DynamicWeb/dynamicweb.py:4059
+#: DynamicWeb//dynamicweb.py:4065
 msgid "Choose your choice of map service for creating the Place Map Pages"
 msgstr "Escolha o seu serviço de mapas para criar as páginas de mapas"
 
-#: DynamicWeb/dynamicweb.py:4063
+#: DynamicWeb//dynamicweb.py:4069
 msgid "Google map API key"
 msgstr "Chave da API Google Maps"
 
-#: DynamicWeb/dynamicweb.py:4064
+#: DynamicWeb//dynamicweb.py:4070
 msgid "The API key used for the Google map"
 msgstr "A chave API usada para o Google Maps"
 
-#: DynamicWeb/dynamicweb.py:4071
+#: DynamicWeb//dynamicweb.py:4077
 msgid "Advanced"
 msgstr "Avançado"
 
-#: DynamicWeb/dynamicweb.py:4074
+#: DynamicWeb//dynamicweb.py:4080
 msgid "Character set encoding"
 msgstr "Codificação de caracteres"
 
-#: DynamicWeb/dynamicweb.py:4077
+#: DynamicWeb//dynamicweb.py:4083
 msgid "The encoding to be used for the web files"
 msgstr "A codificação a usar nas páginas web"
 
-#: DynamicWeb/dynamicweb.py:4080
+#: DynamicWeb//dynamicweb.py:4086
 msgid "Include family pages"
 msgstr "Incluir páginas familiares"
 
-#: DynamicWeb/dynamicweb.py:4081
+#: DynamicWeb//dynamicweb.py:4087
 msgid "Whether or not to include family pages"
 msgstr "Se deve incluir páginas familiares"
 
-#: DynamicWeb/dynamicweb.py:4091
+#: DynamicWeb//dynamicweb.py:4097
 msgid ""
 "Whether to include half and/ or step-siblings with the parents and siblings"
 msgstr "Se deve incluir meio-irmãos com os pais e irmãos"
 
-#: DynamicWeb/dynamicweb.py:4094
+#: DynamicWeb//dynamicweb.py:4100
 msgid "Include GENDEX file (/gendex.txt)"
 msgstr "Incluir ficheiro GENDEX (/gendex.txt)"
 
-#: DynamicWeb/dynamicweb.py:4095
+#: DynamicWeb//dynamicweb.py:4101
 msgid "Whether to include a GENDEX file or not"
 msgstr "Se deve incluir um ficheiro GENDEX"
 
-#: DynamicWeb/dynamicweb.py:4098
+#: DynamicWeb//dynamicweb.py:4104
 msgid "Enable page configuration"
 msgstr "Activar configuração da página"
 
-#: DynamicWeb/dynamicweb.py:4099
+#: DynamicWeb//dynamicweb.py:4105
 msgid "Whether to enable page configuration"
 msgstr "Se deve activar configuração da página"
 
-#: DynamicWeb/dynamicweb.py:4103
+#: DynamicWeb//dynamicweb.py:4109
 msgid "Whether to use tabbed panels for the different sections of the pages."
 msgstr "Se deve usar separadores para diferentes secções das páginas."
 
-#: DynamicWeb/dynamicweb.py:4107
+#: DynamicWeb//dynamicweb.py:4113
 msgid "Whether to show the last modification time in the pages footer"
 msgstr "Se deve mostrar a hora da última modificação no rodapé das páginas."
 
-#: DynamicWeb/dynamicweb.py:4111
+#: DynamicWeb//dynamicweb.py:4117
 msgid "Whether to insert sources author in the sources title"
 msgstr "Se deve inserir o autor das fontes no título das fontes"
 
-#: DynamicWeb/dynamicweb.py:4115
+#: DynamicWeb//dynamicweb.py:4121
 msgid "Whether to hide the Gramps ID"
 msgstr "Se deve ocultar a Id Gramps"
 
-#: DynamicWeb/dynamicweb.py:4124
+#: DynamicWeb//dynamicweb.py:4130
 msgid "List"
 msgstr "Lista"
 
-#: DynamicWeb/dynamicweb.py:4125
+#: DynamicWeb//dynamicweb.py:4131
 msgid "Table"
 msgstr "Tabela"
 
-#: DynamicWeb/dynamicweb.py:4128
+#: DynamicWeb//dynamicweb.py:4134
 msgid "Default format for the surnames index"
 msgstr "Formato predefinido para o índice de apelidos"
 
-#: DynamicWeb/dynamicweb.py:4128
+#: DynamicWeb//dynamicweb.py:4134
 msgid "The default format for the surnames index"
 msgstr "O formato predefinido para o índice de apelidos"
 
-#: DynamicWeb/dynamicweb.py:4129
+#: DynamicWeb//dynamicweb.py:4135
 msgid "Default format for the persons index"
 msgstr "Formato predefinido para o índice de indivíduos"
 
-#: DynamicWeb/dynamicweb.py:4129
+#: DynamicWeb//dynamicweb.py:4135
 msgid "The default format for the persons index"
 msgstr "O formato predefinido para o índice de indivíduos"
 
-#: DynamicWeb/dynamicweb.py:4130
+#: DynamicWeb//dynamicweb.py:4136
 msgid "Default format for the families index"
 msgstr "Formato predefinido para o índice de famílias"
 
-#: DynamicWeb/dynamicweb.py:4130
+#: DynamicWeb//dynamicweb.py:4136
 msgid "The default format for the families index"
 msgstr "O formato predefinido para o índice de famílias"
 
-#: DynamicWeb/dynamicweb.py:4131
+#: DynamicWeb//dynamicweb.py:4137
 msgid "Default format for the sources index"
 msgstr "Formato predefinido para o índice de fontes"
 
-#: DynamicWeb/dynamicweb.py:4131
+#: DynamicWeb//dynamicweb.py:4137
 msgid "The default format for the sources index"
 msgstr "O formato predefinido para o índice de fontes"
 
-#: DynamicWeb/dynamicweb.py:4132
+#: DynamicWeb//dynamicweb.py:4138
 msgid "Default format for the places index"
 msgstr "Formato predefinido para o índice de locais"
 
-#: DynamicWeb/dynamicweb.py:4132
+#: DynamicWeb//dynamicweb.py:4138
 msgid "The default format for the places index"
 msgstr "O formato predefinido para o índice de locais"
 
-#: DynamicWeb/dynamicweb.py:4141
+#: DynamicWeb//dynamicweb.py:4147
 msgid ""
 "Whether to include dates columns (birth, death, marriage) on the index pages"
 msgstr ""
 "Se deve incluir colunas de datas (nascimento, óbito, casamento) nas páginas "
 "de índice"
 
-#: DynamicWeb/dynamicweb.py:4145
+#: DynamicWeb//dynamicweb.py:4151
 msgid "Whether to include a partners column"
 msgstr "Se deve incluir uma coluna de companheiros"
 
-#: DynamicWeb/dynamicweb.py:4149
+#: DynamicWeb//dynamicweb.py:4155
 msgid "Whether to include a parents column"
 msgstr "Se deve incluir uma coluna de pais"
 
-#: DynamicWeb/dynamicweb.py:4152
+#: DynamicWeb//dynamicweb.py:4158
 msgid "Generate a families index page"
 msgstr "Gerar uma página de indice de famílias"
 
-#: DynamicWeb/dynamicweb.py:4153
+#: DynamicWeb//dynamicweb.py:4159
 msgid "Whether to generate an index page for families"
 msgstr "Se deve gerar uma página de índice para famílias"
 
-#: DynamicWeb/dynamicweb.py:4157
+#: DynamicWeb//dynamicweb.py:4163
 msgid "Whether to include a column showing the media path"
 msgstr "Se deve incluir uma coluna com o caminho da multimédia"
 
-#: DynamicWeb/dynamicweb.py:4161
+#: DynamicWeb//dynamicweb.py:4167
 msgid ""
 "Whether to include the references to the items in the index pages. For "
 "example, in the media index page, the names of the individuals, families, "
@@ -1484,23 +1484,23 @@ msgstr ""
 "no índice da multimédia, incluir nomes de indivíduos, famílias, locais e "
 "fontes que referenciem a multimédia"
 
-#: DynamicWeb/dynamicweb.py:4164
+#: DynamicWeb//dynamicweb.py:4170
 msgid "Default number of entries in the indexes"
 msgstr "Número de entradas predefinidas nos índices"
 
-#: DynamicWeb/dynamicweb.py:4167
+#: DynamicWeb//dynamicweb.py:4173
 msgid "The default number of entries shown in one index page"
 msgstr "O número predefinido de entradas mostradas numa página de índice"
 
-#: DynamicWeb/dynamicweb.py:4172
+#: DynamicWeb//dynamicweb.py:4178
 msgid "Trees"
 msgstr "Árvores"
 
-#: DynamicWeb/dynamicweb.py:4175
+#: DynamicWeb//dynamicweb.py:4181
 msgid "Maximum number of generations"
 msgstr "Número máximo de gerações"
 
-#: DynamicWeb/dynamicweb.py:4176
+#: DynamicWeb//dynamicweb.py:4182
 msgid ""
 "The maximum number of generations to include in the ancestor and descendant "
 "trees and graphs"
@@ -1508,118 +1508,121 @@ msgstr ""
 "O número máximo de gerações a incluir nas árvores e gráficos de ascendentes "
 "e descendentes."
 
-#: DynamicWeb/dynamicweb.py:4182
+#: DynamicWeb//dynamicweb.py:4188
 msgid "Choose the default SVG tree graph type"
 msgstr "Escolha o tipo de gráfico SVG predefinido"
 
-#: DynamicWeb/dynamicweb.py:4188
+#: DynamicWeb//dynamicweb.py:4194
 msgid "Choose the default SVG tree graph shape"
 msgstr "Escolha a forma de gráfico SVG predefinida"
 
-#: DynamicWeb/dynamicweb.py:4194
+#: DynamicWeb//dynamicweb.py:4200
 msgid "Choose the default SVG tree parents distribution (for fan charts only)"
 msgstr ""
 "Escolha a árvore de distribuição de pais SVG predefinido (só para leques)"
 
-#: DynamicWeb/dynamicweb.py:4200
+#: DynamicWeb//dynamicweb.py:4206
 msgid "Choose the default SVG tree children distribution (for fan charts only)"
 msgstr ""
 "Escolha a árvore de distribuição de filhos SVG predefinido (só para leques)"
 
-#: DynamicWeb/dynamicweb.py:4206
+#: DynamicWeb//dynamicweb.py:4212
 msgid ""
 "Choose the background color scheme for the persons in the SVG tree graph"
 msgstr "Escolha o esquema de cor do fundo para indivíduos no gráfico SVG"
 
-#: DynamicWeb/dynamicweb.py:4209
+#: DynamicWeb//dynamicweb.py:4215
 msgid "Start gradient/Main color"
 msgstr "Gradação inicial/Cor principal"
 
-#: DynamicWeb/dynamicweb.py:4212
+#: DynamicWeb//dynamicweb.py:4218
 msgid "End gradient/2nd color"
 msgstr "Gradação final/2ª cor"
 
-#: DynamicWeb/dynamicweb.py:4220
+#: DynamicWeb//dynamicweb.py:4226
 msgid "Color for duplicates"
 msgstr "Cor para duplicados"
 
-#: DynamicWeb/dynamicweb.py:4225
+#: DynamicWeb//dynamicweb.py:4231
 msgid "Pages"
 msgstr "Páginas"
 
-#: DynamicWeb/dynamicweb.py:4228
+#: DynamicWeb//dynamicweb.py:4234
 msgid "HTML user header"
 msgstr "Cabeçalho HTML"
 
-#: DynamicWeb/dynamicweb.py:4229
+#: DynamicWeb//dynamicweb.py:4235
 msgid "A note to be used as the page header"
 msgstr "Uma nota a usar como cabeçalho de página"
 
-#: DynamicWeb/dynamicweb.py:4232
+#: DynamicWeb//dynamicweb.py:4238
 msgid "HTML user brand name / icon"
 msgstr "Nome/Ícone de utilizador HTML"
 
-#: DynamicWeb/dynamicweb.py:4233
+#: DynamicWeb//dynamicweb.py:4239
 msgid "A note to be used as the brand name or image in the menu"
 msgstr "Uma nota a usar como imagem de marca ou nome no menu"
 
-#: DynamicWeb/dynamicweb.py:4236
+#: DynamicWeb//dynamicweb.py:4242
 msgid "HTML user footer"
 msgstr "Rodapé HTML"
 
-#: DynamicWeb/dynamicweb.py:4237
+#: DynamicWeb//dynamicweb.py:4243
 msgid "A note to be used as the page footer"
 msgstr "Uma nota a usar como rodapé de página"
 
-#: DynamicWeb/dynamicweb.py:4242
+#: DynamicWeb//dynamicweb.py:4248
 msgid "Custom pages"
 msgstr "Páginas personalizadas"
 
-#: DynamicWeb/dynamicweb.py:4246
+#: DynamicWeb//dynamicweb.py:4252
 #, python-format
 msgid "Title for the custom page %(index)i"
 msgstr "Título da página personalizada %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4247
+#: DynamicWeb//dynamicweb.py:4253
 #, python-format
 msgid "Name for the custom page %(index)i"
 msgstr "Nome da página personalizada %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4250
+#: DynamicWeb//dynamicweb.py:4256
 #, python-format
 msgid "Note for custom page %(index)i"
 msgstr "Nota da página personalizada %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4251
+#: DynamicWeb//dynamicweb.py:4257
 msgid "A note to be used for the custom page content.\n"
 msgstr "Uma nota a usar para o conteúdo da página personalizada.\n"
 
-#: DynamicWeb/dynamicweb.py:4254
+#: DynamicWeb//dynamicweb.py:4260
 #, python-format
 msgid "Menu for the custom page %(index)i"
 msgstr "Menu da página personalizada %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4255
+#: DynamicWeb//dynamicweb.py:4261
 msgid "Whether to print a menu for the custom page"
 msgstr "Se deve imprimir um meu na página personalizada"
 
-#: DynamicWeb/dynamicweb.py:4260
+#: DynamicWeb//dynamicweb.py:4266
 msgid "Pages selection"
 msgstr "Selecção de páginas"
 
-#: DynamicWeb/dynamicweb.py:4263
+#: DynamicWeb//dynamicweb.py:4269
 msgid "Number of pages"
 msgstr "Número de páginas"
 
-#: DynamicWeb/dynamicweb.py:4264
+#: DynamicWeb//dynamicweb.py:4270
 msgid "Number pages in the web site menu."
 msgstr "Número de páginas no menu da página web"
 
-#: DynamicWeb/dynamicweb.py:4280
+#: DynamicWeb//dynamicweb.py:4286
 #, python-format
 msgid "Contents of page %(index)i"
 msgstr "Conteúdo da página %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4283
+#: DynamicWeb//dynamicweb.py:4289
 msgid "Contents of the page"
 msgstr "Conteúdo da página"
+
+#~ msgid "Html|Home"
+#~ msgstr "Início"

--- a/DynamicWeb/po/ru-local.po
+++ b/DynamicWeb/po/ru-local.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gramps50\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-03-03 09:17-0300\n"
+"POT-Creation-Date: 2020-07-24 17:33+0200\n"
 "PO-Revision-Date: 2019-03-03 09:32-0300\n"
 "Last-Translator: Ivan Komaritsyn <vantu5z@mail.ru>\n"
 "Language-Team: Russian\n"
@@ -18,355 +18,355 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
 
-#: DynamicWeb/dynamicweb.gpr.py:15
+#: DynamicWeb//dynamicweb.gpr.py:15
 msgid "Dynamic Web Report"
 msgstr "Динамический веб отчёт"
 
-#: DynamicWeb/dynamicweb.gpr.py:16
+#: DynamicWeb//dynamicweb.gpr.py:16
 msgid "Produces dynamic web pages for the database"
 msgstr "Формирует динамические веб страницы из базы данных"
 
-#: DynamicWeb/dynamicweb.py:265
+#: DynamicWeb//dynamicweb.py:269
 msgid "Street"
 msgstr "Улица"
 
-#: DynamicWeb/dynamicweb.py:266
+#: DynamicWeb//dynamicweb.py:270
 msgid "Locality"
 msgstr "Местность"
 
-#: DynamicWeb/dynamicweb.py:267
+#: DynamicWeb//dynamicweb.py:271
 msgid "City"
 msgstr "Город"
 
-#: DynamicWeb/dynamicweb.py:268
+#: DynamicWeb//dynamicweb.py:272
 msgid "Church Parish"
 msgstr "Церковный приход"
 
-#: DynamicWeb/dynamicweb.py:269
+#: DynamicWeb//dynamicweb.py:273
 msgid "County"
 msgstr "Область/Район/Уезд"
 
-#: DynamicWeb/dynamicweb.py:270
+#: DynamicWeb//dynamicweb.py:274
 msgid "State/ Province"
 msgstr "Штат/Провинция"
 
-#: DynamicWeb/dynamicweb.py:271
+#: DynamicWeb//dynamicweb.py:275
 msgid "Postal Code"
 msgstr "Индекс/Почтовый код"
 
-#: DynamicWeb/dynamicweb.py:272
+#: DynamicWeb//dynamicweb.py:276
 msgid "Country"
 msgstr "Государство/Страна"
 
-#: DynamicWeb/dynamicweb.py:273
+#: DynamicWeb//dynamicweb.py:277
 msgid "Phone"
 msgstr "Телефон"
 
-#: DynamicWeb/dynamicweb.py:279
+#: DynamicWeb//dynamicweb.py:283
 msgid "Home Page"
 msgstr "Домашняя страница"
 
-#: DynamicWeb/dynamicweb.py:280
+#: DynamicWeb//dynamicweb.py:284
 msgid "SVG graphical tree"
 msgstr "Графическое представление древа в SVG"
 
-#: DynamicWeb/dynamicweb.py:283
+#: DynamicWeb//dynamicweb.py:287
 msgid "Indexes pages"
 msgstr "Оглавление"
 
-#: DynamicWeb/dynamicweb.py:287 DynamicWeb/dynamicweb.py:4246
+#: DynamicWeb//dynamicweb.py:291 DynamicWeb//dynamicweb.py:4252
 #, python-format
 msgid "Custom page %(index)i"
 msgstr "Выбранная страница %(index)i"
 
-#: DynamicWeb/dynamicweb.py:305
+#: DynamicWeb//dynamicweb.py:309
 msgid "Ascending tree"
 msgstr "Древо предков"
 
-#: DynamicWeb/dynamicweb.py:306
+#: DynamicWeb//dynamicweb.py:310
 msgid "Descending tree"
 msgstr "Древо потомков"
 
-#: DynamicWeb/dynamicweb.py:307
+#: DynamicWeb//dynamicweb.py:311
 msgid "Descending tree with spouses"
 msgstr "Древо потомков с супругами"
 
-#: DynamicWeb/dynamicweb.py:308
+#: DynamicWeb//dynamicweb.py:312
 msgid "Ascending and descending tree"
 msgstr "Древо предков и потомков"
 
-#: DynamicWeb/dynamicweb.py:309
+#: DynamicWeb//dynamicweb.py:313
 msgid "Ascending and descending tree with spouses"
 msgstr "Древо предков и потомков с супругами"
 
-#: DynamicWeb/dynamicweb.py:321
+#: DynamicWeb//dynamicweb.py:325
 msgid "Vertical (↓)"
 msgstr "Вертикально (↓)"
 
-#: DynamicWeb/dynamicweb.py:322
+#: DynamicWeb//dynamicweb.py:326
 msgid "Vertical (↑)"
 msgstr "Вертикально (↑)"
 
-#: DynamicWeb/dynamicweb.py:323
+#: DynamicWeb//dynamicweb.py:327
 msgid "Horizontal (→)"
 msgstr "Горизонтально (→)"
 
-#: DynamicWeb/dynamicweb.py:324
+#: DynamicWeb//dynamicweb.py:328
 msgid "Horizontal (←)"
 msgstr "Горизонтально (←)"
 
-#: DynamicWeb/dynamicweb.py:325
+#: DynamicWeb//dynamicweb.py:329
 msgid "Full Circle"
 msgstr "Полный круг"
 
-#: DynamicWeb/dynamicweb.py:326
+#: DynamicWeb//dynamicweb.py:330
 msgid "Half Circle"
 msgstr "Полукруг"
 
-#: DynamicWeb/dynamicweb.py:327
+#: DynamicWeb//dynamicweb.py:331
 msgid "Quadrant"
 msgstr "Квадрант"
 
-#: DynamicWeb/dynamicweb.py:339
+#: DynamicWeb//dynamicweb.py:343
 msgid "Size proportional to number of ancestors"
 msgstr "Размер пропорцианален числу предков"
 
-#: DynamicWeb/dynamicweb.py:340
+#: DynamicWeb//dynamicweb.py:344
 msgid "Homogeneous parents distribution"
 msgstr "Однородное распределение родителей"
 
-#: DynamicWeb/dynamicweb.py:343
+#: DynamicWeb//dynamicweb.py:347
 msgid "Size proportional to number of descendants"
 msgstr "Размер пропорцианален числу потомков"
 
-#: DynamicWeb/dynamicweb.py:344
+#: DynamicWeb//dynamicweb.py:348
 msgid "Homogeneous children distribution"
 msgstr "Равномерное распределение детей"
 
-#: DynamicWeb/dynamicweb.py:351 DynamicWeb/dynamicweb.py:374
+#: DynamicWeb//dynamicweb.py:355 DynamicWeb//dynamicweb.py:378
 msgid "Gender colors"
 msgstr "Расцветка по половому признаку"
 
-#: DynamicWeb/dynamicweb.py:352
+#: DynamicWeb//dynamicweb.py:356
 msgid "Generation based gradient"
 msgstr "Градиентная заливка, зависит от поколения"
 
-#: DynamicWeb/dynamicweb.py:353
+#: DynamicWeb//dynamicweb.py:357
 msgid "Age based gradient"
 msgstr "Градиент зависит от возраста"
 
-#: DynamicWeb/dynamicweb.py:354 DynamicWeb/dynamicweb.py:373
+#: DynamicWeb//dynamicweb.py:358 DynamicWeb//dynamicweb.py:377
 msgid "Single main (filter) color"
 msgstr "Одиночный цвет фильтра"
 
-#: DynamicWeb/dynamicweb.py:355
+#: DynamicWeb//dynamicweb.py:359
 msgid "Time period based gradient"
 msgstr "Градиентная заливка, зависит от периода времени"
 
-#: DynamicWeb/dynamicweb.py:356 DynamicWeb/dynamicweb.py:378
+#: DynamicWeb//dynamicweb.py:360 DynamicWeb//dynamicweb.py:382
 msgid "White"
 msgstr "Белый"
 
-#: DynamicWeb/dynamicweb.py:357 DynamicWeb/dynamicweb.py:376
+#: DynamicWeb//dynamicweb.py:361 DynamicWeb//dynamicweb.py:380
 msgid "Color scheme classic report"
 msgstr "Цветовая схема классического отчёта"
 
-#: DynamicWeb/dynamicweb.py:358 DynamicWeb/dynamicweb.py:377
+#: DynamicWeb//dynamicweb.py:362 DynamicWeb//dynamicweb.py:381
 msgid "Color scheme classic view"
 msgstr "Цветовая схема классического вида"
 
-#: DynamicWeb/dynamicweb.py:375
+#: DynamicWeb//dynamicweb.py:379
 msgid "Gradient"
 msgstr "Градиент"
 
-#: DynamicWeb/dynamicweb.py:394
+#: DynamicWeb//dynamicweb.py:398
 msgid "Default"
 msgstr "По умолчанию"
 
-#: DynamicWeb/dynamicweb.py:395
+#: DynamicWeb//dynamicweb.py:399
 msgid "Mainz"
 msgstr "Майнц"
 
-#: DynamicWeb/dynamicweb.py:703
+#: DynamicWeb//dynamicweb.py:707
 #, python-format
 msgid "Neither %(current)s nor %(parent)s are directories"
 msgstr "Ни %(current)s, ни %(parent)s не являются каталогами"
 
-#: DynamicWeb/dynamicweb.py:711 DynamicWeb/dynamicweb.py:716
+#: DynamicWeb//dynamicweb.py:715 DynamicWeb//dynamicweb.py:720
 #, python-format
 msgid "Could not create the directory: %(path)s"
 msgstr "Невозможно создать каталог: %(path)s"
 
-#: DynamicWeb/dynamicweb.py:742 DynamicWeb/dynamicweb.py:3380
+#: DynamicWeb//dynamicweb.py:746 DynamicWeb//dynamicweb.py:3385
 msgid "Dynamic Web Site Report"
 msgstr "Динамический веб-сайт отчёт"
 
-#: DynamicWeb/dynamicweb.py:742
+#: DynamicWeb//dynamicweb.py:746
 msgid "Exporting family tree data ..."
 msgstr "Экспортируются данные семейного древа ..."
 
-#: DynamicWeb/dynamicweb.py:1232 DynamicWeb/dynamicweb.py:2456
+#: DynamicWeb//dynamicweb.py:1237 DynamicWeb//dynamicweb.py:2461
 msgid "Author"
 msgstr "Автор"
 
-#: DynamicWeb/dynamicweb.py:1233 DynamicWeb/dynamicweb.py:2446
+#: DynamicWeb//dynamicweb.py:1238 DynamicWeb//dynamicweb.py:2451
 msgid "Abbreviation"
 msgstr "Аббревиатура"
 
-#: DynamicWeb/dynamicweb.py:1234 DynamicWeb/dynamicweb.py:2543
+#: DynamicWeb//dynamicweb.py:1239 DynamicWeb//dynamicweb.py:2548
 msgid "Publication information"
 msgstr "Информация о публикации"
 
-#: DynamicWeb/dynamicweb.py:1304 DynamicWeb/dynamicweb.py:2474
+#: DynamicWeb//dynamicweb.py:1309 DynamicWeb//dynamicweb.py:2479
 msgid "Date"
 msgstr "Дата"
 
-#: DynamicWeb/dynamicweb.py:1305
+#: DynamicWeb//dynamicweb.py:1310
 msgid "Page"
 msgstr "Страница"
 
-#: DynamicWeb/dynamicweb.py:1306
+#: DynamicWeb//dynamicweb.py:1311
 msgid "Confidence"
 msgstr "Достоверность"
 
-#: DynamicWeb/dynamicweb.py:1625
+#: DynamicWeb//dynamicweb.py:1630
 #, python-format
 msgid "%(type)s: %(value)s"
 msgstr "%(type)s: %(value)s"
 
-#: DynamicWeb/dynamicweb.py:1872
+#: DynamicWeb//dynamicweb.py:1877
 #, python-format
 msgid "Impossible to convert \"%(path)s\" to a relative path."
 msgstr "Не удалось преобразовать \"%(path)s\" в относительный путь."
 
-#: DynamicWeb/dynamicweb.py:2178
+#: DynamicWeb//dynamicweb.py:2183
 msgid ""
 "The pages configuration is not valid: several pages have the same content"
 msgstr ""
 "Неверные настройки страниц: несколько страниц содержат одинаковые данные"
 
-#: DynamicWeb/dynamicweb.py:2189
-msgid "Html|Home"
+#: DynamicWeb//dynamicweb.py:2194
+msgid "DynWeb|Home"
 msgstr "Домой"
 
-#: DynamicWeb/dynamicweb.py:2190 DynamicWeb/dynamicweb.py:2203
-#: DynamicWeb/dynamicweb.py:2204 DynamicWeb/dynamicweb.py:2205
+#: DynamicWeb//dynamicweb.py:2195 DynamicWeb//dynamicweb.py:2208
+#: DynamicWeb//dynamicweb.py:2209 DynamicWeb//dynamicweb.py:2210
 msgid "Tree"
 msgstr "Древо"
 
-#: DynamicWeb/dynamicweb.py:2191 DynamicWeb/dynamicweb.py:2206
-#: DynamicWeb/dynamicweb.py:2207 DynamicWeb/dynamicweb.py:2208
+#: DynamicWeb//dynamicweb.py:2196 DynamicWeb//dynamicweb.py:2211
+#: DynamicWeb//dynamicweb.py:2212 DynamicWeb//dynamicweb.py:2213
 msgid "Statistics"
 msgstr "Статистика"
 
-#: DynamicWeb/dynamicweb.py:2194 DynamicWeb/dynamicweb.py:2470
+#: DynamicWeb//dynamicweb.py:2199 DynamicWeb//dynamicweb.py:2475
 msgid "Configuration"
 msgstr "Конфигурация"
 
-#: DynamicWeb/dynamicweb.py:2196 DynamicWeb/dynamicweb.py:2535
+#: DynamicWeb//dynamicweb.py:2201 DynamicWeb//dynamicweb.py:2540
 msgid "Person"
 msgstr "Лицо"
 
-#: DynamicWeb/dynamicweb.py:2197
+#: DynamicWeb//dynamicweb.py:2202
 msgid "Family"
 msgstr "Семья"
 
-#: DynamicWeb/dynamicweb.py:2198 DynamicWeb/dynamicweb.py:2575
+#: DynamicWeb//dynamicweb.py:2203 DynamicWeb//dynamicweb.py:2580
 msgid "Source"
 msgstr "Источник"
 
-#: DynamicWeb/dynamicweb.py:2199 DynamicWeb/dynamicweb.py:2218
-#: DynamicWeb/dynamicweb.py:2518
+#: DynamicWeb//dynamicweb.py:2204 DynamicWeb//dynamicweb.py:2223
+#: DynamicWeb//dynamicweb.py:2523
 msgid "Media"
 msgstr "Альбом"
 
-#: DynamicWeb/dynamicweb.py:2200 DynamicWeb/dynamicweb.py:2538
+#: DynamicWeb//dynamicweb.py:2205 DynamicWeb//dynamicweb.py:2543
 msgid "Place"
 msgstr "Место"
 
-#: DynamicWeb/dynamicweb.py:2201 DynamicWeb/dynamicweb.py:2550
+#: DynamicWeb//dynamicweb.py:2206 DynamicWeb//dynamicweb.py:2555
 msgid "Repository"
 msgstr "Хранилище"
 
-#: DynamicWeb/dynamicweb.py:2202
+#: DynamicWeb//dynamicweb.py:2207
 msgid "Search results"
 msgstr "Результаты поиска"
 
-#: DynamicWeb/dynamicweb.py:2213 DynamicWeb/dynamicweb.py:2214
-#: DynamicWeb/dynamicweb.py:2582
+#: DynamicWeb//dynamicweb.py:2218 DynamicWeb//dynamicweb.py:2219
+#: DynamicWeb//dynamicweb.py:2587
 msgid "Surnames"
 msgstr "Фамилии"
 
-#: DynamicWeb/dynamicweb.py:2215 DynamicWeb/dynamicweb.py:2503
+#: DynamicWeb//dynamicweb.py:2220 DynamicWeb//dynamicweb.py:2508
 msgid "Individuals"
 msgstr "Люди"
 
-#: DynamicWeb/dynamicweb.py:2216 DynamicWeb/dynamicweb.py:2486
+#: DynamicWeb//dynamicweb.py:2221 DynamicWeb//dynamicweb.py:2491
 msgid "Families"
 msgstr "Семьи"
 
-#: DynamicWeb/dynamicweb.py:2217 DynamicWeb/dynamicweb.py:2577
+#: DynamicWeb//dynamicweb.py:2222 DynamicWeb//dynamicweb.py:2582
 msgid "Sources"
 msgstr "Источники"
 
-#: DynamicWeb/dynamicweb.py:2219 DynamicWeb/dynamicweb.py:2540
+#: DynamicWeb//dynamicweb.py:2224 DynamicWeb//dynamicweb.py:2545
 msgid "Places"
 msgstr "Места"
 
-#: DynamicWeb/dynamicweb.py:2220 DynamicWeb/dynamicweb.py:2448
+#: DynamicWeb//dynamicweb.py:2225 DynamicWeb//dynamicweb.py:2453
 msgid "Addresses"
 msgstr "Адреса"
 
-#: DynamicWeb/dynamicweb.py:2221 DynamicWeb/dynamicweb.py:2549
+#: DynamicWeb//dynamicweb.py:2226 DynamicWeb//dynamicweb.py:2554
 msgid "Repositories"
 msgstr "Хранилища"
 
-#: DynamicWeb/dynamicweb.py:2272 DynamicWeb/dynamicweb.py:2502
-#: DynamicWeb/dynamicweb.py:4120
+#: DynamicWeb//dynamicweb.py:2277 DynamicWeb//dynamicweb.py:2507
+#: DynamicWeb//dynamicweb.py:4126
 msgid "Indexes"
 msgstr "Индексы"
 
-#: DynamicWeb/dynamicweb.py:2436
+#: DynamicWeb//dynamicweb.py:2441
 #, python-format
 msgid "(b. %(birthdate)s, d. %(deathdate)s)"
 msgstr "(р. %(birthdate)s, у. %(deathdate)s)"
 
-#: DynamicWeb/dynamicweb.py:2437
+#: DynamicWeb//dynamicweb.py:2442
 #, python-format
 msgid "(b. %s)"
 msgstr "(р. %s)"
 
-#: DynamicWeb/dynamicweb.py:2438
+#: DynamicWeb//dynamicweb.py:2443
 #, python-format
 msgid "(d. %s)"
 msgstr "(у. %s)"
 
-#: DynamicWeb/dynamicweb.py:2439
+#: DynamicWeb//dynamicweb.py:2444
 msgid "(filtered from _MAX_ total entries)"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2440
+#: DynamicWeb//dynamicweb.py:2445
 #, python-format
 msgid "(m. %s)"
 msgstr "(бр. %s)"
 
-#: DynamicWeb/dynamicweb.py:2441
+#: DynamicWeb//dynamicweb.py:2446
 msgid "(sort by name)"
 msgstr "(сортировка по имени)"
 
-#: DynamicWeb/dynamicweb.py:2442
+#: DynamicWeb//dynamicweb.py:2447
 msgid "(sort by quantity)"
 msgstr "(сортировка по количеству)"
 
-#: DynamicWeb/dynamicweb.py:2443
+#: DynamicWeb//dynamicweb.py:2448
 msgid ": activate to sort column ascending"
 msgstr ": активируйте для сортировки колонки по возрастанию"
 
-#: DynamicWeb/dynamicweb.py:2444
+#: DynamicWeb//dynamicweb.py:2449
 msgid ": activate to sort column descending"
 msgstr ": активируйте для сортировки колонки по убыванию"
 
-#: DynamicWeb/dynamicweb.py:2445
+#: DynamicWeb//dynamicweb.py:2450
 msgid ""
 "<p>This page provides the SVG raw code.<br>Copy the contents into a text "
 "editor and save as an SVG file.<br>Make sure that the text editor encoding "
@@ -376,561 +376,561 @@ msgstr ""
 "редактор и сохраните как файл SVG.<br>Убедитесь, что в текстовом редакторе "
 "установлена кодировка UTF-8.</p>"
 
-#: DynamicWeb/dynamicweb.py:2447
+#: DynamicWeb//dynamicweb.py:2452
 msgid "Address"
 msgstr "Адрес"
 
-#: DynamicWeb/dynamicweb.py:2449
+#: DynamicWeb//dynamicweb.py:2454
 msgid "Age at death"
 msgstr "Возраст смерти"
 
-#: DynamicWeb/dynamicweb.py:2450
+#: DynamicWeb//dynamicweb.py:2455
 msgid "Alternate Marriage"
 msgstr "Альтернативный брак"
 
-#: DynamicWeb/dynamicweb.py:2451
+#: DynamicWeb//dynamicweb.py:2456
 msgid "Alternate Name"
 msgstr "Другое имя"
 
-#: DynamicWeb/dynamicweb.py:2452
+#: DynamicWeb//dynamicweb.py:2457
 msgid "Ancestors"
 msgstr "Предки"
 
-#: DynamicWeb/dynamicweb.py:2453
+#: DynamicWeb//dynamicweb.py:2458
 msgid "Associations"
 msgstr "Связи"
 
-#: DynamicWeb/dynamicweb.py:2454
+#: DynamicWeb//dynamicweb.py:2459
 msgid "Attribute"
 msgstr "Атрибут"
 
-#: DynamicWeb/dynamicweb.py:2455
+#: DynamicWeb//dynamicweb.py:2460
 msgid "Attributes"
 msgstr "Атрибуты"
 
-#: DynamicWeb/dynamicweb.py:2457 DynamicWeb/dynamicweb.py:4203
+#: DynamicWeb//dynamicweb.py:2462 DynamicWeb//dynamicweb.py:4209
 msgid "Background"
 msgstr "Цвет фона"
 
-#: DynamicWeb/dynamicweb.py:2458
+#: DynamicWeb//dynamicweb.py:2463
 msgid "Baptism"
 msgstr "Крещение"
 
-#: DynamicWeb/dynamicweb.py:2459
+#: DynamicWeb//dynamicweb.py:2464
 msgid "Birth"
 msgstr "Рождение"
 
-#: DynamicWeb/dynamicweb.py:2460
+#: DynamicWeb//dynamicweb.py:2465
 msgid "Burial"
 msgstr "Захоронение"
 
-#: DynamicWeb/dynamicweb.py:2461
+#: DynamicWeb//dynamicweb.py:2466
 msgid "Call Name"
 msgstr "Имя в быту"
 
-#: DynamicWeb/dynamicweb.py:2462
+#: DynamicWeb//dynamicweb.py:2467
 msgid "Call Number"
 msgstr "Номер"
 
-#: DynamicWeb/dynamicweb.py:2463
+#: DynamicWeb//dynamicweb.py:2468
 msgid "Cause Of Death"
 msgstr "Причина смерти"
 
-#: DynamicWeb/dynamicweb.py:2464
+#: DynamicWeb//dynamicweb.py:2469
 msgid "Children"
 msgstr "Дети"
 
-#: DynamicWeb/dynamicweb.py:2465
+#: DynamicWeb//dynamicweb.py:2470
 msgid "Christening"
 msgstr "Крещение"
 
-#: DynamicWeb/dynamicweb.py:2466
+#: DynamicWeb//dynamicweb.py:2471
 msgid "Citation"
 msgstr "Цитата"
 
-#: DynamicWeb/dynamicweb.py:2467
+#: DynamicWeb//dynamicweb.py:2472
 msgid "Citations"
 msgstr "Цитаты"
 
-#: DynamicWeb/dynamicweb.py:2468
+#: DynamicWeb//dynamicweb.py:2473
 msgid "Click on the map to show it full-screen"
 msgstr "Нажмите на карте, чтобы развернуть её на весь экран"
 
-#: DynamicWeb/dynamicweb.py:2469
+#: DynamicWeb//dynamicweb.py:2474
 msgid "Code"
 msgstr "Код"
 
-#: DynamicWeb/dynamicweb.py:2471
+#: DynamicWeb//dynamicweb.py:2476
 msgid "Configure"
 msgstr "Конфигурация"
 
-#: DynamicWeb/dynamicweb.py:2472
+#: DynamicWeb//dynamicweb.py:2477
 msgid "Count"
 msgstr "Число"
 
-#: DynamicWeb/dynamicweb.py:2473
+#: DynamicWeb//dynamicweb.py:2478
 msgid "Cremation"
 msgstr "Кремация"
 
-#: DynamicWeb/dynamicweb.py:2475
+#: DynamicWeb//dynamicweb.py:2480
 msgid "Death"
 msgstr "Смерть"
 
-#: DynamicWeb/dynamicweb.py:2476
+#: DynamicWeb//dynamicweb.py:2481
 msgid "Descendants"
 msgstr "Потомки"
 
-#: DynamicWeb/dynamicweb.py:2477
+#: DynamicWeb//dynamicweb.py:2482
 msgid "Description"
 msgstr "Описание"
 
-#: DynamicWeb/dynamicweb.py:2478
+#: DynamicWeb//dynamicweb.py:2483
 msgid "DynamicWeb_report#Help"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2479
+#: DynamicWeb//dynamicweb.py:2484
 msgid "Enclosed By"
 msgstr "Входит в"
 
-#: DynamicWeb/dynamicweb.py:2480
+#: DynamicWeb//dynamicweb.py:2485
 msgid "Engagement"
 msgstr "Помолвка"
 
-#: DynamicWeb/dynamicweb.py:2481
+#: DynamicWeb//dynamicweb.py:2486
 msgid "Event"
 msgstr "Событие"
 
-#: DynamicWeb/dynamicweb.py:2482
+#: DynamicWeb//dynamicweb.py:2487
 msgid "Events"
 msgstr "События"
 
-#: DynamicWeb/dynamicweb.py:2483
+#: DynamicWeb//dynamicweb.py:2488
 msgid "Examples"
 msgstr "Примеры"
 
-#: DynamicWeb/dynamicweb.py:2484
+#: DynamicWeb//dynamicweb.py:2489
 msgid "F"
 msgstr "Ж"
 
-#: DynamicWeb/dynamicweb.py:2485
+#: DynamicWeb//dynamicweb.py:2490
 msgid "Families Index"
 msgstr "Семейный номер"
 
-#: DynamicWeb/dynamicweb.py:2487
+#: DynamicWeb//dynamicweb.py:2492
 msgid "Family Nick Name"
 msgstr "Семейное прозвище"
 
-#: DynamicWeb/dynamicweb.py:2488
+#: DynamicWeb//dynamicweb.py:2493
 msgid "Father"
 msgstr "Отец"
 
-#: DynamicWeb/dynamicweb.py:2489
+#: DynamicWeb//dynamicweb.py:2494
 msgid "Female"
 msgstr "Женский"
 
-#: DynamicWeb/dynamicweb.py:2490
+#: DynamicWeb//dynamicweb.py:2495
 msgid "File ready"
 msgstr "Файл готов"
 
-#: DynamicWeb/dynamicweb.py:2491
+#: DynamicWeb//dynamicweb.py:2496
 msgid "Gender"
 msgstr "Пол"
 
-#: DynamicWeb/dynamicweb.py:2492
+#: DynamicWeb//dynamicweb.py:2497
 msgid "Help"
 msgstr "Справка"
 
-#: DynamicWeb/dynamicweb.py:2493
+#: DynamicWeb//dynamicweb.py:2498
 msgid "ID"
 msgstr "ID"
 
-#: DynamicWeb/dynamicweb.py:2494 DynamicWeb/dynamicweb.py:4035
+#: DynamicWeb//dynamicweb.py:2499 DynamicWeb//dynamicweb.py:4041
 msgid "Include Place map on Place Pages"
 msgstr "Включить карту на страницах с местоположениями"
 
-#: DynamicWeb/dynamicweb.py:2495 DynamicWeb/dynamicweb.py:4140
+#: DynamicWeb//dynamicweb.py:2500 DynamicWeb//dynamicweb.py:4146
 msgid "Include dates columns on the index pages"
 msgstr "Включить колонку с датами в оглавление"
 
-#: DynamicWeb/dynamicweb.py:2496 DynamicWeb/dynamicweb.py:4148
+#: DynamicWeb//dynamicweb.py:2501 DynamicWeb//dynamicweb.py:4154
 msgid "Include a column for parents on the index pages"
 msgstr "Включить колонку с данными о родителях в оглавление"
 
-#: DynamicWeb/dynamicweb.py:2497 DynamicWeb/dynamicweb.py:4156
+#: DynamicWeb//dynamicweb.py:2502 DynamicWeb//dynamicweb.py:4162
 msgid "Include a column for media path on the index pages"
 msgstr "Включить колонку для документов в оглавление"
 
-#: DynamicWeb/dynamicweb.py:2498 DynamicWeb/dynamicweb.py:4144
+#: DynamicWeb//dynamicweb.py:2503 DynamicWeb//dynamicweb.py:4150
 msgid "Include a column for partners on the index pages"
 msgstr "Включить колонку с данными о партнёре в оглавление"
 
-#: DynamicWeb/dynamicweb.py:2499 DynamicWeb/dynamicweb.py:4043
+#: DynamicWeb//dynamicweb.py:2504 DynamicWeb//dynamicweb.py:4049
 msgid "Include a map in the individuals and family pages"
 msgstr "Включить карту на страницы лиц и семей"
 
-#: DynamicWeb/dynamicweb.py:2500 DynamicWeb/dynamicweb.py:4090
+#: DynamicWeb//dynamicweb.py:2505 DynamicWeb//dynamicweb.py:4096
 msgid "Include half and/ or step-siblings on the individual pages"
 msgstr "Включать братьев и сестёр на индивидуальной странице"
 
-#: DynamicWeb/dynamicweb.py:2501 DynamicWeb/dynamicweb.py:4160
+#: DynamicWeb//dynamicweb.py:2506 DynamicWeb//dynamicweb.py:4166
 msgid "Include references in indexes"
 msgstr "Включать ссылки в индексы"
 
-#: DynamicWeb/dynamicweb.py:2504 DynamicWeb/dynamicweb.py:4110
+#: DynamicWeb//dynamicweb.py:2509 DynamicWeb//dynamicweb.py:4116
 msgid "Insert sources author in the sources title"
 msgstr "Включить автора источников в заголовок источника"
 
-#: DynamicWeb/dynamicweb.py:2505
+#: DynamicWeb//dynamicweb.py:2510
 msgid "Last Modified"
 msgstr "Дата последнего изменения"
 
-#: DynamicWeb/dynamicweb.py:2506
+#: DynamicWeb//dynamicweb.py:2511
 msgid "Latitude"
 msgstr "Широта"
 
-#: DynamicWeb/dynamicweb.py:2507
+#: DynamicWeb//dynamicweb.py:2512
 msgid "Link"
 msgstr "Ссылка"
 
-#: DynamicWeb/dynamicweb.py:2508
+#: DynamicWeb//dynamicweb.py:2513
 msgid "Loading..."
 msgstr "Загрузка..."
 
-#: DynamicWeb/dynamicweb.py:2509
+#: DynamicWeb//dynamicweb.py:2514
 msgid "Location"
 msgstr "Расположение"
 
-#: DynamicWeb/dynamicweb.py:2510
+#: DynamicWeb//dynamicweb.py:2515
 msgid "Longitude"
 msgstr "Долгота"
 
-#: DynamicWeb/dynamicweb.py:2511
+#: DynamicWeb//dynamicweb.py:2516
 msgid "M"
 msgstr "М"
 
-#: DynamicWeb/dynamicweb.py:2512
+#: DynamicWeb//dynamicweb.py:2517
 msgid "Male"
 msgstr "Мужской"
 
-#: DynamicWeb/dynamicweb.py:2513
+#: DynamicWeb//dynamicweb.py:2518
 msgid "Map"
 msgstr "Карта"
 
-#: DynamicWeb/dynamicweb.py:2514
+#: DynamicWeb//dynamicweb.py:2519
 msgid "Marriage"
 msgstr "Брак"
 
-#: DynamicWeb/dynamicweb.py:2515
+#: DynamicWeb//dynamicweb.py:2520
 msgid "Maximize"
 msgstr "Развернуть"
 
-#: DynamicWeb/dynamicweb.py:2516
+#: DynamicWeb//dynamicweb.py:2521
 msgid "Media Index"
 msgstr "Индекс документа"
 
-#: DynamicWeb/dynamicweb.py:2517
+#: DynamicWeb//dynamicweb.py:2522
 msgid "Media Type"
 msgstr "Тип документа"
 
-#: DynamicWeb/dynamicweb.py:2519
+#: DynamicWeb//dynamicweb.py:2524
 msgid "Mother"
 msgstr "Мать"
 
-#: DynamicWeb/dynamicweb.py:2520
+#: DynamicWeb//dynamicweb.py:2525
 msgid "Name"
 msgstr "Имя"
 
-#: DynamicWeb/dynamicweb.py:2521
+#: DynamicWeb//dynamicweb.py:2526
 msgid "Nick Name"
 msgstr "Прозвище"
 
-#: DynamicWeb/dynamicweb.py:2522
+#: DynamicWeb//dynamicweb.py:2527
 msgid "No data available in table"
 msgstr "В таблице нет доступных данных"
 
-#: DynamicWeb/dynamicweb.py:2523
+#: DynamicWeb//dynamicweb.py:2528
 msgid "No matches found"
 msgstr "Соответствий не найдено"
 
-#: DynamicWeb/dynamicweb.py:2524
+#: DynamicWeb//dynamicweb.py:2529
 msgid "No matching records found"
 msgstr "Записи не найдены"
 
-#: DynamicWeb/dynamicweb.py:2525
+#: DynamicWeb//dynamicweb.py:2530
 msgid "No matching surname."
 msgstr "Фамилия не найдена."
 
-#: DynamicWeb/dynamicweb.py:2526
+#: DynamicWeb//dynamicweb.py:2531
 msgid "None"
 msgstr "Нет"
 
-#: DynamicWeb/dynamicweb.py:2527
+#: DynamicWeb//dynamicweb.py:2532
 msgid "Notes"
 msgstr "Заметки"
 
-#: DynamicWeb/dynamicweb.py:2528
+#: DynamicWeb//dynamicweb.py:2533
 msgid "Number"
 msgstr "Номер"
 
-#: DynamicWeb/dynamicweb.py:2529
+#: DynamicWeb//dynamicweb.py:2534
 msgid "OK"
 msgstr "OK"
 
-#: DynamicWeb/dynamicweb.py:2530
+#: DynamicWeb//dynamicweb.py:2535
 msgid "Other participants"
 msgstr "Другие участники"
 
-#: DynamicWeb/dynamicweb.py:2531
+#: DynamicWeb//dynamicweb.py:2536
 msgid "Parents"
 msgstr "Родители"
 
-#: DynamicWeb/dynamicweb.py:2532
+#: DynamicWeb//dynamicweb.py:2537
 msgid "Path"
 msgstr "Путь"
 
-#: DynamicWeb/dynamicweb.py:2533
+#: DynamicWeb//dynamicweb.py:2538
 msgid "Person page"
 msgstr "Персональная страница"
 
-#: DynamicWeb/dynamicweb.py:2534
+#: DynamicWeb//dynamicweb.py:2539
 msgid "Person to search for"
 msgstr "Поиск лица"
 
-#: DynamicWeb/dynamicweb.py:2536
+#: DynamicWeb//dynamicweb.py:2541
 msgid "Persons Index"
 msgstr "Список лиц"
 
-#: DynamicWeb/dynamicweb.py:2537
+#: DynamicWeb//dynamicweb.py:2542
 msgid "Persons"
 msgstr "Лица"
 
-#: DynamicWeb/dynamicweb.py:2539
+#: DynamicWeb//dynamicweb.py:2544
 msgid "Places Index"
 msgstr "Список мест"
 
-#: DynamicWeb/dynamicweb.py:2541
+#: DynamicWeb//dynamicweb.py:2546
 msgid "Preparing file ..."
 msgstr "Подготовка файла ..."
 
-#: DynamicWeb/dynamicweb.py:2542
+#: DynamicWeb//dynamicweb.py:2547
 msgid "Processing..."
 msgstr "Обработка..."
 
-#: DynamicWeb/dynamicweb.py:2544
+#: DynamicWeb//dynamicweb.py:2549
 msgid "References"
 msgstr "Ссылки"
 
-#: DynamicWeb/dynamicweb.py:2545
+#: DynamicWeb//dynamicweb.py:2550
 msgid "Relationship to Father"
 msgstr "Отношение к отцу"
 
-#: DynamicWeb/dynamicweb.py:2546
+#: DynamicWeb//dynamicweb.py:2551
 msgid "Relationship to Mother"
 msgstr "Отношение к матери"
 
-#: DynamicWeb/dynamicweb.py:2547
+#: DynamicWeb//dynamicweb.py:2552
 msgid "Relationship"
 msgstr "Отношение"
 
-#: DynamicWeb/dynamicweb.py:2548
+#: DynamicWeb//dynamicweb.py:2553
 msgid "Repositories Index"
 msgstr "Индекс хранилищ"
 
-#: DynamicWeb/dynamicweb.py:2551
+#: DynamicWeb//dynamicweb.py:2556
 msgid "Restore"
 msgstr "Восстановить"
 
-#: DynamicWeb/dynamicweb.py:2552
+#: DynamicWeb//dynamicweb.py:2557
 msgid "Restore default settings"
 msgstr "Восстановление настроек по умолчанию"
 
-#: DynamicWeb/dynamicweb.py:2553 DynamicWeb/dynamicweb.py:4106
+#: DynamicWeb//dynamicweb.py:2558 DynamicWeb//dynamicweb.py:4112
 msgid "Show last modification time"
 msgstr "Показать время последнего изменения"
 
-#: DynamicWeb/dynamicweb.py:2554 DynamicWeb/dynamicweb.py:4197
+#: DynamicWeb//dynamicweb.py:2559 DynamicWeb//dynamicweb.py:4203
 msgid "SVG tree children distribution"
 msgstr "SVG - представление детей в древе"
 
-#: DynamicWeb/dynamicweb.py:2555
+#: DynamicWeb//dynamicweb.py:2560
 msgid "SVG tree configuration"
 msgstr "SVG - натройка древа"
 
-#: DynamicWeb/dynamicweb.py:2556 DynamicWeb/dynamicweb.py:4185
+#: DynamicWeb//dynamicweb.py:2561 DynamicWeb//dynamicweb.py:4191
 msgid "SVG tree graph shape"
 msgstr "SVG - направление древа"
 
-#: DynamicWeb/dynamicweb.py:2557 DynamicWeb/dynamicweb.py:4179
+#: DynamicWeb//dynamicweb.py:2562 DynamicWeb//dynamicweb.py:4185
 msgid "SVG tree graph type"
 msgstr "SVG - тип древа"
 
-#: DynamicWeb/dynamicweb.py:2558 DynamicWeb/dynamicweb.py:4191
+#: DynamicWeb//dynamicweb.py:2563 DynamicWeb//dynamicweb.py:4197
 msgid "SVG tree parents distribution"
 msgstr "SVG - представление родителей в древе"
 
-#: DynamicWeb/dynamicweb.py:2559
+#: DynamicWeb//dynamicweb.py:2564
 msgid "Save tree as file"
 msgstr "Сохранить древо в файл"
 
-#: DynamicWeb/dynamicweb.py:2560
+#: DynamicWeb//dynamicweb.py:2565
 msgid "Search:"
 msgstr "Поиск:"
 
-#: DynamicWeb/dynamicweb.py:2561
+#: DynamicWeb//dynamicweb.py:2566
 msgid "Select the background color scheme"
 msgstr "Выберите цветовую схему фона"
 
-#: DynamicWeb/dynamicweb.py:2562
+#: DynamicWeb//dynamicweb.py:2567
 msgid "Select the children distribution (fan charts only)"
 msgstr "Выберите представление детей (только веерные карты)"
 
-#: DynamicWeb/dynamicweb.py:2563
+#: DynamicWeb//dynamicweb.py:2568
 msgid "Select the number of ascending generations"
 msgstr "Выбарите количество поколений предков"
 
-#: DynamicWeb/dynamicweb.py:2564
+#: DynamicWeb//dynamicweb.py:2569
 msgid "Select the number of descending generations"
 msgstr "Выбарите количество поколений потомков"
 
-#: DynamicWeb/dynamicweb.py:2565
+#: DynamicWeb//dynamicweb.py:2570
 msgid "Select the parents distribution (fan charts only)"
 msgstr "Выберите представление родителей (только веерные карты)"
 
-#: DynamicWeb/dynamicweb.py:2566
+#: DynamicWeb//dynamicweb.py:2571
 msgid "Select the shape of graph"
 msgstr "Выберите направление графа"
 
-#: DynamicWeb/dynamicweb.py:2567
+#: DynamicWeb//dynamicweb.py:2572
 msgid "Select the type of graph"
 msgstr "Выберите тип графа"
 
-#: DynamicWeb/dynamicweb.py:2568
+#: DynamicWeb//dynamicweb.py:2573
 msgid "Several matches.<br>Precise your search or choose in the lists below."
 msgstr ""
 "Несколько совпадений.<br>Уточните поисковый запрос или выбирайте из списка "
 "ниже."
 
-#: DynamicWeb/dynamicweb.py:2569
+#: DynamicWeb//dynamicweb.py:2574
 msgid "Show _MENU_ entries"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2570 DynamicWeb/dynamicweb.py:4215
+#: DynamicWeb//dynamicweb.py:2575 DynamicWeb//dynamicweb.py:4221
 msgid "Show duplicates"
 msgstr "Показать дубликаты"
 
-#: DynamicWeb/dynamicweb.py:2571
+#: DynamicWeb//dynamicweb.py:2576
 msgid "Showing 0 to 0 of 0 entries"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2572
+#: DynamicWeb//dynamicweb.py:2577
 msgid "Showing _START_ to _END_ of _TOTAL_ entries"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2573
+#: DynamicWeb//dynamicweb.py:2578
 msgid "Siblings"
 msgstr "Братья/Сёстры"
 
-#: DynamicWeb/dynamicweb.py:2574
+#: DynamicWeb//dynamicweb.py:2579
 msgid "Sort by:"
 msgstr "Сортировать по:"
 
-#: DynamicWeb/dynamicweb.py:2576
+#: DynamicWeb//dynamicweb.py:2581
 msgid "Sources Index"
 msgstr "Список источников"
 
-#: DynamicWeb/dynamicweb.py:2578
+#: DynamicWeb//dynamicweb.py:2583
 msgid "Spouses"
 msgstr "Супруги"
 
-#: DynamicWeb/dynamicweb.py:2579 DynamicWeb/dynamicweb.py:4114
+#: DynamicWeb//dynamicweb.py:2584 DynamicWeb//dynamicweb.py:4120
 msgid "Suppress Gramps ID"
 msgstr "Не включать Gramps ID"
 
-#: DynamicWeb/dynamicweb.py:2580
+#: DynamicWeb//dynamicweb.py:2585
 msgid "Surname"
 msgstr "Фамилия"
 
-#: DynamicWeb/dynamicweb.py:2581
+#: DynamicWeb//dynamicweb.py:2586
 msgid "Surnames Index"
 msgstr "Список фамилий"
 
-#: DynamicWeb/dynamicweb.py:2583
+#: DynamicWeb//dynamicweb.py:2588
 msgid "Title"
 msgstr "Название"
 
-#: DynamicWeb/dynamicweb.py:2584
+#: DynamicWeb//dynamicweb.py:2589
 msgid "Type"
 msgstr "Тип"
 
-#: DynamicWeb/dynamicweb.py:2585
+#: DynamicWeb//dynamicweb.py:2590
 msgid "U"
 msgstr "Н"
 
-#: DynamicWeb/dynamicweb.py:2586
+#: DynamicWeb//dynamicweb.py:2591
 msgid "Unknown"
 msgstr "Неизвестно"
 
-#: DynamicWeb/dynamicweb.py:2587 DynamicWeb/dynamicweb.py:4102
+#: DynamicWeb//dynamicweb.py:2592 DynamicWeb//dynamicweb.py:4108
 msgid "Use tabbed panels instead of sections"
 msgstr "Использовать панель вкладок вместо секций"
 
-#: DynamicWeb/dynamicweb.py:2588
+#: DynamicWeb//dynamicweb.py:2593
 msgid "Use the search box above in order to find a person."
 msgstr "Использовтать поле выше для поиска лиц. "
 
-#: DynamicWeb/dynamicweb.py:2589
+#: DynamicWeb//dynamicweb.py:2594
 msgid "Use a table format for the surnames index"
 msgstr "Использовать табличный формат для индекса фамилий"
 
-#: DynamicWeb/dynamicweb.py:2590
+#: DynamicWeb//dynamicweb.py:2595
 msgid "Use a table format for the persons index"
 msgstr "Использовать табличный формат для индекса лиц"
 
-#: DynamicWeb/dynamicweb.py:2591
+#: DynamicWeb//dynamicweb.py:2596
 msgid "Use a table format for the families index"
 msgstr "Использовать табличный формат для индекса семей"
 
-#: DynamicWeb/dynamicweb.py:2592
+#: DynamicWeb//dynamicweb.py:2597
 msgid "Use a table format for the sources index"
 msgstr "Использовать табличный формат для индекса источников"
 
-#: DynamicWeb/dynamicweb.py:2593
+#: DynamicWeb//dynamicweb.py:2598
 msgid "Use a table format for the places index"
 msgstr "Использовать табличный формат для индекса мест"
 
-#: DynamicWeb/dynamicweb.py:2594
+#: DynamicWeb//dynamicweb.py:2599
 msgid "Used for family"
 msgstr "Используется для семьи"
 
-#: DynamicWeb/dynamicweb.py:2595
+#: DynamicWeb//dynamicweb.py:2600
 msgid "Used for media"
 msgstr "Используется для документов"
 
-#: DynamicWeb/dynamicweb.py:2596
+#: DynamicWeb//dynamicweb.py:2601
 msgid "Used for person"
 msgstr "Используется для лица"
 
-#: DynamicWeb/dynamicweb.py:2597
+#: DynamicWeb//dynamicweb.py:2602
 msgid "Used for place"
 msgstr "Используется для места"
 
-#: DynamicWeb/dynamicweb.py:2598
+#: DynamicWeb//dynamicweb.py:2603
 msgid "Used for source"
 msgstr "Используется для источника"
 
-#: DynamicWeb/dynamicweb.py:2599
+#: DynamicWeb//dynamicweb.py:2604
 msgid "Value"
 msgstr "Значение"
 
-#: DynamicWeb/dynamicweb.py:2600
+#: DynamicWeb//dynamicweb.py:2605
 msgid "Web Link"
 msgstr "Веб-ссылка"
 
-#: DynamicWeb/dynamicweb.py:2601
+#: DynamicWeb//dynamicweb.py:2606
 msgid "Web Links"
 msgstr "Веб-ссылки"
 
-#: DynamicWeb/dynamicweb.py:2602 DynamicWeb/dynamicweb.py:4216
+#: DynamicWeb//dynamicweb.py:2607 DynamicWeb//dynamicweb.py:4222
 msgid ""
 "Whether to use a special color for the persons that appear several times in "
 "the SVG tree"
@@ -938,49 +938,49 @@ msgstr ""
 "Использовать ли специальный цвет для лиц, которые показаны в SVG древе "
 "несколько раз"
 
-#: DynamicWeb/dynamicweb.py:2603
+#: DynamicWeb//dynamicweb.py:2608
 msgid "Without name"
 msgstr "Без имени"
 
-#: DynamicWeb/dynamicweb.py:2604
+#: DynamicWeb//dynamicweb.py:2609
 msgid "Without surname"
 msgstr "Без фамилии"
 
-#: DynamicWeb/dynamicweb.py:2605
+#: DynamicWeb//dynamicweb.py:2610
 msgid "Without title"
 msgstr "Без титула"
 
-#: DynamicWeb/dynamicweb.py:2606
+#: DynamicWeb//dynamicweb.py:2611
 msgid "Zoom in"
 msgstr "Увеличить"
 
-#: DynamicWeb/dynamicweb.py:2607
+#: DynamicWeb//dynamicweb.py:2612
 msgid "Zoom out"
 msgstr "Уменьшить"
 
-#: DynamicWeb/dynamicweb.py:2608
+#: DynamicWeb//dynamicweb.py:2613
 msgid "all"
 msgstr "все"
 
-#: DynamicWeb/dynamicweb.py:2811
+#: DynamicWeb//dynamicweb.py:2816
 msgid "No Home Person"
 msgstr "Базовое лицо не назначено"
 
-#: DynamicWeb/dynamicweb.py:2952
+#: DynamicWeb//dynamicweb.py:2957
 #, python-format
 msgid "Copying error: %(error)s"
 msgstr "Ошибка копирования: %(error)s"
 
-#: DynamicWeb/dynamicweb.py:2953
+#: DynamicWeb//dynamicweb.py:2958
 #, python-format
 msgid "Impossible to copy \"%(src)s\" to \"%(dst)s\""
 msgstr "Невозможно скопировать \"%(src)s\" в \"%(dst)s\""
 
-#: DynamicWeb/dynamicweb.py:2956
+#: DynamicWeb//dynamicweb.py:2961
 msgid "Possible destination error"
 msgstr "Возможно, некорректный выбор директории назначения"
 
-#: DynamicWeb/dynamicweb.py:2957
+#: DynamicWeb//dynamicweb.py:2962
 msgid ""
 "You appear to have set your target directory to a directory used for data "
 "storage. This could create problems with file management. It is recommended "
@@ -991,64 +991,64 @@ msgstr ""
 "Это может привести к проблеме с файлами. Рекомендуем вам указать другую "
 "директорию для расположения сгенерированных веб-страниц."
 
-#: DynamicWeb/dynamicweb.py:2984
+#: DynamicWeb//dynamicweb.py:2989
 #, python-format
 msgid "Unable to copy web site template files from \"%(path)s\""
 msgstr "Не удалось скопировать файлы шаблонов веб-сайта из \"%(path)s\""
 
-#: DynamicWeb/dynamicweb.py:3028
+#: DynamicWeb//dynamicweb.py:3033
 #, python-format
 msgid "Keeping \"%(dst)s\" (newer than \"%(src)s\")"
 msgstr "Имеющееся \"%(dst)s\" (новее чем \"%(src)s\")"
 
-#: DynamicWeb/dynamicweb.py:3031
+#: DynamicWeb//dynamicweb.py:3036
 #, python-format
 msgid "Copying \"%(src)s\" to \"%(dst)s\""
 msgstr "Копирование \"%(src)s\" в \"%(dst)s\""
 
-#: DynamicWeb/dynamicweb.py:3049
+#: DynamicWeb//dynamicweb.py:3054
 msgid "Invalid file name"
 msgstr "Некорректное имя файла"
 
-#: DynamicWeb/dynamicweb.py:3050
+#: DynamicWeb//dynamicweb.py:3055
 msgid "The archive file must be a file, not a directory"
 msgstr "Архивом должен быть файл, а не каталог"
 
-#: DynamicWeb/dynamicweb.py:3060 DynamicWeb/dynamicweb.py:3078
+#: DynamicWeb//dynamicweb.py:3065 DynamicWeb//dynamicweb.py:3083
 #, python-format
 msgid "Unable to overwrite archive file \"%(path)s\""
 msgstr "Не удалось перезаписать архив \"%(path)s\""
 
-#: DynamicWeb/dynamicweb.py:3070 DynamicWeb/dynamicweb.py:3085
+#: DynamicWeb//dynamicweb.py:3075 DynamicWeb//dynamicweb.py:3090
 #, python-format
 msgid "Unable to add file \"%(file)s\" to archive \"%(archive)s\""
 msgstr "Не удалось добавить файл \"%(file)s\" в архив \"%(archive)s\""
 
-#: DynamicWeb/dynamicweb.py:3138
+#: DynamicWeb//dynamicweb.py:3143
 #, python-format
 msgid "DynamicWebReport ignoring link type '%(class)s'"
 msgstr "DynamicWebReport игнорирует тип ссылки '%(class)s'"
 
-#: DynamicWeb/dynamicweb.py:3381
+#: DynamicWeb//dynamicweb.py:3386
 msgid "Constructing list of other objects..."
 msgstr "Составляется список других объектов..."
 
-#: DynamicWeb/dynamicweb.py:3516
+#: DynamicWeb//dynamicweb.py:3521
 #, python-format
 msgid "Family of %(husband)s and %(spouse)s"
 msgstr "Семья %(husband)s и %(spouse)s"
 
-#: DynamicWeb/dynamicweb.py:3522
+#: DynamicWeb//dynamicweb.py:3527
 #, python-format
 msgid "Family of %(father)s"
 msgstr "Семья %(father)s"
 
-#: DynamicWeb/dynamicweb.py:3526
+#: DynamicWeb//dynamicweb.py:3531
 #, python-format
 msgid "Family of %(mother)s"
 msgstr "Семья %(mother)s"
 
-#: DynamicWeb/dynamicweb.py:3841
+#: DynamicWeb//dynamicweb.py:3846
 msgid ""
 "In this note, the following special words are processed:\n"
 "__SEARCH_FORM__ is replaced by a search form.\n"
@@ -1083,138 +1083,138 @@ msgstr ""
 "URL начинающийся с \"relative://relative.<link>\" заменяется относительным "
 "URL \"<link>\".\n"
 
-#: DynamicWeb/dynamicweb.py:3880
+#: DynamicWeb//dynamicweb.py:3886
 msgid "Report"
 msgstr "Отчёт"
 
-#: DynamicWeb/dynamicweb.py:3885
+#: DynamicWeb//dynamicweb.py:3891
 msgid "Destination"
 msgstr "Расположение"
 
-#: DynamicWeb/dynamicweb.py:3887
+#: DynamicWeb//dynamicweb.py:3893
 msgid "The destination directory for the web files"
 msgstr "Каталог размещения веб файлов"
 
-#: DynamicWeb/dynamicweb.py:3891
+#: DynamicWeb//dynamicweb.py:3897
 msgid "Store web pages in archive"
 msgstr "Сохранить веб-страницы в архив"
 
-#: DynamicWeb/dynamicweb.py:3892
+#: DynamicWeb//dynamicweb.py:3898
 msgid ""
 "Whether to create an archive file (in ZIP or TGZ format) containing the web "
 "site"
 msgstr ""
 "Необходимо ли создать архив (в формате ZIP или TGZ) содержащий веб-сайт"
 
-#: DynamicWeb/dynamicweb.py:3896
+#: DynamicWeb//dynamicweb.py:3902
 msgid "Archive file"
 msgstr "Файл архива"
 
-#: DynamicWeb/dynamicweb.py:3898
+#: DynamicWeb//dynamicweb.py:3904
 msgid "The archive file name (with \".zip\" or \".tgz\" extension)"
 msgstr "Имя архива (с расширением \".zip\" или \".tgz\")"
 
-#: DynamicWeb/dynamicweb.py:3904
+#: DynamicWeb//dynamicweb.py:3910
 msgid "Web site title"
 msgstr "Название сайта"
 
-#: DynamicWeb/dynamicweb.py:3904
+#: DynamicWeb//dynamicweb.py:3910
 msgid "My Family Tree"
 msgstr "Моё семейное древо"
 
-#: DynamicWeb/dynamicweb.py:3905
+#: DynamicWeb//dynamicweb.py:3911
 msgid "The title of the web site"
 msgstr "Название этого веб-сайта"
 
-#: DynamicWeb/dynamicweb.py:3908
+#: DynamicWeb//dynamicweb.py:3914
 msgid "Filter"
 msgstr "Фильтр"
 
-#: DynamicWeb/dynamicweb.py:3910
+#: DynamicWeb//dynamicweb.py:3916
 msgid "Select filter to restrict people that appear on web site"
 msgstr "Выберите фильтр для отбора лиц в отчёт"
 
-#: DynamicWeb/dynamicweb.py:3914
+#: DynamicWeb//dynamicweb.py:3920
 msgid "Filter Person"
 msgstr "Фильтр по лицу"
 
-#: DynamicWeb/dynamicweb.py:3915
+#: DynamicWeb//dynamicweb.py:3921
 msgid "The center person for the filter"
 msgstr "Главное лицо для фильтра"
 
-#: DynamicWeb/dynamicweb.py:3923 DynamicWeb/dynamicweb.py:3943
+#: DynamicWeb//dynamicweb.py:3929 DynamicWeb//dynamicweb.py:3949
 msgid "Name format (short)"
 msgstr "Формат имени (сокр.)"
 
-#: DynamicWeb/dynamicweb.py:3924 DynamicWeb/dynamicweb.py:3946
+#: DynamicWeb//dynamicweb.py:3930 DynamicWeb//dynamicweb.py:3952
 msgid "Select the format to display a shorter version of the names"
 msgstr "Выберите формат для отображения сокращённой версии имени"
 
-#: DynamicWeb/dynamicweb.py:3938
+#: DynamicWeb//dynamicweb.py:3944
 msgid "Name format"
 msgstr "Формат имён"
 
-#: DynamicWeb/dynamicweb.py:3941
+#: DynamicWeb//dynamicweb.py:3947
 msgid "Select the format to display names"
 msgstr "Выберите формат отображения имен"
 
-#: DynamicWeb/dynamicweb.py:3949
+#: DynamicWeb//dynamicweb.py:3955
 msgid "Web site template"
 msgstr "Шаблон веб-сайта"
 
-#: DynamicWeb/dynamicweb.py:3952
+#: DynamicWeb//dynamicweb.py:3958
 msgid "Select the template of the web site"
 msgstr "Выберите шаблон для веб-сайта"
 
-#: DynamicWeb/dynamicweb.py:3955
+#: DynamicWeb//dynamicweb.py:3961
 msgid "Copyright"
 msgstr "Авторское право"
 
-#: DynamicWeb/dynamicweb.py:3958
+#: DynamicWeb//dynamicweb.py:3964
 msgid "The copyright to be used for the web files"
 msgstr "Авторские права, которые будут использоваться для веб-страниц"
 
-#: DynamicWeb/dynamicweb.py:3966
+#: DynamicWeb//dynamicweb.py:3972
 msgid "Privacy"
 msgstr "Личная информация"
 
-#: DynamicWeb/dynamicweb.py:3974
+#: DynamicWeb//dynamicweb.py:3980
 msgid "Include records marked private"
 msgstr "Включать записи помеченные как личные"
 
-#: DynamicWeb/dynamicweb.py:3975
+#: DynamicWeb//dynamicweb.py:3981
 msgid "Whether to include private objects"
 msgstr "Включать ли приватные объекты"
 
-#: DynamicWeb/dynamicweb.py:3977
+#: DynamicWeb//dynamicweb.py:3983
 msgid "Living People"
 msgstr "Ныне живущие люди"
 
-#: DynamicWeb/dynamicweb.py:3978
+#: DynamicWeb//dynamicweb.py:3984
 msgid "Exclude"
 msgstr "Исключить"
 
-#: DynamicWeb/dynamicweb.py:3979
+#: DynamicWeb//dynamicweb.py:3985
 msgid "Include Last Name Only"
 msgstr "Включить только фамилию"
 
-#: DynamicWeb/dynamicweb.py:3980
+#: DynamicWeb//dynamicweb.py:3986
 msgid "Include Full Name Only"
 msgstr "Включить полное имя"
 
-#: DynamicWeb/dynamicweb.py:3981
+#: DynamicWeb//dynamicweb.py:3987
 msgid "Include"
 msgstr "Включить"
 
-#: DynamicWeb/dynamicweb.py:3982
+#: DynamicWeb//dynamicweb.py:3988
 msgid "How to handle living people"
 msgstr "Как поступать с записями о ныне живущих людях"
 
-#: DynamicWeb/dynamicweb.py:3985
+#: DynamicWeb//dynamicweb.py:3991
 msgid "Years from death to consider living"
 msgstr "Лет от смерти, чтобы считать человека живым"
 
-#: DynamicWeb/dynamicweb.py:3986
+#: DynamicWeb//dynamicweb.py:3992
 msgid ""
 "This allows you to restrict information on people who have not been dead for "
 "very long"
@@ -1222,87 +1222,87 @@ msgstr ""
 "Это даёт возможность ограничить информацию о лицах, которые не числятся "
 "умершими долгое время"
 
-#: DynamicWeb/dynamicweb.py:3990
+#: DynamicWeb//dynamicweb.py:3996
 msgid "Export notes"
 msgstr "Экспорт заметок"
 
-#: DynamicWeb/dynamicweb.py:3991
+#: DynamicWeb//dynamicweb.py:3997
 msgid "Whether to export notes in the web pages"
 msgstr "Экспортировать ли заметки в веб-страницы"
 
-#: DynamicWeb/dynamicweb.py:3994
+#: DynamicWeb//dynamicweb.py:4000
 msgid "Export sources"
 msgstr "Экспорт источников"
 
-#: DynamicWeb/dynamicweb.py:3995
+#: DynamicWeb//dynamicweb.py:4001
 msgid "Whether to export sources and citations in the web pages"
 msgstr "Экспортировать ли источники и цитаты в веб-страницы"
 
-#: DynamicWeb/dynamicweb.py:3998
+#: DynamicWeb//dynamicweb.py:4004
 msgid "Export addresses"
 msgstr "Экспорт адресов"
 
-#: DynamicWeb/dynamicweb.py:3999
+#: DynamicWeb//dynamicweb.py:4005
 msgid "Whether to export addresses in the web pages"
 msgstr "Экспортировать ли адреса в веб-страницы"
 
-#: DynamicWeb/dynamicweb.py:4004
+#: DynamicWeb//dynamicweb.py:4010
 msgid "Options"
 msgstr "Параметры"
 
-#: DynamicWeb/dynamicweb.py:4007
+#: DynamicWeb//dynamicweb.py:4013
 msgid "Include repository pages"
 msgstr "Включить страницы с источниками"
 
-#: DynamicWeb/dynamicweb.py:4008
+#: DynamicWeb//dynamicweb.py:4014
 msgid "Whether or not to include the Repository Pages."
 msgstr "Включать или нет страницы с источниками."
 
-#: DynamicWeb/dynamicweb.py:4011
+#: DynamicWeb//dynamicweb.py:4017
 msgid "Include images and media"
 msgstr "Включать изображения и документы"
 
-#: DynamicWeb/dynamicweb.py:4012
+#: DynamicWeb//dynamicweb.py:4018
 msgid "Whether to include images and media in the web pages"
 msgstr "Включать ли изображения и документы в веб-страницы"
 
-#: DynamicWeb/dynamicweb.py:4016
+#: DynamicWeb//dynamicweb.py:4022
 msgid "Copy, rename files with an internal Gramps identifier"
 msgstr "Копировать, переименовать файлы с внутренним идентификатором Gramps"
 
-#: DynamicWeb/dynamicweb.py:4017
+#: DynamicWeb//dynamicweb.py:4023
 msgid "Copy, keep file names unchanged"
 msgstr "Копировать, не изменять имена файлов"
 
-#: DynamicWeb/dynamicweb.py:4018
+#: DynamicWeb//dynamicweb.py:4024
 msgid "Do not copy, reference existing files"
 msgstr "Не копировать, ссылаться на существующие файлы"
 
-#: DynamicWeb/dynamicweb.py:4020
+#: DynamicWeb//dynamicweb.py:4026
 msgid "Images and media"
 msgstr "Изображения и документы"
 
-#: DynamicWeb/dynamicweb.py:4023
+#: DynamicWeb//dynamicweb.py:4029
 msgid "Whether to make a copy of the media"
 msgstr "Необходимо ли делать копии изображений и документов"
 
-#: DynamicWeb/dynamicweb.py:4026
+#: DynamicWeb//dynamicweb.py:4032
 msgid "Print the notes type"
 msgstr "Печатать тип заметок"
 
-#: DynamicWeb/dynamicweb.py:4027
+#: DynamicWeb//dynamicweb.py:4033
 msgid "Whether to print the notes type in the notes text"
 msgstr "Указывать ли тип заметок в тексте заметки"
 
-#: DynamicWeb/dynamicweb.py:4030
+#: DynamicWeb//dynamicweb.py:4036
 msgid "Print place pages"
 msgstr "Печатать страницы мест"
 
-#: DynamicWeb/dynamicweb.py:4031
+#: DynamicWeb//dynamicweb.py:4037
 msgid "Whether to show pages for the places"
 msgstr "Показывать ли страницы с местоположениями"
 
-#: DynamicWeb/dynamicweb.py:4037
+#: DynamicWeb//dynamicweb.py:4043
 msgid ""
 "Whether to include a place map on the Place Pages, where Latitude/ Longitude "
 "are available."
@@ -1310,7 +1310,7 @@ msgstr ""
 "Включать ли карту на странице с местоположениями для мест с известными "
 "широтой и долготой."
 
-#: DynamicWeb/dynamicweb.py:4045
+#: DynamicWeb//dynamicweb.py:4051
 msgid ""
 "Whether or not to add an individual page map showing all the places on this "
 "page. This will allow you to see how your family traveled around the country."
@@ -1319,163 +1319,163 @@ msgstr ""
 "упомянутые на данной странице. Это позволит видеть, как ваша семья "
 "переезжала."
 
-#: DynamicWeb/dynamicweb.py:4053
+#: DynamicWeb//dynamicweb.py:4059
 msgid "Google"
 msgstr "Карты Google"
 
-#: DynamicWeb/dynamicweb.py:4054
+#: DynamicWeb//dynamicweb.py:4060
 msgid "OpenStreetMap"
 msgstr "OpenStreetMap"
 
-#: DynamicWeb/dynamicweb.py:4056
+#: DynamicWeb//dynamicweb.py:4062
 msgid "Map Service"
 msgstr "Картографический сервис"
 
-#: DynamicWeb/dynamicweb.py:4059
+#: DynamicWeb//dynamicweb.py:4065
 msgid "Choose your choice of map service for creating the Place Map Pages"
 msgstr ""
 "Сделайте выбор картографического сервиса для создания страниц с местами на "
 "карте"
 
-#: DynamicWeb/dynamicweb.py:4063
+#: DynamicWeb//dynamicweb.py:4069
 msgid "Google map API key"
 msgstr "Ключ для Google map API"
 
-#: DynamicWeb/dynamicweb.py:4064
+#: DynamicWeb//dynamicweb.py:4070
 msgid "The API key used for the Google map"
 msgstr "API ключ используемый для карт Google"
 
-#: DynamicWeb/dynamicweb.py:4071
+#: DynamicWeb//dynamicweb.py:4077
 msgid "Advanced"
 msgstr "Дополнительно"
 
-#: DynamicWeb/dynamicweb.py:4074
+#: DynamicWeb//dynamicweb.py:4080
 msgid "Character set encoding"
 msgstr "Кодировка символов"
 
-#: DynamicWeb/dynamicweb.py:4077
+#: DynamicWeb//dynamicweb.py:4083
 msgid "The encoding to be used for the web files"
 msgstr "Кодировка, которая будет использоваться для веб-страниц"
 
-#: DynamicWeb/dynamicweb.py:4080
+#: DynamicWeb//dynamicweb.py:4086
 msgid "Include family pages"
 msgstr "Включить семейные страницы"
 
-#: DynamicWeb/dynamicweb.py:4081
+#: DynamicWeb//dynamicweb.py:4087
 msgid "Whether or not to include family pages"
 msgstr "Включать или нет семейные страницы"
 
-#: DynamicWeb/dynamicweb.py:4091
+#: DynamicWeb//dynamicweb.py:4097
 msgid ""
 "Whether to include half and/ or step-siblings with the parents and siblings"
 msgstr "Включать братьев и сестёр с их родителями и братьями/сёстрами"
 
-#: DynamicWeb/dynamicweb.py:4094
+#: DynamicWeb//dynamicweb.py:4100
 msgid "Include GENDEX file (/gendex.txt)"
 msgstr "Включить файл GENDEX (/gendex.txt)"
 
-#: DynamicWeb/dynamicweb.py:4095
+#: DynamicWeb//dynamicweb.py:4101
 msgid "Whether to include a GENDEX file or not"
 msgstr "Включать ли файл GENDEX"
 
-#: DynamicWeb/dynamicweb.py:4098
+#: DynamicWeb//dynamicweb.py:4104
 msgid "Enable page configuration"
 msgstr "Разрешить настройку страницы"
 
-#: DynamicWeb/dynamicweb.py:4099
+#: DynamicWeb//dynamicweb.py:4105
 msgid "Whether to enable page configuration"
 msgstr "Разрешить ли настройку страницы"
 
-#: DynamicWeb/dynamicweb.py:4103
+#: DynamicWeb//dynamicweb.py:4109
 msgid "Whether to use tabbed panels for the different sections of the pages."
 msgstr "Использовать ли панели вкладок для различных секций страниц."
 
-#: DynamicWeb/dynamicweb.py:4107
+#: DynamicWeb//dynamicweb.py:4113
 msgid "Whether to show the last modification time in the pages footer"
 msgstr "Отображать ли время последнего изменения внизу страницы"
 
-#: DynamicWeb/dynamicweb.py:4111
+#: DynamicWeb//dynamicweb.py:4117
 msgid "Whether to insert sources author in the sources title"
 msgstr "Указывать ли автора источников в заголовке источников"
 
-#: DynamicWeb/dynamicweb.py:4115
+#: DynamicWeb//dynamicweb.py:4121
 msgid "Whether to hide the Gramps ID"
 msgstr "Прятать ли идентификатор Gramps"
 
-#: DynamicWeb/dynamicweb.py:4124
+#: DynamicWeb//dynamicweb.py:4130
 msgid "List"
 msgstr "Список"
 
-#: DynamicWeb/dynamicweb.py:4125
+#: DynamicWeb//dynamicweb.py:4131
 msgid "Table"
 msgstr "Таблица"
 
-#: DynamicWeb/dynamicweb.py:4128
+#: DynamicWeb//dynamicweb.py:4134
 msgid "Default format for the surnames index"
 msgstr "Формат для перечня фамилий по умолчанию"
 
-#: DynamicWeb/dynamicweb.py:4128
+#: DynamicWeb//dynamicweb.py:4134
 msgid "The default format for the surnames index"
 msgstr "Формат для перечня фамилий по умолчанию"
 
-#: DynamicWeb/dynamicweb.py:4129
+#: DynamicWeb//dynamicweb.py:4135
 msgid "Default format for the persons index"
 msgstr "Формат для перечня лиц по умолчанию"
 
-#: DynamicWeb/dynamicweb.py:4129
+#: DynamicWeb//dynamicweb.py:4135
 msgid "The default format for the persons index"
 msgstr "Формат для перечня лиц по умолчанию"
 
-#: DynamicWeb/dynamicweb.py:4130
+#: DynamicWeb//dynamicweb.py:4136
 msgid "Default format for the families index"
 msgstr "Формат для перечня семей по умолчанию"
 
-#: DynamicWeb/dynamicweb.py:4130
+#: DynamicWeb//dynamicweb.py:4136
 msgid "The default format for the families index"
 msgstr "Формат для перечня семей по умолчанию"
 
-#: DynamicWeb/dynamicweb.py:4131
+#: DynamicWeb//dynamicweb.py:4137
 msgid "Default format for the sources index"
 msgstr "Формат для перечня источников по умолчанию"
 
-#: DynamicWeb/dynamicweb.py:4131
+#: DynamicWeb//dynamicweb.py:4137
 msgid "The default format for the sources index"
 msgstr "Формат для перечня источников по умолчанию"
 
-#: DynamicWeb/dynamicweb.py:4132
+#: DynamicWeb//dynamicweb.py:4138
 msgid "Default format for the places index"
 msgstr "Формат для перечня мест по умолчанию"
 
-#: DynamicWeb/dynamicweb.py:4132
+#: DynamicWeb//dynamicweb.py:4138
 msgid "The default format for the places index"
 msgstr "Формат для перечня мест по умолчанию"
 
-#: DynamicWeb/dynamicweb.py:4141
+#: DynamicWeb//dynamicweb.py:4147
 msgid ""
 "Whether to include dates columns (birth, death, marriage) on the index pages"
 msgstr "Включать ли колонки дат (рождение, смерть, брак) на страницы"
 
-#: DynamicWeb/dynamicweb.py:4145
+#: DynamicWeb//dynamicweb.py:4151
 msgid "Whether to include a partners column"
 msgstr "Включать ли колонку с данными о партнёре"
 
-#: DynamicWeb/dynamicweb.py:4149
+#: DynamicWeb//dynamicweb.py:4155
 msgid "Whether to include a parents column"
 msgstr "Включать ли колонку с данными о родителях"
 
-#: DynamicWeb/dynamicweb.py:4152
+#: DynamicWeb//dynamicweb.py:4158
 msgid "Generate a families index page"
 msgstr "Создавать страницы для семей"
 
-#: DynamicWeb/dynamicweb.py:4153
+#: DynamicWeb//dynamicweb.py:4159
 msgid "Whether to generate an index page for families"
 msgstr "Создавать ли страницы для семей"
 
-#: DynamicWeb/dynamicweb.py:4157
+#: DynamicWeb//dynamicweb.py:4163
 msgid "Whether to include a column showing the media path"
 msgstr "Включать ли колонку отображающую путь к файлу"
 
-#: DynamicWeb/dynamicweb.py:4161
+#: DynamicWeb//dynamicweb.py:4167
 msgid ""
 "Whether to include the references to the items in the index pages. For "
 "example, in the media index page, the names of the individuals, families, "
@@ -1485,24 +1485,24 @@ msgstr ""
 "документами - имена лиц, семей, мест, источников, которые ссылаются на "
 "документ."
 
-#: DynamicWeb/dynamicweb.py:4164
+#: DynamicWeb//dynamicweb.py:4170
 msgid "Default number of entries in the indexes"
 msgstr "Количество элементов для перечней по умолчанию"
 
-#: DynamicWeb/dynamicweb.py:4167
+#: DynamicWeb//dynamicweb.py:4173
 msgid "The default number of entries shown in one index page"
 msgstr ""
 "Количество элементов по умолчанию, которое будет показано на одной странице"
 
-#: DynamicWeb/dynamicweb.py:4172
+#: DynamicWeb//dynamicweb.py:4178
 msgid "Trees"
 msgstr "Древа"
 
-#: DynamicWeb/dynamicweb.py:4175
+#: DynamicWeb//dynamicweb.py:4181
 msgid "Maximum number of generations"
 msgstr "Максимальное количество поколений"
 
-#: DynamicWeb/dynamicweb.py:4176
+#: DynamicWeb//dynamicweb.py:4182
 msgid ""
 "The maximum number of generations to include in the ancestor and descendant "
 "trees and graphs"
@@ -1510,124 +1510,127 @@ msgstr ""
 "Максимальное количество поколений для включения в графы и древа предков и "
 "потомков"
 
-#: DynamicWeb/dynamicweb.py:4182
+#: DynamicWeb//dynamicweb.py:4188
 msgid "Choose the default SVG tree graph type"
 msgstr "Выберите тип древа по умолчанию (SVG)"
 
-#: DynamicWeb/dynamicweb.py:4188
+#: DynamicWeb//dynamicweb.py:4194
 msgid "Choose the default SVG tree graph shape"
 msgstr "Выберите направление древа по умолчанию (SVG)"
 
-#: DynamicWeb/dynamicweb.py:4194
+#: DynamicWeb//dynamicweb.py:4200
 msgid "Choose the default SVG tree parents distribution (for fan charts only)"
 msgstr ""
 "Выберите представление родителей в древе по умолчанию (только для веерных "
 "карт)"
 
-#: DynamicWeb/dynamicweb.py:4200
+#: DynamicWeb//dynamicweb.py:4206
 msgid "Choose the default SVG tree children distribution (for fan charts only)"
 msgstr ""
 "Выберите представление детей в древе по умолчанию (только для веерных карт)"
 
-#: DynamicWeb/dynamicweb.py:4206
+#: DynamicWeb//dynamicweb.py:4212
 msgid ""
 "Choose the background color scheme for the persons in the SVG tree graph"
 msgstr "Выберите цветовую схему фона для лиц в графе"
 
-#: DynamicWeb/dynamicweb.py:4209
+#: DynamicWeb//dynamicweb.py:4215
 msgid "Start gradient/Main color"
 msgstr "Начало градиента / основной цвет"
 
-#: DynamicWeb/dynamicweb.py:4212
+#: DynamicWeb//dynamicweb.py:4218
 msgid "End gradient/2nd color"
 msgstr "Завершение градиента / второй цвет"
 
-#: DynamicWeb/dynamicweb.py:4220
+#: DynamicWeb//dynamicweb.py:4226
 msgid "Color for duplicates"
 msgstr "Цвет для дубликатов"
 
-#: DynamicWeb/dynamicweb.py:4225
+#: DynamicWeb//dynamicweb.py:4231
 msgid "Pages"
 msgstr "Страницы"
 
-#: DynamicWeb/dynamicweb.py:4228
+#: DynamicWeb//dynamicweb.py:4234
 msgid "HTML user header"
 msgstr "Верхний колонтитул (HTML)"
 
-#: DynamicWeb/dynamicweb.py:4229
+#: DynamicWeb//dynamicweb.py:4235
 msgid "A note to be used as the page header"
 msgstr "Заметка для использования в качестве верхнего колонтитула"
 
-#: DynamicWeb/dynamicweb.py:4232
+#: DynamicWeb//dynamicweb.py:4238
 msgid "HTML user brand name / icon"
 msgstr "Пользовательский знак (HTML) / изображение"
 
-#: DynamicWeb/dynamicweb.py:4233
+#: DynamicWeb//dynamicweb.py:4239
 msgid "A note to be used as the brand name or image in the menu"
 msgstr ""
 "Заметка для использования в качестве знака пользователя или изображения в "
 "меню"
 
-#: DynamicWeb/dynamicweb.py:4236
+#: DynamicWeb//dynamicweb.py:4242
 msgid "HTML user footer"
 msgstr "Нижний колонтитул (HTML)"
 
-#: DynamicWeb/dynamicweb.py:4237
+#: DynamicWeb//dynamicweb.py:4243
 msgid "A note to be used as the page footer"
 msgstr "Заметка для использования в качестве нижнего колонтитула"
 
-#: DynamicWeb/dynamicweb.py:4242
+#: DynamicWeb//dynamicweb.py:4248
 msgid "Custom pages"
 msgstr "Выбранные страницы"
 
-#: DynamicWeb/dynamicweb.py:4246
+#: DynamicWeb//dynamicweb.py:4252
 #, python-format
 msgid "Title for the custom page %(index)i"
 msgstr "Заголовок для выбранной страницы %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4247
+#: DynamicWeb//dynamicweb.py:4253
 #, python-format
 msgid "Name for the custom page %(index)i"
 msgstr "Имя для выбранной страницы %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4250
+#: DynamicWeb//dynamicweb.py:4256
 #, python-format
 msgid "Note for custom page %(index)i"
 msgstr "Заметка для выбранной страницы %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4251
+#: DynamicWeb//dynamicweb.py:4257
 msgid "A note to be used for the custom page content.\n"
 msgstr "Заметка для использования в содержании выбранной страницы.\n"
 
-#: DynamicWeb/dynamicweb.py:4254
+#: DynamicWeb//dynamicweb.py:4260
 #, python-format
 msgid "Menu for the custom page %(index)i"
 msgstr "Меню для выбранной страницы %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4255
+#: DynamicWeb//dynamicweb.py:4261
 msgid "Whether to print a menu for the custom page"
 msgstr "Печатать ли меню для выбранной страницы"
 
-#: DynamicWeb/dynamicweb.py:4260
+#: DynamicWeb//dynamicweb.py:4266
 msgid "Pages selection"
 msgstr "Выбор страниц"
 
-#: DynamicWeb/dynamicweb.py:4263
+#: DynamicWeb//dynamicweb.py:4269
 msgid "Number of pages"
 msgstr "Количество страниц"
 
-#: DynamicWeb/dynamicweb.py:4264
+#: DynamicWeb//dynamicweb.py:4270
 msgid "Number pages in the web site menu."
 msgstr "Количество страниц в меню веб-сайта."
 
-#: DynamicWeb/dynamicweb.py:4280
+#: DynamicWeb//dynamicweb.py:4286
 #, python-format
 msgid "Contents of page %(index)i"
 msgstr "Содержание страницы %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4283
+#: DynamicWeb//dynamicweb.py:4289
 msgid "Contents of the page"
 msgstr "Содержание страницы"
+
+#~ msgid "Html|Home"
+#~ msgstr "Домой"
 
 #~ msgid "Include a column for birth dates on the index pages"
 #~ msgstr "Включить колонку для дат рождения в оглавление"

--- a/DynamicWeb/po/sk-local.po
+++ b/DynamicWeb/po/sk-local.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"POT-Creation-Date: 2020-07-24 17:33+0200\n"
 "PO-Revision-Date: 2019-06-17 09:30+0200\n"
 "Last-Translator: Dominik Sivak <bubakovsky@gmail.com>\n"
 "Language-Team: Slovak\n"
@@ -18,355 +18,355 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
-#: DynamicWeb/dynamicweb.gpr.py:15
+#: DynamicWeb//dynamicweb.gpr.py:15
 msgid "Dynamic Web Report"
 msgstr "Dynamické WWW stránky"
 
-#: DynamicWeb/dynamicweb.gpr.py:16
+#: DynamicWeb//dynamicweb.gpr.py:16
 msgid "Produces dynamic web pages for the database"
 msgstr "Vytvára dynamické WWW stránky z databáze"
 
-#: DynamicWeb/dynamicweb.py:265
+#: DynamicWeb//dynamicweb.py:269
 msgid "Street"
 msgstr "Ulica"
 
-#: DynamicWeb/dynamicweb.py:266
+#: DynamicWeb//dynamicweb.py:270
 msgid "Locality"
 msgstr "Lokalita"
 
-#: DynamicWeb/dynamicweb.py:267
+#: DynamicWeb//dynamicweb.py:271
 msgid "City"
 msgstr "Mesto"
 
-#: DynamicWeb/dynamicweb.py:268
+#: DynamicWeb//dynamicweb.py:272
 msgid "Church Parish"
 msgstr "Farnosť kostola"
 
-#: DynamicWeb/dynamicweb.py:269
+#: DynamicWeb//dynamicweb.py:273
 msgid "County"
 msgstr "Okres"
 
-#: DynamicWeb/dynamicweb.py:270
+#: DynamicWeb//dynamicweb.py:274
 msgid "State/ Province"
 msgstr "Štát/ provincia"
 
-#: DynamicWeb/dynamicweb.py:271
+#: DynamicWeb//dynamicweb.py:275
 msgid "Postal Code"
 msgstr "PSČ"
 
-#: DynamicWeb/dynamicweb.py:272
+#: DynamicWeb//dynamicweb.py:276
 msgid "Country"
 msgstr "Krajina"
 
-#: DynamicWeb/dynamicweb.py:273
+#: DynamicWeb//dynamicweb.py:277
 msgid "Phone"
 msgstr "Telefón"
 
-#: DynamicWeb/dynamicweb.py:279
+#: DynamicWeb//dynamicweb.py:283
 msgid "Home Page"
 msgstr "Domovská stránka"
 
-#: DynamicWeb/dynamicweb.py:280
+#: DynamicWeb//dynamicweb.py:284
 msgid "SVG graphical tree"
 msgstr "SVG grafický strom"
 
-#: DynamicWeb/dynamicweb.py:283
+#: DynamicWeb//dynamicweb.py:287
 msgid "Indexes pages"
 msgstr "Indexové stránky"
 
-#: DynamicWeb/dynamicweb.py:287 DynamicWeb/dynamicweb.py:4246
+#: DynamicWeb//dynamicweb.py:291 DynamicWeb//dynamicweb.py:4252
 #, python-format
 msgid "Custom page %(index)i"
 msgstr "Vlastná stránka %(index)i"
 
-#: DynamicWeb/dynamicweb.py:305
+#: DynamicWeb//dynamicweb.py:309
 msgid "Ascending tree"
 msgstr "Strom predkov"
 
-#: DynamicWeb/dynamicweb.py:306
+#: DynamicWeb//dynamicweb.py:310
 msgid "Descending tree"
 msgstr "Strom potomkov"
 
-#: DynamicWeb/dynamicweb.py:307
+#: DynamicWeb//dynamicweb.py:311
 msgid "Descending tree with spouses"
 msgstr "Strom potomkov s partnermi"
 
-#: DynamicWeb/dynamicweb.py:308
+#: DynamicWeb//dynamicweb.py:312
 msgid "Ascending and descending tree"
 msgstr "Strom predkov a potomkov"
 
-#: DynamicWeb/dynamicweb.py:309
+#: DynamicWeb//dynamicweb.py:313
 msgid "Ascending and descending tree with spouses"
 msgstr "Strom predkov a potomkov s partnermi"
 
-#: DynamicWeb/dynamicweb.py:321
+#: DynamicWeb//dynamicweb.py:325
 msgid "Vertical (↓)"
 msgstr "Vertikálny (↓)"
 
-#: DynamicWeb/dynamicweb.py:322
+#: DynamicWeb//dynamicweb.py:326
 msgid "Vertical (↑)"
 msgstr "Vertikálny (↑)"
 
-#: DynamicWeb/dynamicweb.py:323
+#: DynamicWeb//dynamicweb.py:327
 msgid "Horizontal (→)"
 msgstr "Horizontálny (→)"
 
-#: DynamicWeb/dynamicweb.py:324
+#: DynamicWeb//dynamicweb.py:328
 msgid "Horizontal (←)"
 msgstr "Horizontálny (←)"
 
-#: DynamicWeb/dynamicweb.py:325
+#: DynamicWeb//dynamicweb.py:329
 msgid "Full Circle"
 msgstr "Celý kruh"
 
-#: DynamicWeb/dynamicweb.py:326
+#: DynamicWeb//dynamicweb.py:330
 msgid "Half Circle"
 msgstr "Polkruh"
 
-#: DynamicWeb/dynamicweb.py:327
+#: DynamicWeb//dynamicweb.py:331
 msgid "Quadrant"
 msgstr "Kvadrant"
 
-#: DynamicWeb/dynamicweb.py:339
+#: DynamicWeb//dynamicweb.py:343
 msgid "Size proportional to number of ancestors"
 msgstr "Veľkosť úmerná počtu predkov"
 
-#: DynamicWeb/dynamicweb.py:340
+#: DynamicWeb//dynamicweb.py:344
 msgid "Homogeneous parents distribution"
 msgstr "Homogénne rozdelenie rodičov"
 
-#: DynamicWeb/dynamicweb.py:343
+#: DynamicWeb//dynamicweb.py:347
 msgid "Size proportional to number of descendants"
 msgstr "Veľkosť úmerná počtu potomkov"
 
-#: DynamicWeb/dynamicweb.py:344
+#: DynamicWeb//dynamicweb.py:348
 msgid "Homogeneous children distribution"
 msgstr "Homogénne rozdelenie detí"
 
-#: DynamicWeb/dynamicweb.py:351 DynamicWeb/dynamicweb.py:374
+#: DynamicWeb//dynamicweb.py:355 DynamicWeb//dynamicweb.py:378
 msgid "Gender colors"
 msgstr "Farby pohlaví"
 
-#: DynamicWeb/dynamicweb.py:352
+#: DynamicWeb//dynamicweb.py:356
 msgid "Generation based gradient"
 msgstr "Prechod založený na generáciách"
 
-#: DynamicWeb/dynamicweb.py:353
+#: DynamicWeb//dynamicweb.py:357
 msgid "Age based gradient"
 msgstr "Prechod založený na veku"
 
-#: DynamicWeb/dynamicweb.py:354 DynamicWeb/dynamicweb.py:373
+#: DynamicWeb//dynamicweb.py:358 DynamicWeb//dynamicweb.py:377
 msgid "Single main (filter) color"
 msgstr "Základná hlavná farba (filtru)"
 
-#: DynamicWeb/dynamicweb.py:355
+#: DynamicWeb//dynamicweb.py:359
 msgid "Time period based gradient"
 msgstr "Prechod založený na časovom období"
 
-#: DynamicWeb/dynamicweb.py:356 DynamicWeb/dynamicweb.py:378
+#: DynamicWeb//dynamicweb.py:360 DynamicWeb//dynamicweb.py:382
 msgid "White"
 msgstr "Biela"
 
-#: DynamicWeb/dynamicweb.py:357 DynamicWeb/dynamicweb.py:376
+#: DynamicWeb//dynamicweb.py:361 DynamicWeb//dynamicweb.py:380
 msgid "Color scheme classic report"
 msgstr "Výkaz určený farebnou schémou"
 
-#: DynamicWeb/dynamicweb.py:358 DynamicWeb/dynamicweb.py:377
+#: DynamicWeb//dynamicweb.py:362 DynamicWeb//dynamicweb.py:381
 msgid "Color scheme classic view"
 msgstr "Pohľad určený farebnou schémou"
 
-#: DynamicWeb/dynamicweb.py:375
+#: DynamicWeb//dynamicweb.py:379
 msgid "Gradient"
 msgstr "Prechod"
 
-#: DynamicWeb/dynamicweb.py:394
+#: DynamicWeb//dynamicweb.py:398
 msgid "Default"
 msgstr "Základný"
 
-#: DynamicWeb/dynamicweb.py:395
+#: DynamicWeb//dynamicweb.py:399
 msgid "Mainz"
 msgstr "Mainz"
 
-#: DynamicWeb/dynamicweb.py:703
+#: DynamicWeb//dynamicweb.py:707
 #, python-format
 msgid "Neither %(current)s nor %(parent)s are directories"
 msgstr "%(current)s ani %(parent)s nie sú adresármi"
 
-#: DynamicWeb/dynamicweb.py:711 DynamicWeb/dynamicweb.py:716
+#: DynamicWeb//dynamicweb.py:715 DynamicWeb//dynamicweb.py:720
 #, python-format
 msgid "Could not create the directory: %(path)s"
 msgstr "Nepodarilo sa vytvoriť adresár: %(path)s"
 
-#: DynamicWeb/dynamicweb.py:742 DynamicWeb/dynamicweb.py:3380
+#: DynamicWeb//dynamicweb.py:746 DynamicWeb//dynamicweb.py:3385
 msgid "Dynamic Web Site Report"
 msgstr "Dynamický WWW výkaz"
 
-#: DynamicWeb/dynamicweb.py:742
+#: DynamicWeb//dynamicweb.py:746
 msgid "Exporting family tree data ..."
 msgstr "Exportujú sa data rodokmeňu ..."
 
-#: DynamicWeb/dynamicweb.py:1232 DynamicWeb/dynamicweb.py:2456
+#: DynamicWeb//dynamicweb.py:1237 DynamicWeb//dynamicweb.py:2461
 msgid "Author"
 msgstr "Autor"
 
-#: DynamicWeb/dynamicweb.py:1233 DynamicWeb/dynamicweb.py:2446
+#: DynamicWeb//dynamicweb.py:1238 DynamicWeb//dynamicweb.py:2451
 msgid "Abbreviation"
 msgstr "Skratka"
 
-#: DynamicWeb/dynamicweb.py:1234 DynamicWeb/dynamicweb.py:2543
+#: DynamicWeb//dynamicweb.py:1239 DynamicWeb//dynamicweb.py:2548
 msgid "Publication information"
 msgstr "Informácie o publikácii"
 
-#: DynamicWeb/dynamicweb.py:1304 DynamicWeb/dynamicweb.py:2474
+#: DynamicWeb//dynamicweb.py:1309 DynamicWeb//dynamicweb.py:2479
 msgid "Date"
 msgstr "Dátum"
 
-#: DynamicWeb/dynamicweb.py:1305
+#: DynamicWeb//dynamicweb.py:1310
 msgid "Page"
 msgstr "Stránka"
 
-#: DynamicWeb/dynamicweb.py:1306
+#: DynamicWeb//dynamicweb.py:1311
 msgid "Confidence"
 msgstr "Dôveryhodnosť"
 
-#: DynamicWeb/dynamicweb.py:1625
+#: DynamicWeb//dynamicweb.py:1630
 #, python-format
 msgid "%(type)s: %(value)s"
 msgstr "%(type)s: %(value)s"
 
-#: DynamicWeb/dynamicweb.py:1872
+#: DynamicWeb//dynamicweb.py:1877
 #, python-format
 msgid "Impossible to convert \"%(path)s\" to a relative path."
 msgstr "Nepodarilo sa konvertovať \"%(path)s\" na relatívnu cestu."
 
-#: DynamicWeb/dynamicweb.py:2178
+#: DynamicWeb//dynamicweb.py:2183
 msgid ""
 "The pages configuration is not valid: several pages have the same content"
 msgstr ""
 "Táto konfigurácia stránok je nesprávna: obsah niekoľkých stránok je zhodný"
 
-#: DynamicWeb/dynamicweb.py:2189
-msgid "Html|Home"
+#: DynamicWeb//dynamicweb.py:2194
+msgid "DynWeb|Home"
 msgstr "Domov"
 
-#: DynamicWeb/dynamicweb.py:2190 DynamicWeb/dynamicweb.py:2203
-#: DynamicWeb/dynamicweb.py:2204 DynamicWeb/dynamicweb.py:2205
+#: DynamicWeb//dynamicweb.py:2195 DynamicWeb//dynamicweb.py:2208
+#: DynamicWeb//dynamicweb.py:2209 DynamicWeb//dynamicweb.py:2210
 msgid "Tree"
 msgstr "Strom"
 
-#: DynamicWeb/dynamicweb.py:2191 DynamicWeb/dynamicweb.py:2206
-#: DynamicWeb/dynamicweb.py:2207 DynamicWeb/dynamicweb.py:2208
+#: DynamicWeb//dynamicweb.py:2196 DynamicWeb//dynamicweb.py:2211
+#: DynamicWeb//dynamicweb.py:2212 DynamicWeb//dynamicweb.py:2213
 msgid "Statistics"
 msgstr "Štatistiky"
 
-#: DynamicWeb/dynamicweb.py:2194 DynamicWeb/dynamicweb.py:2470
+#: DynamicWeb//dynamicweb.py:2199 DynamicWeb//dynamicweb.py:2475
 msgid "Configuration"
 msgstr "Konfigurácia"
 
-#: DynamicWeb/dynamicweb.py:2196 DynamicWeb/dynamicweb.py:2535
+#: DynamicWeb//dynamicweb.py:2201 DynamicWeb//dynamicweb.py:2540
 msgid "Person"
 msgstr "Osoba"
 
-#: DynamicWeb/dynamicweb.py:2197
+#: DynamicWeb//dynamicweb.py:2202
 msgid "Family"
 msgstr "Rodina"
 
-#: DynamicWeb/dynamicweb.py:2198 DynamicWeb/dynamicweb.py:2575
+#: DynamicWeb//dynamicweb.py:2203 DynamicWeb//dynamicweb.py:2580
 msgid "Source"
 msgstr "Zdroj"
 
-#: DynamicWeb/dynamicweb.py:2199 DynamicWeb/dynamicweb.py:2218
-#: DynamicWeb/dynamicweb.py:2518
+#: DynamicWeb//dynamicweb.py:2204 DynamicWeb//dynamicweb.py:2223
+#: DynamicWeb//dynamicweb.py:2523
 msgid "Media"
 msgstr "Média"
 
-#: DynamicWeb/dynamicweb.py:2200 DynamicWeb/dynamicweb.py:2538
+#: DynamicWeb//dynamicweb.py:2205 DynamicWeb//dynamicweb.py:2543
 msgid "Place"
 msgstr "Miesto"
 
-#: DynamicWeb/dynamicweb.py:2201 DynamicWeb/dynamicweb.py:2550
+#: DynamicWeb//dynamicweb.py:2206 DynamicWeb//dynamicweb.py:2555
 msgid "Repository"
 msgstr "Archív"
 
-#: DynamicWeb/dynamicweb.py:2202
+#: DynamicWeb//dynamicweb.py:2207
 msgid "Search results"
 msgstr "Výsledky vyhľadávania"
 
-#: DynamicWeb/dynamicweb.py:2213 DynamicWeb/dynamicweb.py:2214
-#: DynamicWeb/dynamicweb.py:2582
+#: DynamicWeb//dynamicweb.py:2218 DynamicWeb//dynamicweb.py:2219
+#: DynamicWeb//dynamicweb.py:2587
 msgid "Surnames"
 msgstr "Priezviská"
 
-#: DynamicWeb/dynamicweb.py:2215 DynamicWeb/dynamicweb.py:2503
+#: DynamicWeb//dynamicweb.py:2220 DynamicWeb//dynamicweb.py:2508
 msgid "Individuals"
 msgstr "Jednotlivci"
 
-#: DynamicWeb/dynamicweb.py:2216 DynamicWeb/dynamicweb.py:2486
+#: DynamicWeb//dynamicweb.py:2221 DynamicWeb//dynamicweb.py:2491
 msgid "Families"
 msgstr "Rodiny"
 
-#: DynamicWeb/dynamicweb.py:2217 DynamicWeb/dynamicweb.py:2577
+#: DynamicWeb//dynamicweb.py:2222 DynamicWeb//dynamicweb.py:2582
 msgid "Sources"
 msgstr "Zdroje"
 
-#: DynamicWeb/dynamicweb.py:2219 DynamicWeb/dynamicweb.py:2540
+#: DynamicWeb//dynamicweb.py:2224 DynamicWeb//dynamicweb.py:2545
 msgid "Places"
 msgstr "Miesta"
 
-#: DynamicWeb/dynamicweb.py:2220 DynamicWeb/dynamicweb.py:2448
+#: DynamicWeb//dynamicweb.py:2225 DynamicWeb//dynamicweb.py:2453
 msgid "Addresses"
 msgstr "Adresy"
 
-#: DynamicWeb/dynamicweb.py:2221 DynamicWeb/dynamicweb.py:2549
+#: DynamicWeb//dynamicweb.py:2226 DynamicWeb//dynamicweb.py:2554
 msgid "Repositories"
 msgstr "Archívy"
 
-#: DynamicWeb/dynamicweb.py:2272 DynamicWeb/dynamicweb.py:2502
-#: DynamicWeb/dynamicweb.py:4120
+#: DynamicWeb//dynamicweb.py:2277 DynamicWeb//dynamicweb.py:2507
+#: DynamicWeb//dynamicweb.py:4126
 msgid "Indexes"
 msgstr "Indexy"
 
-#: DynamicWeb/dynamicweb.py:2436
+#: DynamicWeb//dynamicweb.py:2441
 #, python-format
 msgid "(b. %(birthdate)s, d. %(deathdate)s)"
 msgstr "(nar. %(birthdate)s, úmr. %(deathdate)s)"
 
-#: DynamicWeb/dynamicweb.py:2437
+#: DynamicWeb//dynamicweb.py:2442
 #, python-format
 msgid "(b. %s)"
 msgstr "(nar. %s)"
 
-#: DynamicWeb/dynamicweb.py:2438
+#: DynamicWeb//dynamicweb.py:2443
 #, python-format
 msgid "(d. %s)"
 msgstr "(úmr. %s)"
 
-#: DynamicWeb/dynamicweb.py:2439
+#: DynamicWeb//dynamicweb.py:2444
 msgid "(filtered from _MAX_ total entries)"
 msgstr "(filtrované z _MAX_ položiek celkovo)"
 
-#: DynamicWeb/dynamicweb.py:2440
+#: DynamicWeb//dynamicweb.py:2445
 #, python-format
 msgid "(m. %s)"
 msgstr "(vyd./žen. %s)"
 
-#: DynamicWeb/dynamicweb.py:2441
+#: DynamicWeb//dynamicweb.py:2446
 msgid "(sort by name)"
 msgstr "(zoradiť podľa mena)"
 
-#: DynamicWeb/dynamicweb.py:2442
+#: DynamicWeb//dynamicweb.py:2447
 msgid "(sort by quantity)"
 msgstr "(zoradiť podľa počtu)"
 
-#: DynamicWeb/dynamicweb.py:2443
+#: DynamicWeb//dynamicweb.py:2448
 msgid ": activate to sort column ascending"
 msgstr ": aktivujte pre zoradenie stĺpca vzostupne"
 
-#: DynamicWeb/dynamicweb.py:2444
+#: DynamicWeb//dynamicweb.py:2449
 msgid ": activate to sort column descending"
 msgstr ": aktivujte pre zoradenie stĺpca zostupne"
 
-#: DynamicWeb/dynamicweb.py:2445
+#: DynamicWeb//dynamicweb.py:2450
 msgid ""
 "<p>This page provides the SVG raw code.<br>Copy the contents into a text "
 "editor and save as an SVG file.<br>Make sure that the text editor encoding "
@@ -376,609 +376,609 @@ msgstr ""
 "editoru a uložte ho ako súbor SVG.<br>Uistite sa, že kódovanie znakov je "
 "UTF-8.</p>"
 
-#: DynamicWeb/dynamicweb.py:2447
+#: DynamicWeb//dynamicweb.py:2452
 msgid "Address"
 msgstr "Adresa"
 
-#: DynamicWeb/dynamicweb.py:2449
+#: DynamicWeb//dynamicweb.py:2454
 msgid "Age at death"
 msgstr "Dožitý vek"
 
-#: DynamicWeb/dynamicweb.py:2450
+#: DynamicWeb//dynamicweb.py:2455
 msgid "Alternate Marriage"
 msgstr "Alternatívne manželstvo"
 
-#: DynamicWeb/dynamicweb.py:2451
+#: DynamicWeb//dynamicweb.py:2456
 msgid "Alternate Name"
 msgstr "Alternatívne meno"
 
-#: DynamicWeb/dynamicweb.py:2452
+#: DynamicWeb//dynamicweb.py:2457
 msgid "Ancestors"
 msgstr "Predkovia"
 
-#: DynamicWeb/dynamicweb.py:2453
+#: DynamicWeb//dynamicweb.py:2458
 msgid "Associations"
 msgstr "Spojitosti"
 
-#: DynamicWeb/dynamicweb.py:2454
+#: DynamicWeb//dynamicweb.py:2459
 msgid "Attribute"
 msgstr "Atribút"
 
-#: DynamicWeb/dynamicweb.py:2455
+#: DynamicWeb//dynamicweb.py:2460
 msgid "Attributes"
 msgstr "Atribúty"
 
-#: DynamicWeb/dynamicweb.py:2457 DynamicWeb/dynamicweb.py:4203
+#: DynamicWeb//dynamicweb.py:2462 DynamicWeb//dynamicweb.py:4209
 msgid "Background"
 msgstr "Pozadie"
 
-#: DynamicWeb/dynamicweb.py:2458
+#: DynamicWeb//dynamicweb.py:2463
 msgid "Baptism"
 msgstr "Krst"
 
-#: DynamicWeb/dynamicweb.py:2459
+#: DynamicWeb//dynamicweb.py:2464
 msgid "Birth"
 msgstr "Narodenie"
 
-#: DynamicWeb/dynamicweb.py:2460
+#: DynamicWeb//dynamicweb.py:2465
 msgid "Burial"
 msgstr "Pohreb"
 
-#: DynamicWeb/dynamicweb.py:2461
+#: DynamicWeb//dynamicweb.py:2466
 msgid "Call Name"
 msgstr "Používané meno"
 
-#: DynamicWeb/dynamicweb.py:2462
+#: DynamicWeb//dynamicweb.py:2467
 msgid "Call Number"
 msgstr "Signatúra"
 
-#: DynamicWeb/dynamicweb.py:2463
+#: DynamicWeb//dynamicweb.py:2468
 msgid "Cause Of Death"
 msgstr "Príčina smrti"
 
-#: DynamicWeb/dynamicweb.py:2464
+#: DynamicWeb//dynamicweb.py:2469
 msgid "Children"
 msgstr "Deti"
 
-#: DynamicWeb/dynamicweb.py:2465
+#: DynamicWeb//dynamicweb.py:2470
 msgid "Christening"
 msgstr "Krst"
 
-#: DynamicWeb/dynamicweb.py:2466
+#: DynamicWeb//dynamicweb.py:2471
 msgid "Citation"
 msgstr "Citácia"
 
-#: DynamicWeb/dynamicweb.py:2467
+#: DynamicWeb//dynamicweb.py:2472
 msgid "Citations"
 msgstr "Citácie"
 
-#: DynamicWeb/dynamicweb.py:2468
+#: DynamicWeb//dynamicweb.py:2473
 msgid "Click on the map to show it full-screen"
 msgstr "Kliknite na mapu pre zobrazenie na celú obrazovku"
 
-#: DynamicWeb/dynamicweb.py:2469
+#: DynamicWeb//dynamicweb.py:2474
 msgid "Code"
 msgstr "Kód"
 
-#: DynamicWeb/dynamicweb.py:2471
+#: DynamicWeb//dynamicweb.py:2476
 msgid "Configure"
 msgstr "Nastaviť"
 
-#: DynamicWeb/dynamicweb.py:2472
+#: DynamicWeb//dynamicweb.py:2477
 msgid "Count"
 msgstr "Počet"
 
-#: DynamicWeb/dynamicweb.py:2473
+#: DynamicWeb//dynamicweb.py:2478
 msgid "Cremation"
 msgstr "Kremácia"
 
-#: DynamicWeb/dynamicweb.py:2475
+#: DynamicWeb//dynamicweb.py:2480
 msgid "Death"
 msgstr "Úmrtie"
 
-#: DynamicWeb/dynamicweb.py:2476
+#: DynamicWeb//dynamicweb.py:2481
 msgid "Descendants"
 msgstr "Potomkovia"
 
-#: DynamicWeb/dynamicweb.py:2477
+#: DynamicWeb//dynamicweb.py:2482
 msgid "Description"
 msgstr "Popus"
 
-#: DynamicWeb/dynamicweb.py:2478
+#: DynamicWeb//dynamicweb.py:2483
 msgid "DynamicWeb_report#Help"
 msgstr "DynamicWeb_report#Pomoc"
 
-#: DynamicWeb/dynamicweb.py:2479
+#: DynamicWeb//dynamicweb.py:2484
 msgid "Enclosed By"
 msgstr "Uzavretý"
 
-#: DynamicWeb/dynamicweb.py:2480
+#: DynamicWeb//dynamicweb.py:2485
 msgid "Engagement"
 msgstr "Zasnúbenie"
 
-#: DynamicWeb/dynamicweb.py:2481
+#: DynamicWeb//dynamicweb.py:2486
 msgid "Event"
 msgstr "Udalosť"
 
-#: DynamicWeb/dynamicweb.py:2482
+#: DynamicWeb//dynamicweb.py:2487
 msgid "Events"
 msgstr "Udalosti"
 
-#: DynamicWeb/dynamicweb.py:2483
+#: DynamicWeb//dynamicweb.py:2488
 msgid "Examples"
 msgstr "Príklady"
 
-#: DynamicWeb/dynamicweb.py:2484
+#: DynamicWeb//dynamicweb.py:2489
 msgid "F"
 msgstr "Ž"
 
-#: DynamicWeb/dynamicweb.py:2485
+#: DynamicWeb//dynamicweb.py:2490
 msgid "Families Index"
 msgstr "Index rodín"
 
-#: DynamicWeb/dynamicweb.py:2487
+#: DynamicWeb//dynamicweb.py:2492
 msgid "Family Nick Name"
 msgstr "Domáce meno"
 
-#: DynamicWeb/dynamicweb.py:2488
+#: DynamicWeb//dynamicweb.py:2493
 msgid "Father"
 msgstr "Otec"
 
-#: DynamicWeb/dynamicweb.py:2489
+#: DynamicWeb//dynamicweb.py:2494
 msgid "Female"
 msgstr "Žena"
 
-#: DynamicWeb/dynamicweb.py:2490
+#: DynamicWeb//dynamicweb.py:2495
 msgid "File ready"
 msgstr "Súbor pripravený"
 
-#: DynamicWeb/dynamicweb.py:2491
+#: DynamicWeb//dynamicweb.py:2496
 msgid "Gender"
 msgstr "Pohlavie"
 
-#: DynamicWeb/dynamicweb.py:2492
+#: DynamicWeb//dynamicweb.py:2497
 msgid "Help"
 msgstr "Pomoc"
 
-#: DynamicWeb/dynamicweb.py:2493
+#: DynamicWeb//dynamicweb.py:2498
 msgid "ID"
 msgstr "ID"
 
-#: DynamicWeb/dynamicweb.py:2494 DynamicWeb/dynamicweb.py:4035
+#: DynamicWeb//dynamicweb.py:2499 DynamicWeb//dynamicweb.py:4041
 msgid "Include Place map on Place Pages"
 msgstr "Zahrnúť mapu miest na stránke miest"
 
-#: DynamicWeb/dynamicweb.py:2495 DynamicWeb/dynamicweb.py:4140
+#: DynamicWeb//dynamicweb.py:2500 DynamicWeb//dynamicweb.py:4146
 msgid "Include dates columns on the index pages"
 msgstr "Zahrnúť stĺpec s dátumami na indexových stránkach"
 
-#: DynamicWeb/dynamicweb.py:2496 DynamicWeb/dynamicweb.py:4148
+#: DynamicWeb//dynamicweb.py:2501 DynamicWeb//dynamicweb.py:4154
 msgid "Include a column for parents on the index pages"
 msgstr "Zahrnúť stĺpec rodiča na indexových stránkach"
 
-#: DynamicWeb/dynamicweb.py:2497 DynamicWeb/dynamicweb.py:4156
+#: DynamicWeb//dynamicweb.py:2502 DynamicWeb//dynamicweb.py:4162
 msgid "Include a column for media path on the index pages"
 msgstr "Zahrnúť stĺpec pre cestu k médiám na indexových stránkach"
 
-#: DynamicWeb/dynamicweb.py:2498 DynamicWeb/dynamicweb.py:4144
+#: DynamicWeb//dynamicweb.py:2503 DynamicWeb//dynamicweb.py:4150
 msgid "Include a column for partners on the index pages"
 msgstr "Zahrnúť stĺpec partnerov na indexových stránkach"
 
-#: DynamicWeb/dynamicweb.py:2499 DynamicWeb/dynamicweb.py:4043
+#: DynamicWeb//dynamicweb.py:2504 DynamicWeb//dynamicweb.py:4049
 msgid "Include a map in the individuals and family pages"
 msgstr "Zahrnúť mapu na osobných a rodinných stránkach"
 
-#: DynamicWeb/dynamicweb.py:2500 DynamicWeb/dynamicweb.py:4090
+#: DynamicWeb//dynamicweb.py:2505 DynamicWeb//dynamicweb.py:4096
 msgid "Include half and/ or step-siblings on the individual pages"
 msgstr "Zahrnúť nevlastných súrodencov na osobných stránkach"
 
-#: DynamicWeb/dynamicweb.py:2501 DynamicWeb/dynamicweb.py:4160
+#: DynamicWeb//dynamicweb.py:2506 DynamicWeb//dynamicweb.py:4166
 msgid "Include references in indexes"
 msgstr "Zahrnúť referencie v indexoch"
 
-#: DynamicWeb/dynamicweb.py:2504 DynamicWeb/dynamicweb.py:4110
+#: DynamicWeb//dynamicweb.py:2509 DynamicWeb//dynamicweb.py:4116
 msgid "Insert sources author in the sources title"
 msgstr "Uviesť autora zdrojov v názve zdrojov"
 
-#: DynamicWeb/dynamicweb.py:2505
+#: DynamicWeb//dynamicweb.py:2510
 msgid "Last Modified"
 msgstr "Naposledy zmenené"
 
-#: DynamicWeb/dynamicweb.py:2506
+#: DynamicWeb//dynamicweb.py:2511
 msgid "Latitude"
 msgstr "Zemepisná šírka"
 
-#: DynamicWeb/dynamicweb.py:2507
+#: DynamicWeb//dynamicweb.py:2512
 msgid "Link"
 msgstr "Odkaz"
 
-#: DynamicWeb/dynamicweb.py:2508
+#: DynamicWeb//dynamicweb.py:2513
 msgid "Loading..."
 msgstr "Nahráva sa..."
 
-#: DynamicWeb/dynamicweb.py:2509
+#: DynamicWeb//dynamicweb.py:2514
 msgid "Location"
 msgstr "Poloha"
 
-#: DynamicWeb/dynamicweb.py:2510
+#: DynamicWeb//dynamicweb.py:2515
 msgid "Longitude"
 msgstr "Zemepisná dĺžka"
 
-#: DynamicWeb/dynamicweb.py:2511
+#: DynamicWeb//dynamicweb.py:2516
 msgid "M"
 msgstr "M"
 
-#: DynamicWeb/dynamicweb.py:2512
+#: DynamicWeb//dynamicweb.py:2517
 msgid "Male"
 msgstr "Muž"
 
-#: DynamicWeb/dynamicweb.py:2513
+#: DynamicWeb//dynamicweb.py:2518
 msgid "Map"
 msgstr "Mapa"
 
-#: DynamicWeb/dynamicweb.py:2514
+#: DynamicWeb//dynamicweb.py:2519
 msgid "Marriage"
 msgstr "Manželstvo"
 
-#: DynamicWeb/dynamicweb.py:2515
+#: DynamicWeb//dynamicweb.py:2520
 msgid "Maximize"
 msgstr "Zväčšiť"
 
-#: DynamicWeb/dynamicweb.py:2516
+#: DynamicWeb//dynamicweb.py:2521
 msgid "Media Index"
 msgstr "Index médií"
 
-#: DynamicWeb/dynamicweb.py:2517
+#: DynamicWeb//dynamicweb.py:2522
 msgid "Media Type"
 msgstr "Typ média"
 
-#: DynamicWeb/dynamicweb.py:2519
+#: DynamicWeb//dynamicweb.py:2524
 msgid "Mother"
 msgstr "Matka"
 
-#: DynamicWeb/dynamicweb.py:2520
+#: DynamicWeb//dynamicweb.py:2525
 msgid "Name"
 msgstr "Meno"
 
-#: DynamicWeb/dynamicweb.py:2521
+#: DynamicWeb//dynamicweb.py:2526
 msgid "Nick Name"
 msgstr "Prezývka"
 
-#: DynamicWeb/dynamicweb.py:2522
+#: DynamicWeb//dynamicweb.py:2527
 msgid "No data available in table"
 msgstr "Pre tabuľku nie sú dostupné žiadne dáta"
 
-#: DynamicWeb/dynamicweb.py:2523
+#: DynamicWeb//dynamicweb.py:2528
 msgid "No matches found"
 msgstr "Nenašli sa žiadne zhody"
 
-#: DynamicWeb/dynamicweb.py:2524
+#: DynamicWeb//dynamicweb.py:2529
 msgid "No matching records found"
 msgstr "Nenašli sa žiadne odpovedajúce záznamy"
 
-#: DynamicWeb/dynamicweb.py:2525
+#: DynamicWeb//dynamicweb.py:2530
 msgid "No matching surname."
 msgstr "Žiadne odpovedajúce priezvisko."
 
-#: DynamicWeb/dynamicweb.py:2526
+#: DynamicWeb//dynamicweb.py:2531
 msgid "None"
 msgstr "Žiadny"
 
-#: DynamicWeb/dynamicweb.py:2527
+#: DynamicWeb//dynamicweb.py:2532
 msgid "Notes"
 msgstr "Poznámky"
 
-#: DynamicWeb/dynamicweb.py:2528
+#: DynamicWeb//dynamicweb.py:2533
 msgid "Number"
 msgstr "Číslo"
 
-#: DynamicWeb/dynamicweb.py:2529
+#: DynamicWeb//dynamicweb.py:2534
 msgid "OK"
 msgstr "OK"
 
-#: DynamicWeb/dynamicweb.py:2530
+#: DynamicWeb//dynamicweb.py:2535
 msgid "Other participants"
 msgstr "Ďalší účastníci"
 
-#: DynamicWeb/dynamicweb.py:2531
+#: DynamicWeb//dynamicweb.py:2536
 msgid "Parents"
 msgstr "Rodičia"
 
-#: DynamicWeb/dynamicweb.py:2532
+#: DynamicWeb//dynamicweb.py:2537
 msgid "Path"
 msgstr "Cesta"
 
-#: DynamicWeb/dynamicweb.py:2533
+#: DynamicWeb//dynamicweb.py:2538
 msgid "Person page"
 msgstr "Stránka osoby"
 
-#: DynamicWeb/dynamicweb.py:2534
+#: DynamicWeb//dynamicweb.py:2539
 msgid "Person to search for"
 msgstr "Vyhľadať osobu"
 
-#: DynamicWeb/dynamicweb.py:2536
+#: DynamicWeb//dynamicweb.py:2541
 msgid "Persons Index"
 msgstr "Index osôb"
 
-#: DynamicWeb/dynamicweb.py:2537
+#: DynamicWeb//dynamicweb.py:2542
 msgid "Persons"
 msgstr "Osoby"
 
-#: DynamicWeb/dynamicweb.py:2539
+#: DynamicWeb//dynamicweb.py:2544
 msgid "Places Index"
 msgstr "Index miest"
 
-#: DynamicWeb/dynamicweb.py:2541
+#: DynamicWeb//dynamicweb.py:2546
 msgid "Preparing file ..."
 msgstr "Súbor sa pripravuje ..."
 
-#: DynamicWeb/dynamicweb.py:2542
+#: DynamicWeb//dynamicweb.py:2547
 msgid "Processing..."
 msgstr "Spracúva sa..."
 
-#: DynamicWeb/dynamicweb.py:2544
+#: DynamicWeb//dynamicweb.py:2549
 msgid "References"
 msgstr "Referencie"
 
-#: DynamicWeb/dynamicweb.py:2545
+#: DynamicWeb//dynamicweb.py:2550
 msgid "Relationship to Father"
 msgstr "Vzťah k otcovi"
 
-#: DynamicWeb/dynamicweb.py:2546
+#: DynamicWeb//dynamicweb.py:2551
 msgid "Relationship to Mother"
 msgstr "Vzťah k matke"
 
-#: DynamicWeb/dynamicweb.py:2547
+#: DynamicWeb//dynamicweb.py:2552
 msgid "Relationship"
 msgstr "Vzťah"
 
-#: DynamicWeb/dynamicweb.py:2548
+#: DynamicWeb//dynamicweb.py:2553
 msgid "Repositories Index"
 msgstr "Index prameňov"
 
-#: DynamicWeb/dynamicweb.py:2551
+#: DynamicWeb//dynamicweb.py:2556
 msgid "Restore"
 msgstr "Obnoviť"
 
-#: DynamicWeb/dynamicweb.py:2552
+#: DynamicWeb//dynamicweb.py:2557
 msgid "Restore default settings"
 msgstr "Obnoviť základené nastavenia"
 
-#: DynamicWeb/dynamicweb.py:2553 DynamicWeb/dynamicweb.py:4106
+#: DynamicWeb//dynamicweb.py:2558 DynamicWeb//dynamicweb.py:4112
 msgid "Show last modification time"
 msgstr "Zobraziť čas poslednej úpravy"
 
-#: DynamicWeb/dynamicweb.py:2554 DynamicWeb/dynamicweb.py:4197
+#: DynamicWeb//dynamicweb.py:2559 DynamicWeb//dynamicweb.py:4203
 msgid "SVG tree children distribution"
 msgstr "Rozdelenie SVG stromu detí"
 
-#: DynamicWeb/dynamicweb.py:2555
+#: DynamicWeb//dynamicweb.py:2560
 msgid "SVG tree configuration"
 msgstr "Nastavenie SVG stromu"
 
-#: DynamicWeb/dynamicweb.py:2556 DynamicWeb/dynamicweb.py:4185
+#: DynamicWeb//dynamicweb.py:2561 DynamicWeb//dynamicweb.py:4191
 msgid "SVG tree graph shape"
 msgstr "Tvar SVG stromu"
 
-#: DynamicWeb/dynamicweb.py:2557 DynamicWeb/dynamicweb.py:4179
+#: DynamicWeb//dynamicweb.py:2562 DynamicWeb//dynamicweb.py:4185
 msgid "SVG tree graph type"
 msgstr "Typ SVG stromu"
 
-#: DynamicWeb/dynamicweb.py:2558 DynamicWeb/dynamicweb.py:4191
+#: DynamicWeb//dynamicweb.py:2563 DynamicWeb//dynamicweb.py:4197
 msgid "SVG tree parents distribution"
 msgstr "Rozdelenie SVG stromu rodičov"
 
-#: DynamicWeb/dynamicweb.py:2559
+#: DynamicWeb//dynamicweb.py:2564
 msgid "Save tree as file"
 msgstr "Uložiť strom ako súbor"
 
-#: DynamicWeb/dynamicweb.py:2560
+#: DynamicWeb//dynamicweb.py:2565
 msgid "Search:"
 msgstr "Hľadať:"
 
-#: DynamicWeb/dynamicweb.py:2561
+#: DynamicWeb//dynamicweb.py:2566
 msgid "Select the background color scheme"
 msgstr "Zvoľte farebnú schému pozadia"
 
-#: DynamicWeb/dynamicweb.py:2562
+#: DynamicWeb//dynamicweb.py:2567
 msgid "Select the children distribution (fan charts only)"
 msgstr "Zvoľte rozdelenie detí (iba vejárový graf)"
 
-#: DynamicWeb/dynamicweb.py:2563
+#: DynamicWeb//dynamicweb.py:2568
 msgid "Select the number of ascending generations"
 msgstr "Zvoľte počet generácií predkov"
 
-#: DynamicWeb/dynamicweb.py:2564
+#: DynamicWeb//dynamicweb.py:2569
 msgid "Select the number of descending generations"
 msgstr "Zvoľte počet generácií potomkov"
 
-#: DynamicWeb/dynamicweb.py:2565
+#: DynamicWeb//dynamicweb.py:2570
 msgid "Select the parents distribution (fan charts only)"
 msgstr "Zvoľte rozdelenie rodičov (iba vejárový graf)"
 
-#: DynamicWeb/dynamicweb.py:2566
+#: DynamicWeb//dynamicweb.py:2571
 msgid "Select the shape of graph"
 msgstr "Zvoľte tvar grafu"
 
-#: DynamicWeb/dynamicweb.py:2567
+#: DynamicWeb//dynamicweb.py:2572
 msgid "Select the type of graph"
 msgstr "Zvoľte typ grafu"
 
-#: DynamicWeb/dynamicweb.py:2568
+#: DynamicWeb//dynamicweb.py:2573
 msgid "Several matches.<br>Precise your search or choose in the lists below."
 msgstr ""
 "Viacero zhod.<br>Upresnite vyhľadávanie alebo vyberte zo zoznamu nižšie."
 
-#: DynamicWeb/dynamicweb.py:2569
+#: DynamicWeb//dynamicweb.py:2574
 msgid "Show _MENU_ entries"
 msgstr "Zobraziť _MENU_ položky"
 
-#: DynamicWeb/dynamicweb.py:2570 DynamicWeb/dynamicweb.py:4215
+#: DynamicWeb//dynamicweb.py:2575 DynamicWeb//dynamicweb.py:4221
 msgid "Show duplicates"
 msgstr "Zobraziť duplicity"
 
-#: DynamicWeb/dynamicweb.py:2571
+#: DynamicWeb//dynamicweb.py:2576
 msgid "Showing 0 to 0 of 0 entries"
 msgstr "Zobrazených 0 až 0 z 0 záznamov"
 
-#: DynamicWeb/dynamicweb.py:2572
+#: DynamicWeb//dynamicweb.py:2577
 msgid "Showing _START_ to _END_ of _TOTAL_ entries"
 msgstr "Zobrazených _START_ až _END_ z _TOTAL_ záznamov"
 
-#: DynamicWeb/dynamicweb.py:2573
+#: DynamicWeb//dynamicweb.py:2578
 msgid "Siblings"
 msgstr "Súrodenci"
 
-#: DynamicWeb/dynamicweb.py:2574
+#: DynamicWeb//dynamicweb.py:2579
 msgid "Sort by:"
 msgstr "Zoradiť podľa:"
 
-#: DynamicWeb/dynamicweb.py:2576
+#: DynamicWeb//dynamicweb.py:2581
 msgid "Sources Index"
 msgstr "Index zdrojov:"
 
-#: DynamicWeb/dynamicweb.py:2578
+#: DynamicWeb//dynamicweb.py:2583
 msgid "Spouses"
 msgstr "Partneri(ky)"
 
-#: DynamicWeb/dynamicweb.py:2579 DynamicWeb/dynamicweb.py:4114
+#: DynamicWeb//dynamicweb.py:2584 DynamicWeb//dynamicweb.py:4120
 msgid "Suppress Gramps ID"
 msgstr "Potlačiť Gramps ID"
 
-#: DynamicWeb/dynamicweb.py:2580
+#: DynamicWeb//dynamicweb.py:2585
 msgid "Surname"
 msgstr "Priezvisko"
 
-#: DynamicWeb/dynamicweb.py:2581
+#: DynamicWeb//dynamicweb.py:2586
 msgid "Surnames Index"
 msgstr "Index priezvisk"
 
-#: DynamicWeb/dynamicweb.py:2583
+#: DynamicWeb//dynamicweb.py:2588
 msgid "Title"
 msgstr "Titul"
 
-#: DynamicWeb/dynamicweb.py:2584
+#: DynamicWeb//dynamicweb.py:2589
 msgid "Type"
 msgstr "Typ"
 
-#: DynamicWeb/dynamicweb.py:2585
+#: DynamicWeb//dynamicweb.py:2590
 msgid "U"
 msgstr "N"
 
-#: DynamicWeb/dynamicweb.py:2586
+#: DynamicWeb//dynamicweb.py:2591
 msgid "Unknown"
 msgstr "Neznámý"
 
-#: DynamicWeb/dynamicweb.py:2587 DynamicWeb/dynamicweb.py:4102
+#: DynamicWeb//dynamicweb.py:2592 DynamicWeb//dynamicweb.py:4108
 msgid "Use tabbed panels instead of sections"
 msgstr "Použiť panely s tabmi namiesto sekcií"
 
-#: DynamicWeb/dynamicweb.py:2588
+#: DynamicWeb//dynamicweb.py:2593
 msgid "Use the search box above in order to find a person."
 msgstr "Použite vyhľadávanie vyššie k vyhľadaniu osoby."
 
-#: DynamicWeb/dynamicweb.py:2589
+#: DynamicWeb//dynamicweb.py:2594
 msgid "Use a table format for the surnames index"
 msgstr "Použiť tabuľkový formát v indexe priezvisk"
 
-#: DynamicWeb/dynamicweb.py:2590
+#: DynamicWeb//dynamicweb.py:2595
 msgid "Use a table format for the persons index"
 msgstr "Použiť tabuľkový formát v indexe osôb"
 
-#: DynamicWeb/dynamicweb.py:2591
+#: DynamicWeb//dynamicweb.py:2596
 msgid "Use a table format for the families index"
 msgstr "Použiť tabuľkový formát v indexe rodín"
 
-#: DynamicWeb/dynamicweb.py:2592
+#: DynamicWeb//dynamicweb.py:2597
 msgid "Use a table format for the sources index"
 msgstr "Použiť tabuľkový formát v indexe zdrojov"
 
-#: DynamicWeb/dynamicweb.py:2593
+#: DynamicWeb//dynamicweb.py:2598
 msgid "Use a table format for the places index"
 msgstr "Použiť tabuľkový formát v indexe miest"
 
-#: DynamicWeb/dynamicweb.py:2594
+#: DynamicWeb//dynamicweb.py:2599
 msgid "Used for family"
 msgstr "Použité pre rodinu"
 
-#: DynamicWeb/dynamicweb.py:2595
+#: DynamicWeb//dynamicweb.py:2600
 msgid "Used for media"
 msgstr "Použité pre média"
 
-#: DynamicWeb/dynamicweb.py:2596
+#: DynamicWeb//dynamicweb.py:2601
 msgid "Used for person"
 msgstr "Použité pre osobu"
 
-#: DynamicWeb/dynamicweb.py:2597
+#: DynamicWeb//dynamicweb.py:2602
 msgid "Used for place"
 msgstr "Použité pre miesto"
 
-#: DynamicWeb/dynamicweb.py:2598
+#: DynamicWeb//dynamicweb.py:2603
 msgid "Used for source"
 msgstr "Použité pre zdroj"
 
-#: DynamicWeb/dynamicweb.py:2599
+#: DynamicWeb//dynamicweb.py:2604
 msgid "Value"
 msgstr "Hodnota"
 
-#: DynamicWeb/dynamicweb.py:2600
+#: DynamicWeb//dynamicweb.py:2605
 msgid "Web Link"
 msgstr "Webový odkaz"
 
-#: DynamicWeb/dynamicweb.py:2601
+#: DynamicWeb//dynamicweb.py:2606
 msgid "Web Links"
 msgstr "Webové odkazy"
 
-#: DynamicWeb/dynamicweb.py:2602 DynamicWeb/dynamicweb.py:4216
+#: DynamicWeb//dynamicweb.py:2607 DynamicWeb//dynamicweb.py:4222
 msgid ""
 "Whether to use a special color for the persons that appear several times in "
 "the SVG tree"
 msgstr ""
 "Či použiť špeciálnu farbu pre osoby ktoré sa v SVG strome vyskytujú viac krát"
 
-#: DynamicWeb/dynamicweb.py:2603
+#: DynamicWeb//dynamicweb.py:2608
 msgid "Without name"
 msgstr "Bez mena"
 
-#: DynamicWeb/dynamicweb.py:2604
+#: DynamicWeb//dynamicweb.py:2609
 msgid "Without surname"
 msgstr "Bez priezviska"
 
-#: DynamicWeb/dynamicweb.py:2605
+#: DynamicWeb//dynamicweb.py:2610
 msgid "Without title"
 msgstr "Bez titulu"
 
-#: DynamicWeb/dynamicweb.py:2606
+#: DynamicWeb//dynamicweb.py:2611
 msgid "Zoom in"
 msgstr "Priblížiť"
 
-#: DynamicWeb/dynamicweb.py:2607
+#: DynamicWeb//dynamicweb.py:2612
 msgid "Zoom out"
 msgstr "Oddialiť"
 
-#: DynamicWeb/dynamicweb.py:2608
+#: DynamicWeb//dynamicweb.py:2613
 msgid "all"
 msgstr "všetky"
 
-#: DynamicWeb/dynamicweb.py:2811
+#: DynamicWeb//dynamicweb.py:2816
 msgid "No Home Person"
 msgstr "Žiadna hlavná osoba"
 
-#: DynamicWeb/dynamicweb.py:2952
+#: DynamicWeb//dynamicweb.py:2957
 #, python-format
 msgid "Copying error: %(error)s"
 msgstr "Chyba pri kopírování: %(error)s"
 
-#: DynamicWeb/dynamicweb.py:2953
+#: DynamicWeb//dynamicweb.py:2958
 #, python-format
 msgid "Impossible to copy \"%(src)s\" to \"%(dst)s\""
 msgstr "Nie je možné kopírovať \"%(src)s\" do \"%(dst)s\""
 
-#: DynamicWeb/dynamicweb.py:2956
+#: DynamicWeb//dynamicweb.py:2961
 msgid "Possible destination error"
 msgstr "Možná chyba cieľa"
 
-#: DynamicWeb/dynamicweb.py:2957
+#: DynamicWeb//dynamicweb.py:2962
 msgid ""
 "You appear to have set your target directory to a directory used for data "
 "storage. This could create problems with file management. It is recommended "
@@ -989,64 +989,64 @@ msgstr ""
 "spôsobiť problémy so správou súborov. Odporúča sa zváženie použitia iného "
 "adresára na uloženie vygenerovaných WWW stránok."
 
-#: DynamicWeb/dynamicweb.py:2984
+#: DynamicWeb//dynamicweb.py:2989
 #, python-format
 msgid "Unable to copy web site template files from \"%(path)s\""
 msgstr "Nie je možné kopírovať súbory šablóny WWW stránok z \"%(path)s\""
 
-#: DynamicWeb/dynamicweb.py:3028
+#: DynamicWeb//dynamicweb.py:3033
 #, python-format
 msgid "Keeping \"%(dst)s\" (newer than \"%(src)s\")"
 msgstr "Ponecháva sa \"%(dst)s\" (novší ako \"%(src)s\")"
 
-#: DynamicWeb/dynamicweb.py:3031
+#: DynamicWeb//dynamicweb.py:3036
 #, python-format
 msgid "Copying \"%(src)s\" to \"%(dst)s\""
 msgstr "Kopíruje sa \"%(src)s\" do \"%(dst)s\""
 
-#: DynamicWeb/dynamicweb.py:3049
+#: DynamicWeb//dynamicweb.py:3054
 msgid "Invalid file name"
 msgstr "Neplatný názov súboru"
 
-#: DynamicWeb/dynamicweb.py:3050
+#: DynamicWeb//dynamicweb.py:3055
 msgid "The archive file must be a file, not a directory"
 msgstr "Súbor archívu musí byť súbor, nie adresár"
 
-#: DynamicWeb/dynamicweb.py:3060 DynamicWeb/dynamicweb.py:3078
+#: DynamicWeb//dynamicweb.py:3065 DynamicWeb//dynamicweb.py:3083
 #, python-format
 msgid "Unable to overwrite archive file \"%(path)s\""
 msgstr "Nepodarilo sa prepísať súbor archívu \"%(path)s\""
 
-#: DynamicWeb/dynamicweb.py:3070 DynamicWeb/dynamicweb.py:3085
+#: DynamicWeb//dynamicweb.py:3075 DynamicWeb//dynamicweb.py:3090
 #, python-format
 msgid "Unable to add file \"%(file)s\" to archive \"%(archive)s\""
 msgstr "Nepodarilo sa pridať súbor \"%(file)s\" do archívu \"%(archive)s\""
 
-#: DynamicWeb/dynamicweb.py:3138
+#: DynamicWeb//dynamicweb.py:3143
 #, python-format
 msgid "DynamicWebReport ignoring link type '%(class)s'"
 msgstr "DynamicWebReport ignoruje odkaz typu '%(class)s'"
 
-#: DynamicWeb/dynamicweb.py:3381
+#: DynamicWeb//dynamicweb.py:3386
 msgid "Constructing list of other objects..."
 msgstr "Vytvára sa zoznam ostatných objektov..."
 
-#: DynamicWeb/dynamicweb.py:3516
+#: DynamicWeb//dynamicweb.py:3521
 #, python-format
 msgid "Family of %(husband)s and %(spouse)s"
 msgstr "Rodina patriaca %(husband)s a %(spouse)s"
 
-#: DynamicWeb/dynamicweb.py:3522
+#: DynamicWeb//dynamicweb.py:3527
 #, python-format
 msgid "Family of %(father)s"
 msgstr "Rodina patriaca %(father)s"
 
-#: DynamicWeb/dynamicweb.py:3526
+#: DynamicWeb//dynamicweb.py:3531
 #, python-format
 msgid "Family of %(mother)s"
 msgstr "Rodina patriaca %(mother)s"
 
-#: DynamicWeb/dynamicweb.py:3841
+#: DynamicWeb//dynamicweb.py:3846
 msgid ""
 "In this note, the following special words are processed:\n"
 "__SEARCH_FORM__ is replaced by a search form.\n"
@@ -1081,223 +1081,223 @@ msgstr ""
 "URL začínajúce na \"relative://relative.<link>\" sú nahradené relatívnou URL "
 "\"<link>\".\n"
 
-#: DynamicWeb/dynamicweb.py:3880
+#: DynamicWeb//dynamicweb.py:3886
 msgid "Report"
 msgstr "Výkaz"
 
-#: DynamicWeb/dynamicweb.py:3885
+#: DynamicWeb//dynamicweb.py:3891
 msgid "Destination"
 msgstr "Cieľ"
 
-#: DynamicWeb/dynamicweb.py:3887
+#: DynamicWeb//dynamicweb.py:3893
 msgid "The destination directory for the web files"
 msgstr "Cieľový adresár pre webové súbory"
 
-#: DynamicWeb/dynamicweb.py:3891
+#: DynamicWeb//dynamicweb.py:3897
 msgid "Store web pages in archive"
 msgstr "Uložiť webové súbory do archívu"
 
-#: DynamicWeb/dynamicweb.py:3892
+#: DynamicWeb//dynamicweb.py:3898
 msgid ""
 "Whether to create an archive file (in ZIP or TGZ format) containing the web "
 "site"
 msgstr "Či vytvoriť archív (v ZIP alebo TGZ formáte) obsahujúci web stránku"
 
-#: DynamicWeb/dynamicweb.py:3896
+#: DynamicWeb//dynamicweb.py:3902
 msgid "Archive file"
 msgstr "Súbor archívu"
 
-#: DynamicWeb/dynamicweb.py:3898
+#: DynamicWeb//dynamicweb.py:3904
 msgid "The archive file name (with \".zip\" or \".tgz\" extension)"
 msgstr "Názov súboru archívu (s \".zip\" alebo \".tgz\" príponou)"
 
-#: DynamicWeb/dynamicweb.py:3904
+#: DynamicWeb//dynamicweb.py:3910
 msgid "Web site title"
 msgstr "Nadpis web stránky"
 
-#: DynamicWeb/dynamicweb.py:3904
+#: DynamicWeb//dynamicweb.py:3910
 msgid "My Family Tree"
 msgstr "Môj rodokmeň"
 
-#: DynamicWeb/dynamicweb.py:3905
+#: DynamicWeb//dynamicweb.py:3911
 msgid "The title of the web site"
 msgstr "Nadpis web stránky"
 
-#: DynamicWeb/dynamicweb.py:3908
+#: DynamicWeb//dynamicweb.py:3914
 msgid "Filter"
 msgstr "Filter"
 
-#: DynamicWeb/dynamicweb.py:3910
+#: DynamicWeb//dynamicweb.py:3916
 msgid "Select filter to restrict people that appear on web site"
 msgstr "Zvoľte filter pre vymedzenie osôb zobrazených na web stránke"
 
-#: DynamicWeb/dynamicweb.py:3914
+#: DynamicWeb//dynamicweb.py:3920
 msgid "Filter Person"
 msgstr "Filtrovať osobu"
 
-#: DynamicWeb/dynamicweb.py:3915
+#: DynamicWeb//dynamicweb.py:3921
 msgid "The center person for the filter"
 msgstr "Hlavná osoba filtru"
 
-#: DynamicWeb/dynamicweb.py:3923 DynamicWeb/dynamicweb.py:3943
+#: DynamicWeb//dynamicweb.py:3929 DynamicWeb//dynamicweb.py:3949
 msgid "Name format (short)"
 msgstr "Formát mien (krátky)"
 
-#: DynamicWeb/dynamicweb.py:3924 DynamicWeb/dynamicweb.py:3946
+#: DynamicWeb//dynamicweb.py:3930 DynamicWeb//dynamicweb.py:3952
 msgid "Select the format to display a shorter version of the names"
 msgstr "Zvoľte formát zobrazenia krátkych verzií mien"
 
-#: DynamicWeb/dynamicweb.py:3938
+#: DynamicWeb//dynamicweb.py:3944
 msgid "Name format"
 msgstr "Formát mien"
 
-#: DynamicWeb/dynamicweb.py:3941
+#: DynamicWeb//dynamicweb.py:3947
 msgid "Select the format to display names"
 msgstr "Zvoľte formát zobrazenia mien"
 
-#: DynamicWeb/dynamicweb.py:3949
+#: DynamicWeb//dynamicweb.py:3955
 msgid "Web site template"
 msgstr "Šablóna web stránky"
 
-#: DynamicWeb/dynamicweb.py:3952
+#: DynamicWeb//dynamicweb.py:3958
 msgid "Select the template of the web site"
 msgstr "Zvoľte šablónu web stránky"
 
-#: DynamicWeb/dynamicweb.py:3955
+#: DynamicWeb//dynamicweb.py:3961
 msgid "Copyright"
 msgstr "Copyright"
 
-#: DynamicWeb/dynamicweb.py:3958
+#: DynamicWeb//dynamicweb.py:3964
 msgid "The copyright to be used for the web files"
 msgstr "Copyright ktorý bude použitý pre súbory web stránky"
 
-#: DynamicWeb/dynamicweb.py:3966
+#: DynamicWeb//dynamicweb.py:3972
 msgid "Privacy"
 msgstr "Súkromie"
 
-#: DynamicWeb/dynamicweb.py:3974
+#: DynamicWeb//dynamicweb.py:3980
 msgid "Include records marked private"
 msgstr "Zahrnúť záznamy označené ako súkromné"
 
-#: DynamicWeb/dynamicweb.py:3975
+#: DynamicWeb//dynamicweb.py:3981
 msgid "Whether to include private objects"
 msgstr "Či zahrnúť súkromné objekty"
 
-#: DynamicWeb/dynamicweb.py:3977
+#: DynamicWeb//dynamicweb.py:3983
 msgid "Living People"
 msgstr "Žijúci ľudia"
 
-#: DynamicWeb/dynamicweb.py:3978
+#: DynamicWeb//dynamicweb.py:3984
 msgid "Exclude"
 msgstr "Vynechať"
 
-#: DynamicWeb/dynamicweb.py:3979
+#: DynamicWeb//dynamicweb.py:3985
 msgid "Include Last Name Only"
 msgstr "Zahrnúť iba posledné meno"
 
-#: DynamicWeb/dynamicweb.py:3980
+#: DynamicWeb//dynamicweb.py:3986
 msgid "Include Full Name Only"
 msgstr "Zahrnúť iba celé meno"
 
-#: DynamicWeb/dynamicweb.py:3981
+#: DynamicWeb//dynamicweb.py:3987
 msgid "Include"
 msgstr "Zahrnúť"
 
-#: DynamicWeb/dynamicweb.py:3982
+#: DynamicWeb//dynamicweb.py:3988
 msgid "How to handle living people"
 msgstr "Ako spracovať žijúcich ľudí"
 
-#: DynamicWeb/dynamicweb.py:3985
+#: DynamicWeb//dynamicweb.py:3991
 msgid "Years from death to consider living"
 msgstr "Počet rokov od úmrtia, počas ktorých sa osoba považuje za živú"
 
-#: DynamicWeb/dynamicweb.py:3986
+#: DynamicWeb//dynamicweb.py:3992
 msgid ""
 "This allows you to restrict information on people who have not been dead for "
 "very long"
 msgstr "Toto umožňuje obmedziť informácie o nedávno zosnulých osobách"
 
-#: DynamicWeb/dynamicweb.py:3990
+#: DynamicWeb//dynamicweb.py:3996
 msgid "Export notes"
 msgstr "Exportovať poznámky"
 
-#: DynamicWeb/dynamicweb.py:3991
+#: DynamicWeb//dynamicweb.py:3997
 msgid "Whether to export notes in the web pages"
 msgstr "Či exportovať poznámky do web stránok"
 
-#: DynamicWeb/dynamicweb.py:3994
+#: DynamicWeb//dynamicweb.py:4000
 msgid "Export sources"
 msgstr "Exportovať zdroje"
 
-#: DynamicWeb/dynamicweb.py:3995
+#: DynamicWeb//dynamicweb.py:4001
 msgid "Whether to export sources and citations in the web pages"
 msgstr "Či exportovať zdroje a citácie do web stránok"
 
-#: DynamicWeb/dynamicweb.py:3998
+#: DynamicWeb//dynamicweb.py:4004
 msgid "Export addresses"
 msgstr "Exportovať adresy"
 
-#: DynamicWeb/dynamicweb.py:3999
+#: DynamicWeb//dynamicweb.py:4005
 msgid "Whether to export addresses in the web pages"
 msgstr "Či exportovať adresy do web stránok"
 
-#: DynamicWeb/dynamicweb.py:4004
+#: DynamicWeb//dynamicweb.py:4010
 msgid "Options"
 msgstr "Možnosti"
 
-#: DynamicWeb/dynamicweb.py:4007
+#: DynamicWeb//dynamicweb.py:4013
 msgid "Include repository pages"
 msgstr "Zahrnúť stránky archívov"
 
-#: DynamicWeb/dynamicweb.py:4008
+#: DynamicWeb//dynamicweb.py:4014
 msgid "Whether or not to include the Repository Pages."
 msgstr "Či zahrnúť stránky archívov alebo nie."
 
-#: DynamicWeb/dynamicweb.py:4011
+#: DynamicWeb//dynamicweb.py:4017
 msgid "Include images and media"
 msgstr "Zahrnúť obrázky a médiá"
 
-#: DynamicWeb/dynamicweb.py:4012
+#: DynamicWeb//dynamicweb.py:4018
 msgid "Whether to include images and media in the web pages"
 msgstr "Či zahrnúť obrázky a médiá vo web stránkách"
 
-#: DynamicWeb/dynamicweb.py:4016
+#: DynamicWeb//dynamicweb.py:4022
 msgid "Copy, rename files with an internal Gramps identifier"
 msgstr "Kopírovať, premenovať súbory s interným Gramps identifikátorom"
 
-#: DynamicWeb/dynamicweb.py:4017
+#: DynamicWeb//dynamicweb.py:4023
 msgid "Copy, keep file names unchanged"
 msgstr "Kopírovať, ponechať názvy súborov nezmenené"
 
-#: DynamicWeb/dynamicweb.py:4018
+#: DynamicWeb//dynamicweb.py:4024
 msgid "Do not copy, reference existing files"
 msgstr "Nekopírovať, odkázať na existujúce súbory"
 
-#: DynamicWeb/dynamicweb.py:4020
+#: DynamicWeb//dynamicweb.py:4026
 msgid "Images and media"
 msgstr "Obrázky a médiá"
 
-#: DynamicWeb/dynamicweb.py:4023
+#: DynamicWeb//dynamicweb.py:4029
 msgid "Whether to make a copy of the media"
 msgstr "Či vytvoriť kópiu médií"
 
-#: DynamicWeb/dynamicweb.py:4026
+#: DynamicWeb//dynamicweb.py:4032
 msgid "Print the notes type"
 msgstr "Zahrnúť typ poznámok"
 
-#: DynamicWeb/dynamicweb.py:4027
+#: DynamicWeb//dynamicweb.py:4033
 msgid "Whether to print the notes type in the notes text"
 msgstr "Či zahrnúť v poznámkach aj ich typ"
 
-#: DynamicWeb/dynamicweb.py:4030
+#: DynamicWeb//dynamicweb.py:4036
 msgid "Print place pages"
 msgstr "Zahrnúť stránky s miestami"
 
-#: DynamicWeb/dynamicweb.py:4031
+#: DynamicWeb//dynamicweb.py:4037
 msgid "Whether to show pages for the places"
 msgstr "Či zobraziť stránky s miestami"
 
-#: DynamicWeb/dynamicweb.py:4037
+#: DynamicWeb//dynamicweb.py:4043
 msgid ""
 "Whether to include a place map on the Place Pages, where Latitude/ Longitude "
 "are available."
@@ -1305,7 +1305,7 @@ msgstr ""
 "Či zahrnúť mapu miest na stránke s miestami spolu s ich zememepisnou šírkou "
 "a dĺžkou."
 
-#: DynamicWeb/dynamicweb.py:4045
+#: DynamicWeb//dynamicweb.py:4051
 msgid ""
 "Whether or not to add an individual page map showing all the places on this "
 "page. This will allow you to see how your family traveled around the country."
@@ -1313,163 +1313,163 @@ msgstr ""
 "Či pridať individuálnu mapu zobrazujúcu všetky miesta na tejto stránke. "
 "Umožní to zobraziť ako rodina cestovala po svete."
 
-#: DynamicWeb/dynamicweb.py:4053
+#: DynamicWeb//dynamicweb.py:4059
 msgid "Google"
 msgstr "Google"
 
-#: DynamicWeb/dynamicweb.py:4054
+#: DynamicWeb//dynamicweb.py:4060
 msgid "OpenStreetMap"
 msgstr "OpenStreetMap"
 
-#: DynamicWeb/dynamicweb.py:4056
+#: DynamicWeb//dynamicweb.py:4062
 msgid "Map Service"
 msgstr "Poskytovateľ máp"
 
-#: DynamicWeb/dynamicweb.py:4059
+#: DynamicWeb//dynamicweb.py:4065
 msgid "Choose your choice of map service for creating the Place Map Pages"
 msgstr "Vyberte si poskytovateľa máp pre vyvtvorenie stránky s miestami"
 
-#: DynamicWeb/dynamicweb.py:4063
+#: DynamicWeb//dynamicweb.py:4069
 msgid "Google map API key"
 msgstr "Google map API kľúč"
 
-#: DynamicWeb/dynamicweb.py:4064
+#: DynamicWeb//dynamicweb.py:4070
 msgid "The API key used for the Google map"
 msgstr "API kľúč používaný pre Google mapu"
 
-#: DynamicWeb/dynamicweb.py:4071
+#: DynamicWeb//dynamicweb.py:4077
 msgid "Advanced"
 msgstr "Pokročilé"
 
-#: DynamicWeb/dynamicweb.py:4074
+#: DynamicWeb//dynamicweb.py:4080
 msgid "Character set encoding"
 msgstr "Kódovanie znakov"
 
-#: DynamicWeb/dynamicweb.py:4077
+#: DynamicWeb//dynamicweb.py:4083
 msgid "The encoding to be used for the web files"
 msgstr "Kódovanie ktoré bude použité pre súbory web stránok"
 
-#: DynamicWeb/dynamicweb.py:4080
+#: DynamicWeb//dynamicweb.py:4086
 msgid "Include family pages"
 msgstr "Zahrnúť stránky rodín"
 
-#: DynamicWeb/dynamicweb.py:4081
+#: DynamicWeb//dynamicweb.py:4087
 msgid "Whether or not to include family pages"
 msgstr "Či zahrnúť stránky rodín alebo nie"
 
-#: DynamicWeb/dynamicweb.py:4091
+#: DynamicWeb//dynamicweb.py:4097
 msgid ""
 "Whether to include half and/ or step-siblings with the parents and siblings"
 msgstr "Či zahrnúť nevlastných súrodencov s rodičmi a súrodencami"
 
-#: DynamicWeb/dynamicweb.py:4094
+#: DynamicWeb//dynamicweb.py:4100
 msgid "Include GENDEX file (/gendex.txt)"
 msgstr "Zahrnúť GENDEX súbor (/gendex.txt)"
 
-#: DynamicWeb/dynamicweb.py:4095
+#: DynamicWeb//dynamicweb.py:4101
 msgid "Whether to include a GENDEX file or not"
 msgstr "Či zahrnúť GENDEX súbor alebo nie"
 
-#: DynamicWeb/dynamicweb.py:4098
+#: DynamicWeb//dynamicweb.py:4104
 msgid "Enable page configuration"
 msgstr "Povoliť prispôsobenie stránky"
 
-#: DynamicWeb/dynamicweb.py:4099
+#: DynamicWeb//dynamicweb.py:4105
 msgid "Whether to enable page configuration"
 msgstr "Či povoliť prispôsobenie stránky"
 
-#: DynamicWeb/dynamicweb.py:4103
+#: DynamicWeb//dynamicweb.py:4109
 msgid "Whether to use tabbed panels for the different sections of the pages."
 msgstr "Či použiť panely s tabmi pre rôzne sekcie stránok"
 
-#: DynamicWeb/dynamicweb.py:4107
+#: DynamicWeb//dynamicweb.py:4113
 msgid "Whether to show the last modification time in the pages footer"
 msgstr "Či zobraziť čas poslednej úpravy v pätičke súboru"
 
-#: DynamicWeb/dynamicweb.py:4111
+#: DynamicWeb//dynamicweb.py:4117
 msgid "Whether to insert sources author in the sources title"
 msgstr "Či uviesť autora zdrojov v nadpise zdrojov"
 
-#: DynamicWeb/dynamicweb.py:4115
+#: DynamicWeb//dynamicweb.py:4121
 msgid "Whether to hide the Gramps ID"
 msgstr "Či skryť Gramps ID"
 
-#: DynamicWeb/dynamicweb.py:4124
+#: DynamicWeb//dynamicweb.py:4130
 msgid "List"
 msgstr "Zoznam"
 
-#: DynamicWeb/dynamicweb.py:4125
+#: DynamicWeb//dynamicweb.py:4131
 msgid "Table"
 msgstr "Tabuľka"
 
-#: DynamicWeb/dynamicweb.py:4128
+#: DynamicWeb//dynamicweb.py:4134
 msgid "Default format for the surnames index"
 msgstr "Základný formát pre index priezvisk"
 
-#: DynamicWeb/dynamicweb.py:4128
+#: DynamicWeb//dynamicweb.py:4134
 msgid "The default format for the surnames index"
 msgstr "Základný formát pre index priezvisk"
 
-#: DynamicWeb/dynamicweb.py:4129
+#: DynamicWeb//dynamicweb.py:4135
 msgid "Default format for the persons index"
 msgstr "Základný formát pre index osôb"
 
-#: DynamicWeb/dynamicweb.py:4129
+#: DynamicWeb//dynamicweb.py:4135
 msgid "The default format for the persons index"
 msgstr "Základný formát pre index osôb"
 
-#: DynamicWeb/dynamicweb.py:4130
+#: DynamicWeb//dynamicweb.py:4136
 msgid "Default format for the families index"
 msgstr "Základný formát pre index rodín"
 
-#: DynamicWeb/dynamicweb.py:4130
+#: DynamicWeb//dynamicweb.py:4136
 msgid "The default format for the families index"
 msgstr "Základný formát pre index rodín"
 
-#: DynamicWeb/dynamicweb.py:4131
+#: DynamicWeb//dynamicweb.py:4137
 msgid "Default format for the sources index"
 msgstr "Základný formát pre index zdrojov"
 
-#: DynamicWeb/dynamicweb.py:4131
+#: DynamicWeb//dynamicweb.py:4137
 msgid "The default format for the sources index"
 msgstr "Základný formát pre index zdrojov"
 
-#: DynamicWeb/dynamicweb.py:4132
+#: DynamicWeb//dynamicweb.py:4138
 msgid "Default format for the places index"
 msgstr "Základný formát pre index miest"
 
-#: DynamicWeb/dynamicweb.py:4132
+#: DynamicWeb//dynamicweb.py:4138
 msgid "The default format for the places index"
 msgstr "Základný formát pre index miest"
 
-#: DynamicWeb/dynamicweb.py:4141
+#: DynamicWeb//dynamicweb.py:4147
 msgid ""
 "Whether to include dates columns (birth, death, marriage) on the index pages"
 msgstr ""
 "Či zahrnúť stĺpec s dátumami (narodenie, smrť, manželstvo) na indexových "
 "stránkach"
 
-#: DynamicWeb/dynamicweb.py:4145
+#: DynamicWeb//dynamicweb.py:4151
 msgid "Whether to include a partners column"
 msgstr "Či zahrnúť stĺpec s partnerom"
 
-#: DynamicWeb/dynamicweb.py:4149
+#: DynamicWeb//dynamicweb.py:4155
 msgid "Whether to include a parents column"
 msgstr "Či zahrnúť stĺpec s rodičmi"
 
-#: DynamicWeb/dynamicweb.py:4152
+#: DynamicWeb//dynamicweb.py:4158
 msgid "Generate a families index page"
 msgstr "Generovať indexovú stránku rodín"
 
-#: DynamicWeb/dynamicweb.py:4153
+#: DynamicWeb//dynamicweb.py:4159
 msgid "Whether to generate an index page for families"
 msgstr "Či generovať indexovú stránku rodín"
 
-#: DynamicWeb/dynamicweb.py:4157
+#: DynamicWeb//dynamicweb.py:4163
 msgid "Whether to include a column showing the media path"
 msgstr "Či zahrnúť stĺpec s cestou k médiu"
 
-#: DynamicWeb/dynamicweb.py:4161
+#: DynamicWeb//dynamicweb.py:4167
 msgid ""
 "Whether to include the references to the items in the index pages. For "
 "example, in the media index page, the names of the individuals, families, "
@@ -1479,140 +1479,143 @@ msgstr ""
 "indexovej stránke medií mená osôb, rodín, miest, zdrojov ktoré odkazujú na "
 "médiá."
 
-#: DynamicWeb/dynamicweb.py:4164
+#: DynamicWeb//dynamicweb.py:4170
 msgid "Default number of entries in the indexes"
 msgstr "Základný počet záznamov v indexoch"
 
-#: DynamicWeb/dynamicweb.py:4167
+#: DynamicWeb//dynamicweb.py:4173
 msgid "The default number of entries shown in one index page"
 msgstr "Základný počet záznamov zobrazených na jednej indexovej stránke"
 
-#: DynamicWeb/dynamicweb.py:4172
+#: DynamicWeb//dynamicweb.py:4178
 msgid "Trees"
 msgstr "Stromy"
 
-#: DynamicWeb/dynamicweb.py:4175
+#: DynamicWeb//dynamicweb.py:4181
 msgid "Maximum number of generations"
 msgstr "Maximálny počet generácií"
 
-#: DynamicWeb/dynamicweb.py:4176
+#: DynamicWeb//dynamicweb.py:4182
 msgid ""
 "The maximum number of generations to include in the ancestor and descendant "
 "trees and graphs"
 msgstr ""
 "Maximálny počet generácií zahrnutých v stromoch a grafoch predkov a potomkov"
 
-#: DynamicWeb/dynamicweb.py:4182
+#: DynamicWeb//dynamicweb.py:4188
 msgid "Choose the default SVG tree graph type"
 msgstr "Zvoľte základný typ grafu pre SVG strom"
 
-#: DynamicWeb/dynamicweb.py:4188
+#: DynamicWeb//dynamicweb.py:4194
 msgid "Choose the default SVG tree graph shape"
 msgstr "Zvoľte základný tvar grafu pre SVG strom"
 
-#: DynamicWeb/dynamicweb.py:4194
+#: DynamicWeb//dynamicweb.py:4200
 msgid "Choose the default SVG tree parents distribution (for fan charts only)"
 msgstr ""
 "Zvoľte základné rozdelenie rodičov v SVG strome (len pre vejárové grafy)"
 
-#: DynamicWeb/dynamicweb.py:4200
+#: DynamicWeb//dynamicweb.py:4206
 msgid "Choose the default SVG tree children distribution (for fan charts only)"
 msgstr "Zvoľte základné rozdelenie detí v SVG strome (len pre vejárové grafy)"
 
-#: DynamicWeb/dynamicweb.py:4206
+#: DynamicWeb//dynamicweb.py:4212
 msgid ""
 "Choose the background color scheme for the persons in the SVG tree graph"
 msgstr "Zvoľte schému farby pozadia pre osoby v grafe SVG stromu"
 
-#: DynamicWeb/dynamicweb.py:4209
+#: DynamicWeb//dynamicweb.py:4215
 msgid "Start gradient/Main color"
 msgstr "Štart prechodu/Hlavná farba"
 
-#: DynamicWeb/dynamicweb.py:4212
+#: DynamicWeb//dynamicweb.py:4218
 msgid "End gradient/2nd color"
 msgstr "Koniec prechodu/Sekundárna farba"
 
-#: DynamicWeb/dynamicweb.py:4220
+#: DynamicWeb//dynamicweb.py:4226
 msgid "Color for duplicates"
 msgstr "Farba pre duplicity"
 
-#: DynamicWeb/dynamicweb.py:4225
+#: DynamicWeb//dynamicweb.py:4231
 msgid "Pages"
 msgstr "Stránky"
 
-#: DynamicWeb/dynamicweb.py:4228
+#: DynamicWeb//dynamicweb.py:4234
 msgid "HTML user header"
 msgstr "HTML úžívateľská hlavička"
 
-#: DynamicWeb/dynamicweb.py:4229
+#: DynamicWeb//dynamicweb.py:4235
 msgid "A note to be used as the page header"
 msgstr "Poznámka ktorá sa zobrazí v hlavičke stránky"
 
-#: DynamicWeb/dynamicweb.py:4232
+#: DynamicWeb//dynamicweb.py:4238
 msgid "HTML user brand name / icon"
 msgstr "HTML užívateľský značka / ikona"
 
-#: DynamicWeb/dynamicweb.py:4233
+#: DynamicWeb//dynamicweb.py:4239
 msgid "A note to be used as the brand name or image in the menu"
 msgstr "Poznámka ktorá bude použitá ako značka alebo obrázok v menu"
 
-#: DynamicWeb/dynamicweb.py:4236
+#: DynamicWeb//dynamicweb.py:4242
 msgid "HTML user footer"
 msgstr "HTML užívateľská pätička"
 
-#: DynamicWeb/dynamicweb.py:4237
+#: DynamicWeb//dynamicweb.py:4243
 msgid "A note to be used as the page footer"
 msgstr "Poznámka ktorá sa zobrazí v pätičke stránky"
 
-#: DynamicWeb/dynamicweb.py:4242
+#: DynamicWeb//dynamicweb.py:4248
 msgid "Custom pages"
 msgstr "Vlastné stránky"
 
-#: DynamicWeb/dynamicweb.py:4246
+#: DynamicWeb//dynamicweb.py:4252
 #, python-format
 msgid "Title for the custom page %(index)i"
 msgstr "Nadpis pre vlastnú stránku %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4247
+#: DynamicWeb//dynamicweb.py:4253
 #, python-format
 msgid "Name for the custom page %(index)i"
 msgstr "Názov pre vlastnú stránku %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4250
+#: DynamicWeb//dynamicweb.py:4256
 #, python-format
 msgid "Note for custom page %(index)i"
 msgstr "Poznámka pre vlastnú stránku %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4251
+#: DynamicWeb//dynamicweb.py:4257
 msgid "A note to be used for the custom page content.\n"
 msgstr "Poznámka ktorá sa použije v obsahu vlastnej stránky.\n"
 
-#: DynamicWeb/dynamicweb.py:4254
+#: DynamicWeb//dynamicweb.py:4260
 #, python-format
 msgid "Menu for the custom page %(index)i"
 msgstr "Menu pre vlastnú stránku %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4255
+#: DynamicWeb//dynamicweb.py:4261
 msgid "Whether to print a menu for the custom page"
 msgstr "Či zahrnúť menu pre vlastnú stránku"
 
-#: DynamicWeb/dynamicweb.py:4260
+#: DynamicWeb//dynamicweb.py:4266
 msgid "Pages selection"
 msgstr "Výber stránky"
 
-#: DynamicWeb/dynamicweb.py:4263
+#: DynamicWeb//dynamicweb.py:4269
 msgid "Number of pages"
 msgstr "Počet stránok"
 
-#: DynamicWeb/dynamicweb.py:4264
+#: DynamicWeb//dynamicweb.py:4270
 msgid "Number pages in the web site menu."
 msgstr "Očíslovať stránky v menu"
 
-#: DynamicWeb/dynamicweb.py:4280
+#: DynamicWeb//dynamicweb.py:4286
 #, python-format
 msgid "Contents of page %(index)i"
 msgstr "Obsah stránky %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4283
+#: DynamicWeb//dynamicweb.py:4289
 msgid "Contents of the page"
 msgstr "Obsah stránky"
+
+#~ msgid "Html|Home"
+#~ msgstr "Domov"

--- a/DynamicWeb/po/sv-local.po
+++ b/DynamicWeb/po/sv-local.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: sv\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-04-22 11:04-0500\n"
+"POT-Creation-Date: 2020-07-24 17:33+0200\n"
 "PO-Revision-Date: 2020-06-22 22:10+0200\n"
 "Last-Translator: Pär Ekholm <pehlm@pekholm.se>\n"
 "Language-Team: \n"
@@ -18,1016 +18,1034 @@ msgstr ""
 "X-Generator: Poedit 2.0.6\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: DynamicWeb/dynamicweb.gpr.py:15
+#: DynamicWeb//dynamicweb.gpr.py:15
 msgid "Dynamic Web Report"
 msgstr "Dynamisk Webbsidesrapport"
 
-#: DynamicWeb/dynamicweb.gpr.py:16
+#: DynamicWeb//dynamicweb.gpr.py:16
 msgid "Produces dynamic web pages for the database"
 msgstr "Skapar dynamiska webbidor för databasen"
 
-#: DynamicWeb/dynamicweb.py:265
+#: DynamicWeb//dynamicweb.py:269
 msgid "Street"
 msgstr "Gata"
 
-#: DynamicWeb/dynamicweb.py:266
+#: DynamicWeb//dynamicweb.py:270
 msgid "Locality"
 msgstr "Lokalisering"
 
-#: DynamicWeb/dynamicweb.py:267
+#: DynamicWeb//dynamicweb.py:271
 msgid "City"
 msgstr "Stad"
 
-#: DynamicWeb/dynamicweb.py:268
+#: DynamicWeb//dynamicweb.py:272
 msgid "Church Parish"
 msgstr "Församling"
 
-#: DynamicWeb/dynamicweb.py:269
+#: DynamicWeb//dynamicweb.py:273
 msgid "County"
 msgstr "Län"
 
-#: DynamicWeb/dynamicweb.py:270
+#: DynamicWeb//dynamicweb.py:274
 msgid "State/ Province"
 msgstr "Delstat"
 
-#: DynamicWeb/dynamicweb.py:271
+#: DynamicWeb//dynamicweb.py:275
 msgid "Postal Code"
 msgstr "Postnummer"
 
-#: DynamicWeb/dynamicweb.py:272
+#: DynamicWeb//dynamicweb.py:276
 msgid "Country"
 msgstr "Land"
 
-#: DynamicWeb/dynamicweb.py:273
+#: DynamicWeb//dynamicweb.py:277
 msgid "Phone"
 msgstr "Telefon"
 
-#: DynamicWeb/dynamicweb.py:279
+#: DynamicWeb//dynamicweb.py:283
 msgid "Home Page"
 msgstr "Hemsida"
 
-#: DynamicWeb/dynamicweb.py:280
+#: DynamicWeb//dynamicweb.py:284
 msgid "SVG graphical tree"
 msgstr "Grafiskt SVG-träd"
 
-#: DynamicWeb/dynamicweb.py:283
+#: DynamicWeb//dynamicweb.py:287
 msgid "Indexes pages"
 msgstr "Indexerar sidor"
 
-#: DynamicWeb/dynamicweb.py:287 DynamicWeb/dynamicweb.py:4248
+#: DynamicWeb//dynamicweb.py:291 DynamicWeb//dynamicweb.py:4252
 #, python-format
 msgid "Custom page %(index)i"
 msgstr "Anpassad sida %(index)i"
 
-#: DynamicWeb/dynamicweb.py:305
+#: DynamicWeb//dynamicweb.py:309
 msgid "Ascending tree"
 msgstr "Stigande träd"
 
-#: DynamicWeb/dynamicweb.py:306
+#: DynamicWeb//dynamicweb.py:310
 msgid "Descending tree"
 msgstr "Sjunkande träd"
 
-#: DynamicWeb/dynamicweb.py:307
+#: DynamicWeb//dynamicweb.py:311
 msgid "Descending tree with spouses"
 msgstr "Sjunkande träd med makar"
 
-#: DynamicWeb/dynamicweb.py:308
+#: DynamicWeb//dynamicweb.py:312
 msgid "Ascending and descending tree"
 msgstr "Stigande och sjunkande träd"
 
-#: DynamicWeb/dynamicweb.py:309
+#: DynamicWeb//dynamicweb.py:313
 msgid "Ascending and descending tree with spouses"
 msgstr "Stigande och sjunkande träd med makar"
 
-#: DynamicWeb/dynamicweb.py:321
+#: DynamicWeb//dynamicweb.py:325
 msgid "Vertical (↓)"
 msgstr "Vertikal (↓)"
 
-#: DynamicWeb/dynamicweb.py:322
+#: DynamicWeb//dynamicweb.py:326
 msgid "Vertical (↑)"
 msgstr "Vertikal (↑)"
 
-#: DynamicWeb/dynamicweb.py:323
+#: DynamicWeb//dynamicweb.py:327
 msgid "Horizontal (→)"
 msgstr "Horisontell (→)"
 
-#: DynamicWeb/dynamicweb.py:324
+#: DynamicWeb//dynamicweb.py:328
 msgid "Horizontal (←)"
 msgstr "Horisontell (←)"
 
-#: DynamicWeb/dynamicweb.py:325
+#: DynamicWeb//dynamicweb.py:329
 msgid "Full Circle"
 msgstr "Helcirkel"
 
-#: DynamicWeb/dynamicweb.py:326
+#: DynamicWeb//dynamicweb.py:330
 msgid "Half Circle"
 msgstr "Halvcirkel"
 
-#: DynamicWeb/dynamicweb.py:327
+#: DynamicWeb//dynamicweb.py:331
 msgid "Quadrant"
 msgstr "Kvartscirkel"
 
-#: DynamicWeb/dynamicweb.py:339
+#: DynamicWeb//dynamicweb.py:343
 msgid "Size proportional to number of ancestors"
 msgstr "Storleken proportionell till antalet förfäder"
 
-#: DynamicWeb/dynamicweb.py:340
+#: DynamicWeb//dynamicweb.py:344
 msgid "Homogeneous parents distribution"
 msgstr "Jämn fördelning av föräldrar"
 
-#: DynamicWeb/dynamicweb.py:343
+#: DynamicWeb//dynamicweb.py:347
 msgid "Size proportional to number of descendants"
 msgstr "Storleken proportionell till antalet ättlingar"
 
-#: DynamicWeb/dynamicweb.py:344
+#: DynamicWeb//dynamicweb.py:348
 msgid "Homogeneous children distribution"
 msgstr "Jämn fördelning av barn"
 
-#: DynamicWeb/dynamicweb.py:351 DynamicWeb/dynamicweb.py:374
+#: DynamicWeb//dynamicweb.py:355 DynamicWeb//dynamicweb.py:378
 msgid "Gender colors"
 msgstr "Färg för kön"
 
-#: DynamicWeb/dynamicweb.py:352
+#: DynamicWeb//dynamicweb.py:356
 msgid "Generation based gradient"
 msgstr "Generationsrelaterad gradient"
 
-#: DynamicWeb/dynamicweb.py:353
+#: DynamicWeb//dynamicweb.py:357
 msgid "Age based gradient"
 msgstr "Gradient baserad på ålder"
 
-#: DynamicWeb/dynamicweb.py:354 DynamicWeb/dynamicweb.py:373
+#: DynamicWeb//dynamicweb.py:358 DynamicWeb//dynamicweb.py:377
 msgid "Single main (filter) color"
 msgstr "Enhetlig huvud (filter) färg"
 
-#: DynamicWeb/dynamicweb.py:355
+#: DynamicWeb//dynamicweb.py:359
 msgid "Time period based gradient"
 msgstr "Tidsperiodsrelaterad gradient"
 
-#: DynamicWeb/dynamicweb.py:356 DynamicWeb/dynamicweb.py:378
+#: DynamicWeb//dynamicweb.py:360 DynamicWeb//dynamicweb.py:382
 msgid "White"
 msgstr "Vit"
 
-#: DynamicWeb/dynamicweb.py:357 DynamicWeb/dynamicweb.py:376
+#: DynamicWeb//dynamicweb.py:361 DynamicWeb//dynamicweb.py:380
 msgid "Color scheme classic report"
 msgstr "Färgschema enligt klassisk rapport"
 
-#: DynamicWeb/dynamicweb.py:358 DynamicWeb/dynamicweb.py:377
+#: DynamicWeb//dynamicweb.py:362 DynamicWeb//dynamicweb.py:381
 msgid "Color scheme classic view"
 msgstr "Färgschema enligt klassisk vy"
 
-#: DynamicWeb/dynamicweb.py:375
+#: DynamicWeb//dynamicweb.py:379
 msgid "Gradient"
 msgstr "Gradient"
 
-#: DynamicWeb/dynamicweb.py:394
+#: DynamicWeb//dynamicweb.py:398
 msgid "Default"
 msgstr "Standard"
 
-#: DynamicWeb/dynamicweb.py:395
+#: DynamicWeb//dynamicweb.py:399
 msgid "Mainz"
 msgstr "Mainz"
 
-#: DynamicWeb/dynamicweb.py:703
+#: DynamicWeb//dynamicweb.py:707
 #, python-format
 msgid "Neither %(current)s nor %(parent)s are directories"
 msgstr "Varken %(current)s eller %(parent)s är kataloger"
 
-#: DynamicWeb/dynamicweb.py:711 DynamicWeb/dynamicweb.py:716
+#: DynamicWeb//dynamicweb.py:715 DynamicWeb//dynamicweb.py:720
 #, python-format
 msgid "Could not create the directory: %(path)s"
 msgstr "Kunde inte skapa katalogen: %(path)s"
 
-#: DynamicWeb/dynamicweb.py:742 DynamicWeb/dynamicweb.py:3381
+#: DynamicWeb//dynamicweb.py:746 DynamicWeb//dynamicweb.py:3385
 msgid "Dynamic Web Site Report"
 msgstr "Dynamisk webbsidesrapport"
 
-#: DynamicWeb/dynamicweb.py:742
+#: DynamicWeb//dynamicweb.py:746
 msgid "Exporting family tree data ..."
 msgstr "Exporterar familjeträdsdata ..."
 
-#: DynamicWeb/dynamicweb.py:1233 DynamicWeb/dynamicweb.py:2457
+#: DynamicWeb//dynamicweb.py:1237 DynamicWeb//dynamicweb.py:2461
 msgid "Author"
 msgstr "Författare"
 
-#: DynamicWeb/dynamicweb.py:1234 DynamicWeb/dynamicweb.py:2447
+#: DynamicWeb//dynamicweb.py:1238 DynamicWeb//dynamicweb.py:2451
 msgid "Abbreviation"
 msgstr "Förkortning"
 
-#: DynamicWeb/dynamicweb.py:1235 DynamicWeb/dynamicweb.py:2544
+#: DynamicWeb//dynamicweb.py:1239 DynamicWeb//dynamicweb.py:2548
 msgid "Publication information"
 msgstr "Publiceringsinformation "
 
-#: DynamicWeb/dynamicweb.py:1305 DynamicWeb/dynamicweb.py:2475
+#: DynamicWeb//dynamicweb.py:1309 DynamicWeb//dynamicweb.py:2479
 msgid "Date"
 msgstr "Datum"
 
-#: DynamicWeb/dynamicweb.py:1306
+#: DynamicWeb//dynamicweb.py:1310
 msgid "Page"
 msgstr "Sida"
 
-#: DynamicWeb/dynamicweb.py:1307
+#: DynamicWeb//dynamicweb.py:1311
 msgid "Confidence"
 msgstr "Tillförlitlighet"
 
-#: DynamicWeb/dynamicweb.py:1626
+#: DynamicWeb//dynamicweb.py:1630
 #, python-format
 msgid "%(type)s: %(value)s"
 msgstr "%(type)s: %(value)s"
 
-#: DynamicWeb/dynamicweb.py:1873
+#: DynamicWeb//dynamicweb.py:1877
 #, python-format
 msgid "Impossible to convert \"%(path)s\" to a relative path."
 msgstr "Omöjligt att konvertera \"%(path)s\" till en relativ sökväg."
 
-#: DynamicWeb/dynamicweb.py:2179
-msgid "The pages configuration is not valid: several pages have the same content"
+#: DynamicWeb//dynamicweb.py:2183
+msgid ""
+"The pages configuration is not valid: several pages have the same content"
 msgstr "Sidkonfigurationen är inte giltig: flera sidor har samma innehåll"
 
-#: DynamicWeb/dynamicweb.py:2190
-msgid "Html|Home"
-msgstr "Html|Hem"
+#: DynamicWeb//dynamicweb.py:2194
+msgid "DynWeb|Home"
+msgstr "Hem"
 
-#: DynamicWeb/dynamicweb.py:2191 DynamicWeb/dynamicweb.py:2204
-#: DynamicWeb/dynamicweb.py:2205 DynamicWeb/dynamicweb.py:2206
+#: DynamicWeb//dynamicweb.py:2195 DynamicWeb//dynamicweb.py:2208
+#: DynamicWeb//dynamicweb.py:2209 DynamicWeb//dynamicweb.py:2210
 msgid "Tree"
 msgstr "Träd"
 
-#: DynamicWeb/dynamicweb.py:2192 DynamicWeb/dynamicweb.py:2207
-#: DynamicWeb/dynamicweb.py:2208 DynamicWeb/dynamicweb.py:2209
+#: DynamicWeb//dynamicweb.py:2196 DynamicWeb//dynamicweb.py:2211
+#: DynamicWeb//dynamicweb.py:2212 DynamicWeb//dynamicweb.py:2213
 msgid "Statistics"
 msgstr "Statistik"
 
-#: DynamicWeb/dynamicweb.py:2195 DynamicWeb/dynamicweb.py:2471
+#: DynamicWeb//dynamicweb.py:2199 DynamicWeb//dynamicweb.py:2475
 msgid "Configuration"
 msgstr "Konfiguration"
 
-#: DynamicWeb/dynamicweb.py:2197 DynamicWeb/dynamicweb.py:2536
+#: DynamicWeb//dynamicweb.py:2201 DynamicWeb//dynamicweb.py:2540
 msgid "Person"
 msgstr "Person"
 
-#: DynamicWeb/dynamicweb.py:2198
+#: DynamicWeb//dynamicweb.py:2202
 msgid "Family"
 msgstr "Familj"
 
-#: DynamicWeb/dynamicweb.py:2199 DynamicWeb/dynamicweb.py:2576
+#: DynamicWeb//dynamicweb.py:2203 DynamicWeb//dynamicweb.py:2580
 msgid "Source"
 msgstr "Källa"
 
-#: DynamicWeb/dynamicweb.py:2200 DynamicWeb/dynamicweb.py:2219
-#: DynamicWeb/dynamicweb.py:2519
+#: DynamicWeb//dynamicweb.py:2204 DynamicWeb//dynamicweb.py:2223
+#: DynamicWeb//dynamicweb.py:2523
 msgid "Media"
 msgstr "Media"
 
-#: DynamicWeb/dynamicweb.py:2201 DynamicWeb/dynamicweb.py:2539
+#: DynamicWeb//dynamicweb.py:2205 DynamicWeb//dynamicweb.py:2543
 msgid "Place"
 msgstr "Plats"
 
-#: DynamicWeb/dynamicweb.py:2202 DynamicWeb/dynamicweb.py:2551
+#: DynamicWeb//dynamicweb.py:2206 DynamicWeb//dynamicweb.py:2555
 msgid "Repository"
 msgstr "Arkivplats"
 
-#: DynamicWeb/dynamicweb.py:2203
+#: DynamicWeb//dynamicweb.py:2207
 msgid "Search results"
 msgstr "Sökresultat"
 
-#: DynamicWeb/dynamicweb.py:2214 DynamicWeb/dynamicweb.py:2215
-#: DynamicWeb/dynamicweb.py:2583
+#: DynamicWeb//dynamicweb.py:2218 DynamicWeb//dynamicweb.py:2219
+#: DynamicWeb//dynamicweb.py:2587
 msgid "Surnames"
 msgstr "Efternamn"
 
-#: DynamicWeb/dynamicweb.py:2216 DynamicWeb/dynamicweb.py:2504
+#: DynamicWeb//dynamicweb.py:2220 DynamicWeb//dynamicweb.py:2508
 msgid "Individuals"
 msgstr "Personer"
 
-#: DynamicWeb/dynamicweb.py:2217 DynamicWeb/dynamicweb.py:2487
+#: DynamicWeb//dynamicweb.py:2221 DynamicWeb//dynamicweb.py:2491
 msgid "Families"
 msgstr "Familjer"
 
-#: DynamicWeb/dynamicweb.py:2218 DynamicWeb/dynamicweb.py:2578
+#: DynamicWeb//dynamicweb.py:2222 DynamicWeb//dynamicweb.py:2582
 msgid "Sources"
 msgstr "Källor"
 
-#: DynamicWeb/dynamicweb.py:2220 DynamicWeb/dynamicweb.py:2541
+#: DynamicWeb//dynamicweb.py:2224 DynamicWeb//dynamicweb.py:2545
 msgid "Places"
 msgstr "Orter"
 
-#: DynamicWeb/dynamicweb.py:2221 DynamicWeb/dynamicweb.py:2449
+#: DynamicWeb//dynamicweb.py:2225 DynamicWeb//dynamicweb.py:2453
 msgid "Addresses"
 msgstr "Adresser"
 
-#: DynamicWeb/dynamicweb.py:2222 DynamicWeb/dynamicweb.py:2550
+#: DynamicWeb//dynamicweb.py:2226 DynamicWeb//dynamicweb.py:2554
 msgid "Repositories"
 msgstr "Arkivplatser"
 
-#: DynamicWeb/dynamicweb.py:2273 DynamicWeb/dynamicweb.py:2503
-#: DynamicWeb/dynamicweb.py:4122
+#: DynamicWeb//dynamicweb.py:2277 DynamicWeb//dynamicweb.py:2507
+#: DynamicWeb//dynamicweb.py:4126
 msgid "Indexes"
 msgstr "Index"
 
-#: DynamicWeb/dynamicweb.py:2437
+#: DynamicWeb//dynamicweb.py:2441
 #, python-format
 msgid "(b. %(birthdate)s, d. %(deathdate)s)"
 msgstr "(f. %(birthdate)s, d. %(deathdate)s)"
 
-#: DynamicWeb/dynamicweb.py:2438
+#: DynamicWeb//dynamicweb.py:2442
 #, python-format
 msgid "(b. %s)"
 msgstr "(f. %s)"
 
-#: DynamicWeb/dynamicweb.py:2439
+#: DynamicWeb//dynamicweb.py:2443
 #, python-format
 msgid "(d. %s)"
 msgstr "(d. %s)"
 
-#: DynamicWeb/dynamicweb.py:2440
+#: DynamicWeb//dynamicweb.py:2444
 msgid "(filtered from _MAX_ total entries)"
 msgstr "(filtrerad från _MAX_ totala inmatningar)"
 
-#: DynamicWeb/dynamicweb.py:2441
+#: DynamicWeb//dynamicweb.py:2445
 #, python-format
 msgid "(m. %s)"
 msgstr "(g. %s)"
 
-#: DynamicWeb/dynamicweb.py:2442
+#: DynamicWeb//dynamicweb.py:2446
 msgid "(sort by name)"
 msgstr "(sortera efter namn)"
 
-#: DynamicWeb/dynamicweb.py:2443
+#: DynamicWeb//dynamicweb.py:2447
 msgid "(sort by quantity)"
 msgstr "(sortera efter kvantitet)"
 
-#: DynamicWeb/dynamicweb.py:2444
+#: DynamicWeb//dynamicweb.py:2448
 msgid ": activate to sort column ascending"
 msgstr ": aktivera för att sortera kolumnen stigande"
 
-#: DynamicWeb/dynamicweb.py:2445
+#: DynamicWeb//dynamicweb.py:2449
 msgid ": activate to sort column descending"
 msgstr ": aktivera för att sortera kolumnen sjunkande"
 
-#: DynamicWeb/dynamicweb.py:2446
-msgid "<p>This page provides the SVG raw code.<br>Copy the contents into a text editor and save as an SVG file.<br>Make sure that the text editor encoding is UTF-8.</p>"
-msgstr "<p>Den här sidan innehåller SVG råkod.<br>Kopiera innehållet till en textredigerare och spara som en SVG-fil.<br>Kontrollera att texteditorns textkodningsinställning är UTF-8.</p>"
+#: DynamicWeb//dynamicweb.py:2450
+msgid ""
+"<p>This page provides the SVG raw code.<br>Copy the contents into a text "
+"editor and save as an SVG file.<br>Make sure that the text editor encoding "
+"is UTF-8.</p>"
+msgstr ""
+"<p>Den här sidan innehåller SVG råkod.<br>Kopiera innehållet till en "
+"textredigerare och spara som en SVG-fil.<br>Kontrollera att texteditorns "
+"textkodningsinställning är UTF-8.</p>"
 
-#: DynamicWeb/dynamicweb.py:2448
+#: DynamicWeb//dynamicweb.py:2452
 msgid "Address"
 msgstr "Adress"
 
-#: DynamicWeb/dynamicweb.py:2450
+#: DynamicWeb//dynamicweb.py:2454
 msgid "Age at death"
 msgstr "Ålder vid död"
 
-#: DynamicWeb/dynamicweb.py:2451
+#: DynamicWeb//dynamicweb.py:2455
 msgid "Alternate Marriage"
 msgstr "Alternativt giftermål"
 
-#: DynamicWeb/dynamicweb.py:2452
+#: DynamicWeb//dynamicweb.py:2456
 msgid "Alternate Name"
 msgstr "Alternativt namn"
 
-#: DynamicWeb/dynamicweb.py:2453
+#: DynamicWeb//dynamicweb.py:2457
 msgid "Ancestors"
 msgstr "Förfäder"
 
-#: DynamicWeb/dynamicweb.py:2454
+#: DynamicWeb//dynamicweb.py:2458
 msgid "Associations"
 msgstr "Relationer"
 
-#: DynamicWeb/dynamicweb.py:2455
+#: DynamicWeb//dynamicweb.py:2459
 msgid "Attribute"
 msgstr "Attribut"
 
-#: DynamicWeb/dynamicweb.py:2456
+#: DynamicWeb//dynamicweb.py:2460
 msgid "Attributes"
 msgstr "Attribut"
 
-#: DynamicWeb/dynamicweb.py:2458 DynamicWeb/dynamicweb.py:4205
+#: DynamicWeb//dynamicweb.py:2462 DynamicWeb//dynamicweb.py:4209
 msgid "Background"
 msgstr "Bakgrund"
 
-#: DynamicWeb/dynamicweb.py:2459
+#: DynamicWeb//dynamicweb.py:2463
 msgid "Baptism"
 msgstr "Dop"
 
-#: DynamicWeb/dynamicweb.py:2460
+#: DynamicWeb//dynamicweb.py:2464
 msgid "Birth"
 msgstr "Födelse"
 
-#: DynamicWeb/dynamicweb.py:2461
+#: DynamicWeb//dynamicweb.py:2465
 msgid "Burial"
 msgstr "Begravning"
 
-#: DynamicWeb/dynamicweb.py:2462
+#: DynamicWeb//dynamicweb.py:2466
 msgid "Call Name"
 msgstr "Tilltalsnamn"
 
-#: DynamicWeb/dynamicweb.py:2463
+#: DynamicWeb//dynamicweb.py:2467
 msgid "Call Number"
 msgstr "Referensnummer"
 
-#: DynamicWeb/dynamicweb.py:2464
+#: DynamicWeb//dynamicweb.py:2468
 msgid "Cause Of Death"
 msgstr "Dödsorsak"
 
-#: DynamicWeb/dynamicweb.py:2465
+#: DynamicWeb//dynamicweb.py:2469
 msgid "Children"
 msgstr "Barn"
 
-#: DynamicWeb/dynamicweb.py:2466
+#: DynamicWeb//dynamicweb.py:2470
 msgid "Christening"
 msgstr "Barndop"
 
-#: DynamicWeb/dynamicweb.py:2467
+#: DynamicWeb//dynamicweb.py:2471
 msgid "Citation"
 msgstr "Citat"
 
-#: DynamicWeb/dynamicweb.py:2468
+#: DynamicWeb//dynamicweb.py:2472
 msgid "Citations"
 msgstr "Citeringar"
 
-#: DynamicWeb/dynamicweb.py:2469
+#: DynamicWeb//dynamicweb.py:2473
 msgid "Click on the map to show it full-screen"
 msgstr "Klicka på kartan för att visa den i helskärm"
 
-#: DynamicWeb/dynamicweb.py:2470
+#: DynamicWeb//dynamicweb.py:2474
 msgid "Code"
 msgstr "Kod"
 
-#: DynamicWeb/dynamicweb.py:2472
+#: DynamicWeb//dynamicweb.py:2476
 msgid "Configure"
 msgstr "Konfigurera"
 
-#: DynamicWeb/dynamicweb.py:2473
+#: DynamicWeb//dynamicweb.py:2477
 msgid "Count"
 msgstr "Antal"
 
-#: DynamicWeb/dynamicweb.py:2474
+#: DynamicWeb//dynamicweb.py:2478
 msgid "Cremation"
 msgstr "Kremering"
 
-#: DynamicWeb/dynamicweb.py:2476
+#: DynamicWeb//dynamicweb.py:2480
 msgid "Death"
 msgstr "Död"
 
-#: DynamicWeb/dynamicweb.py:2477
+#: DynamicWeb//dynamicweb.py:2481
 msgid "Descendants"
 msgstr "Ättlingar"
 
-#: DynamicWeb/dynamicweb.py:2478
+#: DynamicWeb//dynamicweb.py:2482
 msgid "Description"
 msgstr "Beskrivning"
 
-#: DynamicWeb/dynamicweb.py:2479
+#: DynamicWeb//dynamicweb.py:2483
 msgid "DynamicWeb_report#Help"
 msgstr "DynamicWeb_report#Hjälp"
 
-#: DynamicWeb/dynamicweb.py:2480
+#: DynamicWeb//dynamicweb.py:2484
 msgid "Enclosed By"
 msgstr "Omgivet av"
 
-#: DynamicWeb/dynamicweb.py:2481
+#: DynamicWeb//dynamicweb.py:2485
 msgid "Engagement"
 msgstr "Förlovning"
 
-#: DynamicWeb/dynamicweb.py:2482
+#: DynamicWeb//dynamicweb.py:2486
 msgid "Event"
 msgstr "Händelse"
 
-#: DynamicWeb/dynamicweb.py:2483
+#: DynamicWeb//dynamicweb.py:2487
 msgid "Events"
 msgstr "Händelser"
 
-#: DynamicWeb/dynamicweb.py:2484
+#: DynamicWeb//dynamicweb.py:2488
 msgid "Examples"
 msgstr "Exempel"
 
-#: DynamicWeb/dynamicweb.py:2485
+#: DynamicWeb//dynamicweb.py:2489
 msgid "F"
 msgstr "K"
 
-#: DynamicWeb/dynamicweb.py:2486
+#: DynamicWeb//dynamicweb.py:2490
 msgid "Families Index"
 msgstr "Familjeindex"
 
-#: DynamicWeb/dynamicweb.py:2488
+#: DynamicWeb//dynamicweb.py:2492
 msgid "Family Nick Name"
 msgstr "Familjesmeknamn"
 
-#: DynamicWeb/dynamicweb.py:2489
+#: DynamicWeb//dynamicweb.py:2493
 msgid "Father"
 msgstr "Far"
 
-#: DynamicWeb/dynamicweb.py:2490
+#: DynamicWeb//dynamicweb.py:2494
 msgid "Female"
 msgstr "Kvinna"
 
-#: DynamicWeb/dynamicweb.py:2491
+#: DynamicWeb//dynamicweb.py:2495
 msgid "File ready"
 msgstr "Fil redo"
 
-#: DynamicWeb/dynamicweb.py:2492
+#: DynamicWeb//dynamicweb.py:2496
 msgid "Gender"
 msgstr "Kön"
 
-#: DynamicWeb/dynamicweb.py:2493
+#: DynamicWeb//dynamicweb.py:2497
 msgid "Help"
 msgstr "Hjälp"
 
-#: DynamicWeb/dynamicweb.py:2494
+#: DynamicWeb//dynamicweb.py:2498
 msgid "ID"
 msgstr "ID"
 
-#: DynamicWeb/dynamicweb.py:2495 DynamicWeb/dynamicweb.py:4037
+#: DynamicWeb//dynamicweb.py:2499 DynamicWeb//dynamicweb.py:4041
 msgid "Include Place map on Place Pages"
 msgstr "Ta med platskarta på platssidor"
 
-#: DynamicWeb/dynamicweb.py:2496 DynamicWeb/dynamicweb.py:4142
+#: DynamicWeb//dynamicweb.py:2500 DynamicWeb//dynamicweb.py:4146
 msgid "Include dates columns on the index pages"
 msgstr "Ta med datumkolumner på indexsidorna"
 
-#: DynamicWeb/dynamicweb.py:2497 DynamicWeb/dynamicweb.py:4150
+#: DynamicWeb//dynamicweb.py:2501 DynamicWeb//dynamicweb.py:4154
 msgid "Include a column for parents on the index pages"
 msgstr "Ta med en kolumn för föräldrar på indexsidorna"
 
-#: DynamicWeb/dynamicweb.py:2498 DynamicWeb/dynamicweb.py:4158
+#: DynamicWeb//dynamicweb.py:2502 DynamicWeb//dynamicweb.py:4162
 msgid "Include a column for media path on the index pages"
 msgstr "Ta med en kolumn för mediasökväg på indexsidorna"
 
-#: DynamicWeb/dynamicweb.py:2499 DynamicWeb/dynamicweb.py:4146
+#: DynamicWeb//dynamicweb.py:2503 DynamicWeb//dynamicweb.py:4150
 msgid "Include a column for partners on the index pages"
 msgstr "Ta med en kolumn för partner på indexsidorna"
 
-#: DynamicWeb/dynamicweb.py:2500 DynamicWeb/dynamicweb.py:4045
+#: DynamicWeb//dynamicweb.py:2504 DynamicWeb//dynamicweb.py:4049
 msgid "Include a map in the individuals and family pages"
 msgstr "Ta med en karta på personer- och familjesidor"
 
-#: DynamicWeb/dynamicweb.py:2501 DynamicWeb/dynamicweb.py:4092
+#: DynamicWeb//dynamicweb.py:2505 DynamicWeb//dynamicweb.py:4096
 msgid "Include half and/ or step-siblings on the individual pages"
 msgstr "Ta med halv och/eller styvsyskon på de individuella sidorna"
 
-#: DynamicWeb/dynamicweb.py:2502 DynamicWeb/dynamicweb.py:4162
+#: DynamicWeb//dynamicweb.py:2506 DynamicWeb//dynamicweb.py:4166
 msgid "Include references in indexes"
 msgstr "Ta med referenser i index"
 
-#: DynamicWeb/dynamicweb.py:2505 DynamicWeb/dynamicweb.py:4112
+#: DynamicWeb//dynamicweb.py:2509 DynamicWeb//dynamicweb.py:4116
 msgid "Insert sources author in the sources title"
 msgstr "Lägg till källförfattare i källtiteln"
 
-#: DynamicWeb/dynamicweb.py:2506
+#: DynamicWeb//dynamicweb.py:2510
 msgid "Last Modified"
 msgstr "Senast ändrat"
 
-#: DynamicWeb/dynamicweb.py:2507
+#: DynamicWeb//dynamicweb.py:2511
 msgid "Latitude"
 msgstr "Latitud"
 
-#: DynamicWeb/dynamicweb.py:2508
+#: DynamicWeb//dynamicweb.py:2512
 msgid "Link"
 msgstr "Länk"
 
-#: DynamicWeb/dynamicweb.py:2509
+#: DynamicWeb//dynamicweb.py:2513
 msgid "Loading..."
 msgstr "Laddar..."
 
-#: DynamicWeb/dynamicweb.py:2510
+#: DynamicWeb//dynamicweb.py:2514
 msgid "Location"
 msgstr "Plats"
 
-#: DynamicWeb/dynamicweb.py:2511
+#: DynamicWeb//dynamicweb.py:2515
 msgid "Longitude"
 msgstr "Longitud"
 
-#: DynamicWeb/dynamicweb.py:2512
+#: DynamicWeb//dynamicweb.py:2516
 msgid "M"
 msgstr "M"
 
-#: DynamicWeb/dynamicweb.py:2513
+#: DynamicWeb//dynamicweb.py:2517
 msgid "Male"
 msgstr "Man"
 
-#: DynamicWeb/dynamicweb.py:2514
+#: DynamicWeb//dynamicweb.py:2518
 msgid "Map"
 msgstr "Karta"
 
-#: DynamicWeb/dynamicweb.py:2515
+#: DynamicWeb//dynamicweb.py:2519
 msgid "Marriage"
 msgstr "Giftermål"
 
-#: DynamicWeb/dynamicweb.py:2516
+#: DynamicWeb//dynamicweb.py:2520
 msgid "Maximize"
 msgstr "Maximera"
 
-#: DynamicWeb/dynamicweb.py:2517
+#: DynamicWeb//dynamicweb.py:2521
 msgid "Media Index"
 msgstr "Medieindex"
 
-#: DynamicWeb/dynamicweb.py:2518
+#: DynamicWeb//dynamicweb.py:2522
 msgid "Media Type"
 msgstr "Mediatyp"
 
-#: DynamicWeb/dynamicweb.py:2520
+#: DynamicWeb//dynamicweb.py:2524
 msgid "Mother"
 msgstr "Mor"
 
-#: DynamicWeb/dynamicweb.py:2521
+#: DynamicWeb//dynamicweb.py:2525
 msgid "Name"
 msgstr "Namn"
 
-#: DynamicWeb/dynamicweb.py:2522
+#: DynamicWeb//dynamicweb.py:2526
 msgid "Nick Name"
 msgstr "Smeknamn"
 
-#: DynamicWeb/dynamicweb.py:2523
+#: DynamicWeb//dynamicweb.py:2527
 msgid "No data available in table"
 msgstr "Ingen data tillgänglig i tabellen"
 
-#: DynamicWeb/dynamicweb.py:2524
+#: DynamicWeb//dynamicweb.py:2528
 msgid "No matches found"
 msgstr "Inga träffar hittades"
 
-#: DynamicWeb/dynamicweb.py:2525
+#: DynamicWeb//dynamicweb.py:2529
 msgid "No matching records found"
 msgstr "Inga motsvarande uppgifter hittades"
 
-#: DynamicWeb/dynamicweb.py:2526
+#: DynamicWeb//dynamicweb.py:2530
 msgid "No matching surname."
 msgstr "Inga motsvarande efternamn."
 
-#: DynamicWeb/dynamicweb.py:2527
+#: DynamicWeb//dynamicweb.py:2531
 msgid "None"
 msgstr "Ingen"
 
-#: DynamicWeb/dynamicweb.py:2528
+#: DynamicWeb//dynamicweb.py:2532
 msgid "Notes"
 msgstr "Notiser"
 
-#: DynamicWeb/dynamicweb.py:2529
+#: DynamicWeb//dynamicweb.py:2533
 msgid "Number"
 msgstr "Nummer"
 
-#: DynamicWeb/dynamicweb.py:2530
+#: DynamicWeb//dynamicweb.py:2534
 msgid "OK"
 msgstr "OK"
 
-#: DynamicWeb/dynamicweb.py:2531
+#: DynamicWeb//dynamicweb.py:2535
 msgid "Other participants"
 msgstr "Andra deltagare"
 
-#: DynamicWeb/dynamicweb.py:2532
+#: DynamicWeb//dynamicweb.py:2536
 msgid "Parents"
 msgstr "Föräldrar"
 
-#: DynamicWeb/dynamicweb.py:2533
+#: DynamicWeb//dynamicweb.py:2537
 msgid "Path"
 msgstr "Sökväg"
 
-#: DynamicWeb/dynamicweb.py:2534
+#: DynamicWeb//dynamicweb.py:2538
 msgid "Person page"
 msgstr "Personsida"
 
-#: DynamicWeb/dynamicweb.py:2535
+#: DynamicWeb//dynamicweb.py:2539
 msgid "Person to search for"
 msgstr "Person att söka efter"
 
-#: DynamicWeb/dynamicweb.py:2537
+#: DynamicWeb//dynamicweb.py:2541
 msgid "Persons Index"
 msgstr "Personindex"
 
-#: DynamicWeb/dynamicweb.py:2538
+#: DynamicWeb//dynamicweb.py:2542
 msgid "Persons"
 msgstr "Personer"
 
-#: DynamicWeb/dynamicweb.py:2540
+#: DynamicWeb//dynamicweb.py:2544
 msgid "Places Index"
 msgstr "Platsindex"
 
-#: DynamicWeb/dynamicweb.py:2542
+#: DynamicWeb//dynamicweb.py:2546
 msgid "Preparing file ..."
 msgstr "Förbereder fil ..."
 
-#: DynamicWeb/dynamicweb.py:2543
+#: DynamicWeb//dynamicweb.py:2547
 msgid "Processing..."
 msgstr "Bearbetar..."
 
-#: DynamicWeb/dynamicweb.py:2545
+#: DynamicWeb//dynamicweb.py:2549
 msgid "References"
 msgstr "Referenser"
 
-#: DynamicWeb/dynamicweb.py:2546
+#: DynamicWeb//dynamicweb.py:2550
 msgid "Relationship to Father"
 msgstr "Släktskap med far"
 
-#: DynamicWeb/dynamicweb.py:2547
+#: DynamicWeb//dynamicweb.py:2551
 msgid "Relationship to Mother"
 msgstr "Släktskap med mor"
 
-#: DynamicWeb/dynamicweb.py:2548
+#: DynamicWeb//dynamicweb.py:2552
 msgid "Relationship"
 msgstr "Släktskap"
 
-#: DynamicWeb/dynamicweb.py:2549
+#: DynamicWeb//dynamicweb.py:2553
 msgid "Repositories Index"
 msgstr "Arkivplatsindex"
 
-#: DynamicWeb/dynamicweb.py:2552
+#: DynamicWeb//dynamicweb.py:2556
 msgid "Restore"
 msgstr "Återställ"
 
-#: DynamicWeb/dynamicweb.py:2553
+#: DynamicWeb//dynamicweb.py:2557
 msgid "Restore default settings"
 msgstr "Återställ standardinställningar"
 
-#: DynamicWeb/dynamicweb.py:2554 DynamicWeb/dynamicweb.py:4108
+#: DynamicWeb//dynamicweb.py:2558 DynamicWeb//dynamicweb.py:4112
 msgid "Show last modification time"
 msgstr "Visa sista ändringstid"
 
-#: DynamicWeb/dynamicweb.py:2555 DynamicWeb/dynamicweb.py:4199
+#: DynamicWeb//dynamicweb.py:2559 DynamicWeb//dynamicweb.py:4203
 msgid "SVG tree children distribution"
 msgstr "SVG-träd med barn"
 
-#: DynamicWeb/dynamicweb.py:2556
+#: DynamicWeb//dynamicweb.py:2560
 msgid "SVG tree configuration"
 msgstr "SVG-trädkonfiguration"
 
-#: DynamicWeb/dynamicweb.py:2557 DynamicWeb/dynamicweb.py:4187
+#: DynamicWeb//dynamicweb.py:2561 DynamicWeb//dynamicweb.py:4191
 msgid "SVG tree graph shape"
 msgstr "SVG-trädets grafikform"
 
-#: DynamicWeb/dynamicweb.py:2558 DynamicWeb/dynamicweb.py:4181
+#: DynamicWeb//dynamicweb.py:2562 DynamicWeb//dynamicweb.py:4185
 msgid "SVG tree graph type"
 msgstr "SVG-trädets grafiktyp"
 
-#: DynamicWeb/dynamicweb.py:2559 DynamicWeb/dynamicweb.py:4193
+#: DynamicWeb//dynamicweb.py:2563 DynamicWeb//dynamicweb.py:4197
 msgid "SVG tree parents distribution"
 msgstr "SVG-träd med föräldrar"
 
-#: DynamicWeb/dynamicweb.py:2560
+#: DynamicWeb//dynamicweb.py:2564
 msgid "Save tree as file"
 msgstr "Spara trädet som fil"
 
-#: DynamicWeb/dynamicweb.py:2561
+#: DynamicWeb//dynamicweb.py:2565
 msgid "Search:"
 msgstr "Sök:"
 
-#: DynamicWeb/dynamicweb.py:2562
+#: DynamicWeb//dynamicweb.py:2566
 msgid "Select the background color scheme"
 msgstr "Välj bakgrundens färgschema"
 
-#: DynamicWeb/dynamicweb.py:2563
+#: DynamicWeb//dynamicweb.py:2567
 msgid "Select the children distribution (fan charts only)"
 msgstr "Välj med barn (endast för antavlor i cirkelformat)"
 
-#: DynamicWeb/dynamicweb.py:2564
+#: DynamicWeb//dynamicweb.py:2568
 msgid "Select the number of ascending generations"
 msgstr "Välj antal stigande generationer"
 
-#: DynamicWeb/dynamicweb.py:2565
+#: DynamicWeb//dynamicweb.py:2569
 msgid "Select the number of descending generations"
 msgstr "Välj antal sjunkande generationer"
 
-#: DynamicWeb/dynamicweb.py:2566
+#: DynamicWeb//dynamicweb.py:2570
 msgid "Select the parents distribution (fan charts only)"
 msgstr "Välj med föräldrar (endast för antavlor i cirkelformat)"
 
-#: DynamicWeb/dynamicweb.py:2567
+#: DynamicWeb//dynamicweb.py:2571
 msgid "Select the shape of graph"
 msgstr "Välj grafikform"
 
-#: DynamicWeb/dynamicweb.py:2568
+#: DynamicWeb//dynamicweb.py:2572
 msgid "Select the type of graph"
 msgstr "Välj grafiktyp"
 
-#: DynamicWeb/dynamicweb.py:2569
+#: DynamicWeb//dynamicweb.py:2573
 msgid "Several matches.<br>Precise your search or choose in the lists below."
 msgstr "Flera sökresultat.<br>Precisera din sökning eller välj i listan."
 
-#: DynamicWeb/dynamicweb.py:2570
+#: DynamicWeb//dynamicweb.py:2574
 msgid "Show _MENU_ entries"
 msgstr "Visa _MENU_ poster"
 
-#: DynamicWeb/dynamicweb.py:2571 DynamicWeb/dynamicweb.py:4217
+#: DynamicWeb//dynamicweb.py:2575 DynamicWeb//dynamicweb.py:4221
 msgid "Show duplicates"
 msgstr "Visa dubbletter"
 
-#: DynamicWeb/dynamicweb.py:2572
+#: DynamicWeb//dynamicweb.py:2576
 msgid "Showing 0 to 0 of 0 entries"
 msgstr "Visar 0 till 0 av 0 poster"
 
-#: DynamicWeb/dynamicweb.py:2573
+#: DynamicWeb//dynamicweb.py:2577
 msgid "Showing _START_ to _END_ of _TOTAL_ entries"
 msgstr "Visar _START_ till _END_ av _TOTAL_ poster"
 
-#: DynamicWeb/dynamicweb.py:2574
+#: DynamicWeb//dynamicweb.py:2578
 msgid "Siblings"
 msgstr "Syskon"
 
-#: DynamicWeb/dynamicweb.py:2575
+#: DynamicWeb//dynamicweb.py:2579
 msgid "Sort by:"
 msgstr "Sortera efter:"
 
-#: DynamicWeb/dynamicweb.py:2577
+#: DynamicWeb//dynamicweb.py:2581
 msgid "Sources Index"
 msgstr "Källindex"
 
-#: DynamicWeb/dynamicweb.py:2579
+#: DynamicWeb//dynamicweb.py:2583
 msgid "Spouses"
 msgstr "Makar"
 
-#: DynamicWeb/dynamicweb.py:2580 DynamicWeb/dynamicweb.py:4116
+#: DynamicWeb//dynamicweb.py:2584 DynamicWeb//dynamicweb.py:4120
 msgid "Suppress Gramps ID"
 msgstr "Dölj Gramps-ID:n"
 
-#: DynamicWeb/dynamicweb.py:2581
+#: DynamicWeb//dynamicweb.py:2585
 msgid "Surname"
 msgstr "Efternamn"
 
-#: DynamicWeb/dynamicweb.py:2582
+#: DynamicWeb//dynamicweb.py:2586
 msgid "Surnames Index"
 msgstr "Efternamnsindex"
 
-#: DynamicWeb/dynamicweb.py:2584
+#: DynamicWeb//dynamicweb.py:2588
 msgid "Title"
 msgstr "Titel"
 
-#: DynamicWeb/dynamicweb.py:2585
+#: DynamicWeb//dynamicweb.py:2589
 msgid "Type"
 msgstr "Typ"
 
-#: DynamicWeb/dynamicweb.py:2586
+#: DynamicWeb//dynamicweb.py:2590
 msgid "U"
 msgstr "O"
 
-#: DynamicWeb/dynamicweb.py:2587
+#: DynamicWeb//dynamicweb.py:2591
 msgid "Unknown"
 msgstr "Okänd"
 
-#: DynamicWeb/dynamicweb.py:2588 DynamicWeb/dynamicweb.py:4104
+#: DynamicWeb//dynamicweb.py:2592 DynamicWeb//dynamicweb.py:4108
 msgid "Use tabbed panels instead of sections"
 msgstr "Använd flikar stället för sektioner"
 
-#: DynamicWeb/dynamicweb.py:2589
+#: DynamicWeb//dynamicweb.py:2593
 msgid "Use the search box above in order to find a person."
 msgstr "Använd sökrutan ovan för att finna en person."
 
-#: DynamicWeb/dynamicweb.py:2590
+#: DynamicWeb//dynamicweb.py:2594
 msgid "Use a table format for the surnames index"
 msgstr "Använd ett tabellformat för efternamnsindexet"
 
-#: DynamicWeb/dynamicweb.py:2591
+#: DynamicWeb//dynamicweb.py:2595
 msgid "Use a table format for the persons index"
 msgstr "Använd ett tabellformat för personindexet"
 
-#: DynamicWeb/dynamicweb.py:2592
+#: DynamicWeb//dynamicweb.py:2596
 msgid "Use a table format for the families index"
 msgstr "Använd ett tabellformat för familjeindexet"
 
-#: DynamicWeb/dynamicweb.py:2593
+#: DynamicWeb//dynamicweb.py:2597
 msgid "Use a table format for the sources index"
 msgstr "Använd ett tabellformat för källindexet"
 
-#: DynamicWeb/dynamicweb.py:2594
+#: DynamicWeb//dynamicweb.py:2598
 msgid "Use a table format for the places index"
 msgstr "Använd ett tabellformat för platsindexet"
 
-#: DynamicWeb/dynamicweb.py:2595
+#: DynamicWeb//dynamicweb.py:2599
 msgid "Used for family"
 msgstr "Använd för familj"
 
-#: DynamicWeb/dynamicweb.py:2596
+#: DynamicWeb//dynamicweb.py:2600
 msgid "Used for media"
 msgstr "Använd för media"
 
-#: DynamicWeb/dynamicweb.py:2597
+#: DynamicWeb//dynamicweb.py:2601
 msgid "Used for person"
 msgstr "Använd för person"
 
-#: DynamicWeb/dynamicweb.py:2598
+#: DynamicWeb//dynamicweb.py:2602
 msgid "Used for place"
 msgstr "Använd för plats"
 
-#: DynamicWeb/dynamicweb.py:2599
+#: DynamicWeb//dynamicweb.py:2603
 msgid "Used for source"
 msgstr "Använd för källa"
 
-#: DynamicWeb/dynamicweb.py:2600
+#: DynamicWeb//dynamicweb.py:2604
 msgid "Value"
 msgstr "Värde"
 
-#: DynamicWeb/dynamicweb.py:2601
+#: DynamicWeb//dynamicweb.py:2605
 msgid "Web Link"
 msgstr "Webblänk"
 
-#: DynamicWeb/dynamicweb.py:2602
+#: DynamicWeb//dynamicweb.py:2606
 msgid "Web Links"
 msgstr "Internetlänkar"
 
-#: DynamicWeb/dynamicweb.py:2603 DynamicWeb/dynamicweb.py:4218
-msgid "Whether to use a special color for the persons that appear several times in the SVG tree"
-msgstr "Huruvida använda en speciell färg för personer som syns flera gånger i SVG-trädet"
+#: DynamicWeb//dynamicweb.py:2607 DynamicWeb//dynamicweb.py:4222
+msgid ""
+"Whether to use a special color for the persons that appear several times in "
+"the SVG tree"
+msgstr ""
+"Huruvida använda en speciell färg för personer som syns flera gånger i SVG-"
+"trädet"
 
-#: DynamicWeb/dynamicweb.py:2604
+#: DynamicWeb//dynamicweb.py:2608
 msgid "Without name"
 msgstr "Utan namn"
 
-#: DynamicWeb/dynamicweb.py:2605
+#: DynamicWeb//dynamicweb.py:2609
 msgid "Without surname"
 msgstr "Utan efternamn"
 
-#: DynamicWeb/dynamicweb.py:2606
+#: DynamicWeb//dynamicweb.py:2610
 msgid "Without title"
 msgstr "Utan titel"
 
-#: DynamicWeb/dynamicweb.py:2607
+#: DynamicWeb//dynamicweb.py:2611
 msgid "Zoom in"
 msgstr "Zooma in"
 
-#: DynamicWeb/dynamicweb.py:2608
+#: DynamicWeb//dynamicweb.py:2612
 msgid "Zoom out"
 msgstr "Zooma ut"
 
-#: DynamicWeb/dynamicweb.py:2609
+#: DynamicWeb//dynamicweb.py:2613
 msgid "all"
 msgstr "alla"
 
-#: DynamicWeb/dynamicweb.py:2812
+#: DynamicWeb//dynamicweb.py:2816
 msgid "No Home Person"
 msgstr "Hemperson är inte bestämd"
 
-#: DynamicWeb/dynamicweb.py:2953
+#: DynamicWeb//dynamicweb.py:2957
 #, python-format
 msgid "Copying error: %(error)s"
 msgstr "Kopieringsfel: %(error)s"
 
-#: DynamicWeb/dynamicweb.py:2954
+#: DynamicWeb//dynamicweb.py:2958
 #, python-format
 msgid "Impossible to copy \"%(src)s\" to \"%(dst)s\""
 msgstr "Omöjligt att kopiera \"%(src)s\" till \"%(dst)s\""
 
-#: DynamicWeb/dynamicweb.py:2957
+#: DynamicWeb//dynamicweb.py:2961
 msgid "Possible destination error"
 msgstr "Möjligt målfel"
 
-#: DynamicWeb/dynamicweb.py:2958
-msgid "You appear to have set your target directory to a directory used for data storage. This could create problems with file management. It is recommended that you consider using a different directory to store your generated web pages."
-msgstr "Du verkar ha satt din målmapp till en mapp, som används för datalagring. Detta skulle kunna skapa problem med filhantering. Det rekommenderas att du bör välja en annan mapp till att lagra webbsidor."
+#: DynamicWeb//dynamicweb.py:2962
+msgid ""
+"You appear to have set your target directory to a directory used for data "
+"storage. This could create problems with file management. It is recommended "
+"that you consider using a different directory to store your generated web "
+"pages."
+msgstr ""
+"Du verkar ha satt din målmapp till en mapp, som används för datalagring. "
+"Detta skulle kunna skapa problem med filhantering. Det rekommenderas att du "
+"bör välja en annan mapp till att lagra webbsidor."
 
-#: DynamicWeb/dynamicweb.py:2985
+#: DynamicWeb//dynamicweb.py:2989
 #, python-format
 msgid "Unable to copy web site template files from \"%(path)s\""
 msgstr "Kan inte kopiera webbsidesmallar från \"%(path)s\""
 
-#: DynamicWeb/dynamicweb.py:3029
+#: DynamicWeb//dynamicweb.py:3033
 #, python-format
 msgid "Keeping \"%(dst)s\" (newer than \"%(src)s\")"
 msgstr "Spar \"%(dst)s\" (nyare än \"%(src)s\")"
 
-#: DynamicWeb/dynamicweb.py:3032
+#: DynamicWeb//dynamicweb.py:3036
 #, python-format
 msgid "Copying \"%(src)s\" to \"%(dst)s\""
 msgstr "Kopiera \"%(src)s\" till \"%(dst)s\""
 
-#: DynamicWeb/dynamicweb.py:3050
+#: DynamicWeb//dynamicweb.py:3054
 msgid "Invalid file name"
 msgstr "Ogiltigt filnamn"
 
-#: DynamicWeb/dynamicweb.py:3051
+#: DynamicWeb//dynamicweb.py:3055
 msgid "The archive file must be a file, not a directory"
 msgstr "Arkivet måste vara en fil, inte en katalog"
 
-#: DynamicWeb/dynamicweb.py:3061 DynamicWeb/dynamicweb.py:3079
+#: DynamicWeb//dynamicweb.py:3065 DynamicWeb//dynamicweb.py:3083
 #, python-format
 msgid "Unable to overwrite archive file \"%(path)s\""
 msgstr "Kan inte skriva över arkivfilen \"%(path)s\""
 
-#: DynamicWeb/dynamicweb.py:3071 DynamicWeb/dynamicweb.py:3086
+#: DynamicWeb//dynamicweb.py:3075 DynamicWeb//dynamicweb.py:3090
 #, python-format
 msgid "Unable to add file \"%(file)s\" to archive \"%(archive)s\""
 msgstr "Kan inte lägga till filen \"%(file)s\" till arkivet \"%(archive)s\""
 
-#: DynamicWeb/dynamicweb.py:3139
+#: DynamicWeb//dynamicweb.py:3143
 #, python-format
 msgid "DynamicWebReport ignoring link type '%(class)s'"
 msgstr "DynamicWebReport ignorerar länktypen '%(class)s'"
 
-#: DynamicWeb/dynamicweb.py:3382
+#: DynamicWeb//dynamicweb.py:3386
 msgid "Constructing list of other objects..."
 msgstr "Bygger lista med andra objekt..."
 
-#: DynamicWeb/dynamicweb.py:3517
+#: DynamicWeb//dynamicweb.py:3521
 #, python-format
 msgid "Family of %(husband)s and %(spouse)s"
 msgstr "Familj för %(husband)s och %(spouse)s"
 
-#: DynamicWeb/dynamicweb.py:3523
+#: DynamicWeb//dynamicweb.py:3527
 #, python-format
 msgid "Family of %(father)s"
 msgstr "Familj för %(father)s"
 
-#: DynamicWeb/dynamicweb.py:3527
+#: DynamicWeb//dynamicweb.py:3531
 #, python-format
 msgid "Family of %(mother)s"
 msgstr "Familj för %(mother)s"
 
-#: DynamicWeb/dynamicweb.py:3842
+#: DynamicWeb//dynamicweb.py:3846
 msgid ""
 "In this note, the following special words are processed:\n"
 "__SEARCH_FORM__ is replaced by a search form.\n"
@@ -1038,11 +1056,13 @@ msgid ""
 "__NB_REPOSITORIES__ is replaced by the number of repositories.\n"
 "__NB_PLACES__ is replaced by the number of places.\n"
 "__MEDIA_<gid>__ is replaced by the media with Gramps ID <gid>.\n"
-"__THUMB_<gid>__ is replaced by the thumbnail of the media with Gramps ID <gid>.\n"
+"__THUMB_<gid>__ is replaced by the thumbnail of the media with Gramps ID "
+"<gid>.\n"
 "__EXPORT_DATE__ is replaced by the current date.\n"
 "__GRAMPS_VERSION__ is replaced by the Gramps version.\n"
 "__GRAMPS_HOMEPAGE__ is replaced by the Gramps homepage link.\n"
-"URL starting with \"relative://relative.<link>\" are replaced by the relative URL \"<link>\".\n"
+"URL starting with \"relative://relative.<link>\" are replaced by the "
+"relative URL \"<link>\".\n"
 msgstr ""
 "I denna notis är följande specialord bearbetade:\n"
 "__SEARCH_FORM__ är ersatt med en sökfunktion.\n"
@@ -1057,513 +1077,549 @@ msgstr ""
 "__EXPORT_DATE__ är ersatt av nuvarande datum.\n"
 "__GRAMPS_VERSION__ är ersatt av GRAMPS versionen.\n"
 "__GRAMPS_HOMEPAGE__ är ersatt av GRAMPS hemsideslänk.\n"
-"URL:er som börjar med \"relative://relative.<länk>\" är ersatt med den relativa URL:en \"<länk>\".\n"
+"URL:er som börjar med \"relative://relative.<länk>\" är ersatt med den "
+"relativa URL:en \"<länk>\".\n"
 
-#: DynamicWeb/dynamicweb.py:3882
+#: DynamicWeb//dynamicweb.py:3886
 msgid "Report"
 msgstr "Rapport"
 
-#: DynamicWeb/dynamicweb.py:3887
+#: DynamicWeb//dynamicweb.py:3891
 msgid "Destination"
 msgstr "Mål"
 
-#: DynamicWeb/dynamicweb.py:3889
+#: DynamicWeb//dynamicweb.py:3893
 msgid "The destination directory for the web files"
 msgstr "Målmappen för webbfiler"
 
-#: DynamicWeb/dynamicweb.py:3893
+#: DynamicWeb//dynamicweb.py:3897
 msgid "Store web pages in archive"
 msgstr "Spara webbsidor i arkivet"
 
-#: DynamicWeb/dynamicweb.py:3894
-msgid "Whether to create an archive file (in ZIP or TGZ format) containing the web site"
-msgstr "Huruvida skapa ett arkiv (i ZIP eller TGZ formatet) innehållande webbsidan"
+#: DynamicWeb//dynamicweb.py:3898
+msgid ""
+"Whether to create an archive file (in ZIP or TGZ format) containing the web "
+"site"
+msgstr ""
+"Huruvida skapa ett arkiv (i ZIP eller TGZ formatet) innehållande webbsidan"
 
-#: DynamicWeb/dynamicweb.py:3898
+#: DynamicWeb//dynamicweb.py:3902
 msgid "Archive file"
 msgstr "Arkivfil"
 
-#: DynamicWeb/dynamicweb.py:3900
+#: DynamicWeb//dynamicweb.py:3904
 msgid "The archive file name (with \".zip\" or \".tgz\" extension)"
 msgstr "Arkivfilsnamnet (med \".zip\" eller \".tgz\" ändelse)"
 
-#: DynamicWeb/dynamicweb.py:3906
+#: DynamicWeb//dynamicweb.py:3910
 msgid "Web site title"
 msgstr "Webbplatstitel"
 
-#: DynamicWeb/dynamicweb.py:3906
+#: DynamicWeb//dynamicweb.py:3910
 msgid "My Family Tree"
 msgstr "Mitt släktträd"
 
-#: DynamicWeb/dynamicweb.py:3907
+#: DynamicWeb//dynamicweb.py:3911
 msgid "The title of the web site"
 msgstr "Webbsidans titel"
 
-#: DynamicWeb/dynamicweb.py:3910
+#: DynamicWeb//dynamicweb.py:3914
 msgid "Filter"
 msgstr "Filter"
 
-#: DynamicWeb/dynamicweb.py:3912
+#: DynamicWeb//dynamicweb.py:3916
 msgid "Select filter to restrict people that appear on web site"
-msgstr "Välj ett filter, som begränsar vilka personer, som visas på en hemsida."
+msgstr ""
+"Välj ett filter, som begränsar vilka personer, som visas på en hemsida."
 
-#: DynamicWeb/dynamicweb.py:3916
+#: DynamicWeb//dynamicweb.py:3920
 msgid "Filter Person"
 msgstr "Filtrera person"
 
-#: DynamicWeb/dynamicweb.py:3917
+#: DynamicWeb//dynamicweb.py:3921
 msgid "The center person for the filter"
 msgstr "Huvudpersonen för filtret"
 
-#: DynamicWeb/dynamicweb.py:3925 DynamicWeb/dynamicweb.py:3945
+#: DynamicWeb//dynamicweb.py:3929 DynamicWeb//dynamicweb.py:3949
 msgid "Name format (short)"
 msgstr "Namnformat (kort)"
 
-#: DynamicWeb/dynamicweb.py:3926 DynamicWeb/dynamicweb.py:3948
+#: DynamicWeb//dynamicweb.py:3930 DynamicWeb//dynamicweb.py:3952
 msgid "Select the format to display a shorter version of the names"
 msgstr "Välj formatet för att visa en kortare version av namnen"
 
-#: DynamicWeb/dynamicweb.py:3940
+#: DynamicWeb//dynamicweb.py:3944
 msgid "Name format"
 msgstr "Namnformat"
 
-#: DynamicWeb/dynamicweb.py:3943
+#: DynamicWeb//dynamicweb.py:3947
 msgid "Select the format to display names"
 msgstr "Välj format vid namnvisning"
 
-#: DynamicWeb/dynamicweb.py:3951
+#: DynamicWeb//dynamicweb.py:3955
 msgid "Web site template"
 msgstr "Webbsidesmall"
 
-#: DynamicWeb/dynamicweb.py:3954
+#: DynamicWeb//dynamicweb.py:3958
 msgid "Select the template of the web site"
 msgstr "Välj webbsidans mall"
 
-#: DynamicWeb/dynamicweb.py:3957
+#: DynamicWeb//dynamicweb.py:3961
 msgid "Copyright"
 msgstr "Copyright"
 
-#: DynamicWeb/dynamicweb.py:3960
+#: DynamicWeb//dynamicweb.py:3964
 msgid "The copyright to be used for the web files"
 msgstr "Den copyright, som skall användas för webbfiler"
 
-#: DynamicWeb/dynamicweb.py:3968
+#: DynamicWeb//dynamicweb.py:3972
 msgid "Privacy"
 msgstr "Skyddade data"
 
-#: DynamicWeb/dynamicweb.py:3976
+#: DynamicWeb//dynamicweb.py:3980
 msgid "Include records marked private"
 msgstr "Ta med data markerade som privata"
 
-#: DynamicWeb/dynamicweb.py:3977
+#: DynamicWeb//dynamicweb.py:3981
 msgid "Whether to include private objects"
 msgstr "Huruvida ta med privata objekt"
 
-#: DynamicWeb/dynamicweb.py:3979
+#: DynamicWeb//dynamicweb.py:3983
 msgid "Living People"
 msgstr "Levande personer"
 
-#: DynamicWeb/dynamicweb.py:3980
+#: DynamicWeb//dynamicweb.py:3984
 msgid "Exclude"
 msgstr "Uteslut"
 
-#: DynamicWeb/dynamicweb.py:3981
+#: DynamicWeb//dynamicweb.py:3985
 msgid "Include Last Name Only"
 msgstr "Ta bara med efternamnet"
 
-#: DynamicWeb/dynamicweb.py:3982
+#: DynamicWeb//dynamicweb.py:3986
 msgid "Include Full Name Only"
 msgstr "Ta bara med kompletta namnet"
 
-#: DynamicWeb/dynamicweb.py:3983
+#: DynamicWeb//dynamicweb.py:3987
 msgid "Include"
 msgstr "Ta med"
 
-#: DynamicWeb/dynamicweb.py:3984
+#: DynamicWeb//dynamicweb.py:3988
 msgid "How to handle living people"
 msgstr "Hur hantera nu levande personer"
 
-#: DynamicWeb/dynamicweb.py:3987
+#: DynamicWeb//dynamicweb.py:3991
 msgid "Years from death to consider living"
 msgstr "År från död att ses som levande"
 
-#: DynamicWeb/dynamicweb.py:3988
-msgid "This allows you to restrict information on people who have not been dead for very long"
-msgstr "Detta tillåter dig att begränsa uppgifter om personer, som inte har varit döda tillräckligt länge."
+#: DynamicWeb//dynamicweb.py:3992
+msgid ""
+"This allows you to restrict information on people who have not been dead for "
+"very long"
+msgstr ""
+"Detta tillåter dig att begränsa uppgifter om personer, som inte har varit "
+"döda tillräckligt länge."
 
-#: DynamicWeb/dynamicweb.py:3992
+#: DynamicWeb//dynamicweb.py:3996
 msgid "Export notes"
 msgstr "Exportera notiser"
 
-#: DynamicWeb/dynamicweb.py:3993
+#: DynamicWeb//dynamicweb.py:3997
 msgid "Whether to export notes in the web pages"
 msgstr "Huruvida exportera notiser i webbsidorna"
 
-#: DynamicWeb/dynamicweb.py:3996
+#: DynamicWeb//dynamicweb.py:4000
 msgid "Export sources"
 msgstr "Exportera källor"
 
-#: DynamicWeb/dynamicweb.py:3997
+#: DynamicWeb//dynamicweb.py:4001
 msgid "Whether to export sources and citations in the web pages"
 msgstr "Huruvida exportera källor och citeringar i webbsidorna"
 
-#: DynamicWeb/dynamicweb.py:4000
+#: DynamicWeb//dynamicweb.py:4004
 msgid "Export addresses"
 msgstr "Exportera adresser"
 
-#: DynamicWeb/dynamicweb.py:4001
+#: DynamicWeb//dynamicweb.py:4005
 msgid "Whether to export addresses in the web pages"
 msgstr "Huruvida exportera adresser i webbsidorna"
 
-#: DynamicWeb/dynamicweb.py:4006
+#: DynamicWeb//dynamicweb.py:4010
 msgid "Options"
 msgstr "Alternativ"
 
-#: DynamicWeb/dynamicweb.py:4009
+#: DynamicWeb//dynamicweb.py:4013
 msgid "Include repository pages"
 msgstr "Ta med arkivplatsförteckning"
 
-#: DynamicWeb/dynamicweb.py:4010
+#: DynamicWeb//dynamicweb.py:4014
 msgid "Whether or not to include the Repository Pages."
 msgstr "Huruvida ta med arkivplatsförteckning eller inte."
 
-#: DynamicWeb/dynamicweb.py:4013
+#: DynamicWeb//dynamicweb.py:4017
 msgid "Include images and media"
 msgstr "Ta med bilder och mediaobjekt"
 
-#: DynamicWeb/dynamicweb.py:4014
+#: DynamicWeb//dynamicweb.py:4018
 msgid "Whether to include images and media in the web pages"
 msgstr "Huruvida ta med mediaobjekt i webbsidorna"
 
-#: DynamicWeb/dynamicweb.py:4018
+#: DynamicWeb//dynamicweb.py:4022
 msgid "Copy, rename files with an internal Gramps identifier"
 msgstr "Kopiera, byt namn på filer med en intern Gramps-identifierare"
 
-#: DynamicWeb/dynamicweb.py:4019
+#: DynamicWeb//dynamicweb.py:4023
 msgid "Copy, keep file names unchanged"
 msgstr "Kopiera, bevara filnamn oförändrade"
 
-#: DynamicWeb/dynamicweb.py:4020
+#: DynamicWeb//dynamicweb.py:4024
 msgid "Do not copy, reference existing files"
 msgstr "Kopiera inte, referera existerande filer"
 
-#: DynamicWeb/dynamicweb.py:4022
+#: DynamicWeb//dynamicweb.py:4026
 msgid "Images and media"
 msgstr "Mediaobjekt"
 
-#: DynamicWeb/dynamicweb.py:4025
+#: DynamicWeb//dynamicweb.py:4029
 msgid "Whether to make a copy of the media"
 msgstr "Huruvida att skapa en kopia av mediaobjekten"
 
-#: DynamicWeb/dynamicweb.py:4028
+#: DynamicWeb//dynamicweb.py:4032
 msgid "Print the notes type"
 msgstr "Skriv ut notistypen"
 
-#: DynamicWeb/dynamicweb.py:4029
+#: DynamicWeb//dynamicweb.py:4033
 msgid "Whether to print the notes type in the notes text"
 msgstr "Huruvida skriva ut notistypen i notistexten"
 
-#: DynamicWeb/dynamicweb.py:4032
+#: DynamicWeb//dynamicweb.py:4036
 msgid "Print place pages"
 msgstr "Skriv ut platssidor"
 
-#: DynamicWeb/dynamicweb.py:4033
+#: DynamicWeb//dynamicweb.py:4037
 msgid "Whether to show pages for the places"
 msgstr "Huruvida visa sidor för platserna"
 
-#: DynamicWeb/dynamicweb.py:4039
-msgid "Whether to include a place map on the Place Pages, where Latitude/ Longitude are available."
-msgstr "Huruvida ta med en platskarta i platssidorna, där Latitud/Longitud finns tillgängliga."
+#: DynamicWeb//dynamicweb.py:4043
+msgid ""
+"Whether to include a place map on the Place Pages, where Latitude/ Longitude "
+"are available."
+msgstr ""
+"Huruvida ta med en platskarta i platssidorna, där Latitud/Longitud finns "
+"tillgängliga."
 
-#: DynamicWeb/dynamicweb.py:4047
-msgid "Whether or not to add an individual page map showing all the places on this page. This will allow you to see how your family traveled around the country."
-msgstr "Huruvida ta med en individuell platskarta som visar alla platser på den sidan. Det gör att du kan se hur din familj reste runt i landet."
+#: DynamicWeb//dynamicweb.py:4051
+msgid ""
+"Whether or not to add an individual page map showing all the places on this "
+"page. This will allow you to see how your family traveled around the country."
+msgstr ""
+"Huruvida ta med en individuell platskarta som visar alla platser på den "
+"sidan. Det gör att du kan se hur din familj reste runt i landet."
 
-#: DynamicWeb/dynamicweb.py:4055
+#: DynamicWeb//dynamicweb.py:4059
 msgid "Google"
 msgstr "Google"
 
-#: DynamicWeb/dynamicweb.py:4056
+#: DynamicWeb//dynamicweb.py:4060
 msgid "OpenStreetMap"
 msgstr "OpenStreetMap"
 
-#: DynamicWeb/dynamicweb.py:4058
+#: DynamicWeb//dynamicweb.py:4062
 msgid "Map Service"
 msgstr "Karttjänst"
 
-#: DynamicWeb/dynamicweb.py:4061
+#: DynamicWeb//dynamicweb.py:4065
 msgid "Choose your choice of map service for creating the Place Map Pages"
 msgstr "Välj din karttjänst för skapande av platskartsidor."
 
-#: DynamicWeb/dynamicweb.py:4065
+#: DynamicWeb//dynamicweb.py:4069
 msgid "Google map API key"
 msgstr "Google map API key"
 
-#: DynamicWeb/dynamicweb.py:4066
+#: DynamicWeb//dynamicweb.py:4070
 msgid "The API key used for the Google map"
 msgstr "API nyckel som används till Google map"
 
-#: DynamicWeb/dynamicweb.py:4073
+#: DynamicWeb//dynamicweb.py:4077
 msgid "Advanced"
 msgstr "Avancerat"
 
-#: DynamicWeb/dynamicweb.py:4076
+#: DynamicWeb//dynamicweb.py:4080
 msgid "Character set encoding"
 msgstr "Teckentabell"
 
-#: DynamicWeb/dynamicweb.py:4079
+#: DynamicWeb//dynamicweb.py:4083
 msgid "The encoding to be used for the web files"
 msgstr "Den kodning, som skall användas för webbfiler"
 
-#: DynamicWeb/dynamicweb.py:4082
+#: DynamicWeb//dynamicweb.py:4086
 msgid "Include family pages"
 msgstr "Ta med familjesidor"
 
-#: DynamicWeb/dynamicweb.py:4083
+#: DynamicWeb//dynamicweb.py:4087
 msgid "Whether or not to include family pages"
 msgstr "Huruvida ta med familjesidor eller inte"
 
-#: DynamicWeb/dynamicweb.py:4093
-msgid "Whether to include half and/ or step-siblings with the parents and siblings"
-msgstr "Huruvida ta med ett halv- och/eller styvsyskon med föräldrarna och syskonen"
+#: DynamicWeb//dynamicweb.py:4097
+msgid ""
+"Whether to include half and/ or step-siblings with the parents and siblings"
+msgstr ""
+"Huruvida ta med ett halv- och/eller styvsyskon med föräldrarna och syskonen"
 
-#: DynamicWeb/dynamicweb.py:4096
+#: DynamicWeb//dynamicweb.py:4100
 msgid "Include GENDEX file (/gendex.txt)"
 msgstr "Inkludera GENDEX-fil (/gendex.txt)"
 
-#: DynamicWeb/dynamicweb.py:4097
+#: DynamicWeb//dynamicweb.py:4101
 msgid "Whether to include a GENDEX file or not"
 msgstr "Huruvida ta med en GENDEX-fil eller inte"
 
-#: DynamicWeb/dynamicweb.py:4100
+#: DynamicWeb//dynamicweb.py:4104
 msgid "Enable page configuration"
 msgstr "Aktivera sidkonfiguration"
 
-#: DynamicWeb/dynamicweb.py:4101
+#: DynamicWeb//dynamicweb.py:4105
 msgid "Whether to enable page configuration"
 msgstr "Huruvida aktivera sidkonfiguration"
 
-#: DynamicWeb/dynamicweb.py:4105
+#: DynamicWeb//dynamicweb.py:4109
 msgid "Whether to use tabbed panels for the different sections of the pages."
 msgstr "Huruvida använda flikar för de olika sektionerna på sidorna."
 
-#: DynamicWeb/dynamicweb.py:4109
+#: DynamicWeb//dynamicweb.py:4113
 msgid "Whether to show the last modification time in the pages footer"
 msgstr "Huruvida visa sista ändringstiden i sidans sidfot"
 
-#: DynamicWeb/dynamicweb.py:4113
+#: DynamicWeb//dynamicweb.py:4117
 msgid "Whether to insert sources author in the sources title"
 msgstr "Huruvida lägga till källförfattare i källtiteln"
 
-#: DynamicWeb/dynamicweb.py:4117
+#: DynamicWeb//dynamicweb.py:4121
 msgid "Whether to hide the Gramps ID"
 msgstr "Huruvida dölja Gramps-IDn"
 
-#: DynamicWeb/dynamicweb.py:4126
+#: DynamicWeb//dynamicweb.py:4130
 msgid "List"
 msgstr "Lista"
 
-#: DynamicWeb/dynamicweb.py:4127
+#: DynamicWeb//dynamicweb.py:4131
 msgid "Table"
 msgstr "Tabell"
 
-#: DynamicWeb/dynamicweb.py:4130
+#: DynamicWeb//dynamicweb.py:4134
 msgid "Default format for the surnames index"
 msgstr "Standardformat för efternamnsindex"
 
-#: DynamicWeb/dynamicweb.py:4130
+#: DynamicWeb//dynamicweb.py:4134
 msgid "The default format for the surnames index"
 msgstr "Standardformatet för efternamnsindexet"
 
-#: DynamicWeb/dynamicweb.py:4131
+#: DynamicWeb//dynamicweb.py:4135
 msgid "Default format for the persons index"
 msgstr "Standardformat för personindex"
 
-#: DynamicWeb/dynamicweb.py:4131
+#: DynamicWeb//dynamicweb.py:4135
 msgid "The default format for the persons index"
 msgstr "Standardformatet för personindexet"
 
-#: DynamicWeb/dynamicweb.py:4132
+#: DynamicWeb//dynamicweb.py:4136
 msgid "Default format for the families index"
 msgstr "Standardformat för familjeindex"
 
-#: DynamicWeb/dynamicweb.py:4132
+#: DynamicWeb//dynamicweb.py:4136
 msgid "The default format for the families index"
 msgstr "Standardformatet för familjeindexet"
 
-#: DynamicWeb/dynamicweb.py:4133
+#: DynamicWeb//dynamicweb.py:4137
 msgid "Default format for the sources index"
 msgstr "Standardformat för källindex"
 
-#: DynamicWeb/dynamicweb.py:4133
+#: DynamicWeb//dynamicweb.py:4137
 msgid "The default format for the sources index"
 msgstr "Standardformatet för källindexet"
 
-#: DynamicWeb/dynamicweb.py:4134
+#: DynamicWeb//dynamicweb.py:4138
 msgid "Default format for the places index"
 msgstr "Standardformat för platsindex"
 
-#: DynamicWeb/dynamicweb.py:4134
+#: DynamicWeb//dynamicweb.py:4138
 msgid "The default format for the places index"
 msgstr "Standardformatet för platsindexet"
 
-#: DynamicWeb/dynamicweb.py:4143
-msgid "Whether to include dates columns (birth, death, marriage) on the index pages"
-msgstr "Huruvida ta med datumkolumner (födelse, död, giftermål) på indexsidorna"
+#: DynamicWeb//dynamicweb.py:4147
+msgid ""
+"Whether to include dates columns (birth, death, marriage) on the index pages"
+msgstr ""
+"Huruvida ta med datumkolumner (födelse, död, giftermål) på indexsidorna"
 
-#: DynamicWeb/dynamicweb.py:4147
+#: DynamicWeb//dynamicweb.py:4151
 msgid "Whether to include a partners column"
 msgstr "Huruvida ta med en partnerkolumn"
 
-#: DynamicWeb/dynamicweb.py:4151
+#: DynamicWeb//dynamicweb.py:4155
 msgid "Whether to include a parents column"
 msgstr "Huruvida ta med en föräldrakolumn"
 
-#: DynamicWeb/dynamicweb.py:4154
+#: DynamicWeb//dynamicweb.py:4158
 msgid "Generate a families index page"
 msgstr "Skapa en familjeindexsida"
 
-#: DynamicWeb/dynamicweb.py:4155
+#: DynamicWeb//dynamicweb.py:4159
 msgid "Whether to generate an index page for families"
 msgstr "Huruvida skapa en indexsida för familjer"
 
-#: DynamicWeb/dynamicweb.py:4159
+#: DynamicWeb//dynamicweb.py:4163
 msgid "Whether to include a column showing the media path"
 msgstr "Huruvida ta med en kolumn som visar mediasökväg"
 
-#: DynamicWeb/dynamicweb.py:4163
-msgid "Whether to include the references to the items in the index pages. For example, in the media index page, the names of the individuals, families, places, sources that reference the media."
-msgstr "Huruvida ta med referenser till artiklarna i indexsidorna. Exempelvis på mediaindexsidan, namnen på personerna, familjerna, platserna, källorna som refererar till mediafilerna."
+#: DynamicWeb//dynamicweb.py:4167
+msgid ""
+"Whether to include the references to the items in the index pages. For "
+"example, in the media index page, the names of the individuals, families, "
+"places, sources that reference the media."
+msgstr ""
+"Huruvida ta med referenser till artiklarna i indexsidorna. Exempelvis på "
+"mediaindexsidan, namnen på personerna, familjerna, platserna, källorna som "
+"refererar till mediafilerna."
 
-#: DynamicWeb/dynamicweb.py:4166
+#: DynamicWeb//dynamicweb.py:4170
 msgid "Default number of entries in the indexes"
 msgstr "Standardnummer på poster i indexen"
 
-#: DynamicWeb/dynamicweb.py:4169
+#: DynamicWeb//dynamicweb.py:4173
 msgid "The default number of entries shown in one index page"
 msgstr "Standardnumret för poster som visas på en indexsida"
 
-#: DynamicWeb/dynamicweb.py:4174
+#: DynamicWeb//dynamicweb.py:4178
 msgid "Trees"
 msgstr "Träd"
 
-#: DynamicWeb/dynamicweb.py:4177
+#: DynamicWeb//dynamicweb.py:4181
 msgid "Maximum number of generations"
 msgstr "Maximalt antal generationer"
 
-#: DynamicWeb/dynamicweb.py:4178
-msgid "The maximum number of generations to include in the ancestor and descendant trees and graphs"
-msgstr "Maximalt antal generationer att ta med i förfäders- och ättlingsträden och grafer"
+#: DynamicWeb//dynamicweb.py:4182
+msgid ""
+"The maximum number of generations to include in the ancestor and descendant "
+"trees and graphs"
+msgstr ""
+"Maximalt antal generationer att ta med i förfäders- och ättlingsträden och "
+"grafer"
 
-#: DynamicWeb/dynamicweb.py:4184
+#: DynamicWeb//dynamicweb.py:4188
 msgid "Choose the default SVG tree graph type"
 msgstr "Välj standard SVG trädgrafiktyp"
 
-#: DynamicWeb/dynamicweb.py:4190
+#: DynamicWeb//dynamicweb.py:4194
 msgid "Choose the default SVG tree graph shape"
 msgstr "Välj standard SVG trädgrafikform"
 
-#: DynamicWeb/dynamicweb.py:4196
+#: DynamicWeb//dynamicweb.py:4200
 msgid "Choose the default SVG tree parents distribution (for fan charts only)"
-msgstr "Välj standard SVG träd för föräldrar (endast för antavlor i cirkelformat)"
+msgstr ""
+"Välj standard SVG träd för föräldrar (endast för antavlor i cirkelformat)"
 
-#: DynamicWeb/dynamicweb.py:4202
+#: DynamicWeb//dynamicweb.py:4206
 msgid "Choose the default SVG tree children distribution (for fan charts only)"
 msgstr "Välj standard SVG träd för barn (endast för antavlor i cirkelformat)"
 
-#: DynamicWeb/dynamicweb.py:4208
-msgid "Choose the background color scheme for the persons in the SVG tree graph"
+#: DynamicWeb//dynamicweb.py:4212
+msgid ""
+"Choose the background color scheme for the persons in the SVG tree graph"
 msgstr "Välj bakgrundens färgschema för personerna i SVG-trädet"
 
-#: DynamicWeb/dynamicweb.py:4211
+#: DynamicWeb//dynamicweb.py:4215
 msgid "Start gradient/Main color"
 msgstr "Start för gradient/huvudfärg"
 
-#: DynamicWeb/dynamicweb.py:4214
+#: DynamicWeb//dynamicweb.py:4218
 msgid "End gradient/2nd color"
 msgstr "Slut för gradient/andra färg"
 
-#: DynamicWeb/dynamicweb.py:4222
+#: DynamicWeb//dynamicweb.py:4226
 msgid "Color for duplicates"
 msgstr "Färg för dubbletter"
 
-#: DynamicWeb/dynamicweb.py:4227
+#: DynamicWeb//dynamicweb.py:4231
 msgid "Pages"
 msgstr "Sidor"
 
-#: DynamicWeb/dynamicweb.py:4230
+#: DynamicWeb//dynamicweb.py:4234
 msgid "HTML user header"
 msgstr "HTML sidhuvud"
 
-#: DynamicWeb/dynamicweb.py:4231
+#: DynamicWeb//dynamicweb.py:4235
 msgid "A note to be used as the page header"
 msgstr "En notis, som skall användas som sidhuvud"
 
-#: DynamicWeb/dynamicweb.py:4234
+#: DynamicWeb//dynamicweb.py:4238
 msgid "HTML user brand name / icon"
 msgstr "HTML varumärke namn/ikon"
 
-#: DynamicWeb/dynamicweb.py:4235
+#: DynamicWeb//dynamicweb.py:4239
 msgid "A note to be used as the brand name or image in the menu"
 msgstr "En notis att användas för varumärkesnamnet eller en bild i menyn"
 
-#: DynamicWeb/dynamicweb.py:4238
+#: DynamicWeb//dynamicweb.py:4242
 msgid "HTML user footer"
 msgstr "HTML sidfot"
 
-#: DynamicWeb/dynamicweb.py:4239
+#: DynamicWeb//dynamicweb.py:4243
 msgid "A note to be used as the page footer"
 msgstr "En notis, som skall används som sidfot"
 
-#: DynamicWeb/dynamicweb.py:4244
+#: DynamicWeb//dynamicweb.py:4248
 msgid "Custom pages"
 msgstr "Anpassade sidor"
 
-#: DynamicWeb/dynamicweb.py:4248
+#: DynamicWeb//dynamicweb.py:4252
 #, python-format
 msgid "Title for the custom page %(index)i"
 msgstr "Den anpassade sidans titel %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4249
+#: DynamicWeb//dynamicweb.py:4253
 #, python-format
 msgid "Name for the custom page %(index)i"
 msgstr "Namn på den anpassade sidan %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4252
+#: DynamicWeb//dynamicweb.py:4256
 #, python-format
 msgid "Note for custom page %(index)i"
 msgstr "Notis för den anpassade sidan %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4253
+#: DynamicWeb//dynamicweb.py:4257
 msgid "A note to be used for the custom page content.\n"
 msgstr "En notis att användas för innehållet på den anpassade sidan.\n"
 
-#: DynamicWeb/dynamicweb.py:4256
+#: DynamicWeb//dynamicweb.py:4260
 #, python-format
 msgid "Menu for the custom page %(index)i"
 msgstr "Meny på den anpassade sidan %(index)i"
 
-#: DynamicWeb/dynamicweb.py:4257
+#: DynamicWeb//dynamicweb.py:4261
 msgid "Whether to print a menu for the custom page"
 msgstr "Huruvida skriva ut en meny för den anpassade sidan"
 
-#: DynamicWeb/dynamicweb.py:4262
+#: DynamicWeb//dynamicweb.py:4266
 msgid "Pages selection"
 msgstr "Sidval"
 
-#: DynamicWeb/dynamicweb.py:4265
+#: DynamicWeb//dynamicweb.py:4269
 msgid "Number of pages"
 msgstr "Antal sidor"
 
-#: DynamicWeb/dynamicweb.py:4266
+#: DynamicWeb//dynamicweb.py:4270
 msgid "Number pages in the web site menu."
 msgstr "Antal sidor i webbsidesmenyn."
 
-#: DynamicWeb/dynamicweb.py:4282
+#: DynamicWeb//dynamicweb.py:4286
 #, python-format
 msgid "Contents of page %(index)i"
 msgstr "Sidan %(index)i innehåll"
 
-#: DynamicWeb/dynamicweb.py:4285
+#: DynamicWeb//dynamicweb.py:4289
 msgid "Contents of the page"
 msgstr "Innehåll på sidan"
+
+#~ msgid "Html|Home"
+#~ msgstr "Html|Hem"

--- a/DynamicWeb/po/template.pot
+++ b/DynamicWeb/po/template.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-04-22 11:04-0500\n"
+"POT-Creation-Date: 2020-07-24 17:33+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,961 +17,961 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: DynamicWeb/dynamicweb.gpr.py:15
+#: DynamicWeb//dynamicweb.gpr.py:15
 msgid "Dynamic Web Report"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.gpr.py:16
+#: DynamicWeb//dynamicweb.gpr.py:16
 msgid "Produces dynamic web pages for the database"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:265
+#: DynamicWeb//dynamicweb.py:269
 msgid "Street"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:266
+#: DynamicWeb//dynamicweb.py:270
 msgid "Locality"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:267
+#: DynamicWeb//dynamicweb.py:271
 msgid "City"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:268
+#: DynamicWeb//dynamicweb.py:272
 msgid "Church Parish"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:269
+#: DynamicWeb//dynamicweb.py:273
 msgid "County"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:270
+#: DynamicWeb//dynamicweb.py:274
 msgid "State/ Province"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:271
+#: DynamicWeb//dynamicweb.py:275
 msgid "Postal Code"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:272
+#: DynamicWeb//dynamicweb.py:276
 msgid "Country"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:273
+#: DynamicWeb//dynamicweb.py:277
 msgid "Phone"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:279
+#: DynamicWeb//dynamicweb.py:283
 msgid "Home Page"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:280
+#: DynamicWeb//dynamicweb.py:284
 msgid "SVG graphical tree"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:283
+#: DynamicWeb//dynamicweb.py:287
 msgid "Indexes pages"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:287 DynamicWeb/dynamicweb.py:4248
+#: DynamicWeb//dynamicweb.py:291 DynamicWeb//dynamicweb.py:4252
 #, python-format
 msgid "Custom page %(index)i"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:305
+#: DynamicWeb//dynamicweb.py:309
 msgid "Ascending tree"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:306
+#: DynamicWeb//dynamicweb.py:310
 msgid "Descending tree"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:307
+#: DynamicWeb//dynamicweb.py:311
 msgid "Descending tree with spouses"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:308
+#: DynamicWeb//dynamicweb.py:312
 msgid "Ascending and descending tree"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:309
+#: DynamicWeb//dynamicweb.py:313
 msgid "Ascending and descending tree with spouses"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:321
+#: DynamicWeb//dynamicweb.py:325
 msgid "Vertical (↓)"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:322
+#: DynamicWeb//dynamicweb.py:326
 msgid "Vertical (↑)"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:323
+#: DynamicWeb//dynamicweb.py:327
 msgid "Horizontal (→)"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:324
+#: DynamicWeb//dynamicweb.py:328
 msgid "Horizontal (←)"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:325
+#: DynamicWeb//dynamicweb.py:329
 msgid "Full Circle"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:326
+#: DynamicWeb//dynamicweb.py:330
 msgid "Half Circle"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:327
+#: DynamicWeb//dynamicweb.py:331
 msgid "Quadrant"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:339
+#: DynamicWeb//dynamicweb.py:343
 msgid "Size proportional to number of ancestors"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:340
+#: DynamicWeb//dynamicweb.py:344
 msgid "Homogeneous parents distribution"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:343
+#: DynamicWeb//dynamicweb.py:347
 msgid "Size proportional to number of descendants"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:344
+#: DynamicWeb//dynamicweb.py:348
 msgid "Homogeneous children distribution"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:351 DynamicWeb/dynamicweb.py:374
+#: DynamicWeb//dynamicweb.py:355 DynamicWeb//dynamicweb.py:378
 msgid "Gender colors"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:352
+#: DynamicWeb//dynamicweb.py:356
 msgid "Generation based gradient"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:353
+#: DynamicWeb//dynamicweb.py:357
 msgid "Age based gradient"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:354 DynamicWeb/dynamicweb.py:373
+#: DynamicWeb//dynamicweb.py:358 DynamicWeb//dynamicweb.py:377
 msgid "Single main (filter) color"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:355
+#: DynamicWeb//dynamicweb.py:359
 msgid "Time period based gradient"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:356 DynamicWeb/dynamicweb.py:378
+#: DynamicWeb//dynamicweb.py:360 DynamicWeb//dynamicweb.py:382
 msgid "White"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:357 DynamicWeb/dynamicweb.py:376
+#: DynamicWeb//dynamicweb.py:361 DynamicWeb//dynamicweb.py:380
 msgid "Color scheme classic report"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:358 DynamicWeb/dynamicweb.py:377
+#: DynamicWeb//dynamicweb.py:362 DynamicWeb//dynamicweb.py:381
 msgid "Color scheme classic view"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:375
+#: DynamicWeb//dynamicweb.py:379
 msgid "Gradient"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:394
+#: DynamicWeb//dynamicweb.py:398
 msgid "Default"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:395
+#: DynamicWeb//dynamicweb.py:399
 msgid "Mainz"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:703
+#: DynamicWeb//dynamicweb.py:707
 #, python-format
 msgid "Neither %(current)s nor %(parent)s are directories"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:711 DynamicWeb/dynamicweb.py:716
+#: DynamicWeb//dynamicweb.py:715 DynamicWeb//dynamicweb.py:720
 #, python-format
 msgid "Could not create the directory: %(path)s"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:742 DynamicWeb/dynamicweb.py:3381
+#: DynamicWeb//dynamicweb.py:746 DynamicWeb//dynamicweb.py:3385
 msgid "Dynamic Web Site Report"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:742
+#: DynamicWeb//dynamicweb.py:746
 msgid "Exporting family tree data ..."
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:1233 DynamicWeb/dynamicweb.py:2457
+#: DynamicWeb//dynamicweb.py:1237 DynamicWeb//dynamicweb.py:2461
 msgid "Author"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:1234 DynamicWeb/dynamicweb.py:2447
+#: DynamicWeb//dynamicweb.py:1238 DynamicWeb//dynamicweb.py:2451
 msgid "Abbreviation"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:1235 DynamicWeb/dynamicweb.py:2544
+#: DynamicWeb//dynamicweb.py:1239 DynamicWeb//dynamicweb.py:2548
 msgid "Publication information"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:1305 DynamicWeb/dynamicweb.py:2475
+#: DynamicWeb//dynamicweb.py:1309 DynamicWeb//dynamicweb.py:2479
 msgid "Date"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:1306
+#: DynamicWeb//dynamicweb.py:1310
 msgid "Page"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:1307
+#: DynamicWeb//dynamicweb.py:1311
 msgid "Confidence"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:1626
+#: DynamicWeb//dynamicweb.py:1630
 #, python-format
 msgid "%(type)s: %(value)s"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:1873
+#: DynamicWeb//dynamicweb.py:1877
 #, python-format
 msgid "Impossible to convert \"%(path)s\" to a relative path."
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2179
+#: DynamicWeb//dynamicweb.py:2183
 msgid ""
 "The pages configuration is not valid: several pages have the same content"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2190
-msgid "Html|Home"
+#: DynamicWeb//dynamicweb.py:2194
+msgid "DynWeb|Home"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2191 DynamicWeb/dynamicweb.py:2204
-#: DynamicWeb/dynamicweb.py:2205 DynamicWeb/dynamicweb.py:2206
+#: DynamicWeb//dynamicweb.py:2195 DynamicWeb//dynamicweb.py:2208
+#: DynamicWeb//dynamicweb.py:2209 DynamicWeb//dynamicweb.py:2210
 msgid "Tree"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2192 DynamicWeb/dynamicweb.py:2207
-#: DynamicWeb/dynamicweb.py:2208 DynamicWeb/dynamicweb.py:2209
+#: DynamicWeb//dynamicweb.py:2196 DynamicWeb//dynamicweb.py:2211
+#: DynamicWeb//dynamicweb.py:2212 DynamicWeb//dynamicweb.py:2213
 msgid "Statistics"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2195 DynamicWeb/dynamicweb.py:2471
+#: DynamicWeb//dynamicweb.py:2199 DynamicWeb//dynamicweb.py:2475
 msgid "Configuration"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2197 DynamicWeb/dynamicweb.py:2536
+#: DynamicWeb//dynamicweb.py:2201 DynamicWeb//dynamicweb.py:2540
 msgid "Person"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2198
+#: DynamicWeb//dynamicweb.py:2202
 msgid "Family"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2199 DynamicWeb/dynamicweb.py:2576
+#: DynamicWeb//dynamicweb.py:2203 DynamicWeb//dynamicweb.py:2580
 msgid "Source"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2200 DynamicWeb/dynamicweb.py:2219
-#: DynamicWeb/dynamicweb.py:2519
+#: DynamicWeb//dynamicweb.py:2204 DynamicWeb//dynamicweb.py:2223
+#: DynamicWeb//dynamicweb.py:2523
 msgid "Media"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2201 DynamicWeb/dynamicweb.py:2539
+#: DynamicWeb//dynamicweb.py:2205 DynamicWeb//dynamicweb.py:2543
 msgid "Place"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2202 DynamicWeb/dynamicweb.py:2551
+#: DynamicWeb//dynamicweb.py:2206 DynamicWeb//dynamicweb.py:2555
 msgid "Repository"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2203
+#: DynamicWeb//dynamicweb.py:2207
 msgid "Search results"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2214 DynamicWeb/dynamicweb.py:2215
-#: DynamicWeb/dynamicweb.py:2583
+#: DynamicWeb//dynamicweb.py:2218 DynamicWeb//dynamicweb.py:2219
+#: DynamicWeb//dynamicweb.py:2587
 msgid "Surnames"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2216 DynamicWeb/dynamicweb.py:2504
+#: DynamicWeb//dynamicweb.py:2220 DynamicWeb//dynamicweb.py:2508
 msgid "Individuals"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2217 DynamicWeb/dynamicweb.py:2487
+#: DynamicWeb//dynamicweb.py:2221 DynamicWeb//dynamicweb.py:2491
 msgid "Families"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2218 DynamicWeb/dynamicweb.py:2578
+#: DynamicWeb//dynamicweb.py:2222 DynamicWeb//dynamicweb.py:2582
 msgid "Sources"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2220 DynamicWeb/dynamicweb.py:2541
+#: DynamicWeb//dynamicweb.py:2224 DynamicWeb//dynamicweb.py:2545
 msgid "Places"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2221 DynamicWeb/dynamicweb.py:2449
+#: DynamicWeb//dynamicweb.py:2225 DynamicWeb//dynamicweb.py:2453
 msgid "Addresses"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2222 DynamicWeb/dynamicweb.py:2550
+#: DynamicWeb//dynamicweb.py:2226 DynamicWeb//dynamicweb.py:2554
 msgid "Repositories"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2273 DynamicWeb/dynamicweb.py:2503
-#: DynamicWeb/dynamicweb.py:4122
+#: DynamicWeb//dynamicweb.py:2277 DynamicWeb//dynamicweb.py:2507
+#: DynamicWeb//dynamicweb.py:4126
 msgid "Indexes"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2437
+#: DynamicWeb//dynamicweb.py:2441
 #, python-format
 msgid "(b. %(birthdate)s, d. %(deathdate)s)"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2438
+#: DynamicWeb//dynamicweb.py:2442
 #, python-format
 msgid "(b. %s)"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2439
+#: DynamicWeb//dynamicweb.py:2443
 #, python-format
 msgid "(d. %s)"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2440
+#: DynamicWeb//dynamicweb.py:2444
 msgid "(filtered from _MAX_ total entries)"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2441
+#: DynamicWeb//dynamicweb.py:2445
 #, python-format
 msgid "(m. %s)"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2442
+#: DynamicWeb//dynamicweb.py:2446
 msgid "(sort by name)"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2443
+#: DynamicWeb//dynamicweb.py:2447
 msgid "(sort by quantity)"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2444
+#: DynamicWeb//dynamicweb.py:2448
 msgid ": activate to sort column ascending"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2445
+#: DynamicWeb//dynamicweb.py:2449
 msgid ": activate to sort column descending"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2446
+#: DynamicWeb//dynamicweb.py:2450
 msgid ""
 "<p>This page provides the SVG raw code.<br>Copy the contents into a text "
 "editor and save as an SVG file.<br>Make sure that the text editor encoding "
 "is UTF-8.</p>"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2448
+#: DynamicWeb//dynamicweb.py:2452
 msgid "Address"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2450
+#: DynamicWeb//dynamicweb.py:2454
 msgid "Age at death"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2451
+#: DynamicWeb//dynamicweb.py:2455
 msgid "Alternate Marriage"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2452
+#: DynamicWeb//dynamicweb.py:2456
 msgid "Alternate Name"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2453
+#: DynamicWeb//dynamicweb.py:2457
 msgid "Ancestors"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2454
+#: DynamicWeb//dynamicweb.py:2458
 msgid "Associations"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2455
+#: DynamicWeb//dynamicweb.py:2459
 msgid "Attribute"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2456
+#: DynamicWeb//dynamicweb.py:2460
 msgid "Attributes"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2458 DynamicWeb/dynamicweb.py:4205
+#: DynamicWeb//dynamicweb.py:2462 DynamicWeb//dynamicweb.py:4209
 msgid "Background"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2459
+#: DynamicWeb//dynamicweb.py:2463
 msgid "Baptism"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2460
+#: DynamicWeb//dynamicweb.py:2464
 msgid "Birth"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2461
+#: DynamicWeb//dynamicweb.py:2465
 msgid "Burial"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2462
+#: DynamicWeb//dynamicweb.py:2466
 msgid "Call Name"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2463
+#: DynamicWeb//dynamicweb.py:2467
 msgid "Call Number"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2464
+#: DynamicWeb//dynamicweb.py:2468
 msgid "Cause Of Death"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2465
+#: DynamicWeb//dynamicweb.py:2469
 msgid "Children"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2466
+#: DynamicWeb//dynamicweb.py:2470
 msgid "Christening"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2467
+#: DynamicWeb//dynamicweb.py:2471
 msgid "Citation"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2468
+#: DynamicWeb//dynamicweb.py:2472
 msgid "Citations"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2469
+#: DynamicWeb//dynamicweb.py:2473
 msgid "Click on the map to show it full-screen"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2470
+#: DynamicWeb//dynamicweb.py:2474
 msgid "Code"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2472
+#: DynamicWeb//dynamicweb.py:2476
 msgid "Configure"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2473
+#: DynamicWeb//dynamicweb.py:2477
 msgid "Count"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2474
+#: DynamicWeb//dynamicweb.py:2478
 msgid "Cremation"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2476
+#: DynamicWeb//dynamicweb.py:2480
 msgid "Death"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2477
+#: DynamicWeb//dynamicweb.py:2481
 msgid "Descendants"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2478
+#: DynamicWeb//dynamicweb.py:2482
 msgid "Description"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2479
+#: DynamicWeb//dynamicweb.py:2483
 msgid "DynamicWeb_report#Help"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2480
+#: DynamicWeb//dynamicweb.py:2484
 msgid "Enclosed By"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2481
+#: DynamicWeb//dynamicweb.py:2485
 msgid "Engagement"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2482
+#: DynamicWeb//dynamicweb.py:2486
 msgid "Event"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2483
+#: DynamicWeb//dynamicweb.py:2487
 msgid "Events"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2484
+#: DynamicWeb//dynamicweb.py:2488
 msgid "Examples"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2485
+#: DynamicWeb//dynamicweb.py:2489
 msgid "F"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2486
+#: DynamicWeb//dynamicweb.py:2490
 msgid "Families Index"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2488
+#: DynamicWeb//dynamicweb.py:2492
 msgid "Family Nick Name"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2489
+#: DynamicWeb//dynamicweb.py:2493
 msgid "Father"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2490
+#: DynamicWeb//dynamicweb.py:2494
 msgid "Female"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2491
+#: DynamicWeb//dynamicweb.py:2495
 msgid "File ready"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2492
+#: DynamicWeb//dynamicweb.py:2496
 msgid "Gender"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2493
+#: DynamicWeb//dynamicweb.py:2497
 msgid "Help"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2494
+#: DynamicWeb//dynamicweb.py:2498
 msgid "ID"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2495 DynamicWeb/dynamicweb.py:4037
+#: DynamicWeb//dynamicweb.py:2499 DynamicWeb//dynamicweb.py:4041
 msgid "Include Place map on Place Pages"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2496 DynamicWeb/dynamicweb.py:4142
+#: DynamicWeb//dynamicweb.py:2500 DynamicWeb//dynamicweb.py:4146
 msgid "Include dates columns on the index pages"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2497 DynamicWeb/dynamicweb.py:4150
+#: DynamicWeb//dynamicweb.py:2501 DynamicWeb//dynamicweb.py:4154
 msgid "Include a column for parents on the index pages"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2498 DynamicWeb/dynamicweb.py:4158
+#: DynamicWeb//dynamicweb.py:2502 DynamicWeb//dynamicweb.py:4162
 msgid "Include a column for media path on the index pages"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2499 DynamicWeb/dynamicweb.py:4146
+#: DynamicWeb//dynamicweb.py:2503 DynamicWeb//dynamicweb.py:4150
 msgid "Include a column for partners on the index pages"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2500 DynamicWeb/dynamicweb.py:4045
+#: DynamicWeb//dynamicweb.py:2504 DynamicWeb//dynamicweb.py:4049
 msgid "Include a map in the individuals and family pages"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2501 DynamicWeb/dynamicweb.py:4092
+#: DynamicWeb//dynamicweb.py:2505 DynamicWeb//dynamicweb.py:4096
 msgid "Include half and/ or step-siblings on the individual pages"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2502 DynamicWeb/dynamicweb.py:4162
+#: DynamicWeb//dynamicweb.py:2506 DynamicWeb//dynamicweb.py:4166
 msgid "Include references in indexes"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2505 DynamicWeb/dynamicweb.py:4112
+#: DynamicWeb//dynamicweb.py:2509 DynamicWeb//dynamicweb.py:4116
 msgid "Insert sources author in the sources title"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2506
+#: DynamicWeb//dynamicweb.py:2510
 msgid "Last Modified"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2507
+#: DynamicWeb//dynamicweb.py:2511
 msgid "Latitude"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2508
+#: DynamicWeb//dynamicweb.py:2512
 msgid "Link"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2509
+#: DynamicWeb//dynamicweb.py:2513
 msgid "Loading..."
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2510
+#: DynamicWeb//dynamicweb.py:2514
 msgid "Location"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2511
+#: DynamicWeb//dynamicweb.py:2515
 msgid "Longitude"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2512
+#: DynamicWeb//dynamicweb.py:2516
 msgid "M"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2513
+#: DynamicWeb//dynamicweb.py:2517
 msgid "Male"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2514
+#: DynamicWeb//dynamicweb.py:2518
 msgid "Map"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2515
+#: DynamicWeb//dynamicweb.py:2519
 msgid "Marriage"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2516
+#: DynamicWeb//dynamicweb.py:2520
 msgid "Maximize"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2517
+#: DynamicWeb//dynamicweb.py:2521
 msgid "Media Index"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2518
+#: DynamicWeb//dynamicweb.py:2522
 msgid "Media Type"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2520
+#: DynamicWeb//dynamicweb.py:2524
 msgid "Mother"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2521
+#: DynamicWeb//dynamicweb.py:2525
 msgid "Name"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2522
+#: DynamicWeb//dynamicweb.py:2526
 msgid "Nick Name"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2523
+#: DynamicWeb//dynamicweb.py:2527
 msgid "No data available in table"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2524
+#: DynamicWeb//dynamicweb.py:2528
 msgid "No matches found"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2525
+#: DynamicWeb//dynamicweb.py:2529
 msgid "No matching records found"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2526
+#: DynamicWeb//dynamicweb.py:2530
 msgid "No matching surname."
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2527
+#: DynamicWeb//dynamicweb.py:2531
 msgid "None"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2528
+#: DynamicWeb//dynamicweb.py:2532
 msgid "Notes"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2529
+#: DynamicWeb//dynamicweb.py:2533
 msgid "Number"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2530
+#: DynamicWeb//dynamicweb.py:2534
 msgid "OK"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2531
+#: DynamicWeb//dynamicweb.py:2535
 msgid "Other participants"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2532
+#: DynamicWeb//dynamicweb.py:2536
 msgid "Parents"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2533
+#: DynamicWeb//dynamicweb.py:2537
 msgid "Path"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2534
+#: DynamicWeb//dynamicweb.py:2538
 msgid "Person page"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2535
+#: DynamicWeb//dynamicweb.py:2539
 msgid "Person to search for"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2537
+#: DynamicWeb//dynamicweb.py:2541
 msgid "Persons Index"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2538
+#: DynamicWeb//dynamicweb.py:2542
 msgid "Persons"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2540
+#: DynamicWeb//dynamicweb.py:2544
 msgid "Places Index"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2542
+#: DynamicWeb//dynamicweb.py:2546
 msgid "Preparing file ..."
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2543
+#: DynamicWeb//dynamicweb.py:2547
 msgid "Processing..."
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2545
+#: DynamicWeb//dynamicweb.py:2549
 msgid "References"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2546
+#: DynamicWeb//dynamicweb.py:2550
 msgid "Relationship to Father"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2547
+#: DynamicWeb//dynamicweb.py:2551
 msgid "Relationship to Mother"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2548
+#: DynamicWeb//dynamicweb.py:2552
 msgid "Relationship"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2549
+#: DynamicWeb//dynamicweb.py:2553
 msgid "Repositories Index"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2552
+#: DynamicWeb//dynamicweb.py:2556
 msgid "Restore"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2553
+#: DynamicWeb//dynamicweb.py:2557
 msgid "Restore default settings"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2554 DynamicWeb/dynamicweb.py:4108
+#: DynamicWeb//dynamicweb.py:2558 DynamicWeb//dynamicweb.py:4112
 msgid "Show last modification time"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2555 DynamicWeb/dynamicweb.py:4199
+#: DynamicWeb//dynamicweb.py:2559 DynamicWeb//dynamicweb.py:4203
 msgid "SVG tree children distribution"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2556
+#: DynamicWeb//dynamicweb.py:2560
 msgid "SVG tree configuration"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2557 DynamicWeb/dynamicweb.py:4187
+#: DynamicWeb//dynamicweb.py:2561 DynamicWeb//dynamicweb.py:4191
 msgid "SVG tree graph shape"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2558 DynamicWeb/dynamicweb.py:4181
+#: DynamicWeb//dynamicweb.py:2562 DynamicWeb//dynamicweb.py:4185
 msgid "SVG tree graph type"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2559 DynamicWeb/dynamicweb.py:4193
+#: DynamicWeb//dynamicweb.py:2563 DynamicWeb//dynamicweb.py:4197
 msgid "SVG tree parents distribution"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2560
+#: DynamicWeb//dynamicweb.py:2564
 msgid "Save tree as file"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2561
+#: DynamicWeb//dynamicweb.py:2565
 msgid "Search:"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2562
+#: DynamicWeb//dynamicweb.py:2566
 msgid "Select the background color scheme"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2563
+#: DynamicWeb//dynamicweb.py:2567
 msgid "Select the children distribution (fan charts only)"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2564
+#: DynamicWeb//dynamicweb.py:2568
 msgid "Select the number of ascending generations"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2565
+#: DynamicWeb//dynamicweb.py:2569
 msgid "Select the number of descending generations"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2566
+#: DynamicWeb//dynamicweb.py:2570
 msgid "Select the parents distribution (fan charts only)"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2567
+#: DynamicWeb//dynamicweb.py:2571
 msgid "Select the shape of graph"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2568
+#: DynamicWeb//dynamicweb.py:2572
 msgid "Select the type of graph"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2569
+#: DynamicWeb//dynamicweb.py:2573
 msgid "Several matches.<br>Precise your search or choose in the lists below."
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2570
+#: DynamicWeb//dynamicweb.py:2574
 msgid "Show _MENU_ entries"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2571 DynamicWeb/dynamicweb.py:4217
+#: DynamicWeb//dynamicweb.py:2575 DynamicWeb//dynamicweb.py:4221
 msgid "Show duplicates"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2572
+#: DynamicWeb//dynamicweb.py:2576
 msgid "Showing 0 to 0 of 0 entries"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2573
+#: DynamicWeb//dynamicweb.py:2577
 msgid "Showing _START_ to _END_ of _TOTAL_ entries"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2574
+#: DynamicWeb//dynamicweb.py:2578
 msgid "Siblings"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2575
+#: DynamicWeb//dynamicweb.py:2579
 msgid "Sort by:"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2577
+#: DynamicWeb//dynamicweb.py:2581
 msgid "Sources Index"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2579
+#: DynamicWeb//dynamicweb.py:2583
 msgid "Spouses"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2580 DynamicWeb/dynamicweb.py:4116
+#: DynamicWeb//dynamicweb.py:2584 DynamicWeb//dynamicweb.py:4120
 msgid "Suppress Gramps ID"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2581
+#: DynamicWeb//dynamicweb.py:2585
 msgid "Surname"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2582
+#: DynamicWeb//dynamicweb.py:2586
 msgid "Surnames Index"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2584
+#: DynamicWeb//dynamicweb.py:2588
 msgid "Title"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2585
+#: DynamicWeb//dynamicweb.py:2589
 msgid "Type"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2586
+#: DynamicWeb//dynamicweb.py:2590
 msgid "U"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2587
+#: DynamicWeb//dynamicweb.py:2591
 msgid "Unknown"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2588 DynamicWeb/dynamicweb.py:4104
+#: DynamicWeb//dynamicweb.py:2592 DynamicWeb//dynamicweb.py:4108
 msgid "Use tabbed panels instead of sections"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2589
+#: DynamicWeb//dynamicweb.py:2593
 msgid "Use the search box above in order to find a person."
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2590
+#: DynamicWeb//dynamicweb.py:2594
 msgid "Use a table format for the surnames index"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2591
+#: DynamicWeb//dynamicweb.py:2595
 msgid "Use a table format for the persons index"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2592
+#: DynamicWeb//dynamicweb.py:2596
 msgid "Use a table format for the families index"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2593
+#: DynamicWeb//dynamicweb.py:2597
 msgid "Use a table format for the sources index"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2594
+#: DynamicWeb//dynamicweb.py:2598
 msgid "Use a table format for the places index"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2595
+#: DynamicWeb//dynamicweb.py:2599
 msgid "Used for family"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2596
+#: DynamicWeb//dynamicweb.py:2600
 msgid "Used for media"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2597
+#: DynamicWeb//dynamicweb.py:2601
 msgid "Used for person"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2598
+#: DynamicWeb//dynamicweb.py:2602
 msgid "Used for place"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2599
+#: DynamicWeb//dynamicweb.py:2603
 msgid "Used for source"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2600
+#: DynamicWeb//dynamicweb.py:2604
 msgid "Value"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2601
+#: DynamicWeb//dynamicweb.py:2605
 msgid "Web Link"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2602
+#: DynamicWeb//dynamicweb.py:2606
 msgid "Web Links"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2603 DynamicWeb/dynamicweb.py:4218
+#: DynamicWeb//dynamicweb.py:2607 DynamicWeb//dynamicweb.py:4222
 msgid ""
 "Whether to use a special color for the persons that appear several times in "
 "the SVG tree"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2604
+#: DynamicWeb//dynamicweb.py:2608
 msgid "Without name"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2605
+#: DynamicWeb//dynamicweb.py:2609
 msgid "Without surname"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2606
+#: DynamicWeb//dynamicweb.py:2610
 msgid "Without title"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2607
+#: DynamicWeb//dynamicweb.py:2611
 msgid "Zoom in"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2608
+#: DynamicWeb//dynamicweb.py:2612
 msgid "Zoom out"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2609
+#: DynamicWeb//dynamicweb.py:2613
 msgid "all"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2812
+#: DynamicWeb//dynamicweb.py:2816
 msgid "No Home Person"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2953
+#: DynamicWeb//dynamicweb.py:2957
 #, python-format
 msgid "Copying error: %(error)s"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2954
+#: DynamicWeb//dynamicweb.py:2958
 #, python-format
 msgid "Impossible to copy \"%(src)s\" to \"%(dst)s\""
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2957
+#: DynamicWeb//dynamicweb.py:2961
 msgid "Possible destination error"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2958
+#: DynamicWeb//dynamicweb.py:2962
 msgid ""
 "You appear to have set your target directory to a directory used for data "
 "storage. This could create problems with file management. It is recommended "
@@ -979,64 +979,64 @@ msgid ""
 "pages."
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:2985
+#: DynamicWeb//dynamicweb.py:2989
 #, python-format
 msgid "Unable to copy web site template files from \"%(path)s\""
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3029
+#: DynamicWeb//dynamicweb.py:3033
 #, python-format
 msgid "Keeping \"%(dst)s\" (newer than \"%(src)s\")"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3032
+#: DynamicWeb//dynamicweb.py:3036
 #, python-format
 msgid "Copying \"%(src)s\" to \"%(dst)s\""
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3050
+#: DynamicWeb//dynamicweb.py:3054
 msgid "Invalid file name"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3051
+#: DynamicWeb//dynamicweb.py:3055
 msgid "The archive file must be a file, not a directory"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3061 DynamicWeb/dynamicweb.py:3079
+#: DynamicWeb//dynamicweb.py:3065 DynamicWeb//dynamicweb.py:3083
 #, python-format
 msgid "Unable to overwrite archive file \"%(path)s\""
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3071 DynamicWeb/dynamicweb.py:3086
+#: DynamicWeb//dynamicweb.py:3075 DynamicWeb//dynamicweb.py:3090
 #, python-format
 msgid "Unable to add file \"%(file)s\" to archive \"%(archive)s\""
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3139
+#: DynamicWeb//dynamicweb.py:3143
 #, python-format
 msgid "DynamicWebReport ignoring link type '%(class)s'"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3382
+#: DynamicWeb//dynamicweb.py:3386
 msgid "Constructing list of other objects..."
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3517
+#: DynamicWeb//dynamicweb.py:3521
 #, python-format
 msgid "Family of %(husband)s and %(spouse)s"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3523
+#: DynamicWeb//dynamicweb.py:3527
 #, python-format
 msgid "Family of %(father)s"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3527
+#: DynamicWeb//dynamicweb.py:3531
 #, python-format
 msgid "Family of %(mother)s"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3842
+#: DynamicWeb//dynamicweb.py:3846
 msgid ""
 "In this note, the following special words are processed:\n"
 "__SEARCH_FORM__ is replaced by a search form.\n"
@@ -1056,527 +1056,527 @@ msgid ""
 "relative URL \"<link>\".\n"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3882
+#: DynamicWeb//dynamicweb.py:3886
 msgid "Report"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3887
+#: DynamicWeb//dynamicweb.py:3891
 msgid "Destination"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3889
+#: DynamicWeb//dynamicweb.py:3893
 msgid "The destination directory for the web files"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3893
+#: DynamicWeb//dynamicweb.py:3897
 msgid "Store web pages in archive"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3894
+#: DynamicWeb//dynamicweb.py:3898
 msgid ""
 "Whether to create an archive file (in ZIP or TGZ format) containing the web "
 "site"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3898
+#: DynamicWeb//dynamicweb.py:3902
 msgid "Archive file"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3900
+#: DynamicWeb//dynamicweb.py:3904
 msgid "The archive file name (with \".zip\" or \".tgz\" extension)"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3906
+#: DynamicWeb//dynamicweb.py:3910
 msgid "Web site title"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3906
+#: DynamicWeb//dynamicweb.py:3910
 msgid "My Family Tree"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3907
+#: DynamicWeb//dynamicweb.py:3911
 msgid "The title of the web site"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3910
+#: DynamicWeb//dynamicweb.py:3914
 msgid "Filter"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3912
+#: DynamicWeb//dynamicweb.py:3916
 msgid "Select filter to restrict people that appear on web site"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3916
+#: DynamicWeb//dynamicweb.py:3920
 msgid "Filter Person"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3917
+#: DynamicWeb//dynamicweb.py:3921
 msgid "The center person for the filter"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3925 DynamicWeb/dynamicweb.py:3945
+#: DynamicWeb//dynamicweb.py:3929 DynamicWeb//dynamicweb.py:3949
 msgid "Name format (short)"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3926 DynamicWeb/dynamicweb.py:3948
+#: DynamicWeb//dynamicweb.py:3930 DynamicWeb//dynamicweb.py:3952
 msgid "Select the format to display a shorter version of the names"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3940
+#: DynamicWeb//dynamicweb.py:3944
 msgid "Name format"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3943
+#: DynamicWeb//dynamicweb.py:3947
 msgid "Select the format to display names"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3951
+#: DynamicWeb//dynamicweb.py:3955
 msgid "Web site template"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3954
+#: DynamicWeb//dynamicweb.py:3958
 msgid "Select the template of the web site"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3957
+#: DynamicWeb//dynamicweb.py:3961
 msgid "Copyright"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3960
+#: DynamicWeb//dynamicweb.py:3964
 msgid "The copyright to be used for the web files"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3968
+#: DynamicWeb//dynamicweb.py:3972
 msgid "Privacy"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3976
+#: DynamicWeb//dynamicweb.py:3980
 msgid "Include records marked private"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3977
+#: DynamicWeb//dynamicweb.py:3981
 msgid "Whether to include private objects"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3979
+#: DynamicWeb//dynamicweb.py:3983
 msgid "Living People"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3980
+#: DynamicWeb//dynamicweb.py:3984
 msgid "Exclude"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3981
+#: DynamicWeb//dynamicweb.py:3985
 msgid "Include Last Name Only"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3982
+#: DynamicWeb//dynamicweb.py:3986
 msgid "Include Full Name Only"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3983
+#: DynamicWeb//dynamicweb.py:3987
 msgid "Include"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3984
+#: DynamicWeb//dynamicweb.py:3988
 msgid "How to handle living people"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3987
+#: DynamicWeb//dynamicweb.py:3991
 msgid "Years from death to consider living"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3988
+#: DynamicWeb//dynamicweb.py:3992
 msgid ""
 "This allows you to restrict information on people who have not been dead for "
 "very long"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3992
+#: DynamicWeb//dynamicweb.py:3996
 msgid "Export notes"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3993
+#: DynamicWeb//dynamicweb.py:3997
 msgid "Whether to export notes in the web pages"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3996
+#: DynamicWeb//dynamicweb.py:4000
 msgid "Export sources"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:3997
+#: DynamicWeb//dynamicweb.py:4001
 msgid "Whether to export sources and citations in the web pages"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4000
+#: DynamicWeb//dynamicweb.py:4004
 msgid "Export addresses"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4001
+#: DynamicWeb//dynamicweb.py:4005
 msgid "Whether to export addresses in the web pages"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4006
+#: DynamicWeb//dynamicweb.py:4010
 msgid "Options"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4009
+#: DynamicWeb//dynamicweb.py:4013
 msgid "Include repository pages"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4010
+#: DynamicWeb//dynamicweb.py:4014
 msgid "Whether or not to include the Repository Pages."
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4013
+#: DynamicWeb//dynamicweb.py:4017
 msgid "Include images and media"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4014
+#: DynamicWeb//dynamicweb.py:4018
 msgid "Whether to include images and media in the web pages"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4018
+#: DynamicWeb//dynamicweb.py:4022
 msgid "Copy, rename files with an internal Gramps identifier"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4019
+#: DynamicWeb//dynamicweb.py:4023
 msgid "Copy, keep file names unchanged"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4020
+#: DynamicWeb//dynamicweb.py:4024
 msgid "Do not copy, reference existing files"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4022
+#: DynamicWeb//dynamicweb.py:4026
 msgid "Images and media"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4025
+#: DynamicWeb//dynamicweb.py:4029
 msgid "Whether to make a copy of the media"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4028
+#: DynamicWeb//dynamicweb.py:4032
 msgid "Print the notes type"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4029
+#: DynamicWeb//dynamicweb.py:4033
 msgid "Whether to print the notes type in the notes text"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4032
+#: DynamicWeb//dynamicweb.py:4036
 msgid "Print place pages"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4033
+#: DynamicWeb//dynamicweb.py:4037
 msgid "Whether to show pages for the places"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4039
+#: DynamicWeb//dynamicweb.py:4043
 msgid ""
 "Whether to include a place map on the Place Pages, where Latitude/ Longitude "
 "are available."
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4047
+#: DynamicWeb//dynamicweb.py:4051
 msgid ""
 "Whether or not to add an individual page map showing all the places on this "
 "page. This will allow you to see how your family traveled around the country."
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4055
+#: DynamicWeb//dynamicweb.py:4059
 msgid "Google"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4056
+#: DynamicWeb//dynamicweb.py:4060
 msgid "OpenStreetMap"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4058
+#: DynamicWeb//dynamicweb.py:4062
 msgid "Map Service"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4061
+#: DynamicWeb//dynamicweb.py:4065
 msgid "Choose your choice of map service for creating the Place Map Pages"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4065
+#: DynamicWeb//dynamicweb.py:4069
 msgid "Google map API key"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4066
+#: DynamicWeb//dynamicweb.py:4070
 msgid "The API key used for the Google map"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4073
+#: DynamicWeb//dynamicweb.py:4077
 msgid "Advanced"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4076
+#: DynamicWeb//dynamicweb.py:4080
 msgid "Character set encoding"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4079
+#: DynamicWeb//dynamicweb.py:4083
 msgid "The encoding to be used for the web files"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4082
+#: DynamicWeb//dynamicweb.py:4086
 msgid "Include family pages"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4083
+#: DynamicWeb//dynamicweb.py:4087
 msgid "Whether or not to include family pages"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4093
+#: DynamicWeb//dynamicweb.py:4097
 msgid ""
 "Whether to include half and/ or step-siblings with the parents and siblings"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4096
+#: DynamicWeb//dynamicweb.py:4100
 msgid "Include GENDEX file (/gendex.txt)"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4097
+#: DynamicWeb//dynamicweb.py:4101
 msgid "Whether to include a GENDEX file or not"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4100
+#: DynamicWeb//dynamicweb.py:4104
 msgid "Enable page configuration"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4101
+#: DynamicWeb//dynamicweb.py:4105
 msgid "Whether to enable page configuration"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4105
+#: DynamicWeb//dynamicweb.py:4109
 msgid "Whether to use tabbed panels for the different sections of the pages."
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4109
+#: DynamicWeb//dynamicweb.py:4113
 msgid "Whether to show the last modification time in the pages footer"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4113
+#: DynamicWeb//dynamicweb.py:4117
 msgid "Whether to insert sources author in the sources title"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4117
+#: DynamicWeb//dynamicweb.py:4121
 msgid "Whether to hide the Gramps ID"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4126
+#: DynamicWeb//dynamicweb.py:4130
 msgid "List"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4127
+#: DynamicWeb//dynamicweb.py:4131
 msgid "Table"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4130
+#: DynamicWeb//dynamicweb.py:4134
 msgid "Default format for the surnames index"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4130
+#: DynamicWeb//dynamicweb.py:4134
 msgid "The default format for the surnames index"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4131
+#: DynamicWeb//dynamicweb.py:4135
 msgid "Default format for the persons index"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4131
+#: DynamicWeb//dynamicweb.py:4135
 msgid "The default format for the persons index"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4132
+#: DynamicWeb//dynamicweb.py:4136
 msgid "Default format for the families index"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4132
+#: DynamicWeb//dynamicweb.py:4136
 msgid "The default format for the families index"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4133
+#: DynamicWeb//dynamicweb.py:4137
 msgid "Default format for the sources index"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4133
+#: DynamicWeb//dynamicweb.py:4137
 msgid "The default format for the sources index"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4134
+#: DynamicWeb//dynamicweb.py:4138
 msgid "Default format for the places index"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4134
+#: DynamicWeb//dynamicweb.py:4138
 msgid "The default format for the places index"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4143
+#: DynamicWeb//dynamicweb.py:4147
 msgid ""
 "Whether to include dates columns (birth, death, marriage) on the index pages"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4147
+#: DynamicWeb//dynamicweb.py:4151
 msgid "Whether to include a partners column"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4151
+#: DynamicWeb//dynamicweb.py:4155
 msgid "Whether to include a parents column"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4154
+#: DynamicWeb//dynamicweb.py:4158
 msgid "Generate a families index page"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4155
+#: DynamicWeb//dynamicweb.py:4159
 msgid "Whether to generate an index page for families"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4159
+#: DynamicWeb//dynamicweb.py:4163
 msgid "Whether to include a column showing the media path"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4163
+#: DynamicWeb//dynamicweb.py:4167
 msgid ""
 "Whether to include the references to the items in the index pages. For "
 "example, in the media index page, the names of the individuals, families, "
 "places, sources that reference the media."
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4166
+#: DynamicWeb//dynamicweb.py:4170
 msgid "Default number of entries in the indexes"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4169
+#: DynamicWeb//dynamicweb.py:4173
 msgid "The default number of entries shown in one index page"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4174
+#: DynamicWeb//dynamicweb.py:4178
 msgid "Trees"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4177
+#: DynamicWeb//dynamicweb.py:4181
 msgid "Maximum number of generations"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4178
+#: DynamicWeb//dynamicweb.py:4182
 msgid ""
 "The maximum number of generations to include in the ancestor and descendant "
 "trees and graphs"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4184
+#: DynamicWeb//dynamicweb.py:4188
 msgid "Choose the default SVG tree graph type"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4190
+#: DynamicWeb//dynamicweb.py:4194
 msgid "Choose the default SVG tree graph shape"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4196
+#: DynamicWeb//dynamicweb.py:4200
 msgid "Choose the default SVG tree parents distribution (for fan charts only)"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4202
+#: DynamicWeb//dynamicweb.py:4206
 msgid "Choose the default SVG tree children distribution (for fan charts only)"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4208
+#: DynamicWeb//dynamicweb.py:4212
 msgid ""
 "Choose the background color scheme for the persons in the SVG tree graph"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4211
+#: DynamicWeb//dynamicweb.py:4215
 msgid "Start gradient/Main color"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4214
+#: DynamicWeb//dynamicweb.py:4218
 msgid "End gradient/2nd color"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4222
+#: DynamicWeb//dynamicweb.py:4226
 msgid "Color for duplicates"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4227
+#: DynamicWeb//dynamicweb.py:4231
 msgid "Pages"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4230
+#: DynamicWeb//dynamicweb.py:4234
 msgid "HTML user header"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4231
+#: DynamicWeb//dynamicweb.py:4235
 msgid "A note to be used as the page header"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4234
+#: DynamicWeb//dynamicweb.py:4238
 msgid "HTML user brand name / icon"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4235
+#: DynamicWeb//dynamicweb.py:4239
 msgid "A note to be used as the brand name or image in the menu"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4238
+#: DynamicWeb//dynamicweb.py:4242
 msgid "HTML user footer"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4239
+#: DynamicWeb//dynamicweb.py:4243
 msgid "A note to be used as the page footer"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4244
+#: DynamicWeb//dynamicweb.py:4248
 msgid "Custom pages"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4248
+#: DynamicWeb//dynamicweb.py:4252
 #, python-format
 msgid "Title for the custom page %(index)i"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4249
+#: DynamicWeb//dynamicweb.py:4253
 #, python-format
 msgid "Name for the custom page %(index)i"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4252
+#: DynamicWeb//dynamicweb.py:4256
 #, python-format
 msgid "Note for custom page %(index)i"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4253
+#: DynamicWeb//dynamicweb.py:4257
 msgid "A note to be used for the custom page content.\n"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4256
+#: DynamicWeb//dynamicweb.py:4260
 #, python-format
 msgid "Menu for the custom page %(index)i"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4257
+#: DynamicWeb//dynamicweb.py:4261
 msgid "Whether to print a menu for the custom page"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4262
+#: DynamicWeb//dynamicweb.py:4266
 msgid "Pages selection"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4265
+#: DynamicWeb//dynamicweb.py:4269
 msgid "Number of pages"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4266
+#: DynamicWeb//dynamicweb.py:4270
 msgid "Number pages in the web site menu."
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4282
+#: DynamicWeb//dynamicweb.py:4286
 #, python-format
 msgid "Contents of page %(index)i"
 msgstr ""
 
-#: DynamicWeb/dynamicweb.py:4285
+#: DynamicWeb//dynamicweb.py:4289
 msgid "Contents of the page"
 msgstr ""


### PR DESCRIPTION
Updated localisation for addon DynamicWeb.
Translation didn't work correctly and word "Home" was not translated due to wrong context use in line 2194.
Based on this update of dynamicweb.py a new template.pot created.
Updated all available po-files based on new template.

Tested without issues in Gramps 5.1.2 on Linux Mint 20.
Please, add it to this branch.
Thanks in advance!