### PR TITLE
[HeadlineNewsGramplet] Updated translation

### DIFF
--- a/HeadlineNewsGramplet/po/nl-local.po
+++ b/HeadlineNewsGramplet/po/nl-local.po
@@ -1,73 +1,38 @@
-# translation of nl.po to nederlands
-# Dutch translation of GRAMPS
-# Copyright (C) 2003 The Free Software Foundation,  Inc.
-#
+# SDutch translation of addon GedcomExtensions.
+# Copyright (C) 2020 Gramps project
+# This file is distributed under the same license as the GedcomExtensions package.
 # Tino Meinen <a.t.meinen@chello.nl>, 2003, 2004, 2005.
 # Kees Bakker <kees.bakker@xs4all.nl>, 2005, 2006, 2007.
 # Erik De Richter <frederik.de.richter@pandora.be>, 2006, 2007, 2008, 2009, 2010.
+# Jan Sparreboom <jan@sparreboom.net>, 2020.
 #
-# --------------------------------------------------
-# Conventies (kan later altijd nog aangepast worden)
-# --------------------------------------------------
-# active             actief (moet hier nog iets beters voor verzinnen)
-# attribute          kenmerk
-# bookmark           bladwijzer
-# view               scherm
-# city               plaats beter is stad dorp
-# marker             aanduiding
-# people             personen
-# place              locatie
-# record             archief/kaart
-# database           gegevensbestand (KB)
-# chart              grafiek
-# Home person        beginpersoon : (EDR)
-# spouse             echtgenoot
-# partner            partner
-# warning            let op
-# at the age of      op een leeftijd van -> toen hij/zij .. oud was
-# repositories       bibliotheken
-# regex              regex onvertaald laten
-# expression         uitdrukking
-# given name         voornaam
-# reference	     waarnaar verwezen wordt
-# count		     aantal maal
-# lineage	     lijn
-# locality	     plaats
-# u gebruiken
-# telkens werkwoord achteraan plaatsen
 msgid ""
 msgstr ""
-"Project-Id-Version: gramps\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2011-04-13 19:56+0200\n"
-"PO-Revision-Date: 2011-04-13 20:02+0100\n"
-"Last-Translator: Erik De Richter <frederik.de.richter@pandora.be>\n"
-"Language-Team: nederlands <frederik.de.richter@googlemail.com>\n"
-"Language: \n"
+"Project-Id-Version: GedcomExtensions 5.x\n"
+"Report-Msgid-Bugs-To: https://www.gramps-project.org/bugs\n"
+"POT-Creation-Date: 2020-04-22 11:04-0500\n"
+"PO-Revision-Date: 2020-07-30 14:25+0200\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
+"Language-Team: Dutch <gramps-users@lists.sourceforge.net>\n"
+"Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Poedit-Language: Nederlands\n"
-"X-Poedit-Country: België\n"
+"X-Generator: Poedit 2.3\n"
 
 #: HeadlineNewsGramplet/HeadlineNewsGramplet.gpr.py:3
-msgid "Headline News Gramplet"
-msgstr "'Belangrijkste nieuws'-gramplet"
-
-#: HeadlineNewsGramplet/HeadlineNewsGramplet.gpr.py:4
-msgid "Gramplet for showing latest the Gramps news"
-msgstr "Gramplet toont het laatste Gramps-nieuws"
-
 #: HeadlineNewsGramplet/HeadlineNewsGramplet.gpr.py:10
 msgid "Headline News"
-msgstr "Het belangrijkste nieuws"
+msgstr "Nieuwsoverzicht"
 
-#: HeadlineNewsGramplet/HeadlineNewsGramplet.py:100
+#: HeadlineNewsGramplet/HeadlineNewsGramplet.gpr.py:4
+msgid "Gramplet that shows the latest Gramps news"
+msgstr "Gramplet met het laatste Gramps-nieuws"
+
+#: HeadlineNewsGramplet/HeadlineNewsGramplet.py:113
 msgid "Read Gramps headline news"
-msgstr "Het belangrijkste Gramps-nieuws lezen"
+msgstr "Lees het Gramps nieuwsoverzicht"
 
-#: HeadlineNewsGramplet/HeadlineNewsGramplet.py:104
+#: HeadlineNewsGramplet/HeadlineNewsGramplet.py:117
 msgid "No Family Tree loaded."
-msgstr "Geen familiestamboom geladen."
-
+msgstr "Geen stamboom geladen."


### PR DESCRIPTION
Updated Dutch translation for addon HeadlineNewsGramplet.
Tested without issues in Gramps 5.1.2 on Linux Mint 20.
Please, add it to this branch.
Thanks in advance!