### PR TITLE
[MediaBrowser] Dutch translation

### DIFF
--- a/MediaBrowser/po/nl-local.po
+++ b/MediaBrowser/po/nl-local.po
@@ -1,0 +1,34 @@
+# Dutch translation of addon MediaBrowser.
+# Copyright (C) 2020 Gramps project
+# This file is distributed under the same license as the MediaBrowser package.
+# Jan Sparreboom <jan@sparreboom.net>, 2020.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: MediaBrowser 5.x\n"
+"Report-Msgid-Bugs-To: https://www.gramps-project.org/bugs\n"
+"POT-Creation-Date: 2019-01-04 18:55-0600\n"
+"PO-Revision-Date: 2020-07-31 17:50+0200\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
+"Language-Team: Dutch <gramps-users@lists.sourceforge.net>\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.3\n"
+
+#: MediaBrowser/MediaBrowser.gpr.py:30
+msgid "Media Browser"
+msgstr "Mediabrowser"
+
+#: MediaBrowser/MediaBrowser.gpr.py:31
+msgid "Gramplet showing details of a person"
+msgstr "Gramplet dat details van een persoon toont"
+
+#: MediaBrowser/MediaBrowser.gpr.py:38
+msgid "Browser"
+msgstr "Browser"
+
+#: MediaBrowser/MediaBrowser.py:53
+msgid "Object"
+msgstr "Object"


### PR DESCRIPTION
Dutch translation for addon MediaBrowser.
Tested without issues in Gramps 5.1.2 on Linux Mint 20.
Please, add it to this branch.
Thanks in advance!