### PR TITLE
[MediaVerify] Dutch translation.

### DIFF
--- a/MediaVerify/po/nl-local.po
+++ b/MediaVerify/po/nl-local.po
@@ -1,0 +1,144 @@
+# Dutch translation of addon MediaVerify.
+# Copyright (C) 2020 Gramps project
+# This file is distributed under the same license as the MediaVerify package.
+# Jan Sparreboom <jan@sparreboom.net>, 2020.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: MediaVerify 5.x\n"
+"Report-Msgid-Bugs-To: https://www.gramps-project.org/bugs\n"
+"POT-Creation-Date: 2019-01-04 18:55-0600\n"
+"PO-Revision-Date: 2020-07-31 22:37+0200\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
+"Language-Team: Dutch <gramps-users@lists.sourceforge.net>\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.3\n"
+
+#: MediaVerify/MediaVerify.gpr.py:30
+msgid "Media Verify"
+msgstr "Mediaverificatie"
+
+#: MediaVerify/MediaVerify.gpr.py:31
+msgid "Verify that media is present in the correct path"
+msgstr "Controleer of media aan het juiste pad gekoppeld zijn"
+
+#: MediaVerify/MediaVerify.py:78
+msgid "Media Verify Tool"
+msgstr "Hulpmiddel voor mediaverificatie"
+
+#: MediaVerify/MediaVerify.py:83
+msgid "Moved/Renamed Files"
+msgstr "Verplaatste/hernoemde bestanden"
+
+#: MediaVerify/MediaVerify.py:83
+msgid "Missing Files"
+msgstr "Ontbrekende bestanden"
+
+#: MediaVerify/MediaVerify.py:84
+msgid "Duplicate Files"
+msgstr "Dubbele bestanden"
+
+#: MediaVerify/MediaVerify.py:84
+msgid "Extra Files"
+msgstr "Extra bestanden"
+
+#: MediaVerify/MediaVerify.py:85
+msgid "No md5 Generated"
+msgstr "Geen md5 gegenereerd"
+
+#: MediaVerify/MediaVerify.py:85
+msgid "Errors"
+msgstr "Fouten"
+
+#: MediaVerify/MediaVerify.py:100
+msgid "Close"
+msgstr "Sluiten"
+
+#: MediaVerify/MediaVerify.py:101
+msgid "Close the Media Verify Tool"
+msgstr "Sluit het hulpmiddel Mediaverificatie"
+
+#: MediaVerify/MediaVerify.py:103
+msgid "Generate"
+msgstr "Genereer"
+
+#: MediaVerify/MediaVerify.py:104
+msgid "Generate md5 hashes for media objects"
+msgstr "Genereer md5-hashes voor media-objecten"
+
+#: MediaVerify/MediaVerify.py:106
+msgid "Verify"
+msgstr "Verifiëren"
+
+#: MediaVerify/MediaVerify.py:107
+msgid "Check media paths and report missing, duplicate and extra files"
+msgstr ""
+"Controleer mediapaden en rapporteer ontbrekende, dubbele en extra bestanden"
+
+#: MediaVerify/MediaVerify.py:110
+msgid "Export"
+msgstr "Exporteren"
+
+#: MediaVerify/MediaVerify.py:111
+msgid "Export the results to a text file"
+msgstr "Exporteer de resultaten naar een tekstbestand"
+
+#: MediaVerify/MediaVerify.py:113
+msgid "Fix"
+msgstr "Herstel"
+
+#: MediaVerify/MediaVerify.py:114
+msgid "Fix media paths of moved and renamed files"
+msgstr "Herstel mediapaden van verplaatste en hernoemde bestanden"
+
+#: MediaVerify/MediaVerify.py:132
+msgid "Verify Gramps media using md5 hashes"
+msgstr "Controleer Gramps-media met md5-hashes"
+
+#: MediaVerify/MediaVerify.py:143
+msgid "Files"
+msgstr "Bestanden"
+
+#: MediaVerify/MediaVerify.py:195
+msgid "Export results to a text file"
+msgstr "Exporteer resultaten naar een tekstbestand"
+
+#: MediaVerify/MediaVerify.py:218
+#, python-format
+msgid "Error when writing the report: %s"
+msgstr "Fout bij het schrijven van het rapport: %s"
+
+#: MediaVerify/MediaVerify.py:259
+msgid "Generating media hashes"
+msgstr "Mediahashes genereren"
+
+#: MediaVerify/MediaVerify.py:261
+msgid "Set media hashes"
+msgstr "Mediahashes instellen"
+
+#: MediaVerify/MediaVerify.py:296
+msgid ""
+"Media path not set.  You must set the \"Base path for relative media paths\" "
+"in the Preferences."
+msgstr ""
+"Mediapad niet ingesteld. U moet het \"Basispad voor relatieve mediapaden\" "
+"instellen in de Voorkeuren."
+
+#: MediaVerify/MediaVerify.py:307
+msgid "Finding files"
+msgstr "Bestanden zoeken"
+
+#: MediaVerify/MediaVerify.py:335
+msgid "Checking paths"
+msgstr "Paden controleren"
+
+#: MediaVerify/MediaVerify.py:388
+msgid "Fixing file paths"
+msgstr "Bestandspaden repareren"
+
+#: MediaVerify/MediaVerify.py:390
+msgid "Fix media paths"
+msgstr "Mediapaden repareren"


### PR DESCRIPTION
Dutch translation for addon MediaVerify.
Tested without issues in Gramps 5.1.2 on Linux Mint 20.
Please, add it to this branch.
Thanks in advance!