### PR TITLE
[MongoDB] Dutch translation

### DIFF
--- a/MongoDB/po/nl-local.po
+++ b/MongoDB/po/nl-local.po
@@ -1,0 +1,34 @@
+# Dutch translation of addon MongoDB.
+# Copyright (C) 2020 Gramps project
+# This file is distributed under the same license as the MongoDB package.
+# Jan Sparreboom <jan@sparreboom.net>, 2020.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: MongoDB 5.x\n"
+"Report-Msgid-Bugs-To: https://www.gramps-project.org/bugs\n"
+"POT-Creation-Date: 2019-01-04 18:55-0600\n"
+"PO-Revision-Date: 2020-07-31 22:56+0200\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
+"Language-Team: Dutch <gramps-users@lists.sourceforge.net>\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.3\n"
+
+#: MongoDB/mongodb.gpr.py:22
+msgid "MongoDB"
+msgstr "MongoDB"
+
+#: MongoDB/mongodb.gpr.py:23
+msgid "_MongoDB Database"
+msgstr "_MongoDB-database"
+
+#: MongoDB/mongodb.gpr.py:24
+msgid "MongoDB Database"
+msgstr "MongoDB-database"
+
+#: MongoDB/mongodb.py:84
+msgid "Database version"
+msgstr "Database versie"


### PR DESCRIPTION
Dutch translation for addon MongoDB.

Not tested as this addon has status 'unstable' and is not listed in Gramps.
Please, add it to this branch.
Thanks in advance!