### PR TITLE
[NumberOfDescendantsQuickview] Updated Dutch translation

### DIFF
--- a/NumberOfDescendantsQuickview/po/nl-local.po
+++ b/NumberOfDescendantsQuickview/po/nl-local.po
@@ -1,55 +1,24 @@
-# translation of nl.po to nederlands
-# Dutch translation of GRAMPS
-# Copyright (C) 2003 The Free Software Foundation,  Inc.
-#
+# SDutch translation of addon NumberOfDescendantsQuickview.
+# Copyright (C) 2020 Gramps project
+# This file is distributed under the same license as the NumberOfDescendantsQuickview package.
 # Tino Meinen <a.t.meinen@chello.nl>, 2003, 2004, 2005.
 # Kees Bakker <kees.bakker@xs4all.nl>, 2005, 2006, 2007.
 # Erik De Richter <frederik.de.richter@pandora.be>, 2006, 2007, 2008, 2009, 2010.
+# Jan Sparreboom <jan@sparreboom.net>, 2020.
 #
-# --------------------------------------------------
-# Conventies (kan later altijd nog aangepast worden)
-# --------------------------------------------------
-# active             actief (moet hier nog iets beters voor verzinnen)
-# attribute          kenmerk
-# bookmark           bladwijzer
-# view               scherm
-# city               plaats beter is stad dorp
-# marker             aanduiding
-# people             personen
-# place              locatie
-# record             archief/kaart
-# database           gegevensbestand (KB)
-# chart              grafiek
-# Home person        beginpersoon : (EDR)
-# spouse             echtgenoot
-# partner            partner
-# warning            let op
-# at the age of      op een leeftijd van -> toen hij/zij .. oud was
-# repositories       bibliotheken
-# regex              regex onvertaald laten
-# expression         uitdrukking
-# given name         voornaam
-# reference	     waarnaar verwezen wordt
-# count		     aantal maal
-# lineage	     lijn
-# locality	     plaats
-# u gebruiken
-# telkens werkwoord achteraan plaatsen
 msgid ""
 msgstr ""
-"Project-Id-Version: gramps\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2011-04-14 20:08+0200\n"
-"PO-Revision-Date: 2011-04-12 20:28+0100\n"
-"Last-Translator: Erik De Richter <frederik.de.richter@pandora.be>\n"
-"Language-Team: nederlands <frederik.de.richter@googlemail.com>\n"
-"Language: \n"
+"Project-Id-Version: NumberOfDescendantsQuickview 5.x\n"
+"Report-Msgid-Bugs-To: https://www.gramps-project.org/bugs\n"
+"POT-Creation-Date: 2020-04-22 11:04-0500\n"
+"PO-Revision-Date: 2020-08-02 14:35+0200\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
+"Language-Team: Dutch <gramps-users@lists.sourceforge.net>\n"
+"Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Poedit-Language: Nederlands\n"
-"X-Poedit-Country: België\n"
+"X-Generator: Poedit 2.3\n"
 
 #: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.gpr.py:3
 msgid "Number of descendants"
@@ -57,46 +26,44 @@ msgstr "Aantal afstammelingen"
 
 #: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.gpr.py:4
 msgid "Shows the number of descendants of the current person"
-msgstr "Aantal afstammelingen van de actieve persoon wordt getoond"
+msgstr "Toont het aantal nakomelingen van de huidige persoon"
 
-#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:57
+#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:62
 #, python-format
 msgid "Number of %s's descendants"
-msgstr "%s afstammelingen"
+msgstr "Aantal afstammelingen van %s"
 
-#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:82
-#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:89
+#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:87
+#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:94
 msgid "Generation"
 msgstr "Generatie"
 
-#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:83
-#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:90
-#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:106
-#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:110
+#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:88
+#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:95
+#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:111
+#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:115
 msgid "Total"
 msgstr "Totaal"
 
-#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:84
+#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:89
 msgid "Seen"
 msgstr "Gezien"
 
-#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:85
+#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:90
 msgid "Outlived"
-msgstr "Overlevend"
+msgstr "Overleefd"
 
-#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:86
 #: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:91
+#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:96
 msgid "Now alive"
-msgstr "Nog in leven"
+msgstr "Nu in leven"
 
-#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:117
+#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:122
 #, python-format
 msgid "Seen = number of descendants whose birth %s has lived to see"
-msgstr ""
-"Gezien = aantal afstammelingen waarvan %s de geboorte kan meegemaakt hebben"
+msgstr "Gezien = aantal afstammelingen waarvan %s hun geboorte nog heeft meegemaakt"
 
-#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:119
+#: NumberOfDescendantsQuickview/NumberOfDescendantsQuickview.py:124
 #, python-format
 msgid "Outlived = number of descendants who died while %s was still alive"
-msgstr ""
-"Overlevend = aantal afstammelingen die stierven terwijl %s nog in leven was"
+msgstr "Overleefd = aantal afstammelingen die overleden zijn terwijl %s nog leefde"


### PR DESCRIPTION
Updated Dutch translation for addon NumberOfDescendantsQuickview.
Tested without issues in Gramps 5.1.2 on Linux Mint 20.
However, some words are not translated in the 'Generation' column, which come from another source. And the code from that source, relationship.py, must be edited before it can be translated. I'll look at that later...

Please, add it to this branch.
Thanks in advance!