### PR TITLE
[RelID] Dutch translation.

### DIFF
--- a/RelID/po/nl-local.po
+++ b/RelID/po/nl-local.po
@@ -1,0 +1,111 @@
+# Dutch translation of addon RelID.
+# Copyright (C) 2020 Gramps project
+# This file is distributed under the same license as the RelID package.
+# Jan Sparreboom <jan@sparreboom.net>, 2020.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: RelID 5.x\n"
+"Report-Msgid-Bugs-To: https://www.gramps-project.org/bugs\n"
+"POT-Creation-Date: 2019-01-04 18:55-0600\n"
+"PO-Revision-Date: 2020-08-10 17:11+0200\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
+"Language-Team: Dutch <gramps-users@lists.sourceforge.net>\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.3\n"
+
+#: RelID/relation_tab.gpr.py:35
+msgid "Display relations and distances with the home person"
+msgstr "Toon relaties en afstanden met de thuispersoon"
+
+#: RelID/relation_tab.gpr.py:36
+msgid "Will display relational informations with the home person"
+msgstr "Geeft relationele informatie weer met de thuispersoon"
+
+#: RelID/relation_tab.py:75
+msgid "Relation and distances with root"
+msgstr "Relatie en afstanden met begin"
+
+#: RelID/relation_tab.py:92
+msgid "Folder Chooser"
+msgstr "Mapkiezer"
+
+#: RelID/relation_tab.py:95
+msgid "_Cancel"
+msgstr "_Annuleren"
+
+#: RelID/relation_tab.py:97
+msgid "_Select"
+msgstr "_Selecteer"
+
+#: RelID/relation_tab.py:99
+msgid "Please, select a folder"
+msgstr "Selecteer een map"
+
+#: RelID/relation_tab.py:110
+msgid "Rel_id"
+msgstr "Rel_id"
+
+#: RelID/relation_tab.py:111
+msgid "Relation"
+msgstr "Relatie"
+
+#: RelID/relation_tab.py:112
+msgid "Name"
+msgstr "Naam"
+
+#: RelID/relation_tab.py:113
+msgid "up"
+msgstr "omhoog"
+
+#: RelID/relation_tab.py:114
+msgid "down"
+msgstr "omlaag"
+
+#: RelID/relation_tab.py:115
+msgid "Common MRA"
+msgstr "Gemeenschappelijke MRA"
+
+#: RelID/relation_tab.py:116
+msgid "Rank"
+msgstr "Rang"
+
+#: RelID/relation_tab.py:117
+msgid "Period"
+msgstr "Periode"
+
+#: RelID/relation_tab.py:126
+msgid "Save"
+msgstr "Opslaan"
+
+#: RelID/relation_tab.py:164
+msgid "Please wait, filtering..."
+msgstr "Een ogenblik geduld, filteren..."
+
+#: RelID/relation_tab.py:169
+msgid "No default_person"
+msgstr "Geen begin_persoon"
+
+#: RelID/relation_tab.py:174
+msgid "Generating relation map..."
+msgstr "Relatiekaart genereren..."
+
+#: RelID/relation_tab.py:190
+#, python-format
+msgid ""
+"%d/%d \n"
+" %d/%d seconds \n"
+" %d/%d \n"
+"%f|\t%f"
+msgstr ""
+"%d/%d \n"
+" %d/%d seconden \n"
+" %d/%d \n"
+"%f|\t%f"
+
+#: RelID/relation_tab.py:308
+msgid "You do not have write rights on this folder"
+msgstr "U heeft geen schrijfrechten op deze map"


### PR DESCRIPTION
Dutch translation for addon RelID.
Not tested as this addon is not listed in Gramps.
Please, add it to this branch.
Thanks in advance!