### PR TITLE
[SetPrivacyTool] Sentences fixed and translation of DE, HR, RU, PT, NL

### DIFF
--- a/SetPrivacyTool/SetPrivacyTool.py
+++ b/SetPrivacyTool/SetPrivacyTool.py
@@ -84,10 +84,10 @@ class SetPrivacyWindow(PluginWindows.ToolManagedWindowBatch):
             self.lock_media(date, lock_no_date)
         txt = ""
         for entry in self.cnt:
-            txt += "Set private: %d %s\n" % (entry[1], entry[0])
+            txt += _("Set private: %d %s\n") % (entry[1], entry[0])
         for entry in self.cnt:
-            txt += "Not private: %d %s\n" % (entry[2], entry[0])
-        OkDialog("Set Privacy Tool", txt, parent=self.window)
+            txt += _("Not private: %d %s\n") % (entry[2], entry[0])
+        OkDialog(_("Set Privacy Tool"), txt, parent=self.window)
 
     def lock_persons(self, date, lock_no_date):
         with DbTxn(_("Set Privacy Tool"), self.db, batch=True) as self.trans:

--- a/SetPrivacyTool/po/de-local.po
+++ b/SetPrivacyTool/po/de-local.po
@@ -7,20 +7,20 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-29 16:16+1000\n"
-"PO-Revision-Date: 2019-10-24 10:22+0200\n"
+"POT-Creation-Date: 2020-08-12 17:40+0200\n"
+"PO-Revision-Date: 2020-08-12 18:02+0200\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
 "Language-Team: \n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.2.4\n"
-"Last-Translator: Milo Ivir <mail@milotype.de>\n"
+"X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: de\n"
 
 #: SetPrivacyTool/SetPrivacyTool.gpr.py:23 SetPrivacyTool/SetPrivacyTool.py:48
-#: SetPrivacyTool/SetPrivacyTool.py:93 SetPrivacyTool/SetPrivacyTool.py:130
-#: SetPrivacyTool/SetPrivacyTool.py:157
+#: SetPrivacyTool/SetPrivacyTool.py:90 SetPrivacyTool/SetPrivacyTool.py:93
+#: SetPrivacyTool/SetPrivacyTool.py:130 SetPrivacyTool/SetPrivacyTool.py:157
 msgid "Set Privacy Tool"
 msgstr "Daten als privat markieren"
 
@@ -28,17 +28,27 @@ msgstr "Daten als privat markieren"
 msgid "Set all objects of the last <number> of years private."
 msgstr "All Objekte der letzten <number> Jahre als privat markieren."
 
+#: SetPrivacyTool/SetPrivacyTool.py:87
+#, python-format
+msgid "Set private: %d %s\n"
+msgstr "Privat einstellen: %d %s\n"
+
+#: SetPrivacyTool/SetPrivacyTool.py:89
+#, python-format
+msgid "Not private: %d %s\n"
+msgstr "Nicht privat: %d %s\n"
+
 #: SetPrivacyTool/SetPrivacyTool.py:96
 msgid "Set persons private.."
-msgstr "Personen als privat markieren …"
+msgstr "Personen als privat markieren…"
 
 #: SetPrivacyTool/SetPrivacyTool.py:133
 msgid "Set events private.."
-msgstr "Ereignisse als privat markieren …"
+msgstr "Ereignisse als privat markieren…"
 
 #: SetPrivacyTool/SetPrivacyTool.py:160
 msgid "Set media private.."
-msgstr "Medien als privat markieren …"
+msgstr "Medien als privat markieren…"
 
 #: SetPrivacyTool/SetPrivacyTool.py:195
 msgid "Persons"

--- a/SetPrivacyTool/po/hr-local.po
+++ b/SetPrivacyTool/po/hr-local.po
@@ -7,27 +7,37 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Gramps 5.x\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-29 16:16+1000\n"
-"PO-Revision-Date: 2019-10-24 12:06+0200\n"
-"Last-Translator: Milo Ivir <mail@milotype.de>\n"
+"POT-Creation-Date: 2020-08-12 17:40+0200\n"
+"PO-Revision-Date: 2020-08-12 18:04+0200\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
 "Language-Team: \n"
 "Language: hr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.2.4\n"
+"X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 
 #: SetPrivacyTool/SetPrivacyTool.gpr.py:23 SetPrivacyTool/SetPrivacyTool.py:48
-#: SetPrivacyTool/SetPrivacyTool.py:93 SetPrivacyTool/SetPrivacyTool.py:130
-#: SetPrivacyTool/SetPrivacyTool.py:157
+#: SetPrivacyTool/SetPrivacyTool.py:90 SetPrivacyTool/SetPrivacyTool.py:93
+#: SetPrivacyTool/SetPrivacyTool.py:130 SetPrivacyTool/SetPrivacyTool.py:157
 msgid "Set Privacy Tool"
 msgstr "Postavi privatnost"
 
 #: SetPrivacyTool/SetPrivacyTool.gpr.py:24
 msgid "Set all objects of the last <number> of years private."
 msgstr "Postavi sve objekte zadnjih <number> godina kao privatne."
+
+#: SetPrivacyTool/SetPrivacyTool.py:87
+#, python-format
+msgid "Set private: %d %s\n"
+msgstr "Postavite privatno: %d %s\n"
+
+#: SetPrivacyTool/SetPrivacyTool.py:89
+#, python-format
+msgid "Not private: %d %s\n"
+msgstr "Nije privatno: %d %s\n"
 
 #: SetPrivacyTool/SetPrivacyTool.py:96
 msgid "Set persons private.."

--- a/SetPrivacyTool/po/nl-local.po
+++ b/SetPrivacyTool/po/nl-local.po
@@ -1,0 +1,91 @@
+# Dutch translation of addon SetPrivacyTool.
+# Copyright (C) 2020 Gramps project
+# This file is distributed under the same license as the SetPrivacyTool package.
+# Jan Sparreboom <jan@sparreboom.net>, 2020.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: SetPrivacyTool 5.x\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-08-12 17:40+0200\n"
+"PO-Revision-Date: 2020-08-12 17:44+0200\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
+"Language-Team: Dutch <gramps-users@lists.sourceforge.net>\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.3\n"
+
+#: SetPrivacyTool/SetPrivacyTool.gpr.py:23 SetPrivacyTool/SetPrivacyTool.py:48
+#: SetPrivacyTool/SetPrivacyTool.py:90 SetPrivacyTool/SetPrivacyTool.py:93
+#: SetPrivacyTool/SetPrivacyTool.py:130 SetPrivacyTool/SetPrivacyTool.py:157
+msgid "Set Privacy Tool"
+msgstr "Markeer privé hulpmiddel"
+
+#: SetPrivacyTool/SetPrivacyTool.gpr.py:24
+msgid "Set all objects of the last <number> of years private."
+msgstr "Markeer alle objecten van de afgelopen <aantal> jaren op privé."
+
+#: SetPrivacyTool/SetPrivacyTool.py:87
+#, python-format
+msgid "Set private: %d %s\n"
+msgstr "Markeer privé %d %s\n"
+
+#: SetPrivacyTool/SetPrivacyTool.py:89
+#, python-format
+msgid "Not private: %d %s\n"
+msgstr "Niet privé: %d %s\n"
+
+#: SetPrivacyTool/SetPrivacyTool.py:96
+msgid "Set persons private.."
+msgstr "Markeer personen op privé."
+
+#: SetPrivacyTool/SetPrivacyTool.py:133
+msgid "Set events private.."
+msgstr "Markeer gebeurtenissen op privé."
+
+#: SetPrivacyTool/SetPrivacyTool.py:160
+msgid "Set media private.."
+msgstr "Markeer media op privé."
+
+#: SetPrivacyTool/SetPrivacyTool.py:195
+msgid "Persons"
+msgstr "Personen"
+
+#: SetPrivacyTool/SetPrivacyTool.py:196 SetPrivacyTool/SetPrivacyTool.py:199
+#: SetPrivacyTool/SetPrivacyTool.py:202 SetPrivacyTool/SetPrivacyTool.py:207
+#: SetPrivacyTool/SetPrivacyTool.py:213
+msgid "Option"
+msgstr "Keuze"
+
+#: SetPrivacyTool/SetPrivacyTool.py:198
+msgid "Events"
+msgstr "Gebeurtenissen"
+
+#: SetPrivacyTool/SetPrivacyTool.py:201
+msgid "Media"
+msgstr "Media"
+
+#: SetPrivacyTool/SetPrivacyTool.py:204
+msgid "Always private if no date."
+msgstr "Altijd privé als er geen datum is."
+
+#: SetPrivacyTool/SetPrivacyTool.py:205
+msgid "If checked, all objects without a date will also be set private."
+msgstr ""
+"Indien aangevinkt, worden alle objecten zonder datum ook als privé "
+"gemarkeerd."
+
+#: SetPrivacyTool/SetPrivacyTool.py:209
+msgid "Years"
+msgstr "Jaren"
+
+#: SetPrivacyTool/SetPrivacyTool.py:210
+msgid ""
+"The time range in years from today you want to set objects private.\n"
+"'0 years' = remove privacy from all objects."
+msgstr ""
+"Het tijdsbereik in jaren vanaf vandaag dat u objecten als privé wilt "
+"markeren.\n"
+"'0 jaar' = verwijder privacy van alle objecten."

--- a/SetPrivacyTool/po/pt_PT-local.po
+++ b/SetPrivacyTool/po/pt_PT-local.po
@@ -6,26 +6,36 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gramps51\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-29 16:16+1000\n"
-"PO-Revision-Date: 2020-04-03 08:33Hora de Verão de GMT\n"
-"Last-Translator: Pedro Albuquerque <pmra@protonmail.com>\n"
+"POT-Creation-Date: 2020-08-12 17:40+0200\n"
+"PO-Revision-Date: 2020-08-12 18:07+0200\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
 "Language-Team: Pedro Albuquerque\n"
 "Language: pt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Geany / PoHelper 1.36\n"
+"X-Generator: Poedit 2.3\n"
 
 #: SetPrivacyTool/SetPrivacyTool.gpr.py:23 SetPrivacyTool/SetPrivacyTool.py:48
-#: SetPrivacyTool/SetPrivacyTool.py:93 SetPrivacyTool/SetPrivacyTool.py:130
-#: SetPrivacyTool/SetPrivacyTool.py:157
+#: SetPrivacyTool/SetPrivacyTool.py:90 SetPrivacyTool/SetPrivacyTool.py:93
+#: SetPrivacyTool/SetPrivacyTool.py:130 SetPrivacyTool/SetPrivacyTool.py:157
 msgid "Set Privacy Tool"
 msgstr "Ferramenta Definir privacidade"
 
 #: SetPrivacyTool/SetPrivacyTool.gpr.py:24
 msgid "Set all objects of the last <number> of years private."
 msgstr "Define todos os objectos dos últimos <número> anos como privados."
+
+#: SetPrivacyTool/SetPrivacyTool.py:87
+#, python-format
+msgid "Set private: %d %s\n"
+msgstr "Definir privado: %d %s\n"
+
+#: SetPrivacyTool/SetPrivacyTool.py:89
+#, python-format
+msgid "Not private: %d %s\n"
+msgstr "Não privado: %d %s\n"
 
 #: SetPrivacyTool/SetPrivacyTool.py:96
 msgid "Set persons private.."

--- a/SetPrivacyTool/po/ru-local.po
+++ b/SetPrivacyTool/po/ru-local.po
@@ -6,26 +6,37 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gramps51\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-29 16:16+1000\n"
-"PO-Revision-Date: 2020-04-27 09:57+0300\n"
-"Last-Translator: vantu5z <vantu5z@mail.ru>\n"
+"POT-Creation-Date: 2020-08-12 17:40+0200\n"
+"PO-Revision-Date: 2020-08-12 18:09+0200\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
 "Language-Team: Russian\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Poedit 2.3\n"
 
 #: SetPrivacyTool/SetPrivacyTool.gpr.py:23 SetPrivacyTool/SetPrivacyTool.py:48
-#: SetPrivacyTool/SetPrivacyTool.py:93 SetPrivacyTool/SetPrivacyTool.py:130
-#: SetPrivacyTool/SetPrivacyTool.py:157
+#: SetPrivacyTool/SetPrivacyTool.py:90 SetPrivacyTool/SetPrivacyTool.py:93
+#: SetPrivacyTool/SetPrivacyTool.py:130 SetPrivacyTool/SetPrivacyTool.py:157
 msgid "Set Privacy Tool"
 msgstr "Установка секретности"
 
 #: SetPrivacyTool/SetPrivacyTool.gpr.py:24
 msgid "Set all objects of the last <number> of years private."
 msgstr "Сделать все объекты последних <number> лет личными."
+
+#: SetPrivacyTool/SetPrivacyTool.py:87
+#, python-format
+msgid "Set private: %d %s\n"
+msgstr "Установить частный: %d %s\n"
+
+#: SetPrivacyTool/SetPrivacyTool.py:89
+#, python-format
+msgid "Not private: %d %s\n"
+msgstr "Не личное: %d %s\n"
 
 #: SetPrivacyTool/SetPrivacyTool.py:96
 msgid "Set persons private.."
@@ -74,5 +85,6 @@ msgid ""
 "The time range in years from today you want to set objects private.\n"
 "'0 years' = remove privacy from all objects."
 msgstr ""
-"Промежуток времени в годах (от текущей даты) для перевода объектов в личные.\n"
+"Промежуток времени в годах (от текущей даты) для перевода объектов в "
+"личные.\n"
 "'0 лет' = удалит метки секретности со всех объектов."

--- a/SetPrivacyTool/po/template.pot
+++ b/SetPrivacyTool/po/template.pot
@@ -8,23 +8,33 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-08-29 16:16+1000\n"
+"POT-Creation-Date: 2020-08-12 17:40+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 #: SetPrivacyTool/SetPrivacyTool.gpr.py:23 SetPrivacyTool/SetPrivacyTool.py:48
-#: SetPrivacyTool/SetPrivacyTool.py:93 SetPrivacyTool/SetPrivacyTool.py:130
-#: SetPrivacyTool/SetPrivacyTool.py:157
+#: SetPrivacyTool/SetPrivacyTool.py:90 SetPrivacyTool/SetPrivacyTool.py:93
+#: SetPrivacyTool/SetPrivacyTool.py:130 SetPrivacyTool/SetPrivacyTool.py:157
 msgid "Set Privacy Tool"
 msgstr ""
 
 #: SetPrivacyTool/SetPrivacyTool.gpr.py:24
 msgid "Set all objects of the last <number> of years private."
+msgstr ""
+
+#: SetPrivacyTool/SetPrivacyTool.py:87
+#, python-format
+msgid "Set private: %d %s\n"
+msgstr ""
+
+#: SetPrivacyTool/SetPrivacyTool.py:89
+#, python-format
+msgid "Not private: %d %s\n"
 msgstr ""
 
 #: SetPrivacyTool/SetPrivacyTool.py:96


### PR DESCRIPTION
Updated internationalisation for addon SetPrivacyTool.
Translation didn't work correctly of some sentences.
Updated po-files based on new template.

Tested without issues in Gramps 5.1.2 on Linux Mint 20.
Please, add it to this branch.
Thanks in advance!