### PR TITLE
[SourceReferences] Dutch translation.

### DIFF
--- a/SourceReferences/po/nl-local.po
+++ b/SourceReferences/po/nl-local.po
@@ -1,0 +1,60 @@
+# Dutch translation of addon SourceReferences.
+# Copyright (C) 2020 Gramps project
+# This file is distributed under the same license as the SourceReferences package.
+# Jan Sparreboom <jan@sparreboom.net>, 2020.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: SourceReferences 5.x\n"
+"Report-Msgid-Bugs-To: https://www.gramps-project.org/bugs\n"
+"POT-Creation-Date: 2019-01-04 18:55-0600\n"
+"PO-Revision-Date: 2020-08-11 10:23+0200\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
+"Language-Team: Dutch <gramps-users@lists.sourceforge.net>\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.3\n"
+
+#: SourceReferences/SourceReferences.gpr.py:31
+msgid "Source References"
+msgstr "Bronreferenties"
+
+#: SourceReferences/SourceReferences.gpr.py:32
+msgid "Gramplet showing the references for a source"
+msgstr "Gramplet dat de bronreferenties  toont"
+
+#: SourceReferences/SourceReferences.gpr.py:40
+msgid "References"
+msgstr "Referenties"
+
+#: SourceReferences/SourceReferences.py:50
+msgid "Type"
+msgstr "Type"
+
+#: SourceReferences/SourceReferences.py:51
+msgid "Name"
+msgstr "Naam"
+
+#: SourceReferences/SourceReferences.py:141
+msgid ""
+"Cannot open new citation editor at this time. Either the citation is already "
+"being edited, or the associated source is already being edited, and opening "
+"a citation editor (which also allows the source to be edited), would create "
+"ambiguity by opening two editors on the same source. \n"
+"\n"
+"To edit the citation, close the source editor and open an editor for the "
+"citation alone"
+msgstr ""
+"Kan op dit moment geen nieuwe citaatbewerker openen. Of het citaat wordt al "
+"bewerkt, of de bijbehorende bron wordt al bewerkt, en het openen van een "
+"citaat-bewerker (waarmee ook de bron kan worden bewerkt) zou "
+"dubbelzinnigheid creëren door twee bewerkers op dezelfde bron te openen. \n"
+"\n"
+"Om het citaat te bewerken, sluit u de bronbewerker en opent u alleen een "
+"bewerker voor het citaat"
+
+#: SourceReferences/SourceReferences.py:154
+msgid "Cannot open new citation editor"
+msgstr "Kan nieuwe citaat-bewerker niet openen"


### PR DESCRIPTION
Dutch translation for addon SourceReferences.
Not tested as this addon is not listed in Gramps.
Please, add it to this branch.
Thanks in advance!