### PR TITLE
[SourcesCitationsReport] Added footer and DE, FR, HR, NL, PT, RU translations

### DIFF
--- a/SourcesCitationsReport/po/de-local.po
+++ b/SourcesCitationsReport/po/de-local.po
@@ -14,185 +14,209 @@ msgid ""
 msgstr ""
 "Project-Id-Version: de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-05-03 15:28+0200\n"
-"PO-Revision-Date: 2018-04-11 19:24+0100\n"
-"Last-Translator: Mirko Leonhäuser <mirko@leonhaeuser.de>\n"
+"POT-Creation-Date: 2020-08-13 22:18+0200\n"
+"PO-Revision-Date: 2020-08-13 22:47+0200\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
 "Language-Team: German <kde-i18n-de@kde.org>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Lokalize 2.0\n"
+"X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: SourcesCitationsReport/SourcesCitationsReport.gpr.py:9
+#: SourcesCitationsReport//SourcesCitationsReport.gpr.py:32
 msgid "Sources and Citations Report"
 msgstr "Quellen und Fundstellenbericht"
 
-#: SourcesCitationsReport/SourcesCitationsReport.gpr.py:10
-msgid "Provides a source and Citations with notes"
+#: SourcesCitationsReport//SourcesCitationsReport.gpr.py:33
+msgid "Provides a source and Citations Report with notes"
 msgstr ""
 "Liefert einen Bericht mit den Notizen (Zitaten) sortiert nach Quelle und "
 "Fundstellen"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:265
+#: SourcesCitationsReport//SourcesCitationsReport.py:278
 #, python-format
-msgid "   key: %s"
-msgstr "   Schlüssel: %s"
+msgid "Key: %s"
+msgstr "Schlüssel: %s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:275
+#: SourcesCitationsReport//SourcesCitationsReport.py:283
+msgid "Citations:"
+msgstr "Zitate:"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:292
 #, python-format
 msgid "%d"
 msgstr "%d"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:277
+#: SourcesCitationsReport//SourcesCitationsReport.py:294
 #, python-format
 msgid "  %s"
 msgstr "  %s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:279
+#: SourcesCitationsReport//SourcesCitationsReport.py:300
 #, python-format
-msgid "   Anno %s - "
-msgstr "   Anno %s - "
+msgid " - %s "
+msgstr "   ( %s ) "
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:285
+#: SourcesCitationsReport//SourcesCitationsReport.py:306
 #, python-format
 msgid "   Type: %s"
 msgstr "   Art: %s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:287
+#: SourcesCitationsReport//SourcesCitationsReport.py:308
 #, python-format
 msgid "   N-ID: %s"
 msgstr "   N-ID: %s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:295
+#: SourcesCitationsReport//SourcesCitationsReport.py:316
 #, python-format
 msgid "   %s"
 msgstr "   %s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:309
-#: SourcesCitationsReport/SourcesCitationsReport.py:323
-#: SourcesCitationsReport/SourcesCitationsReport.py:350
-#: SourcesCitationsReport/SourcesCitationsReport.py:356
-#: SourcesCitationsReport/SourcesCitationsReport.py:362
+#: SourcesCitationsReport//SourcesCitationsReport.py:330
+#: SourcesCitationsReport//SourcesCitationsReport.py:351
+#: SourcesCitationsReport//SourcesCitationsReport.py:378
+#: SourcesCitationsReport//SourcesCitationsReport.py:384
+#: SourcesCitationsReport//SourcesCitationsReport.py:390
 #, python-format
 msgid "%s"
 msgstr "%s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:311
-#: SourcesCitationsReport/SourcesCitationsReport.py:325
+#: SourcesCitationsReport//SourcesCitationsReport.py:332
+#: SourcesCitationsReport//SourcesCitationsReport.py:353
 #, python-format
 msgid "   ( %s )"
 msgstr "   ( %s )"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:314
-#, python-format
-msgid "   Eheleute: %s "
-msgstr "   Eheleute: %s "
+#: SourcesCitationsReport//SourcesCitationsReport.py:339
+msgid "   Spouses: "
+msgstr "   Ehepartner: "
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:316
+#: SourcesCitationsReport//SourcesCitationsReport.py:341
+#, python-format
+msgid "%s "
+msgstr "%s "
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:344
 #, python-format
 msgid "and %s "
 msgstr "und %s "
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:327
+#: SourcesCitationsReport//SourcesCitationsReport.py:355
 #, python-format
 msgid " %s"
 msgstr " %s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:335
+#: SourcesCitationsReport//SourcesCitationsReport.py:363
 msgid "Person"
 msgstr "Person"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:335
+#: SourcesCitationsReport//SourcesCitationsReport.py:363
 msgid "ID"
 msgstr "ID"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:336
+#: SourcesCitationsReport//SourcesCitationsReport.py:364
 msgid "Role"
 msgstr "Rolle"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:388
+#: SourcesCitationsReport//SourcesCitationsReport.py:419
 msgid "Report Options"
 msgstr "Berichtsoptionen"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:390
-msgid "book|Title"
-msgstr "Titel"
+#: SourcesCitationsReport//SourcesCitationsReport.py:421
+msgid "Report Title"
+msgstr "Berichtsoptionen"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:390
-msgid "Title of the Book"
-msgstr "Titel des Buches"
+#: SourcesCitationsReport//SourcesCitationsReport.py:421
+msgid "Title of the Report"
+msgstr "Titel des Berichts"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:391
-msgid "Title string for the book."
-msgstr "Titeltext des Buches."
+#: SourcesCitationsReport//SourcesCitationsReport.py:422
+msgid "Title string for the report."
+msgstr "Titeltext des Berichts."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:394
+#: SourcesCitationsReport//SourcesCitationsReport.py:425
 msgid "Subtitle"
 msgstr "Untertitel"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:394
-msgid "Subtitle of the Book"
-msgstr "Untertitel des Buches"
+#: SourcesCitationsReport//SourcesCitationsReport.py:425
+msgid "Subtitle of the Report"
+msgstr "Untertitel des Berichts"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:395
-msgid "Subtitle string for the book."
-msgstr "Untertiteltext des Buches."
+#: SourcesCitationsReport//SourcesCitationsReport.py:426
+msgid "Subtitle string for the report."
+msgstr "Untertiteltext des Berichts."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:402
+#: SourcesCitationsReport//SourcesCitationsReport.py:431
+msgid "researcher name"
+msgstr "Name des Forschers"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:433
 #, python-format
 msgid "Copyright %(year)d %(name)s"
 msgstr "Copyright %(year)d %(name)s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:404
+#: SourcesCitationsReport//SourcesCitationsReport.py:435
 msgid "Footer"
 msgstr "Fußzeile"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:405
+#: SourcesCitationsReport//SourcesCitationsReport.py:436
 msgid "Footer string for the page."
 msgstr "Text für die Fußzeile."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:412
+#: SourcesCitationsReport//SourcesCitationsReport.py:443
 msgid "Select using filter"
 msgstr "Unter Verwendung vom Filter wählen"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:413
-msgid "Select places using a filter"
+#: SourcesCitationsReport//SourcesCitationsReport.py:444
+msgid "Select sources using a filter"
 msgstr "Ort unter Verwendung vom Filter wählen"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:420
+#: SourcesCitationsReport//SourcesCitationsReport.py:451
 msgid "Show persons"
 msgstr "Tabelle mit Personen im Bericht zeigen"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:421
+#: SourcesCitationsReport//SourcesCitationsReport.py:452
 msgid "Whether to show events and persons mentioned in the note"
-msgstr "Ob Ereignisse und Personen angezeit werden sollen."
+msgstr "Ob Ereignisse und Personen angezeit werden sollen"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:452
+#: SourcesCitationsReport//SourcesCitationsReport.py:488
 msgid "The style used for the title of the report."
 msgstr "Der Stil, der für den Titel des Berichts verwendet wird."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:467
+#: SourcesCitationsReport//SourcesCitationsReport.py:503
+msgid "The style used for the subtitle of the report."
+msgstr "Der Stil, der für den Untertitel des Berichts verwendet wird."
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:517
+msgid "The style used for the footer of the report."
+msgstr "Der Stil, der für die Fußzeile des Berichts verwendet wird."
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:532
 msgid "The style used for source title."
-msgstr "Stil für Quellentitel"
+msgstr "Stil für Quellentitel."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:482
-msgid "The style used for citation title."
-msgstr "Stil für den Fundstellentitel"
+#: SourcesCitationsReport//SourcesCitationsReport.py:544
+msgid "The style used for source subtitle."
+msgstr "Stil für Quellenundertitel."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:494
+#: SourcesCitationsReport//SourcesCitationsReport.py:556
 msgid "The style used for Source details."
-msgstr "Sitl der Quellendetails"
+msgstr "Sitl der Quellendetails."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:506
+#: SourcesCitationsReport//SourcesCitationsReport.py:571
+msgid "The style used for citation title."
+msgstr "Stil für den Fundstellentitel."
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:583
 msgid "The style used for a column title."
 msgstr "Der Stil, der für den Spaltentitel verwendet wird."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:522
+#: SourcesCitationsReport//SourcesCitationsReport.py:599
 msgid "The style used for each section."
 msgstr "Der Stil, der für jeden Absatz verwendet wird."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:553
+#: SourcesCitationsReport//SourcesCitationsReport.py:630
 msgid "The style used for event and person details."
 msgstr "Der Stil, der für Ereignis- und Persondetails verwendet wird."

--- a/SourcesCitationsReport/po/fr-local.po
+++ b/SourcesCitationsReport/po/fr-local.po
@@ -6,184 +6,218 @@ msgid ""
 msgstr ""
 "Project-Id-Version: tronc\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2013-02-07 14:04+0100\n"
-"PO-Revision-Date: 2013-02-07 14:11+0100\n"
-"Last-Translator: \n"
+"POT-Creation-Date: 2020-08-13 22:18+0200\n"
+"PO-Revision-Date: 2020-08-13 22:51+0200\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
 "Language-Team: French\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 2.3\n"
 
-#: SourcesCitationsReport/SourcesCitationsReport.gpr.py:9
+#: SourcesCitationsReport//SourcesCitationsReport.gpr.py:32
 msgid "Sources and Citations Report"
 msgstr "Rapport de sources et citations"
 
-#: SourcesCitationsReport/SourcesCitationsReport.gpr.py:10
-msgid "Provides a source and Citations with notes"
-msgstr "Fournit une source et ses citations avec les notes"
+#: SourcesCitationsReport//SourcesCitationsReport.gpr.py:33
+msgid "Provides a source and Citations Report with notes"
+msgstr "Fournit un rapport sur les sources et les citations avec des notes"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:264
+#: SourcesCitationsReport//SourcesCitationsReport.py:278
 #, python-format
-msgid "   key: %s"
-msgstr "    clé : %s"
+msgid "Key: %s"
+msgstr "Clé : %s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:274
-#, fuzzy, python-format
+#: SourcesCitationsReport//SourcesCitationsReport.py:283
+msgid "Citations:"
+msgstr "Citations:"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:292
+#, python-format
 msgid "%d"
 msgstr "%d"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:276
+#: SourcesCitationsReport//SourcesCitationsReport.py:294
 #, python-format
 msgid "  %s"
-msgstr ""
+msgstr "  %s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:278
-#, fuzzy, python-format
-msgid "   Anno %s - "
-msgstr "   Année %s - "
+#: SourcesCitationsReport//SourcesCitationsReport.py:300
+#, python-format
+msgid " - %s "
+msgstr " et %s "
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:284
-#, fuzzy, python-format
+#: SourcesCitationsReport//SourcesCitationsReport.py:306
+#, python-format
 msgid "   Type: %s"
-msgstr "Type"
+msgstr "   Type: %s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:286
-#, fuzzy, python-format
+#: SourcesCitationsReport//SourcesCitationsReport.py:308
+#, python-format
 msgid "   N-ID: %s"
-msgstr "ID"
+msgstr "   N-ID: %s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:294
+#: SourcesCitationsReport//SourcesCitationsReport.py:316
 #, python-format
 msgid "   %s"
-msgstr ""
+msgstr "   %s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:308
-#: SourcesCitationsReport/SourcesCitationsReport.py:322
-#: SourcesCitationsReport/SourcesCitationsReport.py:349
-#: SourcesCitationsReport/SourcesCitationsReport.py:355
-#: SourcesCitationsReport/SourcesCitationsReport.py:361
+#: SourcesCitationsReport//SourcesCitationsReport.py:330
+#: SourcesCitationsReport//SourcesCitationsReport.py:351
+#: SourcesCitationsReport//SourcesCitationsReport.py:378
+#: SourcesCitationsReport//SourcesCitationsReport.py:384
+#: SourcesCitationsReport//SourcesCitationsReport.py:390
 #, python-format
 msgid "%s"
-msgstr ""
+msgstr "%s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:310
-#: SourcesCitationsReport/SourcesCitationsReport.py:324
+#: SourcesCitationsReport//SourcesCitationsReport.py:332
+#: SourcesCitationsReport//SourcesCitationsReport.py:353
 #, python-format
 msgid "   ( %s )"
-msgstr ""
+msgstr "   ( %s )"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:313
-#, fuzzy, python-format
-msgid "   Eheleute: %s "
-msgstr "   Témoin : %s "
+#: SourcesCitationsReport//SourcesCitationsReport.py:339
+msgid "   Spouses: "
+msgstr "   Conjoints : "
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:315
+#: SourcesCitationsReport//SourcesCitationsReport.py:341
+#, python-format
+msgid "%s "
+msgstr "et %s "
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:344
 #, python-format
 msgid "and %s "
 msgstr "et %s "
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:326
+#: SourcesCitationsReport//SourcesCitationsReport.py:355
 #, python-format
 msgid " %s"
-msgstr ""
+msgstr " %s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:334
+#: SourcesCitationsReport//SourcesCitationsReport.py:363
 msgid "Person"
-msgstr "Individu "
+msgstr "Individu"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:334
-#, fuzzy
+#: SourcesCitationsReport//SourcesCitationsReport.py:363
 msgid "ID"
 msgstr "ID"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:335
+#: SourcesCitationsReport//SourcesCitationsReport.py:364
 msgid "Role"
 msgstr "Rôle"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:387
+#: SourcesCitationsReport//SourcesCitationsReport.py:419
 msgid "Report Options"
 msgstr "Options du rapport"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:389
-msgid "book|Title"
-msgstr "Titre"
+#: SourcesCitationsReport//SourcesCitationsReport.py:421
+msgid "Report Title"
+msgstr "Titre du rapport"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:389
-msgid "Title of the Book"
-msgstr "Titre du livre"
+#: SourcesCitationsReport//SourcesCitationsReport.py:421
+msgid "Title of the Report"
+msgstr "Titre du rapport"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:390
-msgid "Title string for the book."
-msgstr "Titre du livre."
+#: SourcesCitationsReport//SourcesCitationsReport.py:422
+msgid "Title string for the report."
+msgstr "Titre du rapport."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:393
+#: SourcesCitationsReport//SourcesCitationsReport.py:425
 msgid "Subtitle"
 msgstr "Sous-titre"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:393
-msgid "Subtitle of the Book"
+#: SourcesCitationsReport//SourcesCitationsReport.py:425
+msgid "Subtitle of the Report"
 msgstr "Sous-titre du livre"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:394
-msgid "Subtitle string for the book."
+#: SourcesCitationsReport//SourcesCitationsReport.py:426
+msgid "Subtitle string for the report."
 msgstr "Sous-titre du livre."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:401
+#: SourcesCitationsReport//SourcesCitationsReport.py:431
+msgid "researcher name"
+msgstr "nom du chercheur"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:433
 #, python-format
 msgid "Copyright %(year)d %(name)s"
 msgstr "Droit d'auteur %(year)d %(name)s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:403
+#: SourcesCitationsReport//SourcesCitationsReport.py:435
 msgid "Footer"
 msgstr "Pied de page"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:404
+#: SourcesCitationsReport//SourcesCitationsReport.py:436
 msgid "Footer string for the page."
 msgstr "Message au bas de la page."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:411
+#: SourcesCitationsReport//SourcesCitationsReport.py:443
 msgid "Select using filter"
 msgstr "Sélection avec un filtre"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:412
-msgid "Select places using a filter"
-msgstr "Sélection de lieux avec un filtre"
+#: SourcesCitationsReport//SourcesCitationsReport.py:444
+msgid "Select sources using a filter"
+msgstr "Sélectionnez les sources à l'aide d'un filtre"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:419
+#: SourcesCitationsReport//SourcesCitationsReport.py:451
 msgid "Show persons"
 msgstr "Affiche les individus"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:420
+#: SourcesCitationsReport//SourcesCitationsReport.py:452
 msgid "Whether to show events and persons mentioned in the note"
 msgstr "Afficher ou non les événements et individus présents dans une note"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:451
+#: SourcesCitationsReport//SourcesCitationsReport.py:488
 msgid "The style used for the title of the report."
 msgstr "Le style utilisé pour le titre du rapport."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:466
+#: SourcesCitationsReport//SourcesCitationsReport.py:503
+msgid "The style used for the subtitle of the report."
+msgstr "Le style utilisé pour le sous-titre du rapport."
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:517
+msgid "The style used for the footer of the report."
+msgstr "Le style utilisé pour le pied de page du rapport."
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:532
 msgid "The style used for source title."
 msgstr "Le style utilisé pour le titre de la source."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:481
-msgid "The style used for citation title."
-msgstr "Le style utilisé pour le titre de la citation."
+#: SourcesCitationsReport//SourcesCitationsReport.py:544
+msgid "The style used for source subtitle."
+msgstr "Le style utilisé pour le sous-titre source."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:493
+#: SourcesCitationsReport//SourcesCitationsReport.py:556
 msgid "The style used for Source details."
 msgstr "Le style utilisé pour les détails de la source."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:505
+#: SourcesCitationsReport//SourcesCitationsReport.py:571
+msgid "The style used for citation title."
+msgstr "Le style utilisé pour le titre de la citation."
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:583
 msgid "The style used for a column title."
 msgstr "Le style utilisé pour la colonne titre."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:521
+#: SourcesCitationsReport//SourcesCitationsReport.py:599
 msgid "The style used for each section."
 msgstr "Le style utilisé pour chaque section."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:552
+#: SourcesCitationsReport//SourcesCitationsReport.py:630
 msgid "The style used for event and person details."
 msgstr "Le style utilisé pour les détails de l'événement et de l'individu."
 
+#, fuzzy
+#~ msgid "   Anno %s - "
+#~ msgstr "   Année %s - "
+
+#, fuzzy
+#~ msgid "   Eheleute: %s "
+#~ msgstr "   Témoin : %s "
+
+#~ msgid "book|Title"
+#~ msgstr "Titre"

--- a/SourcesCitationsReport/po/hr-local.po
+++ b/SourcesCitationsReport/po/hr-local.po
@@ -7,187 +7,211 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Gramps 5.x\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-01-22 09:28-0600\n"
-"PO-Revision-Date: 2019-03-08 11:52+0100\n"
+"POT-Creation-Date: 2020-08-13 22:18+0200\n"
+"PO-Revision-Date: 2020-08-13 22:54+0200\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
 "Language-Team: \n"
+"Language: hr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.2.1\n"
-"Last-Translator: Milo Ivir <mail@milotype.de>\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
-"Language: hr\n"
+"X-Generator: Poedit 2.3\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 
-#: SourcesCitationsReport/SourcesCitationsReport.gpr.py:10
+#: SourcesCitationsReport//SourcesCitationsReport.gpr.py:32
 msgid "Sources and Citations Report"
 msgstr "Izvještaj o izvorima i citatima"
 
-#: SourcesCitationsReport/SourcesCitationsReport.gpr.py:11
+#: SourcesCitationsReport//SourcesCitationsReport.gpr.py:33
 msgid "Provides a source and Citations Report with notes"
 msgstr "Stvara izvještaj o izvorima i citatima, zajedno sa zabilješkama"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:267
+#: SourcesCitationsReport//SourcesCitationsReport.py:278
 #, python-format
-msgid "   key: %s"
-msgstr "   Ključ: %s"
+msgid "Key: %s"
+msgstr "Ključ: %s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:277
+#: SourcesCitationsReport//SourcesCitationsReport.py:283
+msgid "Citations:"
+msgstr "Citati:"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:292
 #, python-format
 msgid "%d"
 msgstr "%d"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:279
+#: SourcesCitationsReport//SourcesCitationsReport.py:294
 #, python-format
 msgid "  %s"
 msgstr "  %s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:285
+#: SourcesCitationsReport//SourcesCitationsReport.py:300
 #, python-format
 msgid " - %s "
 msgstr " – %s "
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:291
+#: SourcesCitationsReport//SourcesCitationsReport.py:306
 #, python-format
 msgid "   Type: %s"
 msgstr "   Vrsta: %s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:293
+#: SourcesCitationsReport//SourcesCitationsReport.py:308
 #, python-format
 msgid "   N-ID: %s"
 msgstr "   N-ID: %s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:301
+#: SourcesCitationsReport//SourcesCitationsReport.py:316
 #, python-format
 msgid "   %s"
 msgstr "   %s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:315
-#: SourcesCitationsReport/SourcesCitationsReport.py:336
-#: SourcesCitationsReport/SourcesCitationsReport.py:363
-#: SourcesCitationsReport/SourcesCitationsReport.py:369
-#: SourcesCitationsReport/SourcesCitationsReport.py:375
+#: SourcesCitationsReport//SourcesCitationsReport.py:330
+#: SourcesCitationsReport//SourcesCitationsReport.py:351
+#: SourcesCitationsReport//SourcesCitationsReport.py:378
+#: SourcesCitationsReport//SourcesCitationsReport.py:384
+#: SourcesCitationsReport//SourcesCitationsReport.py:390
 #, python-format
 msgid "%s"
 msgstr "%s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:317
-#: SourcesCitationsReport/SourcesCitationsReport.py:338
+#: SourcesCitationsReport//SourcesCitationsReport.py:332
+#: SourcesCitationsReport//SourcesCitationsReport.py:353
 #, python-format
 msgid "   ( %s )"
 msgstr "   ( %s )"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:324
-msgid "   Eheleute: "
+#: SourcesCitationsReport//SourcesCitationsReport.py:339
+msgid "   Spouses: "
 msgstr "   Supružnici: "
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:326
+#: SourcesCitationsReport//SourcesCitationsReport.py:341
 #, python-format
 msgid "%s "
 msgstr "%s "
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:329
+#: SourcesCitationsReport//SourcesCitationsReport.py:344
 #, python-format
 msgid "and %s "
 msgstr "i %s "
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:340
+#: SourcesCitationsReport//SourcesCitationsReport.py:355
 #, python-format
 msgid " %s"
 msgstr " %s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:348
+#: SourcesCitationsReport//SourcesCitationsReport.py:363
 msgid "Person"
 msgstr "Osoba"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:348
+#: SourcesCitationsReport//SourcesCitationsReport.py:363
 msgid "ID"
 msgstr "ID"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:349
+#: SourcesCitationsReport//SourcesCitationsReport.py:364
 msgid "Role"
 msgstr "Uloga"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:404
+#: SourcesCitationsReport//SourcesCitationsReport.py:419
 msgid "Report Options"
 msgstr "Opcije za izvještaj"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:406
+#: SourcesCitationsReport//SourcesCitationsReport.py:421
 msgid "Report Title"
 msgstr "Naslov izvještaja"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:406
+#: SourcesCitationsReport//SourcesCitationsReport.py:421
 msgid "Title of the Report"
 msgstr "Naslov ovog izvještaja"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:407
+#: SourcesCitationsReport//SourcesCitationsReport.py:422
 msgid "Title string for the report."
 msgstr "Znakovni niz za naslov izvještaja."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:410
+#: SourcesCitationsReport//SourcesCitationsReport.py:425
 msgid "Subtitle"
 msgstr "Podnaslov"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:410
+#: SourcesCitationsReport//SourcesCitationsReport.py:425
 msgid "Subtitle of the Report"
 msgstr "Podnaslov ovog izvještaja"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:411
+#: SourcesCitationsReport//SourcesCitationsReport.py:426
 msgid "Subtitle string for the report."
 msgstr "Znakovni niz za podnaslov izvještaja."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:418
+#: SourcesCitationsReport//SourcesCitationsReport.py:431
+msgid "researcher name"
+msgstr "ime istraživača"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:433
 #, python-format
 msgid "Copyright %(year)d %(name)s"
 msgstr "© %(year)d. %(name)s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:420
+#: SourcesCitationsReport//SourcesCitationsReport.py:435
 msgid "Footer"
 msgstr "Podnožje"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:421
+#: SourcesCitationsReport//SourcesCitationsReport.py:436
 msgid "Footer string for the page."
 msgstr "Znakovni niz za podnožje stranice."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:428
+#: SourcesCitationsReport//SourcesCitationsReport.py:443
 msgid "Select using filter"
 msgstr "Odaberi korištenjem filtra"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:429
+#: SourcesCitationsReport//SourcesCitationsReport.py:444
 msgid "Select sources using a filter"
 msgstr "Odaberi izvore pomoću filtra"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:436
+#: SourcesCitationsReport//SourcesCitationsReport.py:451
 msgid "Show persons"
 msgstr "Prikaži osobe"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:437
+#: SourcesCitationsReport//SourcesCitationsReport.py:452
 msgid "Whether to show events and persons mentioned in the note"
 msgstr "Da li prikazati događaje i osobe, navedene u zabilješki"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:470
+#: SourcesCitationsReport//SourcesCitationsReport.py:488
 msgid "The style used for the title of the report."
 msgstr "Stil korišten za naslov izvještaja."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:485
+#: SourcesCitationsReport//SourcesCitationsReport.py:503
+msgid "The style used for the subtitle of the report."
+msgstr "Stil koji se koristi za podnaslov izvještaja."
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:517
+msgid "The style used for the footer of the report."
+msgstr "Stil koji se koristi za podnožje izvješća."
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:532
 msgid "The style used for source title."
 msgstr "Stil korišten za naslov izvora."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:500
-msgid "The style used for citation title."
-msgstr "Stil korišten za naslov citata."
+#: SourcesCitationsReport//SourcesCitationsReport.py:544
+msgid "The style used for source subtitle."
+msgstr "Stil koji se koristi za izvorni podnaslov."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:512
+#: SourcesCitationsReport//SourcesCitationsReport.py:556
 msgid "The style used for Source details."
 msgstr "Stil korišten za detalje izvora."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:524
+#: SourcesCitationsReport//SourcesCitationsReport.py:571
+msgid "The style used for citation title."
+msgstr "Stil korišten za naslov citata."
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:583
 msgid "The style used for a column title."
 msgstr "Stil korišten za naslov stupca."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:540
+#: SourcesCitationsReport//SourcesCitationsReport.py:599
 msgid "The style used for each section."
 msgstr "Stil korišten za odlomke."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:571
+#: SourcesCitationsReport//SourcesCitationsReport.py:630
 msgid "The style used for event and person details."
 msgstr "Stil korišten za detalje događaja i osobe."
+
+#~ msgid "   Eheleute: "
+#~ msgstr "   Supružnici: "

--- a/SourcesCitationsReport/po/nl-local.po
+++ b/SourcesCitationsReport/po/nl-local.po
@@ -1,0 +1,212 @@
+# Dutch translation of addon SourcesCitationsReport.
+# Copyright (C) 2020 Gramps project
+# This file is distributed under the same license as the SourcesCitationsReport package.
+# Jan Sparreboom <jan@sparreboom.net>, 2020.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: SourcesCitationsReport 5.x\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-08-13 22:18+0200\n"
+"PO-Revision-Date: 2020-08-13 22:23+0200\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
+"Language-Team: Dutch <gramps-users@lists.sourceforge.net>\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.3\n"
+
+#: SourcesCitationsReport//SourcesCitationsReport.gpr.py:32
+msgid "Sources and Citations Report"
+msgstr "Bronnen en citatenverslag"
+
+#: SourcesCitationsReport//SourcesCitationsReport.gpr.py:33
+msgid "Provides a source and Citations Report with notes"
+msgstr "Biedt een bron en citatenverslag met notities"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:278
+#, python-format
+msgid "Key: %s"
+msgstr "Sleutel: %s"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:283
+msgid "Citations:"
+msgstr "Citaten:"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:292
+#, python-format
+msgid "%d"
+msgstr "%d"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:294
+#, python-format
+msgid "  %s"
+msgstr "  %s"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:300
+#, python-format
+msgid " - %s "
+msgstr " - %s "
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:306
+#, python-format
+msgid "   Type: %s"
+msgstr "   Type: %s"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:308
+#, python-format
+msgid "   N-ID: %s"
+msgstr "   N-ID: %s"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:316
+#, python-format
+msgid "   %s"
+msgstr "   %s"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:330
+#: SourcesCitationsReport//SourcesCitationsReport.py:351
+#: SourcesCitationsReport//SourcesCitationsReport.py:378
+#: SourcesCitationsReport//SourcesCitationsReport.py:384
+#: SourcesCitationsReport//SourcesCitationsReport.py:390
+#, python-format
+msgid "%s"
+msgstr "%s"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:332
+#: SourcesCitationsReport//SourcesCitationsReport.py:353
+#, python-format
+msgid "   ( %s )"
+msgstr "   ( %s )"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:339
+msgid "   Spouses: "
+msgstr "   Echtgenoten "
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:341
+#, python-format
+msgid "%s "
+msgstr "%s "
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:344
+#, python-format
+msgid "and %s "
+msgstr "en %s "
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:355
+#, python-format
+msgid " %s"
+msgstr " %s"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:363
+msgid "Person"
+msgstr "Persoon"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:363
+msgid "ID"
+msgstr "ID"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:364
+msgid "Role"
+msgstr "Rol"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:419
+msgid "Report Options"
+msgstr "Verslagopties"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:421
+msgid "Report Title"
+msgstr "Verslagtitel"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:421
+msgid "Title of the Report"
+msgstr "Titel van het verslag"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:422
+msgid "Title string for the report."
+msgstr "Titelregel voor het verslag."
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:425
+msgid "Subtitle"
+msgstr "Ondertitel"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:425
+msgid "Subtitle of the Report"
+msgstr "Ondertitel van het verslag"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:426
+msgid "Subtitle string for the report."
+msgstr "Ondertitelregel van het verslag."
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:431
+msgid "researcher name"
+msgstr "naam onderzoeker"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:433
+#, python-format
+msgid "Copyright %(year)d %(name)s"
+msgstr "Auteursrecht %(year)d %(name)s"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:435
+msgid "Footer"
+msgstr "Voettekst"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:436
+msgid "Footer string for the page."
+msgstr "Voettekstzin voor de pagina."
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:443
+msgid "Select using filter"
+msgstr "Selecteer met behulp van filter"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:444
+msgid "Select sources using a filter"
+msgstr "Selecteer bronnen met behulp van een filter"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:451
+msgid "Show persons"
+msgstr "Toon personen"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:452
+msgid "Whether to show events and persons mentioned in the note"
+msgstr "Of gebeurtenissen en personen vermeld in de notitie moeten worden weergegeven"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:488
+msgid "The style used for the title of the report."
+msgstr "De stijl die wordt gebruikt voor de titel van het verslag."
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:503
+msgid "The style used for the subtitle of the report."
+msgstr "De stijl die wordt gebruikt voor de ondertitel van het rapport."
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:517
+msgid "The style used for the footer of the report."
+msgstr "De stijl die wordt gebruikt voor de voettekst van het rapport."
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:532
+msgid "The style used for source title."
+msgstr "De stijl die wordt gebruikt voor de brontitel."
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:544
+msgid "The style used for source subtitle."
+msgstr "De stijl die wordt gebruikt voor de bronondertiteling."
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:556
+msgid "The style used for Source details."
+msgstr "De stijl die wordt gebruikt voor brondetails."
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:571
+msgid "The style used for citation title."
+msgstr "De stijl die wordt gebruikt voor de citaattitel."
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:583
+msgid "The style used for a column title."
+msgstr "De stijl die wordt gebruikt voor een kolomtitel."
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:599
+msgid "The style used for each section."
+msgstr "De stijl die voor elke sectie wordt gebruikt."
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:630
+msgid "The style used for event and person details."
+msgstr "De stijl die wordt gebruikt voor details over gebeurtenissen en personen."

--- a/SourcesCitationsReport/po/pt_PT-local.po
+++ b/SourcesCitationsReport/po/pt_PT-local.po
@@ -6,9 +6,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gramps51\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-19 10:57-0500\n"
-"PO-Revision-Date: 2020-04-03 09:48+0100\n"
-"Last-Translator: Pedro Albuquerque <pmra@protonmail.com>\n"
+"POT-Creation-Date: 2020-08-13 22:18+0200\n"
+"PO-Revision-Date: 2020-08-13 22:59+0200\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
 "Language-Team: Pedro Albuquerque\n"
 "Language: pt\n"
 "MIME-Version: 1.0\n"
@@ -17,176 +17,196 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.3\n"
 
-#: SourcesCitationsReport/SourcesCitationsReport.gpr.py:32
+#: SourcesCitationsReport//SourcesCitationsReport.gpr.py:32
 msgid "Sources and Citations Report"
 msgstr "Relatório de fontes e citações"
 
-#: SourcesCitationsReport/SourcesCitationsReport.gpr.py:33
+#: SourcesCitationsReport//SourcesCitationsReport.gpr.py:33
 msgid "Provides a source and Citations Report with notes"
 msgstr "Fornece um relatório de fontes e citações com notas"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:267
+#: SourcesCitationsReport//SourcesCitationsReport.py:278
 #, python-format
-msgid "   key: %s"
-msgstr "   chave: %s"
+msgid "Key: %s"
+msgstr "Chave: %s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:277
+#: SourcesCitationsReport//SourcesCitationsReport.py:283
+msgid "Citations:"
+msgstr "Citações:"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:292
 #, python-format
 msgid "%d"
 msgstr "%d"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:279
+#: SourcesCitationsReport//SourcesCitationsReport.py:294
 #, python-format
 msgid "  %s"
 msgstr "  %s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:285
+#: SourcesCitationsReport//SourcesCitationsReport.py:300
 #, python-format
 msgid " - %s "
 msgstr " - %s "
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:291
+#: SourcesCitationsReport//SourcesCitationsReport.py:306
 #, python-format
 msgid "   Type: %s"
 msgstr "   Tipo: %s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:293
+#: SourcesCitationsReport//SourcesCitationsReport.py:308
 #, python-format
 msgid "   N-ID: %s"
 msgstr "   N-Id: %s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:301
+#: SourcesCitationsReport//SourcesCitationsReport.py:316
 #, python-format
 msgid "   %s"
 msgstr "   %s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:315
-#: SourcesCitationsReport/SourcesCitationsReport.py:336
-#: SourcesCitationsReport/SourcesCitationsReport.py:363
-#: SourcesCitationsReport/SourcesCitationsReport.py:369
-#: SourcesCitationsReport/SourcesCitationsReport.py:375
+#: SourcesCitationsReport//SourcesCitationsReport.py:330
+#: SourcesCitationsReport//SourcesCitationsReport.py:351
+#: SourcesCitationsReport//SourcesCitationsReport.py:378
+#: SourcesCitationsReport//SourcesCitationsReport.py:384
+#: SourcesCitationsReport//SourcesCitationsReport.py:390
 #, python-format
 msgid "%s"
 msgstr "%s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:317
-#: SourcesCitationsReport/SourcesCitationsReport.py:338
+#: SourcesCitationsReport//SourcesCitationsReport.py:332
+#: SourcesCitationsReport//SourcesCitationsReport.py:353
 #, python-format
 msgid "   ( %s )"
 msgstr "   ( %s )"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:324
-msgid "   Eheleute: "
-msgstr "   Eheleute: "
+#: SourcesCitationsReport//SourcesCitationsReport.py:339
+msgid "   Spouses: "
+msgstr "   Cônjuges: "
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:326
+#: SourcesCitationsReport//SourcesCitationsReport.py:341
 #, python-format
 msgid "%s "
 msgstr "%s "
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:329
+#: SourcesCitationsReport//SourcesCitationsReport.py:344
 #, python-format
 msgid "and %s "
 msgstr "e %s "
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:340
+#: SourcesCitationsReport//SourcesCitationsReport.py:355
 #, python-format
 msgid " %s"
 msgstr " %s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:348
+#: SourcesCitationsReport//SourcesCitationsReport.py:363
 msgid "Person"
 msgstr "Indivíduo"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:348
+#: SourcesCitationsReport//SourcesCitationsReport.py:363
 msgid "ID"
 msgstr "Id"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:349
+#: SourcesCitationsReport//SourcesCitationsReport.py:364
 msgid "Role"
 msgstr "Papel"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:404
+#: SourcesCitationsReport//SourcesCitationsReport.py:419
 msgid "Report Options"
 msgstr "Opções do relatório"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:406
+#: SourcesCitationsReport//SourcesCitationsReport.py:421
 msgid "Report Title"
 msgstr "Título do relatório"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:406
+#: SourcesCitationsReport//SourcesCitationsReport.py:421
 msgid "Title of the Report"
 msgstr "Título do relatório"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:407
+#: SourcesCitationsReport//SourcesCitationsReport.py:422
 msgid "Title string for the report."
 msgstr "Cadeia de título do relatório."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:410
+#: SourcesCitationsReport//SourcesCitationsReport.py:425
 msgid "Subtitle"
 msgstr "Sub-título"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:410
+#: SourcesCitationsReport//SourcesCitationsReport.py:425
 msgid "Subtitle of the Report"
 msgstr "Sub-título do relatório"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:411
+#: SourcesCitationsReport//SourcesCitationsReport.py:426
 msgid "Subtitle string for the report."
 msgstr "Cadeia de sub-título do relatório."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:418
+#: SourcesCitationsReport//SourcesCitationsReport.py:431
+msgid "researcher name"
+msgstr "nome do pesquisador"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:433
 #, python-format
 msgid "Copyright %(year)d %(name)s"
 msgstr "Direitos de autor \\u00A9 %(year)d %(name)s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:420
+#: SourcesCitationsReport//SourcesCitationsReport.py:435
 msgid "Footer"
 msgstr "Rodapé"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:421
+#: SourcesCitationsReport//SourcesCitationsReport.py:436
 msgid "Footer string for the page."
 msgstr "Cadeia de rodapé para a página."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:428
+#: SourcesCitationsReport//SourcesCitationsReport.py:443
 msgid "Select using filter"
 msgstr "Seleccionar com filtro"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:429
+#: SourcesCitationsReport//SourcesCitationsReport.py:444
 msgid "Select sources using a filter"
 msgstr "Seleccionar fontes usando um filtro"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:436
+#: SourcesCitationsReport//SourcesCitationsReport.py:451
 msgid "Show persons"
 msgstr "Mostrar indivíduos"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:437
+#: SourcesCitationsReport//SourcesCitationsReport.py:452
 msgid "Whether to show events and persons mentioned in the note"
 msgstr "Se deve mostrar eventos e indivíduos mencionados na nota"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:470
+#: SourcesCitationsReport//SourcesCitationsReport.py:488
 msgid "The style used for the title of the report."
 msgstr "O estilo usado para o título do relatório."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:485
+#: SourcesCitationsReport//SourcesCitationsReport.py:503
+msgid "The style used for the subtitle of the report."
+msgstr "O estilo usado para o subtítulo do relatório."
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:517
+msgid "The style used for the footer of the report."
+msgstr "O estilo usado para o rodapé do relatório."
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:532
 msgid "The style used for source title."
 msgstr "O estilo usado para o título da fonte."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:500
-msgid "The style used for citation title."
-msgstr "O estilo usado para o título da citação."
+#: SourcesCitationsReport//SourcesCitationsReport.py:544
+msgid "The style used for source subtitle."
+msgstr "O estilo usado para a legenda da fonte."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:512
+#: SourcesCitationsReport//SourcesCitationsReport.py:556
 msgid "The style used for Source details."
 msgstr "O estilo usado para os detalhes da fonte."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:524
+#: SourcesCitationsReport//SourcesCitationsReport.py:571
+msgid "The style used for citation title."
+msgstr "O estilo usado para o título da citação."
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:583
 msgid "The style used for a column title."
 msgstr "O estilo usado para um título de coluna."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:540
+#: SourcesCitationsReport//SourcesCitationsReport.py:599
 msgid "The style used for each section."
 msgstr "O estilo usado para cada secção."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:571
+#: SourcesCitationsReport//SourcesCitationsReport.py:630
 msgid "The style used for event and person details."
 msgstr "O estilo usado para o evento e detalhes pessoais."

--- a/SourcesCitationsReport/po/ru-local.po
+++ b/SourcesCitationsReport/po/ru-local.po
@@ -7,190 +7,208 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gramps50\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-06 11:37+0300\n"
-"PO-Revision-Date: 2018-12-06 11:44+0300\n"
-"Last-Translator: Ivan Komaritsyn <vantu5z@mail.ru>\n"
+"POT-Creation-Date: 2020-08-13 22:18+0200\n"
+"PO-Revision-Date: 2020-08-13 23:02+0200\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
 "Language-Team: Russian\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Gtranslator 2.91.7\n"
-"X-Poedit-Language: Russian\n"
-"X-Poedit-Country: RUSSIAN FEDERATION\n"
+"X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: SourcesCitationsReport/SourcesCitationsReport.gpr.py:10
+#: SourcesCitationsReport//SourcesCitationsReport.gpr.py:32
 msgid "Sources and Citations Report"
 msgstr "Источники и цитаты"
 
-#: SourcesCitationsReport/SourcesCitationsReport.gpr.py:11
+#: SourcesCitationsReport//SourcesCitationsReport.gpr.py:33
 msgid "Provides a source and Citations Report with notes"
 msgstr "Создаёт отчёт об источниках и цитатах с заметками"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:267
+#: SourcesCitationsReport//SourcesCitationsReport.py:278
 #, python-format
-msgid "   key: %s"
-msgstr "   ключ: %s"
+msgid "Key: %s"
+msgstr "Ключ: %s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:277
+#: SourcesCitationsReport//SourcesCitationsReport.py:283
+msgid "Citations:"
+msgstr "Цитирование:"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:292
 #, python-format
 msgid "%d"
 msgstr "%d"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:279
+#: SourcesCitationsReport//SourcesCitationsReport.py:294
 #, python-format
 msgid "  %s"
 msgstr "  %s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:285
+#: SourcesCitationsReport//SourcesCitationsReport.py:300
 #, python-format
 msgid " - %s "
 msgstr " - %s "
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:291
+#: SourcesCitationsReport//SourcesCitationsReport.py:306
 #, python-format
 msgid "   Type: %s"
 msgstr "   Тип: %s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:293
+#: SourcesCitationsReport//SourcesCitationsReport.py:308
 #, python-format
 msgid "   N-ID: %s"
 msgstr "   N-ID: %s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:301
+#: SourcesCitationsReport//SourcesCitationsReport.py:316
 #, python-format
 msgid "   %s"
 msgstr "   %s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:315
-#: SourcesCitationsReport/SourcesCitationsReport.py:336
-#: SourcesCitationsReport/SourcesCitationsReport.py:363
-#: SourcesCitationsReport/SourcesCitationsReport.py:369
-#: SourcesCitationsReport/SourcesCitationsReport.py:375
+#: SourcesCitationsReport//SourcesCitationsReport.py:330
+#: SourcesCitationsReport//SourcesCitationsReport.py:351
+#: SourcesCitationsReport//SourcesCitationsReport.py:378
+#: SourcesCitationsReport//SourcesCitationsReport.py:384
+#: SourcesCitationsReport//SourcesCitationsReport.py:390
 #, python-format
 msgid "%s"
 msgstr "%s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:317
-#: SourcesCitationsReport/SourcesCitationsReport.py:338
+#: SourcesCitationsReport//SourcesCitationsReport.py:332
+#: SourcesCitationsReport//SourcesCitationsReport.py:353
 #, python-format
 msgid "   ( %s )"
 msgstr "   ( %s )"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:324
-msgid "   Eheleute: "
+#: SourcesCitationsReport//SourcesCitationsReport.py:339
+msgid "   Spouses: "
 msgstr "   Супруги: "
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:326
+#: SourcesCitationsReport//SourcesCitationsReport.py:341
 #, python-format
 msgid "%s "
 msgstr "%s "
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:329
+#: SourcesCitationsReport//SourcesCitationsReport.py:344
 #, python-format
 msgid "and %s "
 msgstr "и %s "
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:340
+#: SourcesCitationsReport//SourcesCitationsReport.py:355
 #, python-format
 msgid " %s"
 msgstr " %s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:348
+#: SourcesCitationsReport//SourcesCitationsReport.py:363
 msgid "Person"
 msgstr "Лицо"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:348
+#: SourcesCitationsReport//SourcesCitationsReport.py:363
 msgid "ID"
 msgstr "ID"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:349
+#: SourcesCitationsReport//SourcesCitationsReport.py:364
 msgid "Role"
 msgstr "Роль"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:404
+#: SourcesCitationsReport//SourcesCitationsReport.py:419
 msgid "Report Options"
 msgstr "Параметры отчёта"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:406
+#: SourcesCitationsReport//SourcesCitationsReport.py:421
 msgid "Report Title"
 msgstr "Заголовок отчёта"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:406
+#: SourcesCitationsReport//SourcesCitationsReport.py:421
 msgid "Title of the Report"
 msgstr "Заголовок отчёта"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:407
+#: SourcesCitationsReport//SourcesCitationsReport.py:422
 msgid "Title string for the report."
 msgstr "Строка для заголовка отчёта."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:410
+#: SourcesCitationsReport//SourcesCitationsReport.py:425
 msgid "Subtitle"
 msgstr "Подзаголовок"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:410
+#: SourcesCitationsReport//SourcesCitationsReport.py:425
 msgid "Subtitle of the Report"
 msgstr "Подзаголовок отчёта"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:411
+#: SourcesCitationsReport//SourcesCitationsReport.py:426
 msgid "Subtitle string for the report."
 msgstr "Строка для подзаголовка отчёта."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:418
+#: SourcesCitationsReport//SourcesCitationsReport.py:431
+msgid "researcher name"
+msgstr "имя исследователя"
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:433
 #, python-format
 msgid "Copyright %(year)d %(name)s"
 msgstr "© %(year)d %(name)s"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:420
+#: SourcesCitationsReport//SourcesCitationsReport.py:435
 msgid "Footer"
 msgstr "Нижняя строка"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:421
+#: SourcesCitationsReport//SourcesCitationsReport.py:436
 msgid "Footer string for the page."
 msgstr "Нижний колонтитул страницы."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:428
+#: SourcesCitationsReport//SourcesCitationsReport.py:443
 msgid "Select using filter"
 msgstr "Выбрать используя фильтр"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:429
+#: SourcesCitationsReport//SourcesCitationsReport.py:444
 msgid "Select sources using a filter"
 msgstr "Выбор источников с помощью фильтра"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:436
+#: SourcesCitationsReport//SourcesCitationsReport.py:451
 msgid "Show persons"
 msgstr "Показывать людей"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:437
+#: SourcesCitationsReport//SourcesCitationsReport.py:452
 msgid "Whether to show events and persons mentioned in the note"
 msgstr "Показывать ли события и лиц упомянутых в заметках"
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:470
+#: SourcesCitationsReport//SourcesCitationsReport.py:488
 msgid "The style used for the title of the report."
 msgstr "Стиль, используемый для заголовка отчёта."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:485
+#: SourcesCitationsReport//SourcesCitationsReport.py:503
+msgid "The style used for the subtitle of the report."
+msgstr "Стиль субтитров отчета."
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:517
+msgid "The style used for the footer of the report."
+msgstr "Стиль нижнего колонтитула отчета."
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:532
 msgid "The style used for source title."
 msgstr "Стиль для заголовка источника."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:500
-msgid "The style used for citation title."
-msgstr "Стиль для заголовка цитаты."
+#: SourcesCitationsReport//SourcesCitationsReport.py:544
+msgid "The style used for source subtitle."
+msgstr "Стиль, используемый для исходных субтитров."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:512
+#: SourcesCitationsReport//SourcesCitationsReport.py:556
 msgid "The style used for Source details."
 msgstr "Стиль для информации по источнику."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:524
+#: SourcesCitationsReport//SourcesCitationsReport.py:571
+msgid "The style used for citation title."
+msgstr "Стиль для заголовка цитаты."
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:583
 msgid "The style used for a column title."
 msgstr "Стиль используемый для заголовка столбцов таблицы."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:540
+#: SourcesCitationsReport//SourcesCitationsReport.py:599
 msgid "The style used for each section."
 msgstr "Стиль используемый для заголовков разделов ."
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:571
+#: SourcesCitationsReport//SourcesCitationsReport.py:630
 msgid "The style used for event and person details."
 msgstr "Стиль используемый для информации о событиях и людях."

--- a/SourcesCitationsReport/po/template.pot
+++ b/SourcesCitationsReport/po/template.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-09-19 10:57-0500\n"
+"POT-Creation-Date: 2020-08-13 22:18+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,176 +17,196 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: SourcesCitationsReport/SourcesCitationsReport.gpr.py:32
+#: SourcesCitationsReport//SourcesCitationsReport.gpr.py:32
 msgid "Sources and Citations Report"
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.gpr.py:33
+#: SourcesCitationsReport//SourcesCitationsReport.gpr.py:33
 msgid "Provides a source and Citations Report with notes"
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:267
+#: SourcesCitationsReport//SourcesCitationsReport.py:278
 #, python-format
-msgid "   key: %s"
+msgid "Key: %s"
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:277
+#: SourcesCitationsReport//SourcesCitationsReport.py:283
+msgid "Citations:"
+msgstr ""
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:292
 #, python-format
 msgid "%d"
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:279
+#: SourcesCitationsReport//SourcesCitationsReport.py:294
 #, python-format
 msgid "  %s"
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:285
+#: SourcesCitationsReport//SourcesCitationsReport.py:300
 #, python-format
 msgid " - %s "
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:291
+#: SourcesCitationsReport//SourcesCitationsReport.py:306
 #, python-format
 msgid "   Type: %s"
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:293
+#: SourcesCitationsReport//SourcesCitationsReport.py:308
 #, python-format
 msgid "   N-ID: %s"
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:301
+#: SourcesCitationsReport//SourcesCitationsReport.py:316
 #, python-format
 msgid "   %s"
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:315
-#: SourcesCitationsReport/SourcesCitationsReport.py:336
-#: SourcesCitationsReport/SourcesCitationsReport.py:363
-#: SourcesCitationsReport/SourcesCitationsReport.py:369
-#: SourcesCitationsReport/SourcesCitationsReport.py:375
+#: SourcesCitationsReport//SourcesCitationsReport.py:330
+#: SourcesCitationsReport//SourcesCitationsReport.py:351
+#: SourcesCitationsReport//SourcesCitationsReport.py:378
+#: SourcesCitationsReport//SourcesCitationsReport.py:384
+#: SourcesCitationsReport//SourcesCitationsReport.py:390
 #, python-format
 msgid "%s"
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:317
-#: SourcesCitationsReport/SourcesCitationsReport.py:338
+#: SourcesCitationsReport//SourcesCitationsReport.py:332
+#: SourcesCitationsReport//SourcesCitationsReport.py:353
 #, python-format
 msgid "   ( %s )"
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:324
-msgid "   Eheleute: "
+#: SourcesCitationsReport//SourcesCitationsReport.py:339
+msgid "   Spouses: "
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:326
+#: SourcesCitationsReport//SourcesCitationsReport.py:341
 #, python-format
 msgid "%s "
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:329
+#: SourcesCitationsReport//SourcesCitationsReport.py:344
 #, python-format
 msgid "and %s "
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:340
+#: SourcesCitationsReport//SourcesCitationsReport.py:355
 #, python-format
 msgid " %s"
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:348
+#: SourcesCitationsReport//SourcesCitationsReport.py:363
 msgid "Person"
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:348
+#: SourcesCitationsReport//SourcesCitationsReport.py:363
 msgid "ID"
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:349
+#: SourcesCitationsReport//SourcesCitationsReport.py:364
 msgid "Role"
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:404
+#: SourcesCitationsReport//SourcesCitationsReport.py:419
 msgid "Report Options"
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:406
+#: SourcesCitationsReport//SourcesCitationsReport.py:421
 msgid "Report Title"
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:406
+#: SourcesCitationsReport//SourcesCitationsReport.py:421
 msgid "Title of the Report"
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:407
+#: SourcesCitationsReport//SourcesCitationsReport.py:422
 msgid "Title string for the report."
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:410
+#: SourcesCitationsReport//SourcesCitationsReport.py:425
 msgid "Subtitle"
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:410
+#: SourcesCitationsReport//SourcesCitationsReport.py:425
 msgid "Subtitle of the Report"
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:411
+#: SourcesCitationsReport//SourcesCitationsReport.py:426
 msgid "Subtitle string for the report."
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:418
+#: SourcesCitationsReport//SourcesCitationsReport.py:431
+msgid "researcher name"
+msgstr ""
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:433
 #, python-format
 msgid "Copyright %(year)d %(name)s"
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:420
+#: SourcesCitationsReport//SourcesCitationsReport.py:435
 msgid "Footer"
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:421
+#: SourcesCitationsReport//SourcesCitationsReport.py:436
 msgid "Footer string for the page."
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:428
+#: SourcesCitationsReport//SourcesCitationsReport.py:443
 msgid "Select using filter"
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:429
+#: SourcesCitationsReport//SourcesCitationsReport.py:444
 msgid "Select sources using a filter"
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:436
+#: SourcesCitationsReport//SourcesCitationsReport.py:451
 msgid "Show persons"
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:437
+#: SourcesCitationsReport//SourcesCitationsReport.py:452
 msgid "Whether to show events and persons mentioned in the note"
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:470
+#: SourcesCitationsReport//SourcesCitationsReport.py:488
 msgid "The style used for the title of the report."
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:485
+#: SourcesCitationsReport//SourcesCitationsReport.py:503
+msgid "The style used for the subtitle of the report."
+msgstr ""
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:517
+msgid "The style used for the footer of the report."
+msgstr ""
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:532
 msgid "The style used for source title."
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:500
-msgid "The style used for citation title."
+#: SourcesCitationsReport//SourcesCitationsReport.py:544
+msgid "The style used for source subtitle."
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:512
+#: SourcesCitationsReport//SourcesCitationsReport.py:556
 msgid "The style used for Source details."
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:524
+#: SourcesCitationsReport//SourcesCitationsReport.py:571
+msgid "The style used for citation title."
+msgstr ""
+
+#: SourcesCitationsReport//SourcesCitationsReport.py:583
 msgid "The style used for a column title."
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:540
+#: SourcesCitationsReport//SourcesCitationsReport.py:599
 msgid "The style used for each section."
 msgstr ""
 
-#: SourcesCitationsReport/SourcesCitationsReport.py:571
+#: SourcesCitationsReport//SourcesCitationsReport.py:630
 msgid "The style used for event and person details."
 msgstr ""


### PR DESCRIPTION
Dutch translation for addon SourcesCitationsReport.
Added footer and some extra formatting.
Updated translation of other existing languages.

Tested without issues in Gramps 5.1.2 on Linux Mint 20.
Please, add it to this branch.
Thanks in advance!