### PR TITLE
[RemoveTagTool] Fix internationalization; DE, HR, NL, PT, RU translations.

### DIFF
--- a/RemoveTagTool/RemoveTagTool.py
+++ b/RemoveTagTool/RemoveTagTool.py
@@ -29,9 +29,16 @@ from gramps.gen.plug.menu import FilterOption, TextOption
 from gramps.gen.db import DbTxn
 from gramps.gui.dialog import OkDialog, WarningDialog
 from gramps.gen.filters import CustomFilters, GenericFilterFactory, rules
-from gramps.gen.const import GRAMPS_LOCALE as glocale
-_ = glocale.translation.gettext
 
+#------------------------------------------------------------------------
+# Internationalisation
+#------------------------------------------------------------------------
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+try:
+    _trans = glocale.get_addon_translator(__file__)
+except ValueError:
+    _trans = glocale.translation
+_ = _trans.gettext
 
 # ----------------------------------------------------------------------------
 #
@@ -82,8 +89,8 @@ class RemoveTagOptions(MenuToolOptions):
         menu.add_option(_("General options"), "add_remove", self.add_remove)
 
         # category menu option
-        lst = ["People", "Families", "Events", "Places", "Sources",
-               "Citations", "Repositories", "Media", "Notes"]
+        lst = [_("People"), _("Families"), _("Events"), _("Places"), _("Sources"),
+               _("Citations"), _("Repositories"), _("Media"), _("Notes")]
         category_list = list(enumerate(lst))
         self.tag_category = FilterOption(_("Category"), 0)
         self.tag_category.set_help(_("Choose a category."))
@@ -93,7 +100,7 @@ class RemoveTagOptions(MenuToolOptions):
 
         # tag name list menu option
         tag_list = self.__enum_tag_list()
-        self.tag_name = FilterOption("Choose Tag", 0)
+        self.tag_name = FilterOption(_("Choose Tag"), 0)
         self.tag_name.set_help(_("Choose a tag to remove."))
         menu.add_option(_("General options"), "tag_name", self.tag_name)
         self.tag_name.set_items(tag_list)
@@ -114,16 +121,16 @@ class RemoveTagOptions(MenuToolOptions):
         all_notes = rules.note.AllNotes([])
 
         # create a list used for menu filter option creation later
-        lst = [(_("Person Filter"), 'Person', "Persons", all_persons),
-               (_("Family Filter"), 'Family', "Families", all_families),
-               (_("Event Filter"), 'Event', "Events", all_events),
-               (_("Place Filter"), 'Place', "Places", all_places),
-               (_("Source Filter"), 'Source', "Sources", all_sources),
-               (_("Citation Filter"), 'Citation', "Citations", all_cits),
-               (_("Repository Filter"), 'Repository', "Repositories",
+        lst = [(_("Person Filter"), 'Person', _("Persons"), all_persons),
+               (_("Family Filter"), 'Family', _("Families"), all_families),
+               (_("Event Filter"), 'Event', _("Events"), all_events),
+               (_("Place Filter"), 'Place', _("Places"), all_places),
+               (_("Source Filter"), 'Source', _("Sources"), all_sources),
+               (_("Citation Filter"), 'Citation', _("Citations"), all_cits),
+               (_("Repository Filter"), 'Repository', _("Repositories"),
                 all_repos),
-               (_("Media Filter"), 'Media', "Media", all_media),
-               (_("Note Filter"), 'Note', "Notes", all_notes)]
+               (_("Media Filter"), 'Media', _("Media"), all_media),
+               (_("Note Filter"), 'Note', _("Notes"), all_notes)]
 
         for entry in lst:
             # create a filter option for each category e.g. person, events
@@ -141,7 +148,7 @@ class RemoveTagOptions(MenuToolOptions):
             # generic filter:
             GenericFilter = GenericFilterFactory(entry[1])
             all_filter = GenericFilter()
-            all_filter.set_name(_("All %s" % (entry[2])))
+            all_filter.set_name(_("All %s") % (entry[2]))
             all_filter.add_rule(entry[3])
 
             # only add the generic filter if it isn't already in the menu

--- a/RemoveTagTool/po/de-local.po
+++ b/RemoveTagTool/po/de-local.po
@@ -14,153 +14,197 @@ msgid ""
 msgstr ""
 "Project-Id-Version: de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-08-07 22:14+0200\n"
-"PO-Revision-Date: 2020-08-07 22:26+0200\n"
-"Last-Translator: Mirko Leonhäuser <mirko@leonhaeuser.de>\n"
+"POT-Creation-Date: 2020-08-19 23:12+0200\n"
+"PO-Revision-Date: 2020-08-20 12:02+0200\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
 "Language-Team: German <kde-i18n-de@kde.org>\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Lokalize 19.12.3\n"
+"X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: RemoveTagTool/RemoveTagTool.gpr.py:24 RemoveTagTool/RemoveTagTool.py:179
-#: RemoveTagTool/RemoveTagTool.py:239
+#: RemoveTagTool/RemoveTagTool.gpr.py:24 RemoveTagTool/RemoveTagTool.py:186
+#: RemoveTagTool/RemoveTagTool.py:246
 msgid "Add/Remove Tag Tool"
 msgstr "Markierungen Hinzufügen/Entfernen Werkzeug"
 
 #: RemoveTagTool/RemoveTagTool.gpr.py:25
 msgid "Add or remove a tag from groups of people, events, etc."
 msgstr ""
-"Hinzufügen oder Entfernen einer Markierung zu Gruppen von Personen,"
-" Ereignissen usw."
+"Hinzufügen oder Entfernen einer Markierung zu Gruppen von Personen, "
+"Ereignissen usw."
 
-#: RemoveTagTool/RemoveTagTool.py:51
+#: RemoveTagTool/RemoveTagTool.py:58
 msgid "The Tool requires at least one tag to execute."
 msgstr ""
 "Für die Ausführung des Werkzeug ist mindestens eine Markierung erforderlich."
 
-#: RemoveTagTool/RemoveTagTool.py:52 RemoveTagTool/RemoveTagTool.py:54
+#: RemoveTagTool/RemoveTagTool.py:59 RemoveTagTool/RemoveTagTool.py:61
 msgid "ERROR"
 msgstr "FEHLER"
 
-#: RemoveTagTool/RemoveTagTool.py:79
+#: RemoveTagTool/RemoveTagTool.py:86
 msgid "Add/Remove"
 msgstr "Hinzufügen/Entfernen"
 
-#: RemoveTagTool/RemoveTagTool.py:80
+#: RemoveTagTool/RemoveTagTool.py:87
 msgid "Add or remove tags from objects."
 msgstr "Markierungen zu Objekten hinzufügen oder daraus entfernen."
 
-#: RemoveTagTool/RemoveTagTool.py:81
+#: RemoveTagTool/RemoveTagTool.py:88
 msgid "Add Tags"
 msgstr "Markierungen Hinzufügen"
 
-#: RemoveTagTool/RemoveTagTool.py:81
+#: RemoveTagTool/RemoveTagTool.py:88
 msgid "Remove Tags"
 msgstr "Markierungen Entfernen"
 
-#: RemoveTagTool/RemoveTagTool.py:82 RemoveTagTool/RemoveTagTool.py:90
-#: RemoveTagTool/RemoveTagTool.py:98
+#: RemoveTagTool/RemoveTagTool.py:89 RemoveTagTool/RemoveTagTool.py:97
+#: RemoveTagTool/RemoveTagTool.py:105
 msgid "General options"
 msgstr "Allgemeine Optionen"
 
-#: RemoveTagTool/RemoveTagTool.py:88
+#: RemoveTagTool/RemoveTagTool.py:92
+msgid "People"
+msgstr "Personen"
+
+#: RemoveTagTool/RemoveTagTool.py:92 RemoveTagTool/RemoveTagTool.py:125
+msgid "Families"
+msgstr "Familien"
+
+#: RemoveTagTool/RemoveTagTool.py:92 RemoveTagTool/RemoveTagTool.py:126
+msgid "Events"
+msgstr "Ereignissen"
+
+#: RemoveTagTool/RemoveTagTool.py:92 RemoveTagTool/RemoveTagTool.py:127
+msgid "Places"
+msgstr "Orte"
+
+#: RemoveTagTool/RemoveTagTool.py:92 RemoveTagTool/RemoveTagTool.py:128
+msgid "Sources"
+msgstr "Quellen"
+
+#: RemoveTagTool/RemoveTagTool.py:93 RemoveTagTool/RemoveTagTool.py:129
+msgid "Citations"
+msgstr "Fundstellen"
+
+#: RemoveTagTool/RemoveTagTool.py:93 RemoveTagTool/RemoveTagTool.py:130
+msgid "Repositories"
+msgstr "Aufbewahrungsorte"
+
+#: RemoveTagTool/RemoveTagTool.py:93 RemoveTagTool/RemoveTagTool.py:132
+msgid "Media"
+msgstr "Medien"
+
+#: RemoveTagTool/RemoveTagTool.py:93 RemoveTagTool/RemoveTagTool.py:133
+msgid "Notes"
+msgstr "Notizen"
+
+#: RemoveTagTool/RemoveTagTool.py:95
 msgid "Category"
 msgstr "Kategorie"
 
-#: RemoveTagTool/RemoveTagTool.py:89
+#: RemoveTagTool/RemoveTagTool.py:96
 msgid "Choose a category."
-msgstr "Kategorie wählen"
+msgstr "Kategorie wählen."
 
-#: RemoveTagTool/RemoveTagTool.py:97
+#: RemoveTagTool/RemoveTagTool.py:103
+msgid "Choose Tag"
+msgstr "Markierungen wählen"
+
+#: RemoveTagTool/RemoveTagTool.py:104
 msgid "Choose a tag to remove."
 msgstr "Eine Markierung zum entfernen auswählen."
 
-#: RemoveTagTool/RemoveTagTool.py:117
+#: RemoveTagTool/RemoveTagTool.py:124
 msgid "Person Filter"
 msgstr "Personenfilter"
 
-#: RemoveTagTool/RemoveTagTool.py:118
+#: RemoveTagTool/RemoveTagTool.py:124
+msgid "Persons"
+msgstr "Personen"
+
+#: RemoveTagTool/RemoveTagTool.py:125
 msgid "Family Filter"
 msgstr "Familienfilter"
 
-#: RemoveTagTool/RemoveTagTool.py:119
+#: RemoveTagTool/RemoveTagTool.py:126
 msgid "Event Filter"
 msgstr "Ereignisfilter"
 
-#: RemoveTagTool/RemoveTagTool.py:120
+#: RemoveTagTool/RemoveTagTool.py:127
 msgid "Place Filter"
 msgstr "Ortsfilter"
 
-#: RemoveTagTool/RemoveTagTool.py:121
+#: RemoveTagTool/RemoveTagTool.py:128
 msgid "Source Filter"
 msgstr "Quellenfilter"
 
-#: RemoveTagTool/RemoveTagTool.py:122
+#: RemoveTagTool/RemoveTagTool.py:129
 msgid "Citation Filter"
 msgstr "Fundstellenfilter"
 
-#: RemoveTagTool/RemoveTagTool.py:123
+#: RemoveTagTool/RemoveTagTool.py:130
 msgid "Repository Filter"
 msgstr "Aufbewahrungsortfilter"
 
-#: RemoveTagTool/RemoveTagTool.py:125
+#: RemoveTagTool/RemoveTagTool.py:132
 msgid "Media Filter"
 msgstr "Medienfilter"
 
-#: RemoveTagTool/RemoveTagTool.py:126
+#: RemoveTagTool/RemoveTagTool.py:133
 msgid "Note Filter"
 msgstr "Notizfilter"
 
-#: RemoveTagTool/RemoveTagTool.py:133
+#: RemoveTagTool/RemoveTagTool.py:140
 msgid "Filter options"
 msgstr "Filteroptionen"
 
-#: RemoveTagTool/RemoveTagTool.py:144
+#: RemoveTagTool/RemoveTagTool.py:151
 #, python-format
 msgid "All %s"
 msgstr "Alle %s"
 
-#: RemoveTagTool/RemoveTagTool.py:183
+#: RemoveTagTool/RemoveTagTool.py:190
 msgid "Options"
 msgstr "Optionen"
 
-#: RemoveTagTool/RemoveTagTool.py:191
+#: RemoveTagTool/RemoveTagTool.py:198
 msgid ""
 "Unable to run the tool. Please check if your database contains tags, filters "
 "and objects."
 msgstr ""
-"Das Werkzeug kann nicht ausgeführt werden. Bitte überprüfe, ob deine"
-" Datenbank Markierungen, Filter und Objekte enthält."
+"Das Werkzeug kann nicht ausgeführt werden. Bitte überprüfe, ob deine "
+"Datenbank Markierungen, Filter und Objekte enthält."
 
-#: RemoveTagTool/RemoveTagTool.py:193 RemoveTagTool/RemoveTagTool.py:228
+#: RemoveTagTool/RemoveTagTool.py:200 RemoveTagTool/RemoveTagTool.py:235
 msgid "WARNING"
 msgstr "WARNUNG"
 
-#: RemoveTagTool/RemoveTagTool.py:227
+#: RemoveTagTool/RemoveTagTool.py:234
 #, python-format
 msgid "No %s objects were found in database."
 msgstr "In der Datenbank wurden keine %s Objekte gefunden."
 
-#: RemoveTagTool/RemoveTagTool.py:242
+#: RemoveTagTool/RemoveTagTool.py:249
 msgid "Process tags..."
 msgstr "Bearbeite Markierungen..."
 
-#: RemoveTagTool/RemoveTagTool.py:259
+#: RemoveTagTool/RemoveTagTool.py:266
 msgid "added"
 msgstr "hinzugefügt"
 
-#: RemoveTagTool/RemoveTagTool.py:261
+#: RemoveTagTool/RemoveTagTool.py:268
 msgid "removed"
 msgstr "entfernt"
 
-#: RemoveTagTool/RemoveTagTool.py:262
+#: RemoveTagTool/RemoveTagTool.py:269
 msgid "Tag '{}' was {} to {} {} objects.\n"
 msgstr "Markierung '{}' wurde {} zu {} {} Objekten.\n"
 
-#: RemoveTagTool/RemoveTagTool.py:264
+#: RemoveTagTool/RemoveTagTool.py:271
 msgid "INFO"
 msgstr "INFO"
 
@@ -177,27 +221,6 @@ msgstr "INFO"
 #~ msgstr ""
 #~ "Um das Werkzeug „Markierung entfernen” auszuführen, wird mindestens eine "
 #~ "Person, eine Familie und eine Markierung benötigt."
-
-#~ msgid "All Events"
-#~ msgstr "Alle Ereignisse"
-
-#~ msgid "All Places"
-#~ msgstr "Alle Orte"
-
-#~ msgid "All Sources"
-#~ msgstr "Alle Quellen"
-
-#~ msgid "All Citations"
-#~ msgstr "Alle Fundstellen"
-
-#~ msgid "All Repositories"
-#~ msgstr "Alle Aufbewahrungsorte"
-
-#~ msgid "All Media"
-#~ msgstr "Alle Medien"
-
-#~ msgid "All Notes"
-#~ msgstr "Alle Notizen"
 
 #~ msgid "Select filter to restrict {}"
 #~ msgstr "Filter wählen, um {} einzugrenzen"

--- a/RemoveTagTool/po/hr-local.po
+++ b/RemoveTagTool/po/hr-local.po
@@ -7,156 +7,221 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Gramps 5.x\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-07-05 11:56+1000\n"
-"PO-Revision-Date: 2019-10-24 10:24+0200\n"
-"Last-Translator: Milo Ivir <mail@milotype.de>\n"
+"POT-Creation-Date: 2020-08-19 23:12+0200\n"
+"PO-Revision-Date: 2020-08-20 12:19+0200\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
 "Language-Team: \n"
 "Language: hr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.2.4\n"
+"X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 
-#: RemoveTagTool/RemoveTagTool.gpr.py:23 RemoveTagTool/RemoveTagTool.py:300
-#: RemoveTagTool/RemoveTagTool.py:417
-msgid "Remove Tag Tool"
-msgstr "Ukloni etiketu"
+#: RemoveTagTool/RemoveTagTool.gpr.py:24 RemoveTagTool/RemoveTagTool.py:186
+#: RemoveTagTool/RemoveTagTool.py:246
+msgid "Add/Remove Tag Tool"
+msgstr "Alat za dodavanje/uklanjanje etiketu"
 
-#: RemoveTagTool/RemoveTagTool.gpr.py:24
-msgid "Remove a tag from groups of people, events, etc."
-msgstr "Ukloni etiketu iz grupa osoba, događaja, itd."
+#: RemoveTagTool/RemoveTagTool.gpr.py:25
+msgid "Add or remove a tag from groups of people, events, etc."
+msgstr "Dodavanje ili uklanjanje etiketu iz grupa ljudi, događaja itd."
 
-#: RemoveTagTool/RemoveTagTool.py:88
-msgid ""
-"The Remove Tag Tool requires at least one person, family and tag to execute."
-msgstr ""
-"Za rad s alatom „Ukloni etiketu” je potrebno zadati barem jednu osobu, "
-"obitelj i etiketu."
+#: RemoveTagTool/RemoveTagTool.py:58
+msgid "The Tool requires at least one tag to execute."
+msgstr "Alat zahtijeva najmanje jednu etiketu da se izvrši."
 
-#: RemoveTagTool/RemoveTagTool.py:90 RemoveTagTool/RemoveTagTool.py:91
+#: RemoveTagTool/RemoveTagTool.py:59 RemoveTagTool/RemoveTagTool.py:61
 msgid "ERROR"
 msgstr "GREŠKA"
 
-#: RemoveTagTool/RemoveTagTool.py:98
-msgid "Event Filter"
-msgstr "Filtar događaja"
+#: RemoveTagTool/RemoveTagTool.py:86
+msgid "Add/Remove"
+msgstr "Dodaj/ukloni"
 
-#: RemoveTagTool/RemoveTagTool.py:99
-msgid "All Events"
-msgstr "Svi događaji"
+#: RemoveTagTool/RemoveTagTool.py:87
+msgid "Add or remove tags from objects."
+msgstr "Dodavanje ili uklanjanje etiketu iz objekata."
 
-#: RemoveTagTool/RemoveTagTool.py:100
-msgid "Place Filter"
-msgstr "Filtar mjesta"
+#: RemoveTagTool/RemoveTagTool.py:88
+msgid "Add Tags"
+msgstr "Dodaj etiketu"
 
-#: RemoveTagTool/RemoveTagTool.py:101
-msgid "All Places"
-msgstr "Sva mjesta"
+#: RemoveTagTool/RemoveTagTool.py:88
+msgid "Remove Tags"
+msgstr "Ukloni etiketu"
 
-#: RemoveTagTool/RemoveTagTool.py:102
-msgid "Source Filter"
-msgstr "Filtar izvora"
-
-#: RemoveTagTool/RemoveTagTool.py:103
-msgid "All Sources"
-msgstr "Svi izvori"
-
-#: RemoveTagTool/RemoveTagTool.py:104
-msgid "Citation Filter"
-msgstr "Filtar citata"
-
+#: RemoveTagTool/RemoveTagTool.py:89 RemoveTagTool/RemoveTagTool.py:97
 #: RemoveTagTool/RemoveTagTool.py:105
-msgid "All Citations"
-msgstr "Svi citati"
+msgid "General options"
+msgstr "Opće mogućnosti"
 
-#: RemoveTagTool/RemoveTagTool.py:106
-msgid "Repository Filter"
-msgstr "Filtar spremišta"
+#: RemoveTagTool/RemoveTagTool.py:92
+msgid "People"
+msgstr "Osobe"
 
-#: RemoveTagTool/RemoveTagTool.py:107
-msgid "All Repositories"
-msgstr "Sva spremišta"
+#: RemoveTagTool/RemoveTagTool.py:92 RemoveTagTool/RemoveTagTool.py:125
+msgid "Families"
+msgstr "Obitelji"
 
-#: RemoveTagTool/RemoveTagTool.py:108
-msgid "Media Filter"
-msgstr "Filtar medija"
+#: RemoveTagTool/RemoveTagTool.py:92 RemoveTagTool/RemoveTagTool.py:126
+msgid "Events"
+msgstr "Događaji"
 
-#: RemoveTagTool/RemoveTagTool.py:109
-msgid "All Media"
-msgstr "Svi mediji"
+#: RemoveTagTool/RemoveTagTool.py:92 RemoveTagTool/RemoveTagTool.py:127
+msgid "Places"
+msgstr "Mjesta"
 
-#: RemoveTagTool/RemoveTagTool.py:110
-msgid "Note Filter"
-msgstr "Filtar zabilježaka"
+#: RemoveTagTool/RemoveTagTool.py:92 RemoveTagTool/RemoveTagTool.py:128
+msgid "Sources"
+msgstr "Izvori"
 
-#: RemoveTagTool/RemoveTagTool.py:111
-msgid "All Notes"
-msgstr "Sve zabilješke"
+#: RemoveTagTool/RemoveTagTool.py:93 RemoveTagTool/RemoveTagTool.py:129
+msgid "Citations"
+msgstr "Citati"
 
-#: RemoveTagTool/RemoveTagTool.py:115
-msgid "Select filter to restrict {}"
-msgstr "Odaberi filtar za ograničavanje {}"
+#: RemoveTagTool/RemoveTagTool.py:93 RemoveTagTool/RemoveTagTool.py:130
+msgid "Repositories"
+msgstr "Spremišta"
 
-#: RemoveTagTool/RemoveTagTool.py:117
-msgid "Option 2"
-msgstr "Opcija 2"
+#: RemoveTagTool/RemoveTagTool.py:93 RemoveTagTool/RemoveTagTool.py:132
+msgid "Media"
+msgstr "Mediji"
 
-#: RemoveTagTool/RemoveTagTool.py:146
+#: RemoveTagTool/RemoveTagTool.py:93 RemoveTagTool/RemoveTagTool.py:133
+msgid "Notes"
+msgstr "Zabilješke"
+
+#: RemoveTagTool/RemoveTagTool.py:95
 msgid "Category"
 msgstr "Kategorija"
 
-#: RemoveTagTool/RemoveTagTool.py:147
+#: RemoveTagTool/RemoveTagTool.py:96
 msgid "Choose a category."
 msgstr "Odaberi kategoriju."
 
-#: RemoveTagTool/RemoveTagTool.py:148 RemoveTagTool/RemoveTagTool.py:156
-#: RemoveTagTool/RemoveTagTool.py:212 RemoveTagTool/RemoveTagTool.py:217
-#: RemoveTagTool/RemoveTagTool.py:256 RemoveTagTool/RemoveTagTool.py:263
-msgid "Option 1"
-msgstr "Opcija 1"
+#: RemoveTagTool/RemoveTagTool.py:103
+msgid "Choose Tag"
+msgstr "Odaberite etiketu"
 
-#: RemoveTagTool/RemoveTagTool.py:155
+#: RemoveTagTool/RemoveTagTool.py:104
 msgid "Choose a tag to remove."
 msgstr "Odaberi etiketu koju želiš ukloniti."
 
-#: RemoveTagTool/RemoveTagTool.py:210
+#: RemoveTagTool/RemoveTagTool.py:124
 msgid "Person Filter"
 msgstr "Filtar osoba"
 
-#: RemoveTagTool/RemoveTagTool.py:211
-msgid "Select filter to restrict people"
-msgstr "Odaberi filtar za ograničavanje osoba"
+#: RemoveTagTool/RemoveTagTool.py:124
+msgid "Persons"
+msgstr "Osoba"
 
-#: RemoveTagTool/RemoveTagTool.py:215
-msgid "Center Person"
-msgstr "Središnja osoba"
-
-#: RemoveTagTool/RemoveTagTool.py:216 RemoveTagTool/RemoveTagTool.py:262
-msgid "The center person for the filter"
-msgstr "Središnja osoba za filtar"
-
-#: RemoveTagTool/RemoveTagTool.py:254
+#: RemoveTagTool/RemoveTagTool.py:125
 msgid "Family Filter"
 msgstr "Filtar obitelji"
 
-#: RemoveTagTool/RemoveTagTool.py:255
-msgid "Select filter to restrict families"
-msgstr "Odaberi filtar za ograničavanje obitelji"
+#: RemoveTagTool/RemoveTagTool.py:126
+msgid "Event Filter"
+msgstr "Filtar događaja"
 
-#: RemoveTagTool/RemoveTagTool.py:261
-msgid "Center Family"
-msgstr "Središnja obitelj"
+#: RemoveTagTool/RemoveTagTool.py:127
+msgid "Place Filter"
+msgstr "Filtar mjesta"
 
-#: RemoveTagTool/RemoveTagTool.py:306
+#: RemoveTagTool/RemoveTagTool.py:128
+msgid "Source Filter"
+msgstr "Filtar izvora"
+
+#: RemoveTagTool/RemoveTagTool.py:129
+msgid "Citation Filter"
+msgstr "Filtar citata"
+
+#: RemoveTagTool/RemoveTagTool.py:130
+msgid "Repository Filter"
+msgstr "Filtar spremišta"
+
+#: RemoveTagTool/RemoveTagTool.py:132
+msgid "Media Filter"
+msgstr "Filtar medija"
+
+#: RemoveTagTool/RemoveTagTool.py:133
+msgid "Note Filter"
+msgstr "Filtar zabilježaka"
+
+#: RemoveTagTool/RemoveTagTool.py:140
+msgid "Filter options"
+msgstr "Opcije filtriranja"
+
+#: RemoveTagTool/RemoveTagTool.py:151
+#, python-format
+msgid "All %s"
+msgstr "Svi %s"
+
+#: RemoveTagTool/RemoveTagTool.py:190
 msgid "Options"
 msgstr "Opcije"
 
-#: RemoveTagTool/RemoveTagTool.py:420
-msgid "Removing tags..."
-msgstr "Uklanjanje etiketa …"
+#: RemoveTagTool/RemoveTagTool.py:198
+msgid ""
+"Unable to run the tool. Please check if your database contains tags, filters "
+"and objects."
+msgstr ""
+"Alat nije moguće pokrenuti. Provjerite sadrži li vaša baza podataka oznake, "
+"filtre i objekte."
 
-#: RemoveTagTool/RemoveTagTool.py:432
-msgid "Tag '{}' removed from {} {}.\n"
-msgstr "Etiketa „{}” uklonjena iz {} {}.\n"
+#: RemoveTagTool/RemoveTagTool.py:200 RemoveTagTool/RemoveTagTool.py:235
+msgid "WARNING"
+msgstr "UPOZORENJE"
+
+#: RemoveTagTool/RemoveTagTool.py:234
+#, python-format
+msgid "No %s objects were found in database."
+msgstr "U bazi podataka nije pronađen nijedan %s objekt."
+
+#: RemoveTagTool/RemoveTagTool.py:249
+msgid "Process tags..."
+msgstr "Oznake procesa..."
+
+#: RemoveTagTool/RemoveTagTool.py:266
+msgid "added"
+msgstr "dodano"
+
+#: RemoveTagTool/RemoveTagTool.py:268
+msgid "removed"
+msgstr "ukloniti"
+
+#: RemoveTagTool/RemoveTagTool.py:269
+msgid "Tag '{}' was {} to {} {} objects.\n"
+msgstr "Etiketa \"{}\" bila je {} do {} {} objekata.\n"
+
+#: RemoveTagTool/RemoveTagTool.py:271
+msgid "INFO"
+msgstr "INFO"
+
+#~ msgid "Select filter to restrict {}"
+#~ msgstr "Odaberi filtar za ograničavanje {}"
+
+#~ msgid "Option 2"
+#~ msgstr "Opcija 2"
+
+#~ msgid "Option 1"
+#~ msgstr "Opcija 1"
+
+#~ msgid "Select filter to restrict people"
+#~ msgstr "Odaberi filtar za ograničavanje osoba"
+
+#~ msgid "Center Person"
+#~ msgstr "Središnja osoba"
+
+#~ msgid "The center person for the filter"
+#~ msgstr "Središnja osoba za filtar"
+
+#~ msgid "Select filter to restrict families"
+#~ msgstr "Odaberi filtar za ograničavanje obitelji"
+
+#~ msgid "Center Family"
+#~ msgstr "Središnja obitelj"
+
+#~ msgid "Removing tags..."
+#~ msgstr "Uklanjanje etiketa …"

--- a/RemoveTagTool/po/nl-local.po
+++ b/RemoveTagTool/po/nl-local.po
@@ -1,0 +1,200 @@
+# Dutch translation of addon RemoveTagTool.
+# Copyright (C) 2020 Gramps project
+# This file is distributed under the same license as the RemoveTagTool package.
+# Jan Sparreboom <jan@sparreboom.net>, 2020.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: RemoveTagTool 5.x\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-08-19 23:12+0200\n"
+"PO-Revision-Date: 2020-08-19 23:15+0200\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
+"Language-Team: Dutch <gramps-users@lists.sourceforge.net>\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.3\n"
+
+#: RemoveTagTool/RemoveTagTool.gpr.py:24 RemoveTagTool/RemoveTagTool.py:186
+#: RemoveTagTool/RemoveTagTool.py:246
+msgid "Add/Remove Tag Tool"
+msgstr "Labels toevoegen/verwijderen"
+
+#: RemoveTagTool/RemoveTagTool.gpr.py:25
+msgid "Add or remove a tag from groups of people, events, etc."
+msgstr ""
+"Voeg een label toe of verwijder deze uit groepen personen, gebeurtenissen, "
+"enz."
+
+#: RemoveTagTool/RemoveTagTool.py:58
+msgid "The Tool requires at least one tag to execute."
+msgstr "Het hulpmiddel vereist ten minste één label om uit te voeren."
+
+#: RemoveTagTool/RemoveTagTool.py:59 RemoveTagTool/RemoveTagTool.py:61
+msgid "ERROR"
+msgstr "FOUT"
+
+#: RemoveTagTool/RemoveTagTool.py:86
+msgid "Add/Remove"
+msgstr "Toevoegen/verwijderen"
+
+#: RemoveTagTool/RemoveTagTool.py:87
+msgid "Add or remove tags from objects."
+msgstr "Labels toevoegen aan of verwijderen uit objecten."
+
+#: RemoveTagTool/RemoveTagTool.py:88
+msgid "Add Tags"
+msgstr "Labels toevoegen"
+
+#: RemoveTagTool/RemoveTagTool.py:88
+msgid "Remove Tags"
+msgstr "Labels verwijderen"
+
+#: RemoveTagTool/RemoveTagTool.py:89 RemoveTagTool/RemoveTagTool.py:97
+#: RemoveTagTool/RemoveTagTool.py:105
+msgid "General options"
+msgstr "Algemene opties"
+
+#: RemoveTagTool/RemoveTagTool.py:92
+msgid "People"
+msgstr "Personen"
+
+#: RemoveTagTool/RemoveTagTool.py:92 RemoveTagTool/RemoveTagTool.py:125
+msgid "Families"
+msgstr "Gezinnen"
+
+#: RemoveTagTool/RemoveTagTool.py:92 RemoveTagTool/RemoveTagTool.py:126
+msgid "Events"
+msgstr "Gebeurtenissen"
+
+#: RemoveTagTool/RemoveTagTool.py:92 RemoveTagTool/RemoveTagTool.py:127
+msgid "Places"
+msgstr "Locaties"
+
+#: RemoveTagTool/RemoveTagTool.py:92 RemoveTagTool/RemoveTagTool.py:128
+msgid "Sources"
+msgstr "Bronnen"
+
+#: RemoveTagTool/RemoveTagTool.py:93 RemoveTagTool/RemoveTagTool.py:129
+msgid "Citations"
+msgstr "Citaten"
+
+#: RemoveTagTool/RemoveTagTool.py:93 RemoveTagTool/RemoveTagTool.py:130
+msgid "Repositories"
+msgstr "Bibliotheken"
+
+#: RemoveTagTool/RemoveTagTool.py:93 RemoveTagTool/RemoveTagTool.py:132
+msgid "Media"
+msgstr "Media"
+
+#: RemoveTagTool/RemoveTagTool.py:93 RemoveTagTool/RemoveTagTool.py:133
+msgid "Notes"
+msgstr "Notities"
+
+#: RemoveTagTool/RemoveTagTool.py:95
+msgid "Category"
+msgstr "Categorie"
+
+#: RemoveTagTool/RemoveTagTool.py:96
+msgid "Choose a category."
+msgstr "Kies een categorie."
+
+#: RemoveTagTool/RemoveTagTool.py:103
+msgid "Choose Tag"
+msgstr "Kies label"
+
+#: RemoveTagTool/RemoveTagTool.py:104
+msgid "Choose a tag to remove."
+msgstr "Kies een label om te verwijderen."
+
+#: RemoveTagTool/RemoveTagTool.py:124
+msgid "Person Filter"
+msgstr "Persoonsfilter"
+
+#: RemoveTagTool/RemoveTagTool.py:124
+msgid "Persons"
+msgstr "Personen"
+
+#: RemoveTagTool/RemoveTagTool.py:125
+msgid "Family Filter"
+msgstr "Gezinsfilter"
+
+#: RemoveTagTool/RemoveTagTool.py:126
+msgid "Event Filter"
+msgstr "Gebeurtenisfilter"
+
+#: RemoveTagTool/RemoveTagTool.py:127
+msgid "Place Filter"
+msgstr "Locatiefilter"
+
+#: RemoveTagTool/RemoveTagTool.py:128
+msgid "Source Filter"
+msgstr "Bronfilter"
+
+#: RemoveTagTool/RemoveTagTool.py:129
+msgid "Citation Filter"
+msgstr "Citaatfilter"
+
+#: RemoveTagTool/RemoveTagTool.py:130
+msgid "Repository Filter"
+msgstr "Bibliotheekfilter"
+
+#: RemoveTagTool/RemoveTagTool.py:132
+msgid "Media Filter"
+msgstr "Mediafilter"
+
+#: RemoveTagTool/RemoveTagTool.py:133
+msgid "Note Filter"
+msgstr "Notitiefilter"
+
+#: RemoveTagTool/RemoveTagTool.py:140
+msgid "Filter options"
+msgstr "Filteropties"
+
+#: RemoveTagTool/RemoveTagTool.py:151
+#, python-format
+msgid "All %s"
+msgstr "Alle %s"
+
+#: RemoveTagTool/RemoveTagTool.py:190
+msgid "Options"
+msgstr "Opties"
+
+#: RemoveTagTool/RemoveTagTool.py:198
+msgid ""
+"Unable to run the tool. Please check if your database contains tags, filters "
+"and objects."
+msgstr ""
+"Kan het hulpmiddel niet uitvoeren. Controleer of uw database labels, filters "
+"en objecten bevat."
+
+#: RemoveTagTool/RemoveTagTool.py:200 RemoveTagTool/RemoveTagTool.py:235
+msgid "WARNING"
+msgstr "WAARSCHUWING"
+
+#: RemoveTagTool/RemoveTagTool.py:234
+#, python-format
+msgid "No %s objects were found in database."
+msgstr "Er zijn geen %s objecten gevonden in de database."
+
+#: RemoveTagTool/RemoveTagTool.py:249
+msgid "Process tags..."
+msgstr "Labels verwerken..."
+
+#: RemoveTagTool/RemoveTagTool.py:266
+msgid "added"
+msgstr "toegevoegd"
+
+#: RemoveTagTool/RemoveTagTool.py:268
+msgid "removed"
+msgstr "verwijderd"
+
+#: RemoveTagTool/RemoveTagTool.py:269
+msgid "Tag '{}' was {} to {} {} objects.\n"
+msgstr "Label '{}' was {} naar {} {} objecten.\n"
+
+#: RemoveTagTool/RemoveTagTool.py:271
+msgid "INFO"
+msgstr "INFO"

--- a/RemoveTagTool/po/pt_PT-local.po
+++ b/RemoveTagTool/po/pt_PT-local.po
@@ -6,9 +6,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-07-05 11:56+1000\n"
-"PO-Revision-Date: 2020-04-03 08:17+0100\n"
-"Last-Translator: Pedro Albuquerque <pmra@protonmail.com>\n"
+"POT-Creation-Date: 2020-08-19 23:12+0200\n"
+"PO-Revision-Date: 2020-08-20 12:38+0200\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
 "Language-Team: Pedro Albuquerque\n"
 "Language: pt\n"
 "MIME-Version: 1.0\n"
@@ -17,141 +17,209 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 2.3\n"
 
-#: RemoveTagTool/RemoveTagTool.gpr.py:23 RemoveTagTool/RemoveTagTool.py:300
-#: RemoveTagTool/RemoveTagTool.py:417
-msgid "Remove Tag Tool"
-msgstr "Ferramenta Remover etiqueta"
+#: RemoveTagTool/RemoveTagTool.gpr.py:24 RemoveTagTool/RemoveTagTool.py:186
+#: RemoveTagTool/RemoveTagTool.py:246
+msgid "Add/Remove Tag Tool"
+msgstr "Adicionar / remover ferramenta de etiqueta"
 
-#: RemoveTagTool/RemoveTagTool.gpr.py:24
-msgid "Remove a tag from groups of people, events, etc."
-msgstr "Remover uma etiqueta de um grupo de indivíduos, eventos, etc.."
+#: RemoveTagTool/RemoveTagTool.gpr.py:25
+msgid "Add or remove a tag from groups of people, events, etc."
+msgstr "Adicione ou remova uma etiqueta de grupos de indivíduos, eventos, etc."
 
-#: RemoveTagTool/RemoveTagTool.py:88
-msgid "The Remove Tag Tool requires at least one person, family and tag to execute."
-msgstr "A ferramenta Remover etiqueta requer pelo menos um indivíduo, uma família e uma etiqueta."
+#: RemoveTagTool/RemoveTagTool.py:58
+msgid "The Tool requires at least one tag to execute."
+msgstr "A ferramenta requer pelo menos uma etiqueta para ser executada."
 
-#: RemoveTagTool/RemoveTagTool.py:90 RemoveTagTool/RemoveTagTool.py:91
+#: RemoveTagTool/RemoveTagTool.py:59 RemoveTagTool/RemoveTagTool.py:61
 msgid "ERROR"
 msgstr "ERRO"
 
-#: RemoveTagTool/RemoveTagTool.py:98
-msgid "Event Filter"
-msgstr "Filtro de eventos"
+#: RemoveTagTool/RemoveTagTool.py:86
+msgid "Add/Remove"
+msgstr "Adicionar/Remover"
 
-#: RemoveTagTool/RemoveTagTool.py:99
-msgid "All Events"
-msgstr "Todos os eventos"
+#: RemoveTagTool/RemoveTagTool.py:87
+msgid "Add or remove tags from objects."
+msgstr "Adicione ou remova etiqueta de objetos."
 
-#: RemoveTagTool/RemoveTagTool.py:100
-msgid "Place Filter"
-msgstr "Filtro de locais"
+#: RemoveTagTool/RemoveTagTool.py:88
+msgid "Add Tags"
+msgstr "Adicionar etiqueta"
 
-#: RemoveTagTool/RemoveTagTool.py:101
-msgid "All Places"
-msgstr "Todos os locais"
+#: RemoveTagTool/RemoveTagTool.py:88
+msgid "Remove Tags"
+msgstr "Remover etiqueta"
 
-#: RemoveTagTool/RemoveTagTool.py:102
-msgid "Source Filter"
-msgstr "Filtro de fontes"
-
-#: RemoveTagTool/RemoveTagTool.py:103
-msgid "All Sources"
-msgstr "Todas as fontes"
-
-#: RemoveTagTool/RemoveTagTool.py:104
-msgid "Citation Filter"
-msgstr "Filtro da citações"
-
+#: RemoveTagTool/RemoveTagTool.py:89 RemoveTagTool/RemoveTagTool.py:97
 #: RemoveTagTool/RemoveTagTool.py:105
-msgid "All Citations"
-msgstr "Todas as citações"
+msgid "General options"
+msgstr "Opções gerais"
 
-#: RemoveTagTool/RemoveTagTool.py:106
-msgid "Repository Filter"
-msgstr "Filtro de repositórios"
+#: RemoveTagTool/RemoveTagTool.py:92
+msgid "People"
+msgstr "Individuos"
 
-#: RemoveTagTool/RemoveTagTool.py:107
-msgid "All Repositories"
-msgstr "Todos os repositórios"
+#: RemoveTagTool/RemoveTagTool.py:92 RemoveTagTool/RemoveTagTool.py:125
+msgid "Families"
+msgstr "Famílias"
 
-#: RemoveTagTool/RemoveTagTool.py:108
-msgid "Media Filter"
-msgstr "Filtro de multimédia"
+#: RemoveTagTool/RemoveTagTool.py:92 RemoveTagTool/RemoveTagTool.py:126
+msgid "Events"
+msgstr "Eventos"
 
-#: RemoveTagTool/RemoveTagTool.py:109
-msgid "All Media"
-msgstr "Toda a multimédia"
+#: RemoveTagTool/RemoveTagTool.py:92 RemoveTagTool/RemoveTagTool.py:127
+msgid "Places"
+msgstr "Locais"
 
-#: RemoveTagTool/RemoveTagTool.py:110
-msgid "Note Filter"
-msgstr "Filtro de notas"
+#: RemoveTagTool/RemoveTagTool.py:92 RemoveTagTool/RemoveTagTool.py:128
+msgid "Sources"
+msgstr "Fontes"
 
-#: RemoveTagTool/RemoveTagTool.py:111
-msgid "All Notes"
-msgstr "Todas as notas"
+#: RemoveTagTool/RemoveTagTool.py:93 RemoveTagTool/RemoveTagTool.py:129
+msgid "Citations"
+msgstr "Citações"
 
-#: RemoveTagTool/RemoveTagTool.py:115
-msgid "Select filter to restrict {}"
-msgstr "Seleccionar filtro para restringir {}"
+#: RemoveTagTool/RemoveTagTool.py:93 RemoveTagTool/RemoveTagTool.py:130
+msgid "Repositories"
+msgstr "Repositórios"
 
-#: RemoveTagTool/RemoveTagTool.py:117
-msgid "Option 2"
-msgstr "Opção 2"
+#: RemoveTagTool/RemoveTagTool.py:93 RemoveTagTool/RemoveTagTool.py:132
+msgid "Media"
+msgstr "Multimédia"
 
-#: RemoveTagTool/RemoveTagTool.py:146
+#: RemoveTagTool/RemoveTagTool.py:93 RemoveTagTool/RemoveTagTool.py:133
+msgid "Notes"
+msgstr "Notas"
+
+#: RemoveTagTool/RemoveTagTool.py:95
 msgid "Category"
 msgstr "Categoria"
 
-#: RemoveTagTool/RemoveTagTool.py:147
+#: RemoveTagTool/RemoveTagTool.py:96
 msgid "Choose a category."
 msgstr "Escolha uma categoria."
 
-#: RemoveTagTool/RemoveTagTool.py:148 RemoveTagTool/RemoveTagTool.py:156
-#: RemoveTagTool/RemoveTagTool.py:212 RemoveTagTool/RemoveTagTool.py:217
-#: RemoveTagTool/RemoveTagTool.py:256 RemoveTagTool/RemoveTagTool.py:263
-msgid "Option 1"
-msgstr "Opção 1"
+#: RemoveTagTool/RemoveTagTool.py:103
+msgid "Choose Tag"
+msgstr "Escolha etiqueta"
 
-#: RemoveTagTool/RemoveTagTool.py:155
+#: RemoveTagTool/RemoveTagTool.py:104
 msgid "Choose a tag to remove."
 msgstr "Escolha uma etiqueta a remover."
 
-#: RemoveTagTool/RemoveTagTool.py:210
+#: RemoveTagTool/RemoveTagTool.py:124
 msgid "Person Filter"
 msgstr "Filtro de indivíduos"
 
-#: RemoveTagTool/RemoveTagTool.py:211
-msgid "Select filter to restrict people"
-msgstr "Seleccionar filtro para restringir os indivíduos"
+#: RemoveTagTool/RemoveTagTool.py:124
+msgid "Persons"
+msgstr "Indivíduos"
 
-#: RemoveTagTool/RemoveTagTool.py:215
-msgid "Center Person"
-msgstr "Indivíduo central"
-
-#: RemoveTagTool/RemoveTagTool.py:216 RemoveTagTool/RemoveTagTool.py:262
-msgid "The center person for the filter"
-msgstr "O indivíduo central para o filtro"
-
-#: RemoveTagTool/RemoveTagTool.py:254
+#: RemoveTagTool/RemoveTagTool.py:125
 msgid "Family Filter"
 msgstr "Filtro de famílias"
 
-#: RemoveTagTool/RemoveTagTool.py:255
-msgid "Select filter to restrict families"
-msgstr "Seleccionar filtro para restringir famílias"
+#: RemoveTagTool/RemoveTagTool.py:126
+msgid "Event Filter"
+msgstr "Filtro de eventos"
 
-#: RemoveTagTool/RemoveTagTool.py:261
-msgid "Center Family"
-msgstr "Família central"
+#: RemoveTagTool/RemoveTagTool.py:127
+msgid "Place Filter"
+msgstr "Filtro de locais"
 
-#: RemoveTagTool/RemoveTagTool.py:306
+#: RemoveTagTool/RemoveTagTool.py:128
+msgid "Source Filter"
+msgstr "Filtro de fontes"
+
+#: RemoveTagTool/RemoveTagTool.py:129
+msgid "Citation Filter"
+msgstr "Filtro da citações"
+
+#: RemoveTagTool/RemoveTagTool.py:130
+msgid "Repository Filter"
+msgstr "Filtro de repositórios"
+
+#: RemoveTagTool/RemoveTagTool.py:132
+msgid "Media Filter"
+msgstr "Filtro de multimédia"
+
+#: RemoveTagTool/RemoveTagTool.py:133
+msgid "Note Filter"
+msgstr "Filtro de notas"
+
+#: RemoveTagTool/RemoveTagTool.py:140
+msgid "Filter options"
+msgstr "Opções de filtro"
+
+#: RemoveTagTool/RemoveTagTool.py:151
+#, python-format
+msgid "All %s"
+msgstr "Todos %s"
+
+#: RemoveTagTool/RemoveTagTool.py:190
 msgid "Options"
 msgstr "Opções"
 
-#: RemoveTagTool/RemoveTagTool.py:420
-msgid "Removing tags..."
-msgstr "A remover etiquetas..."
+#: RemoveTagTool/RemoveTagTool.py:198
+msgid ""
+"Unable to run the tool. Please check if your database contains tags, filters "
+"and objects."
+msgstr ""
+"Incapaz de executar a ferramenta. Verifique se seu banco de dados contém "
+"tags, filtros e objetos."
 
-#: RemoveTagTool/RemoveTagTool.py:432
-msgid "Tag '{}' removed from {} {}.\n"
-msgstr "Etiqueta \"{}\" removida de {} {}.\n"
+#: RemoveTagTool/RemoveTagTool.py:200 RemoveTagTool/RemoveTagTool.py:235
+msgid "WARNING"
+msgstr "AVISO"
+
+#: RemoveTagTool/RemoveTagTool.py:234
+#, python-format
+msgid "No %s objects were found in database."
+msgstr "Nenhum objeto %s foi encontrado no banco de dados."
+
+#: RemoveTagTool/RemoveTagTool.py:249
+msgid "Process tags..."
+msgstr "Etiquetas de processo"
+
+#: RemoveTagTool/RemoveTagTool.py:266
+msgid "added"
+msgstr "adicionado"
+
+#: RemoveTagTool/RemoveTagTool.py:268
+msgid "removed"
+msgstr "removido"
+
+#: RemoveTagTool/RemoveTagTool.py:269
+msgid "Tag '{}' was {} to {} {} objects.\n"
+msgstr "Etiqueta '{}' era {} para {} {} objetos.\n"
+
+#: RemoveTagTool/RemoveTagTool.py:271
+msgid "INFO"
+msgstr "INFO"
+
+#~ msgid "Select filter to restrict {}"
+#~ msgstr "Seleccionar filtro para restringir {}"
+
+#~ msgid "Option 2"
+#~ msgstr "Opção 2"
+
+#~ msgid "Option 1"
+#~ msgstr "Opção 1"
+
+#~ msgid "Select filter to restrict people"
+#~ msgstr "Seleccionar filtro para restringir os indivíduos"
+
+#~ msgid "Center Person"
+#~ msgstr "Indivíduo central"
+
+#~ msgid "The center person for the filter"
+#~ msgstr "O indivíduo central para o filtro"
+
+#~ msgid "Select filter to restrict families"
+#~ msgstr "Seleccionar filtro para restringir famílias"
+
+#~ msgid "Center Family"
+#~ msgstr "Família central"
+
+#~ msgid "Removing tags..."
+#~ msgstr "A remover etiquetas..."

--- a/RemoveTagTool/po/ru-local.po
+++ b/RemoveTagTool/po/ru-local.po
@@ -6,155 +6,221 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gramps51\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-07-05 11:56+1000\n"
-"PO-Revision-Date: 2020-04-27 08:35+0300\n"
-"Last-Translator: vantu5z <vantu5z@mail.ru>\n"
+"POT-Creation-Date: 2020-08-19 23:12+0200\n"
+"PO-Revision-Date: 2020-08-20 12:52+0200\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
 "Language-Team: Russian\n"
 "Language: ru\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"X-Generator: Poedit 2.3\n"
 
-#: RemoveTagTool/RemoveTagTool.gpr.py:23 RemoveTagTool/RemoveTagTool.py:300
-#: RemoveTagTool/RemoveTagTool.py:417
-msgid "Remove Tag Tool"
-msgstr "Удаление меток"
+#: RemoveTagTool/RemoveTagTool.gpr.py:24 RemoveTagTool/RemoveTagTool.py:186
+#: RemoveTagTool/RemoveTagTool.py:246
+msgid "Add/Remove Tag Tool"
+msgstr "Инструмент добавления / удаления меток"
 
-#: RemoveTagTool/RemoveTagTool.gpr.py:24
-msgid "Remove a tag from groups of people, events, etc."
-msgstr "Удаление меток для группы людей, событий и т.д."
+#: RemoveTagTool/RemoveTagTool.gpr.py:25
+msgid "Add or remove a tag from groups of people, events, etc."
+msgstr "Добавить или удалить теги для групп людей, событий и т. Д."
 
-#: RemoveTagTool/RemoveTagTool.py:88
-msgid ""
-"The Remove Tag Tool requires at least one person, family and tag to execute."
-msgstr ""
-"Для запуска инструмента необходимо выбрать хотя бы одно лицо, семью, а также "
-"метку."
+#: RemoveTagTool/RemoveTagTool.py:58
+msgid "The Tool requires at least one tag to execute."
+msgstr "Для выполнения Инструменту требуется по крайней мере один тег."
 
-#: RemoveTagTool/RemoveTagTool.py:90 RemoveTagTool/RemoveTagTool.py:91
+#: RemoveTagTool/RemoveTagTool.py:59 RemoveTagTool/RemoveTagTool.py:61
 msgid "ERROR"
 msgstr "ОШИБКА"
 
-#: RemoveTagTool/RemoveTagTool.py:98
-msgid "Event Filter"
-msgstr "Фильтр событий"
+#: RemoveTagTool/RemoveTagTool.py:86
+msgid "Add/Remove"
+msgstr "Добавить/Удалить"
 
-#: RemoveTagTool/RemoveTagTool.py:99
-msgid "All Events"
-msgstr "Все события"
+#: RemoveTagTool/RemoveTagTool.py:87
+msgid "Add or remove tags from objects."
+msgstr "Добавляйте или удаляйте теги с объектов."
 
-#: RemoveTagTool/RemoveTagTool.py:100
-msgid "Place Filter"
-msgstr "Фильтр мест"
+#: RemoveTagTool/RemoveTagTool.py:88
+msgid "Add Tags"
+msgstr "Добавить теги"
 
-#: RemoveTagTool/RemoveTagTool.py:101
-msgid "All Places"
-msgstr "Все места"
+#: RemoveTagTool/RemoveTagTool.py:88
+msgid "Remove Tags"
+msgstr "Удалить теги"
 
-#: RemoveTagTool/RemoveTagTool.py:102
-msgid "Source Filter"
-msgstr "Фильтр источников"
-
-#: RemoveTagTool/RemoveTagTool.py:103
-msgid "All Sources"
-msgstr "Все источники"
-
-#: RemoveTagTool/RemoveTagTool.py:104
-msgid "Citation Filter"
-msgstr "Фильтр цитат"
-
+#: RemoveTagTool/RemoveTagTool.py:89 RemoveTagTool/RemoveTagTool.py:97
 #: RemoveTagTool/RemoveTagTool.py:105
-msgid "All Citations"
-msgstr "Все цитаты"
+msgid "General options"
+msgstr "Общие настройки"
 
-#: RemoveTagTool/RemoveTagTool.py:106
-msgid "Repository Filter"
-msgstr "Фильтр хранилищ"
+#: RemoveTagTool/RemoveTagTool.py:92
+msgid "People"
+msgstr "Человек"
 
-#: RemoveTagTool/RemoveTagTool.py:107
-msgid "All Repositories"
-msgstr "Все хранилища"
+#: RemoveTagTool/RemoveTagTool.py:92 RemoveTagTool/RemoveTagTool.py:125
+msgid "Families"
+msgstr "Семьи"
 
-#: RemoveTagTool/RemoveTagTool.py:108
-msgid "Media Filter"
-msgstr "Фильтр документов"
+#: RemoveTagTool/RemoveTagTool.py:92 RemoveTagTool/RemoveTagTool.py:126
+msgid "Events"
+msgstr "События"
 
-#: RemoveTagTool/RemoveTagTool.py:109
-msgid "All Media"
-msgstr "Все документы"
+#: RemoveTagTool/RemoveTagTool.py:92 RemoveTagTool/RemoveTagTool.py:127
+msgid "Places"
+msgstr "Места"
 
-#: RemoveTagTool/RemoveTagTool.py:110
-msgid "Note Filter"
-msgstr "Фильтр заметок"
+#: RemoveTagTool/RemoveTagTool.py:92 RemoveTagTool/RemoveTagTool.py:128
+msgid "Sources"
+msgstr "Источники"
 
-#: RemoveTagTool/RemoveTagTool.py:111
-msgid "All Notes"
-msgstr "Все заметки"
+#: RemoveTagTool/RemoveTagTool.py:93 RemoveTagTool/RemoveTagTool.py:129
+msgid "Citations"
+msgstr "Цитаты"
 
-#: RemoveTagTool/RemoveTagTool.py:115
-msgid "Select filter to restrict {}"
-msgstr "Выберите фильтр, чтобы ограничить {}"
+#: RemoveTagTool/RemoveTagTool.py:93 RemoveTagTool/RemoveTagTool.py:130
+msgid "Repositories"
+msgstr "Xранилища"
 
-#: RemoveTagTool/RemoveTagTool.py:117
-msgid "Option 2"
-msgstr "Параметр 2"
+#: RemoveTagTool/RemoveTagTool.py:93 RemoveTagTool/RemoveTagTool.py:132
+msgid "Media"
+msgstr "СМИ"
 
-#: RemoveTagTool/RemoveTagTool.py:146
+#: RemoveTagTool/RemoveTagTool.py:93 RemoveTagTool/RemoveTagTool.py:133
+msgid "Notes"
+msgstr "Ноты"
+
+#: RemoveTagTool/RemoveTagTool.py:95
 msgid "Category"
 msgstr "Категория"
 
-#: RemoveTagTool/RemoveTagTool.py:147
+#: RemoveTagTool/RemoveTagTool.py:96
 msgid "Choose a category."
 msgstr "Выберите категорию."
 
-#: RemoveTagTool/RemoveTagTool.py:148 RemoveTagTool/RemoveTagTool.py:156
-#: RemoveTagTool/RemoveTagTool.py:212 RemoveTagTool/RemoveTagTool.py:217
-#: RemoveTagTool/RemoveTagTool.py:256 RemoveTagTool/RemoveTagTool.py:263
-msgid "Option 1"
-msgstr "Параметр 1"
+#: RemoveTagTool/RemoveTagTool.py:103
+msgid "Choose Tag"
+msgstr "Выберите тег"
 
-#: RemoveTagTool/RemoveTagTool.py:155
+#: RemoveTagTool/RemoveTagTool.py:104
 msgid "Choose a tag to remove."
 msgstr "Выберите метку для удаления."
 
-#: RemoveTagTool/RemoveTagTool.py:210
+#: RemoveTagTool/RemoveTagTool.py:124
 msgid "Person Filter"
 msgstr "Фильтр лиц"
 
-#: RemoveTagTool/RemoveTagTool.py:211
-msgid "Select filter to restrict people"
-msgstr "Выберите фильтр для выбора людей"
+#: RemoveTagTool/RemoveTagTool.py:124
+msgid "Persons"
+msgstr "Человек"
 
-#: RemoveTagTool/RemoveTagTool.py:215
-msgid "Center Person"
-msgstr "Основное лицо"
-
-#: RemoveTagTool/RemoveTagTool.py:216 RemoveTagTool/RemoveTagTool.py:262
-msgid "The center person for the filter"
-msgstr "Основное лицо для фильтра"
-
-#: RemoveTagTool/RemoveTagTool.py:254
+#: RemoveTagTool/RemoveTagTool.py:125
 msgid "Family Filter"
 msgstr "Фильтр семей"
 
-#: RemoveTagTool/RemoveTagTool.py:255
-msgid "Select filter to restrict families"
-msgstr "Выберите фильтр для выбора семей"
+#: RemoveTagTool/RemoveTagTool.py:126
+msgid "Event Filter"
+msgstr "Фильтр событий"
 
-#: RemoveTagTool/RemoveTagTool.py:261
-msgid "Center Family"
-msgstr "Основная семья"
+#: RemoveTagTool/RemoveTagTool.py:127
+msgid "Place Filter"
+msgstr "Фильтр мест"
 
-#: RemoveTagTool/RemoveTagTool.py:306
+#: RemoveTagTool/RemoveTagTool.py:128
+msgid "Source Filter"
+msgstr "Фильтр источников"
+
+#: RemoveTagTool/RemoveTagTool.py:129
+msgid "Citation Filter"
+msgstr "Фильтр цитат"
+
+#: RemoveTagTool/RemoveTagTool.py:130
+msgid "Repository Filter"
+msgstr "Фильтр хранилищ"
+
+#: RemoveTagTool/RemoveTagTool.py:132
+msgid "Media Filter"
+msgstr "Фильтр документов"
+
+#: RemoveTagTool/RemoveTagTool.py:133
+msgid "Note Filter"
+msgstr "Фильтр заметок"
+
+#: RemoveTagTool/RemoveTagTool.py:140
+msgid "Filter options"
+msgstr "Параметры фильтра"
+
+#: RemoveTagTool/RemoveTagTool.py:151
+#, python-format
+msgid "All %s"
+msgstr "Все %s"
+
+#: RemoveTagTool/RemoveTagTool.py:190
 msgid "Options"
 msgstr "Параметры"
 
-#: RemoveTagTool/RemoveTagTool.py:420
-msgid "Removing tags..."
-msgstr "Удаление меток..."
+#: RemoveTagTool/RemoveTagTool.py:198
+msgid ""
+"Unable to run the tool. Please check if your database contains tags, filters "
+"and objects."
+msgstr ""
+"Невозможно запустить инструмент. Пожалуйста, проверьте, есть ли в вашей базе "
+"теги, фильтры и объекты."
 
-#: RemoveTagTool/RemoveTagTool.py:432
-msgid "Tag '{}' removed from {} {}.\n"
-msgstr "Удалено меток '{}' из {} {}.\n"
+#: RemoveTagTool/RemoveTagTool.py:200 RemoveTagTool/RemoveTagTool.py:235
+msgid "WARNING"
+msgstr "ПРЕДУПРЕЖДЕНИЕ"
+
+#: RemoveTagTool/RemoveTagTool.py:234
+#, python-format
+msgid "No %s objects were found in database."
+msgstr "В базе данных не найдено %s объектов."
+
+#: RemoveTagTool/RemoveTagTool.py:249
+msgid "Process tags..."
+msgstr "Этикетки процесса..."
+
+#: RemoveTagTool/RemoveTagTool.py:266
+msgid "added"
+msgstr "добавленной"
+
+#: RemoveTagTool/RemoveTagTool.py:268
+msgid "removed"
+msgstr "удалено"
+
+#: RemoveTagTool/RemoveTagTool.py:269
+msgid "Tag '{}' was {} to {} {} objects.\n"
+msgstr "Тег '{}' был {} для {} {} объектов.\n"
+
+#: RemoveTagTool/RemoveTagTool.py:271
+msgid "INFO"
+msgstr "ИНФОРМАЦИЯ"
+
+#~ msgid "Select filter to restrict {}"
+#~ msgstr "Выберите фильтр, чтобы ограничить {}"
+
+#~ msgid "Option 2"
+#~ msgstr "Параметр 2"
+
+#~ msgid "Option 1"
+#~ msgstr "Параметр 1"
+
+#~ msgid "Select filter to restrict people"
+#~ msgstr "Выберите фильтр для выбора людей"
+
+#~ msgid "Center Person"
+#~ msgstr "Основное лицо"
+
+#~ msgid "The center person for the filter"
+#~ msgstr "Основное лицо для фильтра"
+
+#~ msgid "Select filter to restrict families"
+#~ msgstr "Выберите фильтр для выбора семей"
+
+#~ msgid "Center Family"
+#~ msgstr "Основная семья"
+
+#~ msgid "Removing tags..."
+#~ msgstr "Удаление меток..."

--- a/RemoveTagTool/po/template.pot
+++ b/RemoveTagTool/po/template.pot
@@ -8,17 +8,17 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-07-26 10:12-0500\n"
+"POT-Creation-Date: 2020-08-19 23:12+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: RemoveTagTool/RemoveTagTool.gpr.py:24 RemoveTagTool/RemoveTagTool.py:179
-#: RemoveTagTool/RemoveTagTool.py:239
+#: RemoveTagTool/RemoveTagTool.gpr.py:24 RemoveTagTool/RemoveTagTool.py:186
+#: RemoveTagTool/RemoveTagTool.py:246
 msgid "Add/Remove Tag Tool"
 msgstr ""
 
@@ -26,127 +26,171 @@ msgstr ""
 msgid "Add or remove a tag from groups of people, events, etc."
 msgstr ""
 
-#: RemoveTagTool/RemoveTagTool.py:51
+#: RemoveTagTool/RemoveTagTool.py:58
 msgid "The Tool requires at least one tag to execute."
 msgstr ""
 
-#: RemoveTagTool/RemoveTagTool.py:52 RemoveTagTool/RemoveTagTool.py:54
+#: RemoveTagTool/RemoveTagTool.py:59 RemoveTagTool/RemoveTagTool.py:61
 msgid "ERROR"
 msgstr ""
 
-#: RemoveTagTool/RemoveTagTool.py:79
+#: RemoveTagTool/RemoveTagTool.py:86
 msgid "Add/Remove"
 msgstr ""
 
-#: RemoveTagTool/RemoveTagTool.py:80
+#: RemoveTagTool/RemoveTagTool.py:87
 msgid "Add or remove tags from objects."
 msgstr ""
 
-#: RemoveTagTool/RemoveTagTool.py:81
+#: RemoveTagTool/RemoveTagTool.py:88
 msgid "Add Tags"
 msgstr ""
 
-#: RemoveTagTool/RemoveTagTool.py:81
+#: RemoveTagTool/RemoveTagTool.py:88
 msgid "Remove Tags"
 msgstr ""
 
-#: RemoveTagTool/RemoveTagTool.py:82 RemoveTagTool/RemoveTagTool.py:90
-#: RemoveTagTool/RemoveTagTool.py:98
+#: RemoveTagTool/RemoveTagTool.py:89 RemoveTagTool/RemoveTagTool.py:97
+#: RemoveTagTool/RemoveTagTool.py:105
 msgid "General options"
 msgstr ""
 
-#: RemoveTagTool/RemoveTagTool.py:88
+#: RemoveTagTool/RemoveTagTool.py:92
+msgid "People"
+msgstr ""
+
+#: RemoveTagTool/RemoveTagTool.py:92 RemoveTagTool/RemoveTagTool.py:125
+msgid "Families"
+msgstr ""
+
+#: RemoveTagTool/RemoveTagTool.py:92 RemoveTagTool/RemoveTagTool.py:126
+msgid "Events"
+msgstr ""
+
+#: RemoveTagTool/RemoveTagTool.py:92 RemoveTagTool/RemoveTagTool.py:127
+msgid "Places"
+msgstr ""
+
+#: RemoveTagTool/RemoveTagTool.py:92 RemoveTagTool/RemoveTagTool.py:128
+msgid "Sources"
+msgstr ""
+
+#: RemoveTagTool/RemoveTagTool.py:93 RemoveTagTool/RemoveTagTool.py:129
+msgid "Citations"
+msgstr ""
+
+#: RemoveTagTool/RemoveTagTool.py:93 RemoveTagTool/RemoveTagTool.py:130
+msgid "Repositories"
+msgstr ""
+
+#: RemoveTagTool/RemoveTagTool.py:93 RemoveTagTool/RemoveTagTool.py:132
+msgid "Media"
+msgstr ""
+
+#: RemoveTagTool/RemoveTagTool.py:93 RemoveTagTool/RemoveTagTool.py:133
+msgid "Notes"
+msgstr ""
+
+#: RemoveTagTool/RemoveTagTool.py:95
 msgid "Category"
 msgstr ""
 
-#: RemoveTagTool/RemoveTagTool.py:89
+#: RemoveTagTool/RemoveTagTool.py:96
 msgid "Choose a category."
 msgstr ""
 
-#: RemoveTagTool/RemoveTagTool.py:97
+#: RemoveTagTool/RemoveTagTool.py:103
+msgid "Choose Tag"
+msgstr ""
+
+#: RemoveTagTool/RemoveTagTool.py:104
 msgid "Choose a tag to remove."
 msgstr ""
 
-#: RemoveTagTool/RemoveTagTool.py:117
+#: RemoveTagTool/RemoveTagTool.py:124
 msgid "Person Filter"
 msgstr ""
 
-#: RemoveTagTool/RemoveTagTool.py:118
-msgid "Family Filter"
-msgstr ""
-
-#: RemoveTagTool/RemoveTagTool.py:119
-msgid "Event Filter"
-msgstr ""
-
-#: RemoveTagTool/RemoveTagTool.py:120
-msgid "Place Filter"
-msgstr ""
-
-#: RemoveTagTool/RemoveTagTool.py:121
-msgid "Source Filter"
-msgstr ""
-
-#: RemoveTagTool/RemoveTagTool.py:122
-msgid "Citation Filter"
-msgstr ""
-
-#: RemoveTagTool/RemoveTagTool.py:123
-msgid "Repository Filter"
+#: RemoveTagTool/RemoveTagTool.py:124
+msgid "Persons"
 msgstr ""
 
 #: RemoveTagTool/RemoveTagTool.py:125
-msgid "Media Filter"
+msgid "Family Filter"
 msgstr ""
 
 #: RemoveTagTool/RemoveTagTool.py:126
-msgid "Note Filter"
+msgid "Event Filter"
+msgstr ""
+
+#: RemoveTagTool/RemoveTagTool.py:127
+msgid "Place Filter"
+msgstr ""
+
+#: RemoveTagTool/RemoveTagTool.py:128
+msgid "Source Filter"
+msgstr ""
+
+#: RemoveTagTool/RemoveTagTool.py:129
+msgid "Citation Filter"
+msgstr ""
+
+#: RemoveTagTool/RemoveTagTool.py:130
+msgid "Repository Filter"
+msgstr ""
+
+#: RemoveTagTool/RemoveTagTool.py:132
+msgid "Media Filter"
 msgstr ""
 
 #: RemoveTagTool/RemoveTagTool.py:133
+msgid "Note Filter"
+msgstr ""
+
+#: RemoveTagTool/RemoveTagTool.py:140
 msgid "Filter options"
 msgstr ""
 
-#: RemoveTagTool/RemoveTagTool.py:144
+#: RemoveTagTool/RemoveTagTool.py:151
 #, python-format
 msgid "All %s"
 msgstr ""
 
-#: RemoveTagTool/RemoveTagTool.py:183
+#: RemoveTagTool/RemoveTagTool.py:190
 msgid "Options"
 msgstr ""
 
-#: RemoveTagTool/RemoveTagTool.py:191
+#: RemoveTagTool/RemoveTagTool.py:198
 msgid ""
 "Unable to run the tool. Please check if your database contains tags, filters "
 "and objects."
 msgstr ""
 
-#: RemoveTagTool/RemoveTagTool.py:193 RemoveTagTool/RemoveTagTool.py:228
+#: RemoveTagTool/RemoveTagTool.py:200 RemoveTagTool/RemoveTagTool.py:235
 msgid "WARNING"
 msgstr ""
 
-#: RemoveTagTool/RemoveTagTool.py:227
+#: RemoveTagTool/RemoveTagTool.py:234
 #, python-format
 msgid "No %s objects were found in database."
 msgstr ""
 
-#: RemoveTagTool/RemoveTagTool.py:242
+#: RemoveTagTool/RemoveTagTool.py:249
 msgid "Process tags..."
 msgstr ""
 
-#: RemoveTagTool/RemoveTagTool.py:259
+#: RemoveTagTool/RemoveTagTool.py:266
 msgid "added"
 msgstr ""
 
-#: RemoveTagTool/RemoveTagTool.py:261
+#: RemoveTagTool/RemoveTagTool.py:268
 msgid "removed"
 msgstr ""
 
-#: RemoveTagTool/RemoveTagTool.py:262
+#: RemoveTagTool/RemoveTagTool.py:269
 msgid "Tag '{}' was {} to {} {} objects.\n"
 msgstr ""
 
-#: RemoveTagTool/RemoveTagTool.py:264
+#: RemoveTagTool/RemoveTagTool.py:271
 msgid "INFO"
 msgstr ""


### PR DESCRIPTION
Fixed internationalization of addon RemoveTagTool.
Updated translations and template.pot.
Tested without issues in Gramps 5.1.2 on Linux Mint 20.
Please, add it to this branch.
Thanks in advance!