### PR TITLE
[EventDescriptionEditor] Dutch translation

### DIFF
--- a/EventDescriptionEditor/EventDescriptionEditor.py
+++ b/EventDescriptionEditor/EventDescriptionEditor.py
@@ -89,8 +89,8 @@ class EventDescriptionEditor(PluginWindows.ToolManagedWindowBatch):
             db.request_rebuild()
 
             OkDialog(_("INFO"),
-                     _("%s event descriptions of %s events were changed."
-                       % (str(counter), str(num))),
+                     _("%s event descriptions of %s events were changed.")
+                       % (str(counter), str(num)),
                      parent=self.window)
 
 

--- a/EventDescriptionEditor/po/nl-local.po
+++ b/EventDescriptionEditor/po/nl-local.po
@@ -1,0 +1,79 @@
+# Dutch translation of addon EventDescriptionEditor.
+# Copyright (C) 2020 Gramps project
+# This file is distributed under the same license as the EventDescriptionEditor package.
+# Jan Sparreboom <jan@sparreboom.net>, 2020.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: EventDescriptionEditor 5.x\n"
+"Report-Msgid-Bugs-To: https://www.gramps-project.org/bugs\n"
+"POT-Creation-Date: 2020-04-11 09:47-0500\n"
+"PO-Revision-Date: 2020-08-31 16:06+0200\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
+"Language-Team: Dutch <gramps-users@lists.sourceforge.net>\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.3\n"
+
+#: EventDescriptionEditor/EventDescriptionEditor.gpr.py:24
+#: EventDescriptionEditor/EventDescriptionEditor.py:50
+#: EventDescriptionEditor/EventDescriptionEditor.py:61
+msgid "Event Description Editor"
+msgstr "Gebeurtenisbeschrijvingsbewerker"
+
+#: EventDescriptionEditor/EventDescriptionEditor.gpr.py:25
+msgid ""
+"A tool to find and replace a string in event description of multiple events."
+msgstr ""
+"Een hulpmiddel om een string te vinden en te vervangen in de "
+"gebeurtenisbeschrijving van meerdere gebeurtenissen."
+
+#: EventDescriptionEditor/EventDescriptionEditor.py:72
+msgid "Search substring..."
+msgstr "Zoek deeltekenreeks..."
+
+#: EventDescriptionEditor/EventDescriptionEditor.py:91
+msgid "INFO"
+msgstr "INFO"
+
+#: EventDescriptionEditor/EventDescriptionEditor.py:92
+#, python-format
+msgid "%s event descriptions of %s events were changed."
+msgstr "%s gebeurtenisbeschrijvingen van %s gebeurtenissen zijn gewijzigd."
+
+#: EventDescriptionEditor/EventDescriptionEditor.py:112
+msgid "All Events"
+msgstr "Alle gebeurtenissen"
+
+#: EventDescriptionEditor/EventDescriptionEditor.py:121
+msgid "Events"
+msgstr "Gebeurtenissen"
+
+#: EventDescriptionEditor/EventDescriptionEditor.py:122
+#: EventDescriptionEditor/EventDescriptionEditor.py:126
+#: EventDescriptionEditor/EventDescriptionEditor.py:129
+#: EventDescriptionEditor/EventDescriptionEditor.py:135
+msgid "Option"
+msgstr "Keuze"
+
+#: EventDescriptionEditor/EventDescriptionEditor.py:125
+msgid "Find"
+msgstr "Vind"
+
+#: EventDescriptionEditor/EventDescriptionEditor.py:128
+msgid "Replace"
+msgstr "Vervangen"
+
+#: EventDescriptionEditor/EventDescriptionEditor.py:131
+msgid "Replace substring only"
+msgstr "Vervang alleen het zinsdeel"
+
+#: EventDescriptionEditor/EventDescriptionEditor.py:132
+msgid ""
+"If True only the substring will be replaced, otherwise the whole description "
+"will be deleted and replaced by the new one."
+msgstr ""
+"Indien True wordt alleen de deeltekenreeks vervangen, anders wordt de hele "
+"beschrijving verwijderd en vervangen door de nieuwe."


### PR DESCRIPTION
Dutch translation for addon EventDescriptionEditor.
A 'close parenthesis' was in the wrong place causing the translation to fail, fixed on line 92.

Tested without issues in Gramps 5.1.3 on Linux Mint 20.
Please, add it to this branch.
Thanks in advance!