### PR TITLE
Update filter rule "degrees of seperation"

### DIFF
--- a/FilterRules/degreesofseparation.gpr.py
+++ b/FilterRules/degreesofseparation.gpr.py
@@ -24,7 +24,7 @@ register(RULE,
   name = _('People separated less than <N> degrees of <person>'),
   description = _("Filter rule that matches relatives by degrees of "
                   "separation"),
-  version = '1.0.6',
+  version = '1.1.0',
   authors = ["Matthias Kemmer"],
   authors_email = ["matt.familienforschung@gmail.com"],
   gramps_target_version = '5.1',

--- a/FilterRules/degreesofseparation.py
+++ b/FilterRules/degreesofseparation.py
@@ -43,7 +43,7 @@ class DegreesOption(MyInteger):
     """Number option for filter editor."""
 
     def __init__(self, database):
-        MyInteger.__init__(self, 1, 32)
+        MyInteger.__init__(self, 0, 32)
         self.set_tooltip_text(_("Number of degrees of separation from"
                                 " person."))
 
@@ -69,26 +69,6 @@ class InclPartner(MyBoolean):
 
 # -------------------------------------------------------------------------
 #
-# IncPartners boolean option
-#
-# -------------------------------------------------------------------------
-class InclAllParents(MyBoolean):
-    """Boolean option for filter editor."""
-
-    def __init__(self, database):
-        MyBoolean.__init__(self, _('Include all parents'))
-        self.set_tooltip_text(_("Include parents with relationship foster,"
-                                " adopted, stepchild, etc."))
-        self.set_active(True)
-
-    def set_text(self, val):
-        """Set the checkbox active."""
-        is_active = bool(int(val))
-        self.set_active(is_active)
-
-
-# -------------------------------------------------------------------------
-#
 # Degrees of separation filter rule class
 #
 # -------------------------------------------------------------------------
@@ -97,8 +77,7 @@ class DegreesOfSeparation(Rule):
 
     labels = [_('ID:'),
               (_("Degrees:"), DegreesOption),
-              ('', InclPartner),
-              ('', InclAllParents)]
+              ('', InclPartner)]
     name = _('People separated less than <N> degrees of <person>')
     category = _("Relationship filters")
     description = _("Filter rule that matches relatives by degrees of"
@@ -107,97 +86,81 @@ class DegreesOfSeparation(Rule):
     def prepare(self, db, user):
         """Prepare a refernece list for the filter."""
         self.db = db
+        self.ref_list = set()
         self.persons = set()
-        self.ancestors = list()
-        root_handle = self.__get_root_handle()
+        opt_partners = bool(int(self.list[2]))
+        degree = 0
+        max_deg = int(self.list[1])
 
-        self.__get_ancestors(root_handle)
-        for ancestor in self.ancestors:
-            self.__get_desc(ancestor, 0)
+        self.get_root_handle()
+        while degree <= max_deg:
+            for handle in list(self.persons):
+                person = self.db.get_person_from_handle(handle)
+                self.get_parents(person)
+                self.get_children(person)
+                self.get_siblings(person)
+                self.persons.remove(handle)
+                self.ref_list.add(handle)
+            degree += 1
 
-        get_partners = bool(int(self.list[2]))
-        if get_partners:
-            self.__get_partners()
+        if opt_partners:
+            self.get_partners()
 
-    def __get_root_handle(self):
+    def get_root_handle(self):
         """Get the handle of the starting person."""
         pid = self.list[0]
         person = self.db.get_person_from_gramps_id(pid)
         root_handle = person.get_handle()
-        return root_handle
-
-    def __get_ancestors(self, root_handle):
-        """Get the ancestors of a person."""
-        self.queue = [(root_handle, 1)]
-        while self.queue:
-            handle, gen = self.queue.pop(0)
-            if handle in self.ancestors:
-                continue
-            self.ancestors.append(handle)
-            gen += 1
-            if gen <= int(self.list[1]):
-                person = self.db.get_person_from_handle(handle)
-                fam_list = person.get_parent_family_handle_list()
-                for fam_id in fam_list:
-                    if fam_id:
-                        fam = self.db.get_family_from_handle(fam_id)
-                        if fam:
-                            f_id = fam.get_father_handle()
-                            m_id = fam.get_mother_handle()
-                            self.__check_parents(fam, f_id, m_id, person, gen)
-
-    def __check_parents(self, fam, f_id, m_id, person, gen):
-        """Check InclAllParents option and parent-child relationship type."""
-        for child_ref in fam.get_child_ref_list():
-            if child_ref.ref == person.get_handle():
-                f_rel = child_ref.get_father_relation()
-                m_rel = child_ref.get_mother_relation()
-                # check father
-                if f_id and self.list[3] == '1':
-                    self.queue.append((f_id, gen))
-                elif f_id and f_rel == _("Birth"):
-                    self.queue.append((f_id, gen))
-                # check mother
-                if m_id and self.list[3] == '1':
-                    self.queue.append((m_id, gen))
-                elif m_id and m_rel == _("Birth"):
-                    self.queue.append((m_id, gen))
-
-    def __get_desc(self, root_handle, gen):
-        """Get the descendants of a person."""
-        if root_handle in self.persons:
-            return
-
         self.persons.add(root_handle)
-        if gen >= int(self.list[1]):
-            return
 
-        person = self.db.get_person_from_handle(root_handle)
+    def get_parents(self, person):
+        """Get all parents of a person."""
+        fam_list = person.get_parent_family_handle_list()
+        for fam_h in fam_list:
+            fam = self.db.get_family_from_handle(fam_h)
+            father_h = fam.get_father_handle()
+            mother_h = fam.get_mother_handle()
+            if father_h:
+                self.persons.add(father_h)
+            if mother_h:
+                self.persons.add(mother_h)
+
+    def get_children(self, person):
+        """Get all children of a person."""
         fam_list = person.get_family_handle_list()
-        for fam_id in fam_list:
-            fam = self.db.get_family_from_handle(fam_id)
-            if fam:
-                for child_ref in fam.get_child_ref_list():
-                    self.__get_desc(child_ref.ref, gen+1)
+        for fam_h in fam_list:
+            fam = self.db.get_family_from_handle(fam_h)
+            for child_ref in fam.get_child_ref_list():
+                self.persons.add(child_ref.ref)
 
-    def __get_partners(self):
-        """Get the partners."""
-        person_handles = list()
-        for handle in self.persons:
-            person_handles.append(handle)
-
-        for handle in person_handles:
-            person = self.db.get_person_from_handle(handle)
-            family_list = person.get_family_handle_list()
-            for family_handle in family_list:
-                family = self.db.get_family_from_handle(family_handle)
-                father = family.get_father_handle()
-                mother = family.get_mother_handle()
+    def get_siblings(self, person):
+        """Get all siblings of a person."""
+        fam_list = person.get_parent_family_handle_list()
+        for fam_h in fam_list:
+            fam = self.db.get_family_from_handle(fam_h)
+            father_h = fam.get_father_handle()
+            if father_h:
+                father = self.db.get_person_from_handle(father_h)
                 if father:
-                    self.persons.add(father)
+                    self.get_children(father)
+            mother_h = fam.get_mother_handle()
+            if mother_h:
+                mother = self.db.get_person_from_handle(mother_h)
                 if mother:
-                    self.persons.add(mother)
+                    self.get_children(mother)
+
+    def get_partners(self):
+        """Get all partners."""
+        for handle in list(self.ref_list):
+            person = self.db.get_person_from_handle(handle)
+            fam_list = person.get_family_handle_list()
+            if fam_list:
+                for fam_h in fam_list:
+                    fam = self.db.get_family_from_handle(fam_h)
+                    father_h = fam.get_father_handle()
+                    mother_h = fam.get_mother_handle()
+                    self.ref_list.update([father_h, mother_h])
 
     def apply(self, db, person):
         """Check if the filter applies to the person."""
-        return person.handle in self.persons
+        return person.handle in self.ref_list


### PR DESCRIPTION
Rewrite to make it more intuitive as requested in:
https://gramps.discourse.group/t/degrees-of-separation-filter/148/17

The rule now searches recursivly for the parents, siblings, children and partners of a person, instead of using the rules "ancestors  less then N generations" and "descendants less than N generations".