### PR TITLE
SetPrivacyTool: add filters, don't touch if unchanged

### DIFF
--- a/SetPrivacyTool/SetPrivacyTool.py
+++ b/SetPrivacyTool/SetPrivacyTool.py
@@ -1,6 +1,7 @@
 #
 # Gramps - a GTK+/GNOME based genealogy program
 #
+# Copyright (C) 2020  David Straub
 # Copyright (C) 2019  Matthias Kemmer
 #
 # This program is free software; you can redistribute it and/or modify
@@ -22,8 +23,9 @@
 # GRAMPS modules
 #
 # ----------------------------------------------------------------------------
+from gramps.gen.filters import CustomFilters, GenericFilterFactory
 from gramps.gui.plug import MenuToolOptions, PluginWindows
-from gramps.gen.plug.menu import NumberOption, BooleanOption
+from gramps.gen.plug.menu import NumberOption, BooleanOption, FilterOption
 from gramps.gui.dialog import OkDialog
 from gramps.gen.lib.date import Today
 from gramps.gen.db import DbTxn
@@ -93,34 +95,46 @@ class SetPrivacyWindow(PluginWindows.ToolManagedWindowBatch):
         with DbTxn(_("Set Privacy Tool"), self.db, batch=True) as self.trans:
             self.db.disable_signals()
             person_list = list(self.db.iter_people())
+
+            filter_option = self.options.menu.get_option_by_name('person_filter')
+            person_filter = filter_option.get_filter()
+            filtered_person_handles = person_filter.apply(self.db, self.db.iter_person_handles())
+
             self.progress.set_pass(_('Set persons private..'),
-                                   len(person_list))
+                                   len(filtered_person_handles))
             cnt = [0, 0]
+
+
             for Person in person_list:
+                if Person.handle not in filtered_person_handles:
+                    continue
                 birth_ref = Person.get_birth_ref()
                 if birth_ref:
                     birth = self.db.get_event_from_handle(birth_ref.ref)
                     birth_date = birth.get_date_object()
+                    set_privacy = None
                     if birth_date.get_year() == 0 and lock_no_date:
-                        Person.set_privacy(True)
+                        set_privacy = True
                         cnt[0] += 1
                     elif birth_date.get_year() == 0 and not lock_no_date:
-                        Person.set_privacy(False)
+                        set_privacy = False
                         cnt[1] += 1
                     elif birth_date.get_year() != 0 and birth_date >= date:
-                        Person.set_privacy(True)
+                        set_privacy = True
                         cnt[0] += 1
                     else:
-                        Person.set_privacy(False)
+                        set_privacy = False
                         cnt[1] += 1
                 else:
                     if lock_no_date:
-                        Person.set_privacy(True)
+                        set_privacy = True
                         cnt[0] += 1
                     else:
-                        Person.set_privacy(False)
+                        set_privacy = False
                         cnt[1] += 1
-                self.db.commit_person(Person, self.trans)
+                if set_privacy is not None and set_privacy != Person.private:
+                    Person.set_privacy(set_privacy)
+                    self.db.commit_person(Person, self.trans)
                 self.progress.step()
         self.db.enable_signals()
         self.db.request_rebuild()
@@ -130,24 +144,35 @@ class SetPrivacyWindow(PluginWindows.ToolManagedWindowBatch):
         with DbTxn(_("Set Privacy Tool"), self.db, batch=True) as self.trans:
             self.db.disable_signals()
             event_list = list(self.db.iter_events())
+
+            filter_option = self.options.menu.get_option_by_name('event_filter')
+            event_filter = filter_option.get_filter()
+            filtered_event_handles = event_filter.apply(self.db, self.db.iter_event_handles())
+
             self.progress.set_pass(_('Set events private..'),
-                                   len(event_list))
+                                   len(filtered_event_handles))
+
             cnt = [0, 0]
             for Event in event_list:
+                if Event.handle not in filtered_event_handles:
+                    continue
                 event_date = Event.get_date_object()
+                set_privacy = None
                 if event_date.get_year() == 0 and lock_no_date:
-                    Event.set_privacy(True)
+                    set_privacy = True
                     cnt[0] += 1
                 elif event_date.get_year() == 0 and not lock_no_date:
-                    Event.set_privacy(False)
+                    set_privacy = False
                     cnt[1] += 1
                 elif event_date.get_year() != 0 and event_date >= date:
-                    Event.set_privacy(True)
+                    set_privacy = True
                     cnt[0] += 1
                 else:
-                    Event.set_privacy(False)
+                    set_privacy = False
                     cnt[1] += 1
-                self.db.commit_event(Event, self.trans)
+                if set_privacy is not None and set_privacy != Event.private:
+                    Event.set_privacy(set_privacy)
+                    self.db.commit_event(Event, self.trans)
                 self.progress.step()
         self.db.enable_signals()
         self.db.request_rebuild()
@@ -157,24 +182,35 @@ class SetPrivacyWindow(PluginWindows.ToolManagedWindowBatch):
         with DbTxn(_("Set Privacy Tool"), self.db, batch=True) as self.trans:
             self.db.disable_signals()
             media_list = list(self.db.iter_media())
+
+            filter_option = self.options.menu.get_option_by_name('media_filter')
+            media_filter = filter_option.get_filter()
+            filtered_media_handles = media_filter.apply(self.db, self.db.iter_media_handles())
+
             self.progress.set_pass(_('Set media private..'),
-                                   len(media_list))
+                                   len(filtered_media_handles))
+
             cnt = [0, 0]
             for Media in media_list:
+                if Media.handle not in filtered_media_handles:
+                    continue
                 media_date = Media.get_date_object()
+                set_privacy = None
                 if media_date.get_year() == 0 and lock_no_date:
-                    Media.set_privacy(True)
+                    set_privacy = True
                     cnt[0] += 1
                 elif media_date.get_year() == 0 and not lock_no_date:
-                    Media.set_privacy(False)
+                    set_privacy = False
                     cnt[1] += 1
                 elif media_date.get_year() != 0 and media_date >= date:
-                    Media.set_privacy(True)
+                    set_privacy = True
                     cnt[0] += 1
                 else:
-                    Media.set_privacy(False)
+                    set_privacy = False
                     cnt[1] += 1
-                self.db.commit_media(Media, self.trans)
+                if set_privacy is not None and set_privacy != Media.private:
+                    Media.set_privacy(set_privacy)
+                    self.db.commit_media(Media, self.trans)
                 self.progress.step()
         self.db.enable_signals()
         self.db.request_rebuild()
@@ -192,14 +228,39 @@ class SetPrivacyOptions(MenuToolOptions):
         MenuToolOptions.__init__(self, name, person_id, dbstate)
 
     def add_menu_options(self, menu):
+
         self.person = BooleanOption(_("Persons"), False)
         menu.add_option(_("Option"), "person", self.person)
+
+        self.__person_filter = FilterOption(_("Person Filter"), 0)
+        self.__person_filter.set_help(_("Select filter to restrict people"))
+        menu.add_option(_("Option"), "person_filter", self.__person_filter)
+        person_filter_all = GenericFilterFactory("Person")()
+        person_filter_all.name = _("Entire Database")
+        person_filter_list =  [person_filter_all] + CustomFilters.get_filters("Person")
+        self.__person_filter.set_filters(person_filter_list)
 
         self.event = BooleanOption(_("Events"), False)
         menu.add_option(_("Option"), "event", self.event)
 
+        self.__event_filter = FilterOption(_("Event Filter"), 0)
+        self.__event_filter.set_help(_("Select filter to restrict events"))
+        menu.add_option(_("Option"), "event_filter", self.__event_filter)
+        event_filter_all = GenericFilterFactory("Event")()
+        event_filter_all.name = _("Entire Database")
+        event_filter_list = [event_filter_all] + CustomFilters.get_filters('Event')
+        self.__event_filter.set_filters(event_filter_list)
+
         self.media = BooleanOption(_("Media"), False)
         menu.add_option(_("Option"), "media", self.media)
+
+        self.__media_filter = FilterOption(_("Media Filter"), 0)
+        self.__media_filter.set_help(_("Select filter to restrict medias"))
+        menu.add_option(_("Option"), "media_filter", self.__media_filter)
+        media_filter_all = GenericFilterFactory("Media")()
+        media_filter_all.name = _("Entire Database")
+        media_filter_list = [media_filter_all] + CustomFilters.get_filters('Media')
+        self.__media_filter.set_filters(media_filter_list)
 
         self.no_date = BooleanOption(_("Always private if no date."), False)
         self.no_date.set_help(_("If checked, all objects without a date will "


### PR DESCRIPTION
Hi,

@Mattkmmr's set privacy tool is great, however I was missing one feature and noticed one problem. This PR fixes both:

1. It implements optionally applying custom filters to people, events, and handles. These filters are applied on top of the already existing options. Thanks to the very flexible filter system, they allow for very complex patterns.
2. I noticed the tool commits all objects it iterates over, even if it doesn't change them. This is bad (IMO) since it changes the last changed timestamp. In an extreme case, if it iterates over the entire DB and doesn't change any of the objects (e.g. because it wants to set them all public but they are already public), it still resets all the timestamps, so one looses all the information when an object was last modified.