### PR TITLE
FamilyRelationshipTool: update Dutch translation

### DIFF
--- a/EventDescriptionEditor/po/nl-local.po
+++ b/EventDescriptionEditor/po/nl-local.po
@@ -1,14 +1,14 @@
 # Dutch translation of addon EventDescriptionEditor.
-# Copyright (C) 2020 Gramps project
+# Copyright (C) 2021 Gramps project
 # This file is distributed under the same license as the EventDescriptionEditor package.
-# Jan Sparreboom <jan@sparreboom.net>, 2020.
+# Jan Sparreboom <jan@sparreboom.net>, 2021.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: EventDescriptionEditor 5.x\n"
-"Report-Msgid-Bugs-To: https://www.gramps-project.org/bugs\n"
-"POT-Creation-Date: 2020-04-11 09:47-0500\n"
-"PO-Revision-Date: 2020-08-31 16:06+0200\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-09-14 10:31-0500\n"
+"PO-Revision-Date: 2021-05-01 17:11+0200\n"
 "Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
 "Language-Team: Dutch <gramps-users@lists.sourceforge.net>\n"
 "Language: nl\n"
@@ -18,8 +18,8 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 
 #: EventDescriptionEditor/EventDescriptionEditor.gpr.py:24
-#: EventDescriptionEditor/EventDescriptionEditor.py:50
-#: EventDescriptionEditor/EventDescriptionEditor.py:61
+#: EventDescriptionEditor/EventDescriptionEditor.py:52
+#: EventDescriptionEditor/EventDescriptionEditor.py:64
 msgid "Event Description Editor"
 msgstr "Gebeurtenisbeschrijvingsbewerker"
 
@@ -30,50 +30,59 @@ msgstr ""
 "Een hulpmiddel om een string te vinden en te vervangen in de "
 "gebeurtenisbeschrijving van meerdere gebeurtenissen."
 
-#: EventDescriptionEditor/EventDescriptionEditor.py:72
+#: EventDescriptionEditor/EventDescriptionEditor.py:75
 msgid "Search substring..."
 msgstr "Zoek deeltekenreeks..."
 
-#: EventDescriptionEditor/EventDescriptionEditor.py:91
+#: EventDescriptionEditor/EventDescriptionEditor.py:105
 msgid "INFO"
 msgstr "INFO"
 
-#: EventDescriptionEditor/EventDescriptionEditor.py:92
+#: EventDescriptionEditor/EventDescriptionEditor.py:106
 #, python-format
 msgid "%s event descriptions of %s events were changed."
 msgstr "%s gebeurtenisbeschrijvingen van %s gebeurtenissen zijn gewijzigd."
 
-#: EventDescriptionEditor/EventDescriptionEditor.py:112
+#: EventDescriptionEditor/EventDescriptionEditor.py:126
 msgid "All Events"
 msgstr "Alle gebeurtenissen"
 
-#: EventDescriptionEditor/EventDescriptionEditor.py:121
+#: EventDescriptionEditor/EventDescriptionEditor.py:135
 msgid "Events"
 msgstr "Gebeurtenissen"
 
-#: EventDescriptionEditor/EventDescriptionEditor.py:122
-#: EventDescriptionEditor/EventDescriptionEditor.py:126
-#: EventDescriptionEditor/EventDescriptionEditor.py:129
-#: EventDescriptionEditor/EventDescriptionEditor.py:135
+#: EventDescriptionEditor/EventDescriptionEditor.py:136
+#: EventDescriptionEditor/EventDescriptionEditor.py:140
+#: EventDescriptionEditor/EventDescriptionEditor.py:143
+#: EventDescriptionEditor/EventDescriptionEditor.py:149
+#: EventDescriptionEditor/EventDescriptionEditor.py:153
 msgid "Option"
 msgstr "Keuze"
 
-#: EventDescriptionEditor/EventDescriptionEditor.py:125
+#: EventDescriptionEditor/EventDescriptionEditor.py:139
 msgid "Find"
-msgstr "Vind"
+msgstr "Zoek"
 
-#: EventDescriptionEditor/EventDescriptionEditor.py:128
+#: EventDescriptionEditor/EventDescriptionEditor.py:142
 msgid "Replace"
 msgstr "Vervangen"
 
-#: EventDescriptionEditor/EventDescriptionEditor.py:131
+#: EventDescriptionEditor/EventDescriptionEditor.py:145
 msgid "Replace substring only"
 msgstr "Vervang alleen het zinsdeel"
 
-#: EventDescriptionEditor/EventDescriptionEditor.py:132
+#: EventDescriptionEditor/EventDescriptionEditor.py:146
 msgid ""
 "If True only the substring will be replaced, otherwise the whole description "
 "will be deleted and replaced by the new one."
 msgstr ""
 "Indien True wordt alleen de deeltekenreeks vervangen, anders wordt de hele "
 "beschrijving verwijderd en vervangen door de nieuwe."
+
+#: EventDescriptionEditor/EventDescriptionEditor.py:151
+msgid "Allow regex"
+msgstr "Regex toestaan"
+
+#: EventDescriptionEditor/EventDescriptionEditor.py:152
+msgid "Allow regular expressions."
+msgstr "Sta reguliere expressies toe."

--- a/FamilyRelationshipTool/po/nl-local.po
+++ b/FamilyRelationshipTool/po/nl-local.po
@@ -1,25 +1,25 @@
 # Dutch translation of Gramps addon FamilyRelationshipTool
 # Copyright (C) 2020 Gramps project
 # This file is distributed under the same license as the FamilyRelationshipTool package.
-# Jan Sparreboom <jan@sparreboom.net>, 2020.
+# Jan Sparreboom <jan@sparreboom.net>, 2020, 2021.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: FamilyRelationshipTool 5.1.x\n"
-"Report-Msgid-Bugs-To: https://www.gramps-project.org/bugs\n"
-"POT-Creation-Date: 2020-05-10 18:31+0200\n"
-"PO-Revision-Date: 2020-05-10 18:57+0200\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-26 17:29-0500\n"
+"PO-Revision-Date: 2021-05-02 14:27+0200\n"
 "Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
 "Language-Team: Dutch <gramps-users@lists.sourceforge.net>\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.0.6\n"
+"X-Generator: Poedit 2.3\n"
 
 #: FamilyRelationshipTool/FamilyRelationshipTool.gpr.py:24
-#: FamilyRelationshipTool/FamilyRelationshipTool.py:76
-#: FamilyRelationshipTool/FamilyRelationshipTool.py:91
+#: FamilyRelationshipTool/FamilyRelationshipTool.py:88
+#: FamilyRelationshipTool/FamilyRelationshipTool.py:103
 msgid "Family Relationship Tool"
 msgstr "Familierelaties hulpmiddel"
 
@@ -27,11 +27,15 @@ msgstr "Familierelaties hulpmiddel"
 msgid "Mass-edit the family relationship type for a group of families."
 msgstr "Het in bulk bewerken van het familierelatie type voor een groep families."
 
-#: FamilyRelationshipTool/FamilyRelationshipTool.py:51
+#: FamilyRelationshipTool/FamilyRelationshipTool.py:53
+msgid "All Families"
+msgstr "Alle gezinnen"
+
+#: FamilyRelationshipTool/FamilyRelationshipTool.py:63
 msgid "Family Filter"
 msgstr "Familiefilter"
 
-#: FamilyRelationshipTool/FamilyRelationshipTool.py:52
+#: FamilyRelationshipTool/FamilyRelationshipTool.py:64
 msgid ""
 "Choose the set of families to process.\n"
 "Create custom filters if empty."
@@ -39,17 +43,17 @@ msgstr ""
 "Kies de families die verwerkt moeten worden.\n"
 "Maak aangepaste filters als ze leeg zijn."
 
-#: FamilyRelationshipTool/FamilyRelationshipTool.py:55
-#: FamilyRelationshipTool/FamilyRelationshipTool.py:63
-#: FamilyRelationshipTool/FamilyRelationshipTool.py:80
+#: FamilyRelationshipTool/FamilyRelationshipTool.py:67
+#: FamilyRelationshipTool/FamilyRelationshipTool.py:75
+#: FamilyRelationshipTool/FamilyRelationshipTool.py:92
 msgid "Options"
 msgstr "Opties"
 
-#: FamilyRelationshipTool/FamilyRelationshipTool.py:58
+#: FamilyRelationshipTool/FamilyRelationshipTool.py:70
 msgid "Relationship Type"
 msgstr "Soort relatie"
 
-#: FamilyRelationshipTool/FamilyRelationshipTool.py:59
+#: FamilyRelationshipTool/FamilyRelationshipTool.py:71
 msgid ""
 "Choose the new family relationship type.\n"
 "Custom relationship types aren't supported."
@@ -57,22 +61,22 @@ msgstr ""
 "Kies het nieuwe type gezinsrelatie.\n"
 "Aangepaste relatietypen worden niet ondersteund."
 
-#: FamilyRelationshipTool/FamilyRelationshipTool.py:61
+#: FamilyRelationshipTool/FamilyRelationshipTool.py:73
 msgid "Married"
 msgstr "Getrouwd"
 
-#: FamilyRelationshipTool/FamilyRelationshipTool.py:61
+#: FamilyRelationshipTool/FamilyRelationshipTool.py:73
 msgid "Unmarried"
 msgstr "Ongetrouwd"
 
-#: FamilyRelationshipTool/FamilyRelationshipTool.py:62
+#: FamilyRelationshipTool/FamilyRelationshipTool.py:74
 msgid "Civil Union"
 msgstr "Geregistreerd samenwonen"
 
-#: FamilyRelationshipTool/FamilyRelationshipTool.py:62
+#: FamilyRelationshipTool/FamilyRelationshipTool.py:74
 msgid "Unknown"
 msgstr "Onbekend"
 
-#: FamilyRelationshipTool/FamilyRelationshipTool.py:95
+#: FamilyRelationshipTool/FamilyRelationshipTool.py:107
 msgid "Process relationships..."
 msgstr "Relaties verwerken..."


### PR DESCRIPTION
Updated Dutch translation for addon FamilyRelationshipTool.
Tested without issues in Gramps 5.1.3 on Linux Mint 20.1.
Please, add it to this branch.
Thanks in advance!