### PR TITLE
PhotoTaggingGramplet: update Dutch translation

### DIFF
--- a/EventDescriptionEditor/po/nl-local.po
+++ b/EventDescriptionEditor/po/nl-local.po
@@ -1,14 +1,14 @@
 # Dutch translation of addon EventDescriptionEditor.
-# Copyright (C) 2020 Gramps project
+# Copyright (C) 2021 Gramps project
 # This file is distributed under the same license as the EventDescriptionEditor package.
-# Jan Sparreboom <jan@sparreboom.net>, 2020.
+# Jan Sparreboom <jan@sparreboom.net>, 2021.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: EventDescriptionEditor 5.x\n"
-"Report-Msgid-Bugs-To: https://www.gramps-project.org/bugs\n"
-"POT-Creation-Date: 2020-04-11 09:47-0500\n"
-"PO-Revision-Date: 2020-08-31 16:06+0200\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-09-14 10:31-0500\n"
+"PO-Revision-Date: 2021-05-01 17:11+0200\n"
 "Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
 "Language-Team: Dutch <gramps-users@lists.sourceforge.net>\n"
 "Language: nl\n"
@@ -18,8 +18,8 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 
 #: EventDescriptionEditor/EventDescriptionEditor.gpr.py:24
-#: EventDescriptionEditor/EventDescriptionEditor.py:50
-#: EventDescriptionEditor/EventDescriptionEditor.py:61
+#: EventDescriptionEditor/EventDescriptionEditor.py:52
+#: EventDescriptionEditor/EventDescriptionEditor.py:64
 msgid "Event Description Editor"
 msgstr "Gebeurtenisbeschrijvingsbewerker"
 
@@ -30,50 +30,59 @@ msgstr ""
 "Een hulpmiddel om een string te vinden en te vervangen in de "
 "gebeurtenisbeschrijving van meerdere gebeurtenissen."
 
-#: EventDescriptionEditor/EventDescriptionEditor.py:72
+#: EventDescriptionEditor/EventDescriptionEditor.py:75
 msgid "Search substring..."
 msgstr "Zoek deeltekenreeks..."
 
-#: EventDescriptionEditor/EventDescriptionEditor.py:91
+#: EventDescriptionEditor/EventDescriptionEditor.py:105
 msgid "INFO"
 msgstr "INFO"
 
-#: EventDescriptionEditor/EventDescriptionEditor.py:92
+#: EventDescriptionEditor/EventDescriptionEditor.py:106
 #, python-format
 msgid "%s event descriptions of %s events were changed."
 msgstr "%s gebeurtenisbeschrijvingen van %s gebeurtenissen zijn gewijzigd."
 
-#: EventDescriptionEditor/EventDescriptionEditor.py:112
+#: EventDescriptionEditor/EventDescriptionEditor.py:126
 msgid "All Events"
 msgstr "Alle gebeurtenissen"
 
-#: EventDescriptionEditor/EventDescriptionEditor.py:121
+#: EventDescriptionEditor/EventDescriptionEditor.py:135
 msgid "Events"
 msgstr "Gebeurtenissen"
 
-#: EventDescriptionEditor/EventDescriptionEditor.py:122
-#: EventDescriptionEditor/EventDescriptionEditor.py:126
-#: EventDescriptionEditor/EventDescriptionEditor.py:129
-#: EventDescriptionEditor/EventDescriptionEditor.py:135
+#: EventDescriptionEditor/EventDescriptionEditor.py:136
+#: EventDescriptionEditor/EventDescriptionEditor.py:140
+#: EventDescriptionEditor/EventDescriptionEditor.py:143
+#: EventDescriptionEditor/EventDescriptionEditor.py:149
+#: EventDescriptionEditor/EventDescriptionEditor.py:153
 msgid "Option"
 msgstr "Keuze"
 
-#: EventDescriptionEditor/EventDescriptionEditor.py:125
+#: EventDescriptionEditor/EventDescriptionEditor.py:139
 msgid "Find"
-msgstr "Vind"
+msgstr "Zoek"
 
-#: EventDescriptionEditor/EventDescriptionEditor.py:128
+#: EventDescriptionEditor/EventDescriptionEditor.py:142
 msgid "Replace"
 msgstr "Vervangen"
 
-#: EventDescriptionEditor/EventDescriptionEditor.py:131
+#: EventDescriptionEditor/EventDescriptionEditor.py:145
 msgid "Replace substring only"
 msgstr "Vervang alleen het zinsdeel"
 
-#: EventDescriptionEditor/EventDescriptionEditor.py:132
+#: EventDescriptionEditor/EventDescriptionEditor.py:146
 msgid ""
 "If True only the substring will be replaced, otherwise the whole description "
 "will be deleted and replaced by the new one."
 msgstr ""
 "Indien True wordt alleen de deeltekenreeks vervangen, anders wordt de hele "
 "beschrijving verwijderd en vervangen door de nieuwe."
+
+#: EventDescriptionEditor/EventDescriptionEditor.py:151
+msgid "Allow regex"
+msgstr "Regex toestaan"
+
+#: EventDescriptionEditor/EventDescriptionEditor.py:152
+msgid "Allow regular expressions."
+msgstr "Sta reguliere expressies toe."

--- a/PhotoTaggingGramplet/po/nl-local.po
+++ b/PhotoTaggingGramplet/po/nl-local.po
@@ -1,14 +1,14 @@
 # Dutch translation of addon PhotoTaggingGramplet.
-# Copyright (C) 2020 Gramps project
+# Copyright (C) 2021 Gramps project
 # This file is distributed under the same license as the PhotoTaggingGramplet package.
-# Jan Sparreboom <jan@sparreboom.net>, 2020.
+# Jan Sparreboom <jan@sparreboom.net>, 2020, 2021.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: PhotoTaggingGramplet 5.x\n"
-"Report-Msgid-Bugs-To: https://www.gramps-project.org/bugs\n"
-"POT-Creation-Date: 2019-01-04 18:55-0600\n"
-"PO-Revision-Date: 2020-08-06 14:19+0200\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-03-05 11:11-0600\n"
+"PO-Revision-Date: 2021-05-03 18:33+0200\n"
 "Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
 "Language-Team: Dutch <gramps-users@lists.sourceforge.net>\n"
 "Language: nl\n"
@@ -26,147 +26,165 @@ msgstr "Fotolabelling"
 msgid "Gramplet for tagging people in photos"
 msgstr "Gramplet voor het labellen van mensen op foto's"
 
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:120
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:101
+msgid "https://www.gramps-project.org/wiki/index.php/Photo_Tagging_Gramplet"
+msgstr "https://www.gramps-project.org/wiki/index.php/Photo_Tagging_Gramplet"
+
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:125
 msgid "Selection"
 msgstr "Selectie"
 
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:122
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:127
 msgid "Replace existing references to the person being assigned without asking"
-msgstr "Vervang bestaande verwijzingen naar de toegewezen persoon zonder te vragen"
+msgstr ""
+"Vervang bestaande verwijzingen naar de toegewezen persoon zonder te vragen"
 
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:129
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:134
 msgid "Face detection"
 msgstr "Gezichtsherkenning"
 
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:132
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:137
 msgid "Minimum face width (px)"
 msgstr "Minimale gezichtsbreedte (px)"
 
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:134
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:139
 msgid "Minimum face height (px)"
 msgstr "Minimale gezichtshoogte (px)"
 
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:137
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:142
 msgid "Detect faces inside existing boxes"
 msgstr "Detecteer gezichten binnen bestaande kaders"
 
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:139
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:144
 msgid "Sensitivity (1 min .. 20 max)"
 msgstr "Gevoeligheid (1 min .. 20 max)"
 
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:275
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:743
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:183
+msgid "_OK"
+msgstr "_OK"
+
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:283
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:760
 msgid "Select Person"
 msgstr "Selecteer persoon"
 
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:276
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:284
 msgid "Add Person"
 msgstr "Voeg persoon toe"
 
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:277
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:285
 msgid "Clear Reference"
 msgstr "Wis referentie"
 
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:278
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:286
 msgid "Remove Selection"
 msgstr "Verwijder selectie"
 
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:279
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:287
 msgid "Edit referenced Person"
 msgstr "Bewerk gerefereerd persoon"
 
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:280
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:288
 msgid "Zoom In"
 msgstr "Inzoomen"
 
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:281
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:289
 msgid "Zoom Out"
 msgstr "Uitzoomen"
 
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:284
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:292
 msgid "Detect faces"
 msgstr "Herken gezichten"
 
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:286
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:294
 msgid "Detect faces (OpenCV module required)"
 msgstr "Herken gezichten (OpenCV-module vereist)"
 
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:289
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:805
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:297
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:822
 msgid "Settings"
 msgstr "Instellingen"
 
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:337
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:298
+msgid "Help"
+msgstr "Help"
+
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:346
 msgid "Preview"
 msgstr "Voorbeeld"
 
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:338
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:347
 msgid "Person"
 msgstr "Persoon"
 
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:339
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:348
 msgid "Age"
 msgstr "Leeftijd"
 
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:459
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:474
 msgid "Set as active person"
 msgstr "Stel in als actieve persoon"
 
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:462
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:477
 msgid "_Select"
 msgstr "_Selecteer"
 
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:465
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:480
 msgid "_Add"
 msgstr "_Toevoegen"
 
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:468
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:483
 msgid "_Clear"
 msgstr "_Wis"
 
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:471
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:486
 msgid "_Remove"
 msgstr "_Verwijderen"
 
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:618
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:635
 #, python-format
 msgid "Edit Person (%s)"
 msgstr "Bewerk persoon (%s)"
 
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:674
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:691
 #, python-brace-format
 msgid "Replace to {0}"
 msgstr "Vervang door {0}"
 
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:775
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:792
 msgid "Detecting faces..."
 msgstr "Gezichten detecteren..."
 
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:800
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:817
 msgid "Detection finished"
 msgstr "Detectie voltooid"
 
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:850
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:867
 #, python-brace-format
 msgid "Another region of this image is associated with {name}. Remove it?"
-msgstr "Een ander deel van deze afbeelding is geassocieerd met {name}. Dit verwijderen?"
+msgstr ""
+"Een ander deel van deze afbeelding is geassocieerd met {name}. Dit "
+"verwijderen?"
 
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:853
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:870
 #, python-brace-format
-msgid "{count} other regions of this image are associated with {name}. Remove them?"
-msgstr "{count} andere delen van deze afbeelding zijn geassocieerd met {name}. Die verwijderen?"
+msgid ""
+"{count} other regions of this image are associated with {name}. Remove them?"
+msgstr ""
+"{count} andere delen van deze afbeelding zijn geassocieerd met {name}. Die "
+"verwijderen?"
 
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:997
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:1014
 #, python-format
 msgid "Male person|Dead at %s"
 msgstr "Overleden op %s"
 
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:999
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:1016
 #, python-format
 msgid "Female person|Dead at %s"
 msgstr "Overleden op %s"
 
-#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:1001
+#: PhotoTaggingGramplet/PhotoTaggingGramplet.py:1018
 #, python-format
 msgid "Unknown gender person|Dead at %s"
 msgstr "Overleden op %s"


### PR DESCRIPTION
Updated Dutch translation for addon PhotoTaggingGramplet.
Tested without issues in Gramps 5.1.3 on Linux Mint 20.1.
Please, add it to this branch.
Thanks in advance!