### PR TITLE
PlaceCoordinateGramplet: update Dutch translation

### DIFF
--- a/EventDescriptionEditor/po/nl-local.po
+++ b/EventDescriptionEditor/po/nl-local.po
@@ -1,14 +1,14 @@
 # Dutch translation of addon EventDescriptionEditor.
-# Copyright (C) 2020 Gramps project
+# Copyright (C) 2021 Gramps project
 # This file is distributed under the same license as the EventDescriptionEditor package.
-# Jan Sparreboom <jan@sparreboom.net>, 2020.
+# Jan Sparreboom <jan@sparreboom.net>, 2021.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: EventDescriptionEditor 5.x\n"
-"Report-Msgid-Bugs-To: https://www.gramps-project.org/bugs\n"
-"POT-Creation-Date: 2020-04-11 09:47-0500\n"
-"PO-Revision-Date: 2020-08-31 16:06+0200\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-09-14 10:31-0500\n"
+"PO-Revision-Date: 2021-05-01 17:11+0200\n"
 "Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
 "Language-Team: Dutch <gramps-users@lists.sourceforge.net>\n"
 "Language: nl\n"
@@ -18,8 +18,8 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 
 #: EventDescriptionEditor/EventDescriptionEditor.gpr.py:24
-#: EventDescriptionEditor/EventDescriptionEditor.py:50
-#: EventDescriptionEditor/EventDescriptionEditor.py:61
+#: EventDescriptionEditor/EventDescriptionEditor.py:52
+#: EventDescriptionEditor/EventDescriptionEditor.py:64
 msgid "Event Description Editor"
 msgstr "Gebeurtenisbeschrijvingsbewerker"
 
@@ -30,50 +30,59 @@ msgstr ""
 "Een hulpmiddel om een string te vinden en te vervangen in de "
 "gebeurtenisbeschrijving van meerdere gebeurtenissen."
 
-#: EventDescriptionEditor/EventDescriptionEditor.py:72
+#: EventDescriptionEditor/EventDescriptionEditor.py:75
 msgid "Search substring..."
 msgstr "Zoek deeltekenreeks..."
 
-#: EventDescriptionEditor/EventDescriptionEditor.py:91
+#: EventDescriptionEditor/EventDescriptionEditor.py:105
 msgid "INFO"
 msgstr "INFO"
 
-#: EventDescriptionEditor/EventDescriptionEditor.py:92
+#: EventDescriptionEditor/EventDescriptionEditor.py:106
 #, python-format
 msgid "%s event descriptions of %s events were changed."
 msgstr "%s gebeurtenisbeschrijvingen van %s gebeurtenissen zijn gewijzigd."
 
-#: EventDescriptionEditor/EventDescriptionEditor.py:112
+#: EventDescriptionEditor/EventDescriptionEditor.py:126
 msgid "All Events"
 msgstr "Alle gebeurtenissen"
 
-#: EventDescriptionEditor/EventDescriptionEditor.py:121
+#: EventDescriptionEditor/EventDescriptionEditor.py:135
 msgid "Events"
 msgstr "Gebeurtenissen"
 
-#: EventDescriptionEditor/EventDescriptionEditor.py:122
-#: EventDescriptionEditor/EventDescriptionEditor.py:126
-#: EventDescriptionEditor/EventDescriptionEditor.py:129
-#: EventDescriptionEditor/EventDescriptionEditor.py:135
+#: EventDescriptionEditor/EventDescriptionEditor.py:136
+#: EventDescriptionEditor/EventDescriptionEditor.py:140
+#: EventDescriptionEditor/EventDescriptionEditor.py:143
+#: EventDescriptionEditor/EventDescriptionEditor.py:149
+#: EventDescriptionEditor/EventDescriptionEditor.py:153
 msgid "Option"
 msgstr "Keuze"
 
-#: EventDescriptionEditor/EventDescriptionEditor.py:125
+#: EventDescriptionEditor/EventDescriptionEditor.py:139
 msgid "Find"
-msgstr "Vind"
+msgstr "Zoek"
 
-#: EventDescriptionEditor/EventDescriptionEditor.py:128
+#: EventDescriptionEditor/EventDescriptionEditor.py:142
 msgid "Replace"
 msgstr "Vervangen"
 
-#: EventDescriptionEditor/EventDescriptionEditor.py:131
+#: EventDescriptionEditor/EventDescriptionEditor.py:145
 msgid "Replace substring only"
 msgstr "Vervang alleen het zinsdeel"
 
-#: EventDescriptionEditor/EventDescriptionEditor.py:132
+#: EventDescriptionEditor/EventDescriptionEditor.py:146
 msgid ""
 "If True only the substring will be replaced, otherwise the whole description "
 "will be deleted and replaced by the new one."
 msgstr ""
 "Indien True wordt alleen de deeltekenreeks vervangen, anders wordt de hele "
 "beschrijving verwijderd en vervangen door de nieuwe."
+
+#: EventDescriptionEditor/EventDescriptionEditor.py:151
+msgid "Allow regex"
+msgstr "Regex toestaan"
+
+#: EventDescriptionEditor/EventDescriptionEditor.py:152
+msgid "Allow regular expressions."
+msgstr "Sta reguliere expressies toe."

--- a/PlaceCoordinateGramplet/po/nl-local.po
+++ b/PlaceCoordinateGramplet/po/nl-local.po
@@ -1,14 +1,14 @@
 # Dutch translation of addon PlaceCoordinateGramplet.
-# Copyright (C) 2020 Gramps project
+# Copyright (C) 2021 Gramps project
 # This file is distributed under the same license as the PlaceCoordinateGramplet package.
-# Jan Sparreboom <jan@sparreboom.net>, 2020.
+# Jan Sparreboom <jan@sparreboom.net>, 2020, 2021.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: PlaceCoordinateGramplet 5.x\n"
-"Report-Msgid-Bugs-To: https://www.gramps-project.org/bugs\n"
-"POT-Creation-Date: 2020-08-26 11:18-0500\n"
-"PO-Revision-Date: 2020-09-03 13:16+0200\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-09-14 10:55-0500\n"
+"PO-Revision-Date: 2021-05-03 18:51+0200\n"
 "Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
 "Language-Team: Dutch <gramps-users@lists.sourceforge.net>\n"
 "Language: nl\n"
@@ -26,6 +26,7 @@ msgid "Places map"
 msgstr "Locaties kaart"
 
 #: PlaceCoordinateGramplet/PlaceCoordinateGeoView.py:264
+#: PlaceCoordinateGramplet/PlaceCoordinateGramplet.gpr.py:62
 msgid "Place Coordinate Gramplet"
 msgstr "Plaatscoördinaten gramplet"
 
@@ -226,42 +227,41 @@ msgstr "Bewerk plaats"
 msgid "Center on this place"
 msgstr "Centreer op deze plek"
 
-#: PlaceCoordinateGramplet/PlaceCoordinateGramplet.gpr.py:67
+#: PlaceCoordinateGramplet/PlaceCoordinateGramplet.gpr.py:73
 #, python-brace-format
 msgid "Failed to load the required module {module_name}."
 msgstr "Kan de vereiste module {module_name} niet laden."
 
-#: PlaceCoordinateGramplet/PlaceCoordinateGramplet.gpr.py:96
-#, python-brace-format
-msgid "Internet connectivity test failed for {module_name}."
-msgstr "Internetverbindingstest mislukt voor {module_name}."
+#: PlaceCoordinateGramplet/PlaceCoordinateGramplet.gpr.py:81
+msgid "Don't show again"
+msgstr "Niet meer laten zien"
 
-#: PlaceCoordinateGramplet/PlaceCoordinateGramplet.gpr.py:109
-msgid "Warning disabled."
-msgstr "Waarschuwing uitgeschakeld."
+#: PlaceCoordinateGramplet/PlaceCoordinateGramplet.gpr.py:81
+msgid "OK"
+msgstr "OK"
 
-#: PlaceCoordinateGramplet/PlaceCoordinateGramplet.gpr.py:130
+#: PlaceCoordinateGramplet/PlaceCoordinateGramplet.gpr.py:138
 msgid "Place Coordinate Gramplet view"
 msgstr "Plaatscoördinaten grampletweergave"
 
-#: PlaceCoordinateGramplet/PlaceCoordinateGramplet.gpr.py:131
+#: PlaceCoordinateGramplet/PlaceCoordinateGramplet.gpr.py:139
 msgid "View for the place coordinate gramplet."
 msgstr "Weergave van de plaatscoördinatengramplet."
 
-#: PlaceCoordinateGramplet/PlaceCoordinateGramplet.gpr.py:138
+#: PlaceCoordinateGramplet/PlaceCoordinateGramplet.gpr.py:146
 msgid "Geography"
 msgstr "Geografie"
 
-#: PlaceCoordinateGramplet/PlaceCoordinateGramplet.gpr.py:146
+#: PlaceCoordinateGramplet/PlaceCoordinateGramplet.gpr.py:154
 msgid "Place and Coordinates"
 msgstr "Plaats en coördinaten"
 
-#: PlaceCoordinateGramplet/PlaceCoordinateGramplet.gpr.py:148
+#: PlaceCoordinateGramplet/PlaceCoordinateGramplet.gpr.py:156
 msgid "Gramplet that simplifies setting the coordinates of a place"
 msgstr ""
 "Gramplet die het instellen van de coördinaten van een plaats vereenvoudigt"
 
-#: PlaceCoordinateGramplet/PlaceCoordinateGramplet.gpr.py:157
+#: PlaceCoordinateGramplet/PlaceCoordinateGramplet.gpr.py:165
 msgid "Place Coordinates"
 msgstr "Plaatscoördinaten"
 


### PR DESCRIPTION
Updated Dutch translation for addon PlaceCoordinateGramplet.
Tested without issues in Gramps 5.1.3 on Linux Mint 20.1.
Please, add it to this branch.
Thanks in advance!