### PR TITLE
[MediaReport] Allow all output formats [WIP]

### DIFF
--- a/MediaReport/media_report.gpr.py
+++ b/MediaReport/media_report.gpr.py
@@ -1,7 +1,8 @@
 #
 # Gramps - a GTK+/GNOME based genealogy program
 #
-# Copyright (C) 2019  Matthias Kemmer <matt.familienforschung@gmail.com>
+# Copyright (C) 2019-2021 Matthias Kemmer
+# Copyright (C) 2021 George Baynes
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -23,14 +24,14 @@ register(REPORT,
          name = _("Media Report"),
          description = _("Generates report including images, image data"
                          " and notes."),
-         version = '1.1.7',
+         version = '1.2.0',
          gramps_target_version = "5.1",
          status = STABLE,
          fname = "media_report.py",
-         authors = ["Matthias Kemmer"],
-         authors_email = ["matt.familienforschung@gmail.com"],
+         authors = ["Matthias Kemmer", "George Baynes"],
+         authors_email = ["matt.familienforschung@gmail.com", "baynes@ntlworld.com"],
          category = CATEGORY_TEXT,
          reportclass = 'MediaReport',
          optionclass = 'ReportOptions',
-         report_modes = [REPORT_MODE_CLI, REPORT_MODE_GUI],
+         report_modes = [REPORT_MODE_GUI],
          )


### PR DESCRIPTION
This PR includes modifications by George Baynes (allow all output formats instead of just PDF) and some code refactoring by me. We also decided to remove the footer, which was added initially, because it is overwritten by loading from report_options.xml anyways.

Known problems:
- Latex output fails to generate
- HTML output: images aren't generated