### PR TITLE
PostgreSQL: don't re-create collation if it already exists

### DIFF
--- a/PostgreSQL/postgresql.gpr.py
+++ b/PostgreSQL/postgresql.gpr.py
@@ -26,7 +26,7 @@ if module1 or locals().get('build_script'):
              name=_('PostgreSQL'),
              name_accell=_('_PostgreSQL Database'),
              description=_('PostgreSQL Database'),
-             version = '1.0.11',
+             version = '1.0.12',
              gramps_target_version='5.1',
              status=STABLE,
              fname='postgresql.py',

--- a/PostgreSQL/postgresql.py
+++ b/PostgreSQL/postgresql.py
@@ -129,12 +129,8 @@ class Connection:
         """
         # Duplicating system collations works, but to delete them the schema
         # must be specified, so get the current schema
-        self.execute('SELECT current_schema()')
-        current_schema, = self.fetchone()
         collation = locale.get_collation()
-        self.execute('DROP COLLATION IF EXISTS "%s"."%s"'
-                     % (current_schema, collation))
-        self.execute('CREATE COLLATION "%s"'
+        self.execute('CREATE COLLATION IF NOT EXISTS "%s"'
                      "(LOCALE = '%s')" % (collation, locale.collation))
 
     def _hack_query(self, query):


### PR DESCRIPTION
Currently, the PostgreSQL plugin drops the existing collation and creates it again on each database connection. That shouldn't be necessary and creates [issues with Web API](https://github.com/gramps-project/gramps-webapi/issues/262). So this PR changes the behaviour to only create the collation for a given locale if it doesn't exist yet.