### PR TITLE
Add SharedPostgreSQL add-on

### DIFF
--- a/SharedPostgreSQL/po/de-local.po
+++ b/SharedPostgreSQL/po/de-local.po
@@ -1,0 +1,82 @@
+# German translation for Gramps
+# This file is distributed under the same license as the Gramps package.
+# translation of de.po to Deutsch
+#
+#
+# Anton Huber <anton_huber@gmx.de>, 2005,2006.
+# Sebastian Vöcking <sebastian_voecking@gmx.de>, 2005.
+# Sebastian Vöcking <voeck@web.de>, 2005.
+# Martin Hawlisch <martin@hawlisch.de>, 2005, 2006.
+# Alex Roitman <shura@gramps-project.org>, 2006.
+# Mirko Leonhäuser <mirko@leonhaeuser.de>, 2007, 2008, 2009, 2010, 2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020.
+# Alois Pöttker <alois.poettker@gmx.de>, 2017.
+msgid ""
+msgstr ""
+"Project-Id-Version: de\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-08-06 18:43+0200\n"
+"PO-Revision-Date: 2020-08-06 18:46+0200\n"
+"Last-Translator: Mirko Leonhäuser <mirko@leonhaeuser.de>\n"
+"Language-Team: German <kde-i18n-de@kde.org>\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Lokalize 19.12.3\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: PostgreSQL/postgresql.gpr.py:26
+msgid "PostgreSQL"
+msgstr "PostgreSQL"
+
+#: PostgreSQL/postgresql.gpr.py:27
+msgid "_PostgreSQL Database"
+msgstr "_PostgreSQL Datenbank"
+
+#: PostgreSQL/postgresql.gpr.py:28
+msgid "PostgreSQL Database"
+msgstr "PostgreSQL Datenbank"
+
+#: PostgreSQL/postgresql.gpr.py:42
+msgid "PostgreSQL Warning:  Python psycopg2 module not found."
+msgstr "PostgresSQL Warnung: Python psycopg2 Modul nicht gefunden."
+
+#: PostgreSQL/postgresql.gpr.py:48
+msgid "PostgreSQL Failed to Load"
+msgstr "PostgreSQL konnte nicht geladen werden"
+
+#: PostgreSQL/postgresql.gpr.py:49
+msgid ""
+"\n"
+"\n"
+"PostgreSQL is missing the psycopg2 python module.\n"
+"For now, it may be possible to install the files manually. See\n"
+"\n"
+"https://gramps-project.org/wiki/index.php?title=PostgreSQL \n"
+"\n"
+"To dismiss all future PostgreSQL warnings click Dismiss."
+msgstr ""
+"\n"
+"\n"
+"PostgreSQL vermisst das psycopg2 Python Modul.\n"
+"Momentan ist es möglich, die Dateien manuell zu installieren. Siehe\n"
+"\n"
+"https://gramps-project.org/wiki/index.php?title=PostgreSQL \n"
+"\n"
+"Um alle zukünftigen PostgreSQL Warnungen auszublenden klicke Ausblenden."
+
+#: PostgreSQL/postgresql.gpr.py:53
+msgid " Dismiss "
+msgstr "Verwerfen"
+
+#: PostgreSQL/postgresql.gpr.py:54
+msgid "Continue"
+msgstr "Fortsetzen"
+
+#: PostgreSQL/postgresql.py:68
+msgid "Database version"
+msgstr "Datenbankversion"
+
+#: PostgreSQL/postgresql.py:69
+msgid "Database module location"
+msgstr "Speicherort des Datenbankmoduls"

--- a/SharedPostgreSQL/po/hr-local.po
+++ b/SharedPostgreSQL/po/hr-local.po
@@ -1,0 +1,75 @@
+# Croatian translation for Gramps
+# This file is distributed under the same license as the Gramps package.
+# Copyright (C) Gramps project
+# Milo Ivir <mail@milotype.de>, 2019.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Gramps 5.x\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: 2019-03-08 03:18+0100\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.2.1\n"
+"Last-Translator: Milo Ivir <mail@milotype.de>\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+"Language: hr\n"
+
+#: PostgreSQL/postgresql.gpr.py:26
+msgid "PostgreSQL"
+msgstr "PostgreSQL"
+
+#: PostgreSQL/postgresql.gpr.py:27
+msgid "_PostgreSQL Database"
+msgstr "_PostgreSQL baza podataka"
+
+#: PostgreSQL/postgresql.gpr.py:28
+msgid "PostgreSQL Database"
+msgstr "PostgreSQL baza podataka"
+
+#: PostgreSQL/postgresql.gpr.py:42
+msgid "PostgreSQL Warning:  Python psycopg2 module not found."
+msgstr "PostgreSQL upozorenje: Python modul psycopg2 nije pornađen."
+
+#: PostgreSQL/postgresql.gpr.py:48
+msgid "PostgreSQL Failed to Load"
+msgstr "Nije uspjelo pokretanje PostgreSQL-a"
+
+#: PostgreSQL/postgresql.gpr.py:49
+msgid ""
+"\n"
+"\n"
+"PostgreSQL is missing the psycopg2 python module.\n"
+"For now, it may be possible to install the files manually. See\n"
+"\n"
+"https://gramps-project.org/wiki/index.php?title=PostgreSQL \n"
+"\n"
+"To dismiss all future PostgreSQL warnings click Dismiss."
+msgstr ""
+"\n"
+"\n"
+"Za PostgreSQL nedostaje psycopg2 Python modul.\n"
+"Za sada je možda moguće instalirati datoteke ručno. Vidi\n"
+"\n"
+"https://gramps-project.org/wiki/index.php?title=PostgreSQL \n"
+"\n"
+"Za zanemarivanje budućih PostgreSQL upozorenja, klikni na „Zanemari”."
+
+#: PostgreSQL/postgresql.gpr.py:53
+msgid " Dismiss "
+msgstr " Zanemari "
+
+#: PostgreSQL/postgresql.gpr.py:54
+msgid "Continue"
+msgstr "Nastavi"
+
+#: PostgreSQL/postgresql.py:68
+msgid "Database version"
+msgstr "Verzija baze podatka"
+
+#: PostgreSQL/postgresql.py:69
+msgid "Database module location"
+msgstr "Mjesto modula baze podataka"

--- a/SharedPostgreSQL/po/nl-local.po
+++ b/SharedPostgreSQL/po/nl-local.po
@@ -1,0 +1,74 @@
+# Dutch translation of addon PostgreSQL.
+# Copyright (C) 2020 Gramps project
+# This file is distributed under the same license as the PostgreSQL package.
+# Jan Sparreboom <jan@sparreboom.net>, 2020.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PostgreSQL 5.x\n"
+"Report-Msgid-Bugs-To: https://www.gramps-project.org/bugs\n"
+"POT-Creation-Date: 2019-01-04 18:55-0600\n"
+"PO-Revision-Date: 2020-08-07 14:37+0200\n"
+"Last-Translator: Jan Sparreboom <jan@sparreboom.net>\n"
+"Language-Team: Dutch <gramps-users@lists.sourceforge.net>\n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.3\n"
+
+#: PostgreSQL/postgresql.gpr.py:26
+msgid "PostgreSQL"
+msgstr "PostgreSQL"
+
+#: PostgreSQL/postgresql.gpr.py:27
+msgid "_PostgreSQL Database"
+msgstr "_PostgreSQL Database"
+
+#: PostgreSQL/postgresql.gpr.py:28
+msgid "PostgreSQL Database"
+msgstr "PostgreSQL-database"
+
+#: PostgreSQL/postgresql.gpr.py:42
+msgid "PostgreSQL Warning:  Python psycopg2 module not found."
+msgstr "PostgreSQL-waarschuwing: Python psycopg2-module niet gevonden."
+
+#: PostgreSQL/postgresql.gpr.py:48
+msgid "PostgreSQL Failed to Load"
+msgstr "PostgreSQL kan niet worden geladen"
+
+#: PostgreSQL/postgresql.gpr.py:49
+msgid ""
+"\n"
+"\n"
+"PostgreSQL is missing the psycopg2 python module.\n"
+"For now, it may be possible to install the files manually. See\n"
+"\n"
+"https://gramps-project.org/wiki/index.php?title=PostgreSQL \n"
+"\n"
+"To dismiss all future PostgreSQL warnings click Dismiss."
+msgstr ""
+"\n"
+"\n"
+"PostgreSQL mist de psycopg2 python-module.\n"
+"Voorlopig is het wellicht mogelijk om de bestanden handmatig te installeren. Zie\n"
+"\n"
+"https://gramps-project.org/wiki/index.php?title=PostgreSQL \n"
+"\n"
+"Om alle toekomstige PostgreSQL-waarschuwingen af te wijzen, klikt u op Negeren."
+
+#: PostgreSQL/postgresql.gpr.py:53
+msgid " Dismiss "
+msgstr " Negeren "
+
+#: PostgreSQL/postgresql.gpr.py:54
+msgid "Continue"
+msgstr "Doorgaan"
+
+#: PostgreSQL/postgresql.py:68
+msgid "Database version"
+msgstr "Database versie"
+
+#: PostgreSQL/postgresql.py:69
+msgid "Database module location"
+msgstr "Databasemodule locatie"

--- a/SharedPostgreSQL/po/pt_PT-local.po
+++ b/SharedPostgreSQL/po/pt_PT-local.po
@@ -1,0 +1,74 @@
+# Addon PostgreSQL for Gramps.
+# Copyright (C) 2020 Gramps
+# This file is distributed under the same license as the gramps package.
+# Pedro Albuquerque <pmra@protonmail.com>, 2020.
+msgid ""
+msgstr ""
+"Project-Id-Version: gramps51\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: 2020-04-02 11:09Hora de Verão de GMT\n"
+"Last-Translator: Pedro Albuquerque <pmra@protonmail.com>\n"
+"Language-Team: Pedro Albuquerque\n"
+"Language: pt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Geany / PoHelper 1.36\n"
+
+#: PostgreSQL/postgresql.gpr.py:26
+msgid "PostgreSQL"
+msgstr "PostgreSQL"
+
+#: PostgreSQL/postgresql.gpr.py:27
+msgid "_PostgreSQL Database"
+msgstr "Base de dados _PostgreSQL"
+
+#: PostgreSQL/postgresql.gpr.py:28
+msgid "PostgreSQL Database"
+msgstr "Base de dados PostgreSQL"
+
+#: PostgreSQL/postgresql.gpr.py:42
+msgid "PostgreSQL Warning:  Python psycopg2 module not found."
+msgstr "Aviso PostgreSQL: módulo Python psycopg2não encontrado."
+
+#: PostgreSQL/postgresql.gpr.py:48
+msgid "PostgreSQL Failed to Load"
+msgstr "Falha ao carregar o PostgreSQL"
+
+#: PostgreSQL/postgresql.gpr.py:49
+msgid ""
+"\n"
+"\n"
+"PostgreSQL is missing the psycopg2 python module.\n"
+"For now, it may be possible to install the files manually. See\n"
+"\n"
+"https://gramps-project.org/wiki/index.php?title=PostgreSQL \n"
+"\n"
+"To dismiss all future PostgreSQL warnings click Dismiss."
+msgstr ""
+"\n"
+"\n"
+"O PostgreSQL tem o módulo python psycopg2 em falta.\n"
+"Por agora, é possível instalar os ficheiros manualmente. Veja\n"
+"\n"
+"https://gramps-project.org/wiki/index.php?title=PostgreSQL \n"
+"\n"
+"Para descartar todos os futuros avisos do PostgreSQL clique em Descartar."
+
+#: PostgreSQL/postgresql.gpr.py:53
+msgid " Dismiss "
+msgstr "Descartar"
+
+#: PostgreSQL/postgresql.gpr.py:54
+msgid "Continue"
+msgstr "Continuar"
+
+#: PostgreSQL/postgresql.py:68
+msgid "Database version"
+msgstr "Versão da base de dados"
+
+#: PostgreSQL/postgresql.py:69
+msgid "Database module location"
+msgstr "Localização do módulo da base de dados"

--- a/SharedPostgreSQL/po/ru-local.po
+++ b/SharedPostgreSQL/po/ru-local.po
@@ -1,0 +1,78 @@
+# Russian translation for PostgreSQL
+# This file is distributed under the same license as the Gramps package.
+#
+# Ivan Komaritsyn <vantu5z@mail.ru>, 2018.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: gramps50\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-12-06 09:18+0300\n"
+"PO-Revision-Date: 2018-12-06 09:21+0300\n"
+"Last-Translator: Ivan Komaritsyn <vantu5z@mail.ru>\n"
+"Language-Team: Russian\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Gtranslator 2.91.7\n"
+"X-Poedit-Language: Russian\n"
+"X-Poedit-Country: RUSSIAN FEDERATION\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
+
+#: PostgreSQL/postgresql.gpr.py:26
+msgid "PostgreSQL"
+msgstr "PostgreSQL"
+
+#: PostgreSQL/postgresql.gpr.py:27
+msgid "_PostgreSQL Database"
+msgstr "База данных _PostgreSQL"
+
+#: PostgreSQL/postgresql.gpr.py:28
+msgid "PostgreSQL Database"
+msgstr "База данных PostgreSQL"
+
+#: PostgreSQL/postgresql.gpr.py:42
+msgid "PostgreSQL Warning:  Python psycopg2 module not found."
+msgstr "PostgreSQL ВНИМАНИЕ:  модуль Python psycopg2 не найден."
+
+#: PostgreSQL/postgresql.gpr.py:48
+msgid "PostgreSQL Failed to Load"
+msgstr "Не удалось запустить PostgreSQL"
+
+#: PostgreSQL/postgresql.gpr.py:49
+msgid ""
+"\n"
+"\n"
+"PostgreSQL is missing the psycopg2 python module.\n"
+"For now, it may be possible to install the files manually. See\n"
+"\n"
+"https://gramps-project.org/wiki/index.php?title=PostgreSQL \n"
+"\n"
+"To dismiss all future PostgreSQL warnings click Dismiss."
+msgstr ""
+"\n"
+"\n"
+"PostgreSQL не удалось найти модуль psycopg2 python.\n"
+"На данный момент модуль может быть установлен только вручную.\n"
+"Смотрите\n"
+"https://gramps-project.org/wiki/index.php?title=PostgreSQL \n"
+"\n"
+"Для отключения последующих уведомлений PostgreSQL нажмите 'Отключить'."
+
+#: PostgreSQL/postgresql.gpr.py:53
+msgid " Dismiss "
+msgstr " Отключить "
+
+#: PostgreSQL/postgresql.gpr.py:54
+msgid "Continue"
+msgstr "Продолжить"
+
+#: PostgreSQL/postgresql.py:68
+msgid "Database version"
+msgstr "Версия базы данных"
+
+#: PostgreSQL/postgresql.py:69
+msgid "Database module location"
+msgstr "Расположение модуля базы данных"

--- a/SharedPostgreSQL/po/template.pot
+++ b/SharedPostgreSQL/po/template.pot
@@ -1,0 +1,66 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-01-22 09:28-0600\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: PostgreSQL/postgresql.gpr.py:26
+msgid "PostgreSQL"
+msgstr ""
+
+#: PostgreSQL/postgresql.gpr.py:27
+msgid "_PostgreSQL Database"
+msgstr ""
+
+#: PostgreSQL/postgresql.gpr.py:28
+msgid "PostgreSQL Database"
+msgstr ""
+
+#: PostgreSQL/postgresql.gpr.py:42
+msgid "PostgreSQL Warning:  Python psycopg2 module not found."
+msgstr ""
+
+#: PostgreSQL/postgresql.gpr.py:48
+msgid "PostgreSQL Failed to Load"
+msgstr ""
+
+#: PostgreSQL/postgresql.gpr.py:49
+msgid ""
+"\n"
+"\n"
+"PostgreSQL is missing the psycopg2 python module.\n"
+"For now, it may be possible to install the files manually. See\n"
+"\n"
+"https://gramps-project.org/wiki/index.php?title=PostgreSQL \n"
+"\n"
+"To dismiss all future PostgreSQL warnings click Dismiss."
+msgstr ""
+
+#: PostgreSQL/postgresql.gpr.py:53
+msgid " Dismiss "
+msgstr ""
+
+#: PostgreSQL/postgresql.gpr.py:54
+msgid "Continue"
+msgstr ""
+
+#: PostgreSQL/postgresql.py:68
+msgid "Database version"
+msgstr ""
+
+#: PostgreSQL/postgresql.py:69
+msgid "Database module location"
+msgstr ""

--- a/SharedPostgreSQL/shareddbapi.py
+++ b/SharedPostgreSQL/shareddbapi.py
@@ -1,0 +1,1296 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2015-2016 Douglas S. Blank <doug.blank@gmail.com>
+# Copyright (C) 2016-2017 Nick Hall
+# Copyright (C) 2022 David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+# -------------------------------------------------------------------------
+#
+# Standard python modules
+#
+# -------------------------------------------------------------------------
+import time
+import pickle
+import logging
+
+# ------------------------------------------------------------------------
+#
+# Gramps Modules
+#
+# ------------------------------------------------------------------------
+from gramps.gen.db.dbconst import (
+    DBLOGNAME,
+    DBBACKEND,
+    KEY_TO_NAME_MAP,
+    KEY_TO_CLASS_MAP,
+    TXNADD,
+    TXNUPD,
+    TXNDEL,
+    PERSON_KEY,
+    FAMILY_KEY,
+    SOURCE_KEY,
+    EVENT_KEY,
+    MEDIA_KEY,
+    PLACE_KEY,
+    NOTE_KEY,
+    TAG_KEY,
+    CITATION_KEY,
+    REPOSITORY_KEY,
+    REFERENCE_KEY,
+)
+from gramps.gen.db.generic import DbGeneric
+from gramps.gen.updatecallback import UpdateCallback
+from gramps.gen.lib import (
+    Tag,
+    Media,
+    Person,
+    Family,
+    Source,
+    Citation,
+    Event,
+    Place,
+    Repository,
+    Note,
+)
+from gramps.gen.lib.genderstats import GenderStats
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+
+LOG = logging.getLogger(".shareddbapi")
+_LOG = logging.getLogger(DBLOGNAME)
+
+
+class SharedDBAPI(DbGeneric):
+    """
+    Database backends class for DB-API 2.0 databases
+    """
+
+    def _initialize(self, directory, username, password):
+        raise NotImplementedError
+
+    def _schema_exists(self):
+        """
+        Check to see if the schema exists.
+
+        We use the existence of the person table as a proxy for the database
+        being new.
+        """
+        return self.dbapi.table_exists("trees")
+
+    def _create_schema(self):
+        """
+        Create and update schema.
+        """
+        self.dbapi.begin()
+
+        # make sure schema is up to date:
+        self.dbapi.execute(
+            "CREATE TABLE trees "
+            "("
+            "treeid INTEGER PRIMARY KEY, "
+            "uuid VARCHAR(50) UNIQUE NOT NULL"
+            ")"
+        )
+        self.dbapi.execute(
+            "CREATE TABLE person "
+            "("
+            "treeid INTEGER NOT NULL, "
+            "handle VARCHAR(50) NOT NULL, "
+            "PRIMARY KEY (treeid, handle), "
+            "given_name TEXT, "
+            "surname TEXT, "
+            "blob_data BLOB"
+            ")"
+        )
+        self.dbapi.execute(
+            "CREATE TABLE family "
+            "("
+            "treeid INTEGER NOT NULL, "
+            "handle VARCHAR(50) NOT NULL, "
+            "PRIMARY KEY (treeid, handle), "
+            "blob_data BLOB"
+            ")"
+        )
+        self.dbapi.execute(
+            "CREATE TABLE source "
+            "("
+            "treeid INTEGER NOT NULL, "
+            "handle VARCHAR(50) NOT NULL, "
+            "PRIMARY KEY (treeid, handle), "
+            "blob_data BLOB"
+            ")"
+        )
+        self.dbapi.execute(
+            "CREATE TABLE citation "
+            "("
+            "treeid INTEGER NOT NULL, "
+            "handle VARCHAR(50) NOT NULL, "
+            "PRIMARY KEY (treeid, handle), "
+            "blob_data BLOB"
+            ")"
+        )
+        self.dbapi.execute(
+            "CREATE TABLE event "
+            "("
+            "treeid INTEGER NOT NULL, "
+            "handle VARCHAR(50) NOT NULL, "
+            "PRIMARY KEY (treeid, handle), "
+            "blob_data BLOB"
+            ")"
+        )
+        self.dbapi.execute(
+            "CREATE TABLE media "
+            "("
+            "treeid INTEGER NOT NULL, "
+            "handle VARCHAR(50) NOT NULL, "
+            "PRIMARY KEY (treeid, handle), "
+            "blob_data BLOB"
+            ")"
+        )
+        self.dbapi.execute(
+            "CREATE TABLE place "
+            "("
+            "treeid INTEGER NOT NULL, "
+            "handle VARCHAR(50) NOT NULL, "
+            "PRIMARY KEY (treeid, handle), "
+            "enclosed_by VARCHAR(50), "
+            "blob_data BLOB"
+            ")"
+        )
+        self.dbapi.execute(
+            "CREATE TABLE repository "
+            "("
+            "treeid INTEGER NOT NULL, "
+            "handle VARCHAR(50) NOT NULL, "
+            "PRIMARY KEY (treeid, handle), "
+            "blob_data BLOB"
+            ")"
+        )
+        self.dbapi.execute(
+            "CREATE TABLE note "
+            "("
+            "treeid INTEGER NOT NULL, "
+            "handle VARCHAR(50) NOT NULL, "
+            "PRIMARY KEY (treeid, handle), "
+            "blob_data BLOB"
+            ")"
+        )
+        self.dbapi.execute(
+            "CREATE TABLE tag "
+            "("
+            "treeid INTEGER NOT NULL, "
+            "handle VARCHAR(50) NOT NULL, "
+            "PRIMARY KEY (treeid, handle), "
+            "blob_data BLOB"
+            ")"
+        )
+        # Secondary:
+        self.dbapi.execute(
+            "CREATE TABLE reference "
+            "("
+            "treeid INTEGER, "
+            "obj_handle VARCHAR(50), "
+            "obj_class TEXT, "
+            "ref_handle VARCHAR(50), "
+            "ref_class TEXT"
+            ")"
+        )
+        self.dbapi.execute(
+            "CREATE TABLE name_group "
+            "("
+            "treeid INTEGER NOT NULL, "
+            "name VARCHAR(50) NOT NULL, "
+            "PRIMARY KEY (treeid, name), "
+            "grouping TEXT"
+            ")"
+        )
+        self.dbapi.execute(
+            "CREATE TABLE metadata "
+            "("
+            "treeid INTEGER NOT NULL, "
+            "setting VARCHAR(50) NOT NULL, "
+            "PRIMARY KEY (treeid, setting), "
+            "value BLOB"
+            ")"
+        )
+        self.dbapi.execute(
+            "CREATE TABLE gender_stats "
+            "("
+            "treeid INTEGER NOT NULL, "
+            "given_name TEXT, "
+            "female INTEGER, "
+            "male INTEGER, "
+            "unknown INTEGER"
+            ")"
+        )
+
+        self._create_secondary_columns()
+
+        ## Indices:
+        self.dbapi.execute(
+            "CREATE INDEX person_gramps_id " "ON person(treeid,gramps_id)"
+        )
+        self.dbapi.execute("CREATE INDEX person_surname " "ON person(treeid,surname)")
+        self.dbapi.execute(
+            "CREATE INDEX person_given_name " "ON person(treeid,given_name)"
+        )
+        self.dbapi.execute("CREATE INDEX source_title " "ON source(treeid,title)")
+        self.dbapi.execute(
+            "CREATE INDEX source_gramps_id " "ON source(treeid,gramps_id)"
+        )
+        self.dbapi.execute("CREATE INDEX citation_page " "ON citation(treeid,page)")
+        self.dbapi.execute(
+            "CREATE INDEX citation_gramps_id " "ON citation(treeid,gramps_id)"
+        )
+        self.dbapi.execute("CREATE INDEX media_desc " "ON media(treeid,desc)")
+        self.dbapi.execute("CREATE INDEX media_gramps_id " "ON media(treeid,gramps_id)")
+        self.dbapi.execute("CREATE INDEX place_title " "ON place(treeid,title)")
+        self.dbapi.execute(
+            "CREATE INDEX place_enclosed_by " "ON place(treeid,enclosed_by)"
+        )
+        self.dbapi.execute("CREATE INDEX place_gramps_id " "ON place(treeid,gramps_id)")
+        self.dbapi.execute("CREATE INDEX tag_name " "ON tag(treeid,name)")
+        self.dbapi.execute(
+            "CREATE INDEX reference_ref_handle " "ON reference(treeid,ref_handle)"
+        )
+        self.dbapi.execute(
+            "CREATE INDEX family_gramps_id " "ON family(treeid,gramps_id)"
+        )
+        self.dbapi.execute("CREATE INDEX event_gramps_id " "ON event(treeid,gramps_id)")
+        self.dbapi.execute(
+            "CREATE INDEX repository_gramps_id " "ON repository(treeid,gramps_id)"
+        )
+        self.dbapi.execute("CREATE INDEX note_gramps_id " "ON note(treeid,gramps_id)")
+        self.dbapi.execute(
+            "CREATE INDEX reference_obj_handle " "ON reference(treeid,obj_handle)"
+        )
+
+        self.dbapi.commit()
+
+    def _close(self):
+        self.dbapi.close()
+
+    def _txn_begin(self):
+        """
+        Lowlevel interface to the backend transaction.
+        Executes a db BEGIN;
+        """
+        if self.transaction == None:
+            _LOG.debug("    DBAPI %s transaction begin", hex(id(self)))
+            self.dbapi.begin()
+
+    def _txn_commit(self):
+        """
+        Lowlevel interface to the backend transaction.
+        Executes a db END;
+        """
+        if self.transaction == None:
+            _LOG.debug("    DBAPI %s transaction commit", hex(id(self)))
+            self.dbapi.commit()
+
+    def _txn_abort(self):
+        """
+        Lowlevel interface to the backend transaction.
+        Executes a db ROLLBACK;
+        """
+        if self.transaction == None:
+            self.dbapi.rollback()
+
+    def transaction_begin(self, transaction):
+        """
+        Transactions are handled automatically by the db layer.
+        """
+        _LOG.debug(
+            "    %sDBAPI %s transaction begin for '%s'",
+            "Batch " if transaction.batch else "",
+            hex(id(self)),
+            transaction.get_description(),
+        )
+        if transaction.batch:
+            # A batch transaction does not store the commits
+            # Aborting the session completely will become impossible.
+            self.abort_possible = False
+        self.transaction = transaction
+        self.dbapi.begin()
+        return transaction
+
+    def transaction_commit(self, txn):
+        """
+        Executed at the end of a transaction.
+        """
+        _LOG.debug(
+            "    %sDBAPI %s transaction commit for '%s'",
+            "Batch " if txn.batch else "",
+            hex(id(self)),
+            txn.get_description(),
+        )
+
+        action = {TXNADD: "-add", TXNUPD: "-update", TXNDEL: "-delete", None: "-delete"}
+        if txn.batch:
+            # FIXME: need a User GUI update callback here:
+            self.reindex_reference_map(lambda percent: percent)
+        self.dbapi.commit()
+        if not txn.batch:
+            # Now, emit signals:
+            # do deletes and adds first
+            for trans_type in [TXNDEL, TXNADD, TXNUPD]:
+                for obj_type in range(11):
+                    if obj_type != REFERENCE_KEY and (obj_type, trans_type) in txn:
+                        if trans_type == TXNDEL:
+                            handles = [
+                                handle for (handle, data) in txn[(obj_type, trans_type)]
+                            ]
+                        else:
+                            handles = [
+                                handle
+                                for (handle, data) in txn[(obj_type, trans_type)]
+                                if (handle, None) not in txn[(obj_type, TXNDEL)]
+                            ]
+                        if handles:
+                            signal = KEY_TO_NAME_MAP[obj_type] + action[trans_type]
+                            self.emit(signal, (handles,))
+        self.transaction = None
+        msg = txn.get_description()
+        self.undodb.commit(txn, msg)
+        self._after_commit(txn)
+        txn.clear()
+        self.has_changed += 1  # Also gives commits since startup
+
+    def transaction_abort(self, txn):
+        """
+        Executed after a batch operation abort.
+        """
+        self.dbapi.rollback()
+        self.transaction = None
+        txn.clear()
+        txn.first = None
+        txn.last = None
+        self._after_commit(txn)
+
+    def _get_metadata(self, key, default=[]):
+        """
+        Get an item from the database.
+
+        Default is an empty list, which is a mutable and
+        thus a bad default (pylint will complain).
+
+        However, it is just used as a value, and not altered, so
+        its use here is ok.
+        """
+        self.dbapi.execute(
+            "SELECT value FROM metadata WHERE setting = ? AND treeid = ?",
+            [key, self.dbapi.treeid],
+        )
+        row = self.dbapi.fetchone()
+        if row:
+            return pickle.loads(row[0])
+        elif default == []:
+            return []
+        else:
+            return default
+
+    def _set_metadata(self, key, value):
+        """
+        key: string
+        value: item, will be serialized here
+        """
+        self._txn_begin()
+        self.dbapi.execute(
+            "SELECT 1 FROM metadata WHERE setting = ? AND treeid = ?",
+            [key, self.dbapi.treeid],
+        )
+        row = self.dbapi.fetchone()
+        if row:
+            self.dbapi.execute(
+                "UPDATE metadata SET value = ? WHERE setting = ? AND treeid = ?",
+                [pickle.dumps(value), key, self.dbapi.treeid],
+            )
+        else:
+            self.dbapi.execute(
+                "INSERT INTO metadata (treeid, setting, value) VALUES (?, ?, ?)",
+                [self.dbapi.treeid, key, pickle.dumps(value)],
+            )
+        self._txn_commit()
+
+    def get_name_group_keys(self):
+        """
+        Return the defined names that have been assigned to a default grouping.
+        """
+        self.dbapi.execute(
+            "SELECT name, grouping FROM name_group WHERE treeid = ? ORDER BY name",
+            [self.dbapi.treeid],
+        )
+        rows = self.dbapi.fetchall()
+        # not None test below fixes db corrupted by 11011 for export
+        return [row[0] for row in rows if row[1] is not None]
+
+    def get_name_group_mapping(self, key):
+        """
+        Return the default grouping name for a surname.
+        """
+        self.dbapi.execute(
+            "SELECT grouping FROM name_group WHERE name = ? AND treeid = ?",
+            [key, self.dbapi.treeid],
+        )
+        row = self.dbapi.fetchone()
+        if row and row[0] is not None:
+            # not None test fixes db corrupted by 11011
+            return row[0]
+        else:
+            return key
+
+    def get_person_handles(self, sort_handles=False, locale=glocale):
+        """
+        Return a list of database handles, one handle for each Person in
+        the database.
+
+        :param sort_handles: If True, the list is sorted by surnames.
+        :type sort_handles: bool
+        :param locale: The locale to use for collation.
+        :type locale: A GrampsLocale object.
+        """
+        if sort_handles:
+            if locale != glocale:
+                self.dbapi.check_collation(locale)
+
+            self.dbapi.execute(
+                "SELECT handle FROM person "
+                "WHERE treeid = ? "
+                "ORDER BY surname "
+                'COLLATE "%s"' % locale.get_collation(),
+                [self.dbapi.treeid],
+            )
+        else:
+            self.dbapi.execute(
+                "SELECT handle FROM person WHERE treeid = ?", [self.dbapi.treeid]
+            )
+        rows = self.dbapi.fetchall()
+        return [row[0] for row in rows]
+
+    def get_family_handles(self, sort_handles=False, locale=glocale):
+        """
+        Return a list of database handles, one handle for each Family in
+        the database.
+
+        :param sort_handles: If True, the list is sorted by surnames.
+        :type sort_handles: bool
+        :param locale: The locale to use for collation.
+        :type locale: A GrampsLocale object.
+        """
+        if sort_handles:
+            if locale != glocale:
+                self.dbapi.check_collation(locale)
+
+            sql = (
+                "SELECT family.handle "
+                + "FROM family "
+                + "WHERE family.treeid = ?"
+                + "LEFT JOIN person AS father "
+                + "ON (family.father_handle = father.handle AND family.treeid = father.treeid) "
+                + "LEFT JOIN person AS mother "
+                + "ON (family.mother_handle = mother.handle AND family.treeid = mother.treeid)"
+                + "ORDER BY (CASE WHEN father.handle IS NULL "
+                + "THEN mother.surname "
+                + "ELSE father.surname "
+                + "END), "
+                + "(CASE WHEN family.handle IS NULL "
+                + "THEN mother.given_name "
+                + "ELSE father.given_name "
+                + "END) "
+                + 'COLLATE "%s"' % locale.get_collation()
+            )
+            self.dbapi.execute(sql, [self.dbapi.treeid])
+        else:
+            self.dbapi.execute(
+                "SELECT handle FROM family WHERE treeid = ?", [self.dbapi.treeid]
+            )
+        rows = self.dbapi.fetchall()
+        return [row[0] for row in rows]
+
+    def get_event_handles(self):
+        """
+        Return a list of database handles, one handle for each Event in the
+        database.
+        """
+        self.dbapi.execute(
+            "SELECT handle FROM event WHERE treeid = ?", [self.dbapi.treeid]
+        )
+        rows = self.dbapi.fetchall()
+        return [row[0] for row in rows]
+
+    def get_citation_handles(self, sort_handles=False, locale=glocale):
+        """
+        Return a list of database handles, one handle for each Citation in
+        the database.
+
+        :param sort_handles: If True, the list is sorted by Citation title.
+        :type sort_handles: bool
+        :param locale: The locale to use for collation.
+        :type locale: A GrampsLocale object.
+        """
+        if sort_handles:
+            if locale != glocale:
+                self.dbapi.check_collation(locale)
+
+            self.dbapi.execute(
+                "SELECT handle FROM citation "
+                "WHERE treeid = ? "
+                "ORDER BY page "
+                'COLLATE "%s"' % locale.get_collation(),
+                [self.dbapi.treeid],
+            )
+        else:
+            self.dbapi.execute(
+                "SELECT handle FROM citation WHERE treeid = ?", [self.dbapi.treeid]
+            )
+        rows = self.dbapi.fetchall()
+        return [row[0] for row in rows]
+
+    def get_source_handles(self, sort_handles=False, locale=glocale):
+        """
+        Return a list of database handles, one handle for each Source in
+        the database.
+
+        :param sort_handles: If True, the list is sorted by Source title.
+        :type sort_handles: bool
+        :param locale: The locale to use for collation.
+        :type locale: A GrampsLocale object.
+        """
+        if sort_handles:
+            if locale != glocale:
+                self.dbapi.check_collation(locale)
+
+            self.dbapi.execute(
+                "SELECT handle FROM source "
+                "WHERE treeid = ? "
+                "ORDER BY title "
+                'COLLATE "%s"' % locale.get_collation(),
+                [self.dbapi.treeid],
+            )
+        else:
+            self.dbapi.execute(
+                "SELECT handle from source WHERE treeid = ?", [self.dbapi.treeid]
+            )
+        rows = self.dbapi.fetchall()
+        return [row[0] for row in rows]
+
+    def get_place_handles(self, sort_handles=False, locale=glocale):
+        """
+        Return a list of database handles, one handle for each Place in
+        the database.
+
+        :param sort_handles: If True, the list is sorted by Place title.
+        :type sort_handles: bool
+        :param locale: The locale to use for collation.
+        :type locale: A GrampsLocale object.
+        """
+        if sort_handles:
+            if locale != glocale:
+                self.dbapi.check_collation(locale)
+
+            self.dbapi.execute(
+                "SELECT handle FROM place "
+                "WHERE treeid = ? "
+                "ORDER BY title "
+                'COLLATE "%s"' % locale.get_collation(),
+                [self.dbapi.treeid],
+            )
+        else:
+            self.dbapi.execute(
+                "SELECT handle FROM place WHERE treeid = ?", [self.dbapi.treeid]
+            )
+        rows = self.dbapi.fetchall()
+        return [row[0] for row in rows]
+
+    def get_repository_handles(self):
+        """
+        Return a list of database handles, one handle for each Repository in
+        the database.
+        """
+        self.dbapi.execute(
+            "SELECT handle FROM repository WHERE treeid = ?", [self.dbapi.treeid]
+        )
+        rows = self.dbapi.fetchall()
+        return [row[0] for row in rows]
+
+    def get_media_handles(self, sort_handles=False, locale=glocale):
+        """
+        Return a list of database handles, one handle for each Media in
+        the database.
+
+        :param sort_handles: If True, the list is sorted by title.
+        :type sort_handles: bool
+        :param locale: The locale to use for collation.
+        :type locale: A GrampsLocale object.
+        """
+        if sort_handles:
+            if locale != glocale:
+                self.dbapi.check_collation(locale)
+
+            self.dbapi.execute(
+                "SELECT handle FROM media "
+                "WHERE treeid = ? "
+                "ORDER BY desc "
+                'COLLATE "%s"' % locale.get_collation(),
+                [self.dbapi.treeid],
+            )
+        else:
+            self.dbapi.execute(
+                "SELECT handle FROM media WHERE treeid = ?", [self.dbapi.treeid]
+            )
+        rows = self.dbapi.fetchall()
+        return [row[0] for row in rows]
+
+    def get_note_handles(self):
+        """
+        Return a list of database handles, one handle for each Note in the
+        database.
+        """
+        self.dbapi.execute(
+            "SELECT handle FROM note WHERE treeid = ?", [self.dbapi.treeid]
+        )
+        rows = self.dbapi.fetchall()
+        return [row[0] for row in rows]
+
+    def get_tag_handles(self, sort_handles=False, locale=glocale):
+        """
+        Return a list of database handles, one handle for each Tag in
+        the database.
+
+        :param sort_handles: If True, the list is sorted by Tag name.
+        :type sort_handles: bool
+        :param locale: The locale to use for collation.
+        :type locale: A GrampsLocale object.
+        """
+        if sort_handles:
+            if locale != glocale:
+                self.dbapi.check_collation(locale)
+
+            self.dbapi.execute(
+                "SELECT handle FROM tag "
+                "WHERE treeid = ? "
+                "ORDER BY name "
+                'COLLATE "%s"' % locale.get_collation(),
+                [self.dbapi.treeid],
+            )
+        else:
+            self.dbapi.execute(
+                "SELECT handle FROM tag WHERE treeid = ?", [self.dbapi.treeid]
+            )
+        rows = self.dbapi.fetchall()
+        return [row[0] for row in rows]
+
+    def get_tag_from_name(self, name):
+        """
+        Find a Tag in the database from the passed Tag name.
+
+        If no such Tag exists, None is returned.
+        """
+        self.dbapi.execute(
+            "SELECT blob_data FROM tag WHERE name = ? AND treeid = ?",
+            [name, self.dbapi.treeid],
+        )
+        row = self.dbapi.fetchone()
+        if row:
+            return Tag.create(pickle.loads(row[0]))
+        return None
+
+    def _get_number_of(self, obj_key):
+        table = KEY_TO_NAME_MAP[obj_key]
+        sql = "SELECT count(1) FROM %s WHERE treeid = ?" % table
+        self.dbapi.execute(sql, [self.dbapi.treeid])
+        row = self.dbapi.fetchone()
+        return row[0]
+
+    def has_name_group_key(self, key):
+        """
+        Return if a key exists in the name_group table.
+        """
+        self.dbapi.execute(
+            "SELECT grouping FROM name_group WHERE name = ? AND treeid = ?",
+            [key, self.dbapi.treeid],
+        )
+        row = self.dbapi.fetchone()
+        return row and row[0] is not None
+
+    def set_name_group_mapping(self, name, grouping):
+        """
+        Set the default grouping name for a surname.
+        """
+        self._txn_begin()
+        self.dbapi.execute(
+            "SELECT 1 FROM name_group WHERE name = ? AND treeid = ?",
+            [name, self.dbapi.treeid],
+        )
+        row = self.dbapi.fetchone()
+        if row and grouping is not None:
+            self.dbapi.execute(
+                "UPDATE name_group SET grouping=? WHERE name = ? AND treeid = ?",
+                [grouping, name, self.dbapi.treeid],
+            )
+        elif row and grouping is None:
+            self.dbapi.execute(
+                "DELETE FROM name_group WHERE name = ?  AND treeid = ?",
+                [name, self.dbapi.treeid],
+            )
+            grouping = ""
+        else:
+            self.dbapi.execute(
+                "INSERT INTO name_group (treeid, name, grouping) VALUES (?, ?, ?)",
+                [self.dbapi.treeid, name, grouping],
+            )
+        self._txn_commit()
+        self.emit("person-groupname-rebuild", (name, grouping))
+
+    def _commit_base(self, obj, obj_key, trans, change_time):
+        """
+        Commit the specified object to the database, storing the changes as
+        part of the transaction.
+        """
+        old_data = None
+        obj.change = int(change_time or time.time())
+        table = KEY_TO_NAME_MAP[obj_key]
+
+        if self._has_handle(obj_key, obj.handle):
+            old_data = self._get_raw_data(obj_key, obj.handle)
+            # update the object:
+            sql = "UPDATE %s SET blob_data = ? WHERE handle = ? AND treeid = ?" % table
+            self.dbapi.execute(
+                sql, [pickle.dumps(obj.serialize()), obj.handle, self.dbapi.treeid]
+            )
+        else:
+            # Insert the object:
+            sql = (
+                "INSERT INTO %s (treeid, handle, blob_data) VALUES (?, ?, ?)"
+            ) % table
+            self.dbapi.execute(
+                sql, [self.dbapi.treeid, obj.handle, pickle.dumps(obj.serialize())]
+            )
+        self._update_secondary_values(obj)
+        if not trans.batch:
+            self._update_backlinks(obj, trans)
+            if old_data:
+                trans.add(obj_key, TXNUPD, obj.handle, old_data, obj.serialize())
+            else:
+                trans.add(obj_key, TXNADD, obj.handle, None, obj.serialize())
+
+        return old_data
+
+    def _commit_raw(self, data, obj_key):
+        """
+        Commit a serialized primary object to the database, storing the
+        changes as part of the transaction.
+        """
+        table = KEY_TO_NAME_MAP[obj_key]
+        handle = data[0]
+
+        if self._has_handle(obj_key, handle):
+            # update the object:
+            sql = "UPDATE %s SET blob_data = ? WHERE handle = ? AND treeid = ?" % table
+            self.dbapi.execute(sql, [pickle.dumps(data), handle, self.dbapi.treeid])
+        else:
+            # Insert the object:
+            sql = ("INSERT INTO %s (treeid, handle, blob_data) VALUES (?, ?)") % table
+            self.dbapi.execute(sql, [self.dbapi.treeid, handle, pickle.dumps(data)])
+
+        return
+
+    def _update_backlinks(self, obj, transaction):
+
+        # Find existing references
+        sql = "SELECT ref_class, ref_handle FROM reference WHERE obj_handle = ? AND treeid = ?"
+        self.dbapi.execute(sql, [obj.handle, self.dbapi.treeid])
+        existing_references = set(self.dbapi.fetchall())
+
+        # Once we have the list of rows that already have a reference
+        # we need to compare it with the list of objects that are
+        # still references from the primary object.
+        current_references = set(obj.get_referenced_handles_recursively())
+        no_longer_required_references = existing_references.difference(
+            current_references
+        )
+        new_references = current_references.difference(existing_references)
+
+        # Delete the existing references
+        self.dbapi.execute(
+            "DELETE FROM reference WHERE obj_handle = ? AND treeid = ?",
+            [obj.handle, self.dbapi.treeid],
+        )
+
+        # Now, add the current ones
+        for (ref_class_name, ref_handle) in current_references:
+            sql = (
+                "INSERT INTO reference "
+                + "(treeid, obj_handle, obj_class, ref_handle, ref_class)"
+                + "VALUES(?, ?, ?, ?, ?)"
+            )
+            self.dbapi.execute(
+                sql,
+                [
+                    self.dbapi.treeid,
+                    obj.handle,
+                    obj.__class__.__name__,
+                    ref_handle,
+                    ref_class_name,
+                ],
+            )
+
+        if not transaction.batch:
+            # Add new references to the transaction
+            for (ref_class_name, ref_handle) in new_references:
+                key = (obj.handle, ref_handle)
+                data = (obj.handle, obj.__class__.__name__, ref_handle, ref_class_name)
+                transaction.add(REFERENCE_KEY, TXNADD, key, None, data)
+
+            # Add old references to the transaction
+            for (ref_class_name, ref_handle) in no_longer_required_references:
+                key = (obj.handle, ref_handle)
+                old_data = (
+                    obj.handle,
+                    obj.__class__.__name__,
+                    ref_handle,
+                    ref_class_name,
+                )
+                transaction.add(REFERENCE_KEY, TXNDEL, key, old_data, None)
+
+    def _do_remove(self, handle, transaction, obj_key):
+        if self.readonly or not handle:
+            return
+        if self._has_handle(obj_key, handle):
+            data = self._get_raw_data(obj_key, handle)
+            obj_class = KEY_TO_CLASS_MAP[obj_key]
+            self._remove_backlinks(obj_class, handle, transaction)
+            table = KEY_TO_NAME_MAP[obj_key]
+            sql = "DELETE FROM %s WHERE handle = ? AND treeid = ?" % table
+            self.dbapi.execute(sql, [handle, self.dbapi.treeid])
+            if not transaction.batch:
+                transaction.add(obj_key, TXNDEL, handle, data, None)
+
+    def _remove_backlinks(self, obj_class, obj_handle, transaction):
+        """
+        Removes all references from this object (backlinks).
+        """
+        # collect backlinks from this object for undo
+        self.dbapi.execute(
+            "SELECT ref_class, ref_handle FROM reference WHERE obj_handle = ? AND treeid = ?",
+            [obj_handle, self.dbapi.treeid],
+        )
+        rows = self.dbapi.fetchall()
+        # Now, delete backlinks from this object:
+        self.dbapi.execute(
+            "DELETE FROM reference WHERE obj_handle = ? AND treeid = ?;",
+            [obj_handle, self.dbapi.treeid],
+        )
+        # Add old references to the transaction
+        if not transaction.batch:
+            for (ref_class_name, ref_handle) in rows:
+                key = (obj_handle, ref_handle)
+                old_data = (obj_handle, obj_class, ref_handle, ref_class_name)
+                transaction.add(REFERENCE_KEY, TXNDEL, key, old_data, None)
+
+    def find_backlink_handles(self, handle, include_classes=None):
+        """
+        Find all objects that hold a reference to the object handle.
+
+        Returns an interator over a list of (class_name, handle) tuples.
+
+        :param handle: handle of the object to search for.
+        :type handle: database handle
+        :param include_classes: list of class names to include in the results.
+            Default: None means include all classes.
+        :type include_classes: list of class names
+
+        Note that this is a generator function, it returns a iterator for
+        use in loops. If you want a list of the results use::
+
+            result_list = list(find_backlink_handles(handle))
+        """
+        self.dbapi.execute(
+            "SELECT obj_class, obj_handle FROM reference WHERE ref_handle = ? AND treeid = ?",
+            [handle, self.dbapi.treeid],
+        )
+        rows = self.dbapi.fetchall()
+        for row in rows:
+            if (include_classes is None) or (row[0] in include_classes):
+                yield (row[0], row[1])
+
+    def find_initial_person(self):
+        """
+        Returns first person in the database
+        """
+        handle = self.get_default_handle()
+        person = None
+        if handle:
+            person = self.get_person_from_handle(handle)
+            if person:
+                return person
+        self.dbapi.execute(
+            "SELECT handle FROM person WHERE treeid = ?", [self.dbapi.treeid]
+        )
+        row = self.dbapi.fetchone()
+        if row:
+            return self.get_person_from_handle(row[0])
+
+    def _iter_handles(self, obj_key):
+        """
+        Return an iterator over handles in the database
+        """
+        table = KEY_TO_NAME_MAP[obj_key]
+        sql = "SELECT handle FROM %s WHERE treeid = ?" % table
+        self.dbapi.execute(sql, [self.dbapi.treeid])
+        rows = self.dbapi.fetchall()
+        for row in rows:
+            yield row[0]
+
+    def _iter_raw_data(self, obj_key):
+        """
+        Return an iterator over raw data in the database.
+        """
+        table = KEY_TO_NAME_MAP[obj_key]
+        sql = "SELECT handle, blob_data FROM %s WHERE treeid = ?" % table
+        with self.dbapi.cursor() as cursor:
+            cursor.execute(sql, [self.dbapi.treeid])
+            rows = cursor.fetchmany()
+            while rows:
+                for row in rows:
+                    yield (row[0], pickle.loads(row[1]))
+                rows = cursor.fetchmany()
+
+    def _iter_raw_place_tree_data(self):
+        """
+        Return an iterator over raw data in the place hierarchy.
+        """
+        to_do = [""]
+        sql = "SELECT handle, blob_data FROM place WHERE enclosed_by = ? AND treeid = ?"
+        while to_do:
+            handle = to_do.pop()
+            self.dbapi.execute(sql, [handle, self.dbapi.treeid])
+            rows = self.dbapi.fetchall()
+            for row in rows:
+                to_do.append(row[0])
+                yield (row[0], pickle.loads(row[1]))
+
+    def reindex_reference_map(self, callback):
+        """
+        Reindex all primary records in the database.
+        """
+        self._txn_begin()
+        self.dbapi.execute(
+            "DELETE FROM reference WHERE treeid = ?", [self.dbapi.treeid]
+        )
+        total = 0
+        for tbl in (
+            "people",
+            "families",
+            "events",
+            "places",
+            "sources",
+            "citations",
+            "media",
+            "repositories",
+            "notes",
+            "tags",
+        ):
+            total += self.method("get_number_of_%s", tbl)()
+        UpdateCallback.__init__(self, callback)
+        self.set_total(total)
+        primary_table = (
+            (self.get_person_cursor, Person),
+            (self.get_family_cursor, Family),
+            (self.get_event_cursor, Event),
+            (self.get_place_cursor, Place),
+            (self.get_source_cursor, Source),
+            (self.get_citation_cursor, Citation),
+            (self.get_media_cursor, Media),
+            (self.get_repository_cursor, Repository),
+            (self.get_note_cursor, Note),
+            (self.get_tag_cursor, Tag),
+        )
+        # Now we use the functions and classes defined above
+        # to loop through each of the primary object tables.
+        for cursor_func, class_func in primary_table:
+            logging.info("Rebuilding %s reference map", class_func.__name__)
+            with cursor_func() as cursor:
+                for found_handle, val in cursor:
+                    obj = class_func.create(val)
+                    references = set(obj.get_referenced_handles_recursively())
+                    # handle addition of new references
+                    for (ref_class_name, ref_handle) in references:
+                        self.dbapi.execute(
+                            "INSERT INTO reference "
+                            "(treeid, obj_handle, obj_class, ref_handle, ref_class) "
+                            "VALUES (?, ?, ?, ?, ?)",
+                            [
+                                self.dbapi.treeid,
+                                obj.handle,
+                                obj.__class__.__name__,
+                                ref_handle,
+                                ref_class_name,
+                            ],
+                        )
+                    self.update()
+        self._txn_commit()
+
+    def rebuild_secondary(self, callback=None):
+        """
+        Rebuild secondary indices
+        """
+        if self.readonly:
+            return
+
+        total = 0
+        for tbl in (
+            "people",
+            "families",
+            "events",
+            "places",
+            "sources",
+            "citations",
+            "media",
+            "repositories",
+            "notes",
+            "tags",
+        ):
+            total += self.method("get_number_of_%s", tbl)()
+        UpdateCallback.__init__(self, callback)
+        self.set_total(total)
+
+        # First, expand blob to individual fields:
+        self._txn_begin()
+        for obj_type in (
+            "Person",
+            "Family",
+            "Event",
+            "Place",
+            "Repository",
+            "Source",
+            "Citation",
+            "Media",
+            "Note",
+            "Tag",
+        ):
+            for handle in self.method("get_%s_handles", obj_type)():
+                obj = self.method("get_%s_from_handle", obj_type)(handle)
+                self._update_secondary_values(obj)
+                self.update()
+        self._txn_commit()
+
+        # Next, rebuild stats:
+        gstats = self.get_gender_stats()
+        self.genderStats = GenderStats(gstats)
+
+    def _has_handle(self, obj_key, handle):
+        table = KEY_TO_NAME_MAP[obj_key]
+        sql = "SELECT 1 FROM %s WHERE handle = ? AND treeid = ?" % table
+        self.dbapi.execute(sql, [handle, self.dbapi.treeid])
+        return self.dbapi.fetchone() is not None
+
+    def _has_gramps_id(self, obj_key, gramps_id):
+        table = KEY_TO_NAME_MAP[obj_key]
+        sql = "SELECT 1 FROM %s WHERE gramps_id = ? AND treeid = ?" % table
+        self.dbapi.execute(sql, [gramps_id, self.dbapi.treeid])
+        return self.dbapi.fetchone() != None
+
+    def _get_gramps_ids(self, obj_key):
+        table = KEY_TO_NAME_MAP[obj_key]
+        sql = "SELECT gramps_id FROM %s WHERE treeid = ?" % table
+        self.dbapi.execute(sql, [self.dbapi.treeid])
+        rows = self.dbapi.fetchall()
+        return [row[0] for row in rows]
+
+    def _get_raw_data(self, obj_key, handle):
+        table = KEY_TO_NAME_MAP[obj_key]
+        sql = "SELECT blob_data FROM %s WHERE handle = ? AND treeid = ?" % table
+        self.dbapi.execute(sql, [handle, self.dbapi.treeid])
+        row = self.dbapi.fetchone()
+        if row:
+            return pickle.loads(row[0])
+
+    def _get_raw_from_id_data(self, obj_key, gramps_id):
+        table = KEY_TO_NAME_MAP[obj_key]
+        sql = "SELECT blob_data FROM %s WHERE gramps_id = ? AND treeid = ?" % table
+        self.dbapi.execute(sql, [gramps_id, self.dbapi.treeid])
+        row = self.dbapi.fetchone()
+        if row:
+            return pickle.loads(row[0])
+
+    def get_gender_stats(self):
+        """
+        Returns a dictionary of
+        {given_name: (male_count, female_count, unknown_count)}
+        """
+        self.dbapi.execute(
+            "SELECT given_name, female, male, unknown FROM gender_stats WHERE treeid = ?",
+            [self.dbapi.treeid],
+        )
+        gstats = {}
+        for row in self.dbapi.fetchall():
+            gstats[row[0]] = (row[1], row[2], row[3])
+        return gstats
+
+    def save_gender_stats(self, gstats):
+        self._txn_begin()
+        self.dbapi.execute(
+            "DELETE FROM gender_stats WHERE treeid = ?", [self.dbapi.treeid]
+        )
+        for key in gstats.stats:
+            female, male, unknown = gstats.stats[key]
+            self.dbapi.execute(
+                "INSERT INTO gender_stats "
+                "(treeid, given_name, female, male, unknown) "
+                "VALUES (?, ?, ?, ?, ?)",
+                [self.dbapi.treeid, key, female, male, unknown],
+            )
+        self._txn_commit()
+
+    def undo_reference(self, data, handle):
+        """
+        Helper method to undo a reference map entry
+        """
+        if data is None:
+            sql = "DELETE FROM reference WHERE obj_handle = ? AND ref_handle = ? AND treeid = ?"
+            self.dbapi.execute(sql, [handle[0], handle[1], self.dbapi.treeid])
+        else:
+            sql = (
+                "INSERT INTO reference "
+                + "(treeid, obj_handle, obj_class, ref_handle, ref_class) "
+                + "VALUES(?, ?, ?, ?, ?)"
+            )
+            self.dbapi.execute(sql, [self.dbapi.treeid] + list(data))
+
+    def undo_data(self, data, handle, obj_key):
+        """
+        Helper method to undo/redo the changes made
+        """
+        cls = KEY_TO_CLASS_MAP[obj_key]
+        table = cls.lower()
+        if data is None:
+            sql = "DELETE FROM %s WHERE handle = ? AND treeid = ?" % table
+            self.dbapi.execute(sql, [handle, self.dbapi.treeid])
+        else:
+            if self._has_handle(obj_key, handle):
+                sql = (
+                    "UPDATE %s SET blob_data = ? WHERE handle = ? AND treeid = ?"
+                    % table
+                )
+                self.dbapi.execute(sql, [pickle.dumps(data), handle, self.dbapi.treeid])
+            else:
+                sql = (
+                    "INSERT INTO %s (treeid, handle, blob_data) VALUES (?, ?, ?)"
+                    % table
+                )
+                self.dbapi.execute(sql, [self.dbapi.treeid, handle, pickle.dumps(data)])
+            obj = self._get_table_func(cls)["class_func"].create(data)
+            self._update_secondary_values(obj)
+
+    def get_surname_list(self):
+        """
+        Return the list of locale-sorted surnames contained in the database.
+        """
+        self.dbapi.execute(
+            "SELECT DISTINCT surname FROM person WHERE treeid = ? ORDER BY surname",
+            [self.dbapi.treeid],
+        )
+        surname_list = []
+        for row in self.dbapi.fetchall():
+            surname_list.append(row[0])
+        return surname_list
+
+    def _sql_type(self, schema_type, max_length):
+        """
+        Given a schema type, return the SQL type for
+        a new column.
+        """
+        if schema_type == "string":
+            if max_length:
+                return "VARCHAR(%s)" % max_length
+            else:
+                return "TEXT"
+        elif schema_type in ["boolean", "integer"]:
+            return "INTEGER"
+        elif schema_type == "number":
+            return "REAL"
+        else:
+            return "BLOB"
+
+    def _create_secondary_columns(self):
+        """
+        Create secondary columns.
+        """
+        LOG.info("Creating secondary columns...")
+        for cls in (
+            Person,
+            Family,
+            Event,
+            Place,
+            Repository,
+            Source,
+            Citation,
+            Media,
+            Note,
+            Tag,
+        ):
+            table_name = cls.__name__.lower()
+            for field, schema_type, max_length in cls.get_secondary_fields():
+                if field != "handle":
+                    sql_type = self._sql_type(schema_type, max_length)
+                    self.dbapi.execute(
+                        "ALTER TABLE %s ADD COLUMN %s %s"
+                        % (table_name, field, sql_type)
+                    )
+
+    def _update_secondary_values(self, obj):
+        """
+        Given a primary object update its secondary field values
+        in the database.
+        Does not commit.
+        """
+        table = obj.__class__.__name__
+        fields = [field[0] for field in obj.get_secondary_fields()]
+        sets = []
+        values = []
+        for field in fields:
+            sets.append("%s = ?" % field)
+            values.append(getattr(obj, field))
+
+        # Derived fields
+        if table == "Person":
+            given_name, surname = self._get_person_data(obj)
+            sets.append("given_name = ?")
+            values.append(given_name)
+            sets.append("surname = ?")
+            values.append(surname)
+        if table == "Place":
+            handle = self._get_place_data(obj)
+            sets.append("enclosed_by = ?")
+            values.append(handle)
+
+        if len(values) > 0:
+            table_name = table.lower()
+            self.dbapi.execute(
+                "UPDATE %s SET %s where handle = ? AND treeid = ?"
+                % (table_name, ", ".join(sets)),
+                self._sql_cast_list(values) + [obj.handle, self.dbapi.treeid],
+            )
+
+    def _sql_cast_list(self, values):
+        """
+        Given a list of field names and values, return the values
+        in the appropriate type.
+        """
+        return [v if not isinstance(v, bool) else int(v) for v in values]

--- a/SharedPostgreSQL/sharedpostgresql.gpr.py
+++ b/SharedPostgreSQL/sharedpostgresql.gpr.py
@@ -1,0 +1,68 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2016 Douglas Blank <doug.blank@gmail.com>
+# Copyright (C) 2022 David Straub <straub@protonmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+import importlib
+
+module1 = importlib.find_loader("psycopg2") is not None
+# Don't register if not runnable, but have to 'Make build' anyway
+if module1 or locals().get("build_script"):
+    register(
+        DATABASE,
+        id="sharedpostgresql",
+        name=_("SharedPostgreSQL"),
+        name_accell=_("Shared _PostgreSQL Database"),
+        description=_("Shared PostgreSQL Database"),
+        version="0.1.0",
+        gramps_target_version="5.1",
+        status=STABLE,
+        fname="sharedpostgresql.py",
+        databaseclass="SharedPostgreSQL",
+        authors=["Doug Blank", "David Straub"],
+        authors_email=["doug.blank@gmail.com", "straub@protonmail.com"],
+    )
+elif locals().get("uistate"):  # don't start GUI if in CLI mode, just ignore
+    from gramps.gen.config import config
+    from gramps.gui.dialog import QuestionDialog2
+    from gramps.gen.config import logging
+
+    if not module1:
+        warn_msg = _("PostgreSQL Warning:  Python psycopg2 module not found.")
+        logging.log(logging.WARNING, warn_msg)
+    inifile = config.register_manager("postgresqlwarn")
+    inifile.load()
+    sects = inifile.get_sections()
+    if "postgresqlwarn" not in sects:
+        yes_no = QuestionDialog2(
+            _("PostgreSQL Failed to Load"),
+            _(
+                "\n\nPostgreSQL is missing the psycopg2 python module.\n"
+                "For now, it may be possible to install the files manually. See\n\n"
+                "https://gramps-project.org/wiki/index.php?title=PostgreSQL \n\n"
+                "To dismiss all future PostgreSQL warnings click Dismiss."
+            ),
+            _(" Dismiss "),
+            _("Continue"),
+            parent=uistate.window,
+        )
+        prompt = yes_no.run()
+        if prompt is True:
+            inifile.register("postgresqlwarn.MissingModules", "")
+            inifile.set("postgresqlwarn.MissingModules", "True")
+            inifile.save()

--- a/SharedPostgreSQL/sharedpostgresql.py
+++ b/SharedPostgreSQL/sharedpostgresql.py
@@ -1,0 +1,274 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2015-2016 Douglas S. Blank <doug.blank@gmail.com>
+# Copyright (C) 2016-2017 Nick Hall
+# Copyright (C) 2022 David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Backend for PostgreSQL database.
+"""
+
+# -------------------------------------------------------------------------
+#
+# Standard python modules
+#
+# -------------------------------------------------------------------------
+import psycopg2
+import os
+import re
+from uuid import uuid4
+
+# -------------------------------------------------------------------------
+#
+# Gramps modules
+#
+# -------------------------------------------------------------------------
+from gramps.gen.utils.configmanager import ConfigManager
+from gramps.gen.config import config
+from gramps.gen.db.dbconst import ARRAYSIZE
+from gramps.gen.db.exceptions import DbConnectionError
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+
+try:
+    _trans = glocale.get_addon_translator(__file__)
+except ValueError:
+    _trans = glocale.translation
+_ = _trans.gettext
+
+from shareddbapi import SharedDBAPI
+
+
+psycopg2.paramstyle = "format"
+
+# -------------------------------------------------------------------------
+#
+# SharedPostgreSQL class
+#
+# -------------------------------------------------------------------------
+class SharedPostgreSQL(SharedDBAPI):
+    def get_summary(self):
+        """
+        Return a diction of information about this database
+        backend.
+        """
+        summary = super().get_summary()
+        summary.update(
+            {
+                _("Database version"): psycopg2.__version__,
+                _("Database module location"): psycopg2.__file__,
+            }
+        )
+        return summary
+
+    def requires_login(self):
+        return True
+
+    def _initialize(self, directory, username, password):
+        config_file = os.path.join(directory, "settings.ini")
+        config_mgr = ConfigManager(config_file)
+        config_mgr.register("database.dbname", "")
+        config_mgr.register("database.host", "")
+        config_mgr.register("database.port", "")
+        config_mgr.register("tree.uuid", "")
+
+        if not os.path.exists(config_file):
+            config_mgr.set("database.dbname", "gramps")
+            config_mgr.set("database.host", config.get("database.host"))
+            config_mgr.set("database.port", config.get("database.port"))
+            config_mgr.set("tree.uuid", uuid4().hex)
+            config_mgr.save()
+
+        config_mgr.load()
+
+        dbkwargs = {}
+        for key in config_mgr.get_section_settings("database"):
+            value = config_mgr.get("database." + key)
+            if value:
+                dbkwargs[key] = value
+        if username:
+            dbkwargs["user"] = username
+        if password:
+            dbkwargs["password"] = password
+
+        uuid = config_mgr.get("tree.uuid")
+
+        if not uuid:
+            raise ValueError("No tree UUID found.")
+        try:
+            self.dbapi = Connection(uuid=uuid, **dbkwargs)
+        except psycopg2.OperationalError as msg:
+            raise DbConnectionError(str(msg), config_file)
+
+
+# -------------------------------------------------------------------------
+#
+# Connection class
+#
+# -------------------------------------------------------------------------
+class Connection:
+    def __init__(self, *args, uuid, **kwargs):
+        self.__connection = psycopg2.connect(*args, **kwargs)
+        self.__connection.autocommit = True
+        self.__cursor = self.__connection.cursor()
+        self.uuid = uuid
+        self._treeid = ""
+        self.check_collation(glocale)
+
+    @property
+    def treeid(self):
+        """Return an integer treeid from the UUID."""
+        # return cached value
+        if self._treeid:
+            return self._treeid
+        # try to fetch ID from database
+        self.execute("SELECT treeid FROM trees WHERE uuid = %s", [self.uuid])
+        row = self.fetchone()
+        if row:
+            self._treeid = row[0]
+            return self.treeid
+        # create new ID
+        self.execute("INSERT INTO trees (uuid) VALUES (%s)", [self.uuid])
+        return self.treeid
+
+    def check_collation(self, locale):
+        """
+        Checks that a collation exists and if not creates it.
+
+        :param locale: Locale to be checked.
+        :param type: A GrampsLocale object.
+        """
+        # Duplicating system collations works, but to delete them the schema
+        # must be specified, so get the current schema
+        collation = locale.get_collation()
+        self.execute(
+            'CREATE COLLATION IF NOT EXISTS "%s"'
+            "(LOCALE = '%s')" % (collation, locale.collation)
+        )
+
+    def execute(self, *args, **kwargs):
+        sql = _hack_query(args[0])
+        if len(args) > 1:
+            args = args[1]
+        else:
+            args = None
+        try:
+            self.__cursor.execute(sql, args, **kwargs)
+        except:
+            self.__cursor.execute("rollback")
+            raise
+
+    def fetchone(self):
+        try:
+            return self.__cursor.fetchone()
+        except:
+            return None
+
+    def fetchall(self):
+        return self.__cursor.fetchall()
+
+    def begin(self):
+        self.__cursor.execute("BEGIN;")
+
+    def commit(self):
+        self.__cursor.execute("COMMIT;")
+
+    def rollback(self):
+        self.__connection.rollback()
+
+    def table_exists(self, table):
+        self.__cursor.execute(
+            "SELECT COUNT(*) " "FROM information_schema.tables " "WHERE table_name=%s;",
+            [table],
+        )
+        return self.fetchone()[0] != 0
+
+    def close(self):
+        self.__connection.close()
+
+    def cursor(self):
+        return Cursor(self.__connection)
+
+
+# -------------------------------------------------------------------------
+#
+# Cursor class
+#
+# -------------------------------------------------------------------------
+class Cursor:
+    def __init__(self, connection):
+        self.__connection = connection
+
+    def __enter__(self):
+        self.__cursor = self.__connection.cursor()
+        self.__cursor.arraysize = ARRAYSIZE
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        self.__cursor.close()
+
+    def execute(self, *args, **kwargs):
+        """
+        Executes an SQL statement.
+
+        :param args: arguments to be passed to the sqlite3 execute statement
+        :type args: list
+        :param kwargs: arguments to be passed to the sqlite3 execute statement
+        :type kwargs: list
+        """
+        sql = _hack_query(args[0])
+        if len(args) > 1:
+            args = args[1]
+        else:
+            args = None
+        self.__cursor.execute(sql, args, **kwargs)
+
+    def fetchmany(self):
+        """
+        Fetches the next set of rows of a query result, returning a list. An
+        empty list is returned when no more rows are available.
+        """
+        try:
+            return self.__cursor.fetchmany()
+        except:
+            return None
+
+
+
+def _hack_query(query):
+    query = query.replace("?", "%s")
+    query = query.replace("REGEXP", "~")
+    query = query.replace("desc", "desc_")
+    query = query.replace("BLOB", "bytea")
+    query = query.replace("INTEGER PRIMARY KEY", "SERIAL PRIMARY KEY")
+    ## LIMIT offset, count
+    ## count can be -1, for all
+    ## LIMIT -1
+    ## LIMIT offset, -1
+    query = query.replace("LIMIT -1", "LIMIT all")  ##
+    match = re.match(".* LIMIT (.*), (.*) ", query)
+    if match and match.groups():
+        offset, count = match.groups()
+        if count == "-1":
+            count = "all"
+        query = re.sub(
+            "(.*) LIMIT (.*), (.*) ",
+            "\\1 LIMIT %s OFFSET %s " % (count, offset),
+            query,
+        )
+    return query


### PR DESCRIPTION
This database add-on is a variation of the existing PostgreSQL add-on which allows to store an arbitrary number of family trees, rather than just a single one, in a Postgres database.

The original PostgreSQL add-on works as follows: it assumes the existince of a database with the name being the name of the family tree in Gramps. It then creates the database tables exactly like in the SQLite core module.

The new shared PostgreSQL add-on works on a single database (assumed to be named `gramps` by default). It has the same database tables as the original one, but adds a new column `treeid` to all tables and a new table `trees` with two columns: `treeid` and `uuid`. When a new family tree of type `sharedpostgresql` is created in Gramps, it generates a random UUIDv4, stores it in `settings.ini` in the family tree's directory (where also the host and port are stored just like in the original add-on) and adds a row to the `trees` table, linking the UUID to an integer. This integer `treeid` is set for all objects in the other tables. In the end, for instance, the `person` table can contain people from arbitrarily many family trees, but the data doesn't interefere because all the SQL queries have `WHERE treeid = ?` in them to filter out only the data from a single tree. The indices are adapted to be on the `(treeid, handle)` tuple rather than just the handle. Only this tuple is required to be unique, not the handle itself.

The motivation for creating this add-on is that it allows to build a generalized version of Gramps Web API where a single server hosts arbitrarily many family trees (each user only having access to a single tree).

