### PR TITLE
[CombinedView] Fixes #0011814 Validate father handle before using.

### DIFF
--- a/CombinedView/basepage.py
+++ b/CombinedView/basepage.py
@@ -348,10 +348,11 @@ class BasePage(Callback):
             name.add_surname(Surname())
             name.set_primary_surname(0)
             family = self.dbstate.db.get_family_from_handle(handle)
-            father = self.dbstate.db.get_person_from_handle(
-                                        family.get_father_handle())
-            if father:
-                preset_name(father, name)
+            father_h = family.get_father_handle()
+            if father_h:
+                father = self.dbstate.db.get_person_from_handle(father_h)
+                if father:
+                    preset_name(father, name)
             person.set_primary_name(name)
             try:
                 EditPerson(self.dbstate, self.uistate, [], person,


### PR DESCRIPTION
If father handle can not be obtained, don't try to get details about the father because it raises an exception and leads to the crash described in the bug report.

Fixes [#11814](https://gramps-project.org/bugs/view.php?id=11814)