### PR TITLE
[LifeLineChartView] Fix 12621 life_line_chart update for Python >= 3.9

### DIFF
--- a/LifeLineChartView/lifelinechartview.gpr.py
+++ b/LifeLineChartView/lifelinechartview.gpr.py
@@ -270,7 +270,7 @@ class ModuleProvider:
 ##########################################
 
 
-life_line_chart_version_required = (1, 7, 5)
+life_line_chart_version_required = (1, 7, 7)
 life_line_chart_version_required_str = '.'.join(
     [str(i) for i in life_line_chart_version_required])
 some_import_error = False


### PR DESCRIPTION
LifeLineChartView addon requires life_line_chart python package, currently version 1.7.5. However when Gramps is isntalled on systems such as Fedora 35 with Python versions >= 3.9, this results in the bug #0012621, causing failure to load on gramps startup.

Luckily [life_line_chart 1.7.7 includes a fix for this issue](https://github.com/CWSchulze/life_line_chart/commit/bc7b050c571f40709d709b2eefb62c4a582a4a9d), so the resolution in gramps is easy - just upgrade the requirement for LifeLineChartView addon.

Fix has been tested on Windows. With an existing install of the plugin, on startup Gramps correctly informs me that pre-req v1.7.7 is not installed, and gives a choice to "Download module". On selecting that option, pre-req is downloaded and the plugin is functional.

Could use testing on Linux (especially by users who reported the bug on Fedora 35), and MacOS.