### PR TITLE
Fixes #11596 GetGOV language setting is case sensitive

### DIFF
--- a/GetGOV/getgov.py
+++ b/GetGOV/getgov.py
@@ -332,7 +332,7 @@ class GetGOV(Gramplet):
         except AttributeError:
             fmt = config.get('preferences.place-format')
             pf = _pd.get_formats()[fmt]
-            preferred_lang = pf.language
+            preferred_lang = pf.language.lower()
         if len(preferred_lang) != 2:
             preferred_lang = 'de'
         visited = {}


### PR DESCRIPTION
Gramps Preferences > Display > Place Format's language setting allows input in mixed case, but GetGOV addon interprets it correctly only when the language code is in lower case otherwise it defaults to German ('de').

This change converts the value of the language field to lower case when used by the addon so that GetGOV accepts it and returns results in that language (as far as possible).

Fixes #11596

@GaryGriffin A review of this change would be appreciated. Thanks.