### PR TITLE
Fix missing space leading to syntax error

### DIFF
--- a/SharedPostgreSQL/shareddbapi.py
+++ b/SharedPostgreSQL/shareddbapi.py
@@ -499,11 +499,11 @@ class SharedDBAPI(DbGeneric):
             sql = (
                 "SELECT family.handle "
                 + "FROM family "
-                + "WHERE family.treeid = ?"
+                + "WHERE family.treeid = ? "
                 + "LEFT JOIN person AS father "
                 + "ON (family.father_handle = father.handle AND family.treeid = father.treeid) "
                 + "LEFT JOIN person AS mother "
-                + "ON (family.mother_handle = mother.handle AND family.treeid = mother.treeid)"
+                + "ON (family.mother_handle = mother.handle AND family.treeid = mother.treeid) "
                 + "ORDER BY (CASE WHEN father.handle IS NULL "
                 + "THEN mother.surname "
                 + "ELSE father.surname "

--- a/SharedPostgreSQL/sharedpostgresql.gpr.py
+++ b/SharedPostgreSQL/sharedpostgresql.gpr.py
@@ -29,7 +29,7 @@ if module1 or locals().get("build_script"):
         name=_("SharedPostgreSQL"),
         name_accell=_("Shared _PostgreSQL Database"),
         description=_("Shared PostgreSQL Database"),
-        version = '0.1.2',
+        version = '0.1.3',
         gramps_target_version="5.1",
         status=STABLE,
         fname="sharedpostgresql.py",


### PR DESCRIPTION
Dear maintainers,

I found this bug that breaks Gramps Web instances using the shared PostgreSQL addon. I would appreciate if you could merge this as soon as possible. Thanks a lot!