### PR TITLE
New Gramplet: DNA matches (Gramps 5.1)

### DIFF
--- a/DNAMatches/dnamatches.gpr.py
+++ b/DNAMatches/dnamatches.gpr.py
@@ -35,7 +35,8 @@ register(GRAMPLET,
          gramplet_title=_("DNA Matches"),
          detached_width = 600,
          detached_height = 450,
-         version = '1.0.1',
+         version = '1.1.0',
          gramps_target_version='5.1',
+         help_url="Addon:DNAMatches",
          include_in_listing = True
          )

--- a/DNAMatches/dnamatches.gpr.py
+++ b/DNAMatches/dnamatches.gpr.py
@@ -1,0 +1,41 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+# http://gramps-project.org
+# Gramplet registration - plug-in/add-on to extend Gramps
+#
+# Copyright (C) 2020        Nick Hall
+# Copyright (C) 2020-2022   Gary Griffin
+# Copyright (C) 2023        Milan Kurovsky
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+register(GRAMPLET,
+         id = "DNAMatches",
+         name = _("DNA Matches"),
+         authors = ["Milan Kurovsky"],
+         authors_email = ["gxm210@gmail.com"],
+         description = _("Gramplet to display a list of DNA matches"),
+         status = STABLE,
+         fname="dnamatches.py",
+         height=100,
+         expand=True,
+         gramplet = 'DNAMatches',
+         gramplet_title=_("DNA Matches"),
+         detached_width = 600,
+         detached_height = 450,
+         version = '1.0.0',
+         gramps_target_version='5.1',
+         include_in_listing = True
+         )

--- a/DNAMatches/dnamatches.gpr.py
+++ b/DNAMatches/dnamatches.gpr.py
@@ -35,7 +35,7 @@ register(GRAMPLET,
          gramplet_title=_("DNA Matches"),
          detached_width = 600,
          detached_height = 450,
-         version = '1.1.0',
+         version = '2.0.0',
          gramps_target_version='5.1',
          help_url="Addon:DNAMatches",
          include_in_listing = True

--- a/DNAMatches/dnamatches.gpr.py
+++ b/DNAMatches/dnamatches.gpr.py
@@ -35,7 +35,7 @@ register(GRAMPLET,
          gramplet_title=_("DNA Matches"),
          detached_width = 600,
          detached_height = 450,
-         version = '1.0.0',
+         version = '1.0.1',
          gramps_target_version='5.1',
          include_in_listing = True
          )

--- a/DNAMatches/dnamatches.py
+++ b/DNAMatches/dnamatches.py
@@ -38,7 +38,7 @@ from gi.repository import Gtk
 #
 #------------------------------------------------------------------------
 from gramps.gui.listmodel import ListModel, NOSORT
-from gramps.gui.editors import EditPersonRef
+from gramps.gui.editors import EditPerson, EditPersonRef
 from gramps.gen.plug import Gramplet
 from gramps.gen.lib import Date
 from gramps.gen.errors import WindowActiveError
@@ -86,8 +86,7 @@ class DNAMatches(Gramplet):
         self.connect(self.dbstate.db, 'source-update', self.update)
         self.connect(self.dbstate.db, 'source-add', self.update)
         self.connect(self.dbstate.db, 'source-delete', self.update)
-        self.connect_signal('Person',self.update)
-
+        self.connect_signal('Person', self.update)
 
     def build_gui(self):
         """
@@ -100,14 +99,15 @@ class DNAMatches(Gramplet):
 
         top = Gtk.TreeView()
         titles = [('', NOSORT, 50),
-                  (_('Person'), 1, 200),
-                  (_('Relationship'), 2, 250),
+                  (_('ID'), 1, 50),
+                  (_('Person'), 2, 150),
+                  (_('Relationship'), 3, 125),
                   ('', NOSORT, 50),
-                  (_('Shared DNA'), 3, 125),
-                  (_('Shared segments'), 5, 150, 4),
+                  (_('Shared DNA'), 4, 125),
+                  (_('Segments'), 6, 105, 4),
                   ('', NOSORT, 50),
-                  (_('Largest segment'), 6, 150),
-                  (_('Source(s)'), 8, 200)]
+                  (_('Largest Segment'), 7, 150),
+                  (_('Source(s)'), 9, 200)]
 
         self.model = ListModel(top,
                                titles,
@@ -139,7 +139,7 @@ class DNAMatches(Gramplet):
                             self.__get_match_info(active, assoc, note, True)
 
         # Sort by shared DNA initially
-        model.model.set_sort_column_id(self.model.cids[4], 1)
+        model.model.set_sort_column_id(self.model.cids[5], 1)
         model.sort()
 
     def __get_match_info(self, active, assoc, note, is_citation_note):
@@ -175,6 +175,7 @@ class DNAMatches(Gramplet):
 
         # Adding a row of DNA match data
         self.model.add((assoc.ref,
+                       associate.get_gramps_id(),
                        _nd.display_name(associate.get_primary_name()),
                        relationship,
                        self.__sort_number_columns(total_cms_rounded),
@@ -268,6 +269,7 @@ class DNAMatches(Gramplet):
                 for assoc in active.get_person_ref_list():
                     if assoc.ref == handle:
                         try:
-                            EditPersonRef(self.dbstate, self.uistate, [], assoc, None)
+                            EditPerson(self.dbstate, self.uistate, [], active)
+                            EditPersonRef(self.dbstate, self.uistate, [0], assoc, None)
                         except WindowActiveError:
                             pass

--- a/DNAMatches/dnamatches.py
+++ b/DNAMatches/dnamatches.py
@@ -1,0 +1,264 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2020        Nick Hall
+# Copyright (C) 2020-2022   Gary Griffin
+# Copyright (C) 2023        Milan Kurovsky
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+DNA Matches Gramplet
+This Gramplet lists a user's DNA matches.
+"""
+#-------------------------------------------------------------------------
+#
+# Non-Gramps Modules
+#
+#-------------------------------------------------------------------------
+import re
+from gi.repository import Gtk
+
+#------------------------------------------------------------------------
+#
+# Gramps modules
+#
+#------------------------------------------------------------------------
+from gramps.gui.listmodel import ListModel, NOSORT
+from gramps.gui.editors import EditPersonRef
+from gramps.gen.plug import Gramplet
+from gramps.gen.lib import Date
+from gramps.gen.errors import WindowActiveError
+from gramps.gen.display.name import displayer as _nd
+from gramps.gen.relationship import get_relationship_calculator
+
+#------------------------------------------------------------------------
+#
+# Internationalisation
+#
+#------------------------------------------------------------------------
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+try:
+    _trans = glocale.get_addon_translator(__file__)
+except ValueError:
+    _trans = glocale.translation
+_ = _trans.gettext
+
+
+class DNAMatches(Gramplet):
+    """
+    DNA Matches Gramplet class.
+    """
+    def __init__(self, gui, nav_group=0):
+        Gramplet.__init__(self, gui, nav_group)
+
+        self.gui.WIDGET = self.build_gui()
+        self.gui.get_container_widget().remove(self.gui.textview)
+        self.gui.get_container_widget().add(self.gui.WIDGET)
+        self.gui.WIDGET.show()
+
+    def db_changed(self):
+        """
+        Update DNA matches when People, Family, Note or Source changes are made.
+        """
+        self.connect(self.dbstate.db, 'person-add', self.update)
+        self.connect(self.dbstate.db, 'person-delete', self.update)
+        self.connect(self.dbstate.db, 'person-update', self.update)
+        self.connect(self.dbstate.db, 'family-update', self.update)
+        self.connect(self.dbstate.db, 'family-add', self.update)
+        self.connect(self.dbstate.db, 'family-delete', self.update)
+        self.connect(self.dbstate.db, 'note-add', self.update)
+        self.connect(self.dbstate.db, 'note-delete', self.update)
+        self.connect(self.dbstate.db, 'note-update', self.update)
+        self.connect(self.dbstate.db, 'source-update', self.update)
+        self.connect(self.dbstate.db, 'source-add', self.update)
+        self.connect(self.dbstate.db, 'source-delete', self.update)
+        self.connect_signal('Person',self.update)
+
+
+    def build_gui(self):
+        """
+        Build the GUI interface.
+        """
+        tip1 = _('Double-click on a row to navigate to the matched person.\n')
+        tip2 = _('Right click to edit selected association.')
+        tooltip = tip1 + tip2
+        self.set_tooltip(tooltip)
+
+        top = Gtk.TreeView()
+        titles = [('', NOSORT, 50),
+                  (_('Person'), 1, 200),
+                  (_('Relationship'), 2, 250),
+                  ('', NOSORT, 50),
+                  (_('Shared DNA'), 3, 125),
+                  (_('Shared segments'), 5, 150, 4),
+                  ('', NOSORT, 50),
+                  (_('Largest segment'), 6, 150),
+                  (_('Source(s)'), 8, 200)]
+
+        self.model = ListModel(top,
+                               titles,
+                               event_func=self.go_to_person,
+                               right_click=self.edit_association)
+        return top
+
+    def main(self):
+        """
+        Gets all DNA matches for current person and displays them.
+        """
+        active_handle = self.get_active('Person')
+        model = self.model
+        model.clear()
+
+        if active_handle:
+            active = self.dbstate.db.get_person_from_handle(active_handle)
+            for assoc in active.get_person_ref_list():
+                if assoc.get_relation() == 'DNA':
+                    # Get Notes attached to Association
+                    for handle in assoc.get_note_list():
+                        note = self.dbstate.db.get_note_from_handle(handle)
+                        self.__get_match_info(active, assoc, note)
+                    # Get Notes attached to Citation which is attached to the Association
+                    for citation_handle in assoc.get_citation_list():
+                        citation = self.dbstate.db.get_citation_from_handle(citation_handle)
+                        for handle in citation.get_note_list():
+                            note = self.dbstate.db.get_note_from_handle(handle)
+                            self.__get_match_info(active, assoc, note)
+
+        # Sort by shared DNA initially
+        model.model.set_sort_column_id(self.model.cids[4], 1)
+        model.sort()
+
+    def __get_match_info(self, active, assoc, note):
+        """
+        Get and display all relevant DNA match information.
+        """
+        # DNA
+        segments = 0
+        total_cms = 0
+        largest_cms = 0
+
+        lines = note.get().split('\n')
+        for line in lines:
+            segments, total_cms, largest_cms = self.__process_line(line,
+                                                                 segments,
+                                                                 total_cms,
+                                                                 largest_cms)
+        if segments == 0 or total_cms == 0 or largest_cms == 0:
+            return
+
+        # Relationship
+        relationship = _('unknown')
+        associate = self.dbstate.db.get_person_from_handle(assoc.ref)
+        rel = get_relationship_calculator(glocale)
+        rel_strings = rel.get_all_relationships(self.dbstate.db,
+                                                active,
+                                                associate)[0]
+        if len(rel_strings) > 0 :
+            relationship = rel_strings[0]
+
+        # Rounding floats
+        total_cms_rounded = round(total_cms, 1)
+        largest_cms_rounded = round (largest_cms, 1)
+
+        # Adding a row of DNA match data
+        self.model.add((assoc.ref,
+                       _nd.display_name(associate.get_primary_name()),
+                       relationship,
+                       self.__sort_number_columns(total_cms_rounded),
+                       str(total_cms_rounded) + " " + _('cM'),
+                       segments,
+                       self.__sort_number_columns(largest_cms_rounded),
+                       str(largest_cms_rounded) + " " + _('cM'),
+                       self.__get_sources(assoc)))
+
+    def __process_line(self, line, segments, total_cms, largest_cms):
+        """
+        Process a line in a DNA association note.
+        """
+        fail = (segments, total_cms, largest_cms)
+        if re.search('\t',line) is not None:
+            line2 = re.sub(',','',line)
+            line = re.sub('\t',',',line2)
+
+        field = line.split(',')
+        if len(field) >= 4:
+            try:
+                cms = float(field[3].strip())
+            except ValueError:
+                return fail
+            segments += 1
+            total_cms += cms
+            if cms > largest_cms:
+                largest_cms = cms
+        elif len(field) == 3:
+            try:
+                total_cms = float(field[0].strip())
+                segments = int(field[1].strip())
+                largest_cms = float(field[2].strip())
+            except ValueError:
+                return fail
+        else:
+            return fail
+
+        return (segments, total_cms, largest_cms)
+
+    def __get_sources(self, assoc):
+        """
+        Get sources for the association.
+        """
+        sources = _('Not specified')
+        for citation_handle in assoc.get_citation_list():
+            citation = self.dbstate.db.get_citation_from_handle(citation_handle)
+            source = self.dbstate.db.get_source_from_handle(citation.get_reference_handle())
+            if sources == _('Not specified'):
+                sources = ""
+                sources += source.get_title()
+            else:
+                sources += ", " + source.get_title()
+        return sources
+
+    def __sort_number_columns(self, number):
+        """
+        Hacky way to sort the number columns.
+        """
+        return str(Date(int(number)).get_sort_value())
+
+    def go_to_person(self, treeview):
+        """
+        Make the DNA match the active person.
+        """
+        model, iter_ = treeview.get_selection().get_selected()
+        if iter_:
+            handle = model.get_value(iter_, 0)
+            self.set_active('Person', handle)
+
+    def edit_association(self, treeview, _event):
+        """
+        Edit the association.
+        """
+        model, iter_ = treeview.get_selection().get_selected()
+        if iter_:
+            handle = model.get_value(iter_, 0)
+            active_handle = self.get_active('Person')
+            if active_handle:
+                active = self.dbstate.db.get_person_from_handle(active_handle)
+                for assoc in active.get_person_ref_list():
+                    if assoc.ref == handle:
+                        try:
+                            EditPersonRef(self.dbstate, self.uistate, [], assoc, None)
+                        except WindowActiveError:
+                            pass

--- a/DNAMatches/po/sk-local.po
+++ b/DNAMatches/po/sk-local.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: 2023-10-19 21:03+0100\n"
-"PO-Revision-Date: 2023-10-21 02:02+0100\n"
+"PO-Revision-Date: 2023-10-23 02:23+0100\n"
 "Last-Translator: MILAN KUROVSKY\n"
 "Language-Team: Slovak\n"
 "Language: sk\n"
@@ -32,6 +32,10 @@ msgstr "Dvojklikom myši na riadok sa môžete presunúť na zvolenú osobu.\n"
 msgid "Right click to edit selected association."
 msgstr "Kliknutím pravého tlačítka myši môžete upraviť zvolenú asociáciu."
 
+#: dnamatches.py:102
+msgid "ID"
+msgstr "ID"
+
 #: dnamatches.py:103
 msgid "Person"
 msgstr "Osoba"
@@ -45,11 +49,11 @@ msgid "Shared DNA"
 msgstr "Zdieľaná DNA"
 
 #: dnamatches.py:107
-msgid "Shared segments"
-msgstr "Zdieľané segmenty"
+msgid "Segments"
+msgstr "Segmenty"
 
 #: dnamatches.py:109
-msgid "Largest segment"
+msgid "Largest Segment"
 msgstr "Najväčší segment"
 
 #: dnamatches.py:110
@@ -60,10 +64,10 @@ msgstr "Zdroje"
 msgid "unknown"
 msgstr "neznámy"
 
-#: dnamatches.py:181 dnamatches.py:184
+#: dnamatches.py:182 dnamatches.py:185
 msgid "cM"
 msgstr "cM"
 
-#: dnamatches.py:224 dnamatches.py:235
+#: dnamatches.py:225 dnamatches.py:236
 msgid "Not specified"
 msgstr "Neuvedené"

--- a/DNAMatches/po/sk-local.po
+++ b/DNAMatches/po/sk-local.po
@@ -6,10 +6,10 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"POT-Creation-Date: 2023-10-19 21:03+0100\n"
-"PO-Revision-Date: 2023-10-23 02:23+0100\n"
-"Last-Translator: MILAN KUROVSKY\n"
-"Language-Team: Slovak\n"
+"POT-Creation-Date: 2023-10-24 01:49+0100\n"
+"PO-Revision-Date: 2023-10-24 01:52+0100\n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "Language: sk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -24,50 +24,82 @@ msgstr "DNA zhody"
 msgid "Gramplet to display a list of DNA matches"
 msgstr "Gramplet na zobrazenie zoznamu DNA zhôd"
 
-#: dnamatches.py:96
-msgid "Double-click on a row to navigate to the matched person.\n"
-msgstr "Dvojklikom myši na riadok sa môžete presunúť na zvolenú osobu.\n"
+#: dnamatches.py:153
+msgid "Pers."
+msgstr "Osob."
 
-#: dnamatches.py:97
-msgid "Right click to edit selected association."
-msgstr "Kliknutím pravého tlačítka myši môžete upraviť zvolenú asociáciu."
+#: dnamatches.py:153
+msgid "Rel."
+msgstr "Vzťh."
 
-#: dnamatches.py:102
-msgid "ID"
-msgstr "ID"
+#: dnamatches.py:153
+msgid "S. DNA"
+msgstr "DNA"
 
-#: dnamatches.py:103
+#: dnamatches.py:153
+msgid "S. Leg."
+msgstr "Seg."
+
+#: dnamatches.py:153
+msgid "L. Seg"
+msgstr "Naj. seg."
+
+#: dnamatches.py:153
+msgid "Src(s)"
+msgstr "Zdrj(e)"
+
+#: dnamatches.py:154
 msgid "Person"
 msgstr "Osoba"
 
-#: dnamatches.py:104
+#: dnamatches.py:155
 msgid "Relationship"
 msgstr "Vzťah"
 
-#: dnamatches.py:106
+#: dnamatches.py:156
 msgid "Shared DNA"
 msgstr "Zdieľaná DNA"
 
-#: dnamatches.py:107
-msgid "Segments"
-msgstr "Segmenty"
+#: dnamatches.py:157
+msgid "Shared Segments"
+msgstr "Zdieľané segmenty"
 
-#: dnamatches.py:109
+#: dnamatches.py:158
 msgid "Largest Segment"
 msgstr "Najväčší segment"
 
-#: dnamatches.py:110
+#: dnamatches.py:159
 msgid "Source(s)"
-msgstr "Zdroje"
+msgstr "Zdroj(e)"
 
-#: dnamatches.py:164
+#: dnamatches.py:165
+msgid "ID"
+msgstr "ID"
+
+#: dnamatches.py:194
+msgid "Double-click on a row to navigate to the matched person."
+msgstr "Dvojklikom myši na riadok sa môžete presunúť na zvolenú osobu."
+
+#: dnamatches.py:195
+msgid "Right click to edit selected association."
+msgstr "Kliknutím pravého tlačítka myši môžete upraviť zvolenú asociáciu."
+
+#: dnamatches.py:210
+msgid "LEGEND"
+msgstr "VYSVETLIVKY"
+
+#: dnamatches.py:228
+msgid "="
+msgstr "="
+
+#: dnamatches.py:310 dnamatches.py:409 dnamatches.py:420
+msgid "Not specified"
+msgstr "Neuvedené"
+
+#: dnamatches.py:348
 msgid "unknown"
 msgstr "neznámy"
 
-#: dnamatches.py:182 dnamatches.py:185
+#: dnamatches.py:366 dnamatches.py:369
 msgid "cM"
 msgstr "cM"
-
-#: dnamatches.py:225 dnamatches.py:236
-msgid "Not specified"
-msgstr "Neuvedené"

--- a/DNAMatches/po/sk-local.po
+++ b/DNAMatches/po/sk-local.po
@@ -1,0 +1,69 @@
+# Slovak translation for DNA Matches Gramplet
+# Copyright (C) 2023 Milan Kurovsky
+# This file is distributed under the same license as the DNA Matches package.
+# MILAN KUROVSKY, 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"POT-Creation-Date: 2023-10-19 21:03+0100\n"
+"PO-Revision-Date: 2023-10-19 22:09+0100\n"
+"Last-Translator: MILAN KUROVSKY\n"
+"Language-Team: Slovak\n"
+"Language: sk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.4\n"
+
+#: dnamatches.gpr.py:26 dnamatches.gpr.py:35
+msgid "DNA Matches"
+msgstr "DNA zhody"
+
+#: dnamatches.gpr.py:29
+msgid "Gramplet to display a list of DNA matches"
+msgstr "Gramplet na zobrazenie zoznamu DNA zhôd"
+
+#: dnamatches.py:96
+msgid "Double-click on a row to navigate to the matched person.\n"
+msgstr "Dvojklikom myši na riadok sa môžete presunúť na zvolenú osobu.\n"
+
+#: dnamatches.py:97
+msgid "Right click to edit selected association."
+msgstr "Kliknutím pravého tlačítka myši môžete upraviť zvolenú asociáciu."
+
+#: dnamatches.py:103
+msgid "Person"
+msgstr "Osoba"
+
+#: dnamatches.py:104
+msgid "Relationship"
+msgstr "Vzťah"
+
+#: dnamatches.py:106
+msgid "Shared DNA"
+msgstr "Zdieľaná DNA"
+
+#: dnamatches.py:107
+msgid "Shared segments"
+msgstr "Zdieľané segmenty"
+
+#: dnamatches.py:109
+msgid "Largest segment"
+msgstr "Najväčší segment"
+
+#: dnamatches.py:110
+msgid "Source(s)"
+msgstr "Zdroje"
+
+#: dnamatches.py:164
+msgid "unknown"
+msgstr "neznámy"
+
+#: dnamatches.py:182 dnamatches.py:185
+msgid "cM"
+msgstr "cM"
+
+#: dnamatches.py:223 dnamatches.py:227
+msgid "Not specified"
+msgstr "Neuvedené"

--- a/DNAMatches/po/sk-local.po
+++ b/DNAMatches/po/sk-local.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "POT-Creation-Date: 2023-10-19 21:03+0100\n"
-"PO-Revision-Date: 2023-10-19 22:09+0100\n"
+"PO-Revision-Date: 2023-10-21 02:02+0100\n"
 "Last-Translator: MILAN KUROVSKY\n"
 "Language-Team: Slovak\n"
 "Language: sk\n"
@@ -60,10 +60,10 @@ msgstr "Zdroje"
 msgid "unknown"
 msgstr "neznámy"
 
-#: dnamatches.py:182 dnamatches.py:185
+#: dnamatches.py:181 dnamatches.py:184
 msgid "cM"
 msgstr "cM"
 
-#: dnamatches.py:223 dnamatches.py:227
+#: dnamatches.py:224 dnamatches.py:235
 msgid "Not specified"
 msgstr "Neuvedené"

--- a/DNAMatches/po/template.pot
+++ b/DNAMatches/po/template.pot
@@ -60,10 +60,10 @@ msgstr ""
 msgid "unknown"
 msgstr ""
 
-#: dnamatches.py:182 dnamatches.py:185
+#: dnamatches.py:181 dnamatches.py:184
 msgid "cM"
 msgstr ""
 
-#: dnamatches.py:223 dnamatches.py:227
+#: dnamatches.py:224 dnamatches.py:235
 msgid "Not specified"
 msgstr ""

--- a/DNAMatches/po/template.pot
+++ b/DNAMatches/po/template.pot
@@ -1,0 +1,69 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-10-19 13:54+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: dnamatches.gpr.py:26 dnamatches.gpr.py:35
+msgid "DNA Matches"
+msgstr ""
+
+#: dnamatches.gpr.py:29
+msgid "Gramplet to display a list of DNA matches"
+msgstr ""
+
+#: dnamatches.py:96
+msgid "Double-click on a row to navigate to the matched person.\n"
+msgstr ""
+
+#: dnamatches.py:97
+msgid "Right click to edit selected association."
+msgstr ""
+
+#: dnamatches.py:103
+msgid "Person"
+msgstr ""
+
+#: dnamatches.py:104
+msgid "Relationship"
+msgstr ""
+
+#: dnamatches.py:106
+msgid "Shared DNA"
+msgstr ""
+
+#: dnamatches.py:107
+msgid "Shared segments"
+msgstr ""
+
+#: dnamatches.py:109
+msgid "Largest segment"
+msgstr ""
+
+#: dnamatches.py:110
+msgid "Source(s)"
+msgstr ""
+
+#: dnamatches.py:164
+msgid "unknown"
+msgstr ""
+
+#: dnamatches.py:182 dnamatches.py:185
+msgid "cM"
+msgstr ""
+
+#: dnamatches.py:223 dnamatches.py:227
+msgid "Not specified"
+msgstr ""

--- a/DNAMatches/po/template.pot
+++ b/DNAMatches/po/template.pot
@@ -32,6 +32,10 @@ msgstr ""
 msgid "Right click to edit selected association."
 msgstr ""
 
+#: dnamatches.py:102
+msgid "ID"
+msgstr ""
+
 #: dnamatches.py:103
 msgid "Person"
 msgstr ""
@@ -45,11 +49,11 @@ msgid "Shared DNA"
 msgstr ""
 
 #: dnamatches.py:107
-msgid "Shared segments"
+msgid "Segments"
 msgstr ""
 
 #: dnamatches.py:109
-msgid "Largest segment"
+msgid "Largest Segment"
 msgstr ""
 
 #: dnamatches.py:110
@@ -60,10 +64,10 @@ msgstr ""
 msgid "unknown"
 msgstr ""
 
-#: dnamatches.py:181 dnamatches.py:184
+#: dnamatches.py:182 dnamatches.py:185
 msgid "cM"
 msgstr ""
 
-#: dnamatches.py:224 dnamatches.py:235
+#: dnamatches.py:225 dnamatches.py:236
 msgid "Not specified"
 msgstr ""

--- a/DNAMatches/po/template.pot
+++ b/DNAMatches/po/template.pot
@@ -24,50 +24,82 @@ msgstr ""
 msgid "Gramplet to display a list of DNA matches"
 msgstr ""
 
-#: dnamatches.py:96
-msgid "Double-click on a row to navigate to the matched person.\n"
+#: dnamatches.py:153
+msgid "Pers."
 msgstr ""
 
-#: dnamatches.py:97
-msgid "Right click to edit selected association."
+#: dnamatches.py:153
+msgid "Rel."
 msgstr ""
 
-#: dnamatches.py:102
-msgid "ID"
+#: dnamatches.py:153
+msgid "S. DNA"
 msgstr ""
 
-#: dnamatches.py:103
+#: dnamatches.py:153
+msgid "S. Leg."
+msgstr ""
+
+#: dnamatches.py:153
+msgid "L. Seg"
+msgstr ""
+
+#: dnamatches.py:153
+msgid "Src(s)"
+msgstr ""
+
+#: dnamatches.py:154
 msgid "Person"
 msgstr ""
 
-#: dnamatches.py:104
+#: dnamatches.py:155
 msgid "Relationship"
 msgstr ""
 
-#: dnamatches.py:106
+#: dnamatches.py:156
 msgid "Shared DNA"
 msgstr ""
 
-#: dnamatches.py:107
-msgid "Segments"
+#: dnamatches.py:157
+msgid "Shared Segments"
 msgstr ""
 
-#: dnamatches.py:109
+#: dnamatches.py:158
 msgid "Largest Segment"
 msgstr ""
 
-#: dnamatches.py:110
+#: dnamatches.py:159
 msgid "Source(s)"
 msgstr ""
 
-#: dnamatches.py:164
+#: dnamatches.py:165
+msgid "ID"
+msgstr ""
+
+#: dnamatches.py:194
+msgid "Double-click on a row to navigate to the matched person."
+msgstr ""
+
+#: dnamatches.py:195
+msgid "Right click to edit selected association."
+msgstr ""
+
+#: dnamatches.py:210
+msgid "LEGEND"
+msgstr ""
+
+#: dnamatches.py:228
+msgid "="
+msgstr ""
+
+#: dnamatches.py:310 dnamatches.py:409 dnamatches.py:420
+msgid "Not specified"
+msgstr ""
+
+#: dnamatches.py:348
 msgid "unknown"
 msgstr ""
 
-#: dnamatches.py:182 dnamatches.py:185
+#: dnamatches.py:366 dnamatches.py:369
 msgid "cM"
-msgstr ""
-
-#: dnamatches.py:225 dnamatches.py:236
-msgid "Not specified"
 msgstr ""


### PR DESCRIPTION
Hey, I made this Gramplet for personal use but thought others may find it useful as well, so here it is. 

![DNAMatches](https://github.com/gramps-project/addons-source/assets/20477036/610b7634-cbfb-490c-a592-b2b19c750964)

DNA Matches will list the active person's DNA matches including information about their relationship, cMs, number of segments, largest segment and sources. It is designed to complement the [DNA Segment Map](https://gramps-project.org/wiki/index.php/Addon:DNASegmentMapGramplet) and also works with the [Sync Associations](https://gramps-project.org/wiki/index.php/Addon:SyncAssociation) gramplet, but can be used without them. 

Information is gathered from Notes in Associations of type "DNA" between persons, same as with the DNA Segment Map (exact same format). However, there is also an alternative format for websites that don't have chromosome browsers such as Ancestry. This takes the form of a note with a single line specifying shared DNA, shared segments and the largest segment, in that order, separated by tabs or commas, like so:

`168,5,68`

You can see one Ancestry match in the attached screenshot above to give you an idea.

This initial version also comes with a Slovak translation by myself as I am Slovak. 😄

Btw, I did spin this off from the DNA Segment Map initially so I left the original developers' credits in the files. Hope that's ok.

Let me know if there are any issues!