### PR TITLE
Update getgov.py for python change

### DIFF
--- a/GetGOV/getgov.py
+++ b/GetGOV/getgov.py
@@ -349,7 +349,7 @@ class GetGOV(Gramplet):
                 else:
                     place, ref_list = self.__get_place(gov_id, self.type_dic,
                                                        preferred_lang)
-                    if place.get_name().get_value is not '':
+                    if place.get_name().get_value != '':
                         self.dbstate.db.add_place(place, trans)
                         visited[gov_id] = (place, ref_list)
                         for ref, date in ref_list:


### PR DESCRIPTION
Address python warning:

plugins/GetGOV/getgov.py:352: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if place.get_name().get_value is not '':