### PR TITLE
Update PrerequisitesCheckerGramplet.gpr.py

### DIFF
--- a/PrerequisitesCheckerGramplet/PrerequisitesCheckerGramplet.gpr.py
+++ b/PrerequisitesCheckerGramplet/PrerequisitesCheckerGramplet.gpr.py
@@ -34,5 +34,6 @@ register(GRAMPLET,
          height=300,
          gramplet='PrerequisitesCheckerGramplet',
          gramplet_title=_("Prerequisites Checker"),
-         help_url="Addon:Prerequisites_Checker_Gramplet"
+         help_url="Addon:Prerequisites_Checker_Gramplet",
+         navtypes=["Dashboard"],
          )


### PR DESCRIPTION
The Prerequisites Checker will only give results in the Dashboard.  Add 'navtypes' plugin registration restriction for that category