### PR TITLE
Update 1921 England Census form: Separate age years and age months

### DIFF
--- a/Form/form_gb.xml
+++ b/Form/form_gb.xml
@@ -740,6 +740,11 @@
                 <_longname>AGE</_longname>
             </column>
             <column>
+                <_attribute>Age Months</_attribute>
+                <size>5</size>
+                <_longname>AGE</_longname>
+            </column>
+            <column>
                 <_attribute>Sex</_attribute>
                 <size>5</size>
                 <_longname>SEX</_longname>

--- a/Form/form_gb.xml
+++ b/Form/form_gb.xml
@@ -737,12 +737,12 @@
             <column>
                 <_attribute>Age</_attribute>
                 <size>5</size>
-                <_longname>AGE</_longname>
+                <_longname>AGE years</_longname>
             </column>
             <column>
                 <_attribute>Age Months</_attribute>
                 <size>5</size>
-                <_longname>AGE</_longname>
+                <_longname>AGE months</_longname>
             </column>
             <column>
                 <_attribute>Sex</_attribute>

--- a/Form/form_gb.xml
+++ b/Form/form_gb.xml
@@ -1128,8 +1128,13 @@
             </column>
             <column>
                 <_attribute>Age</_attribute>
-                <size>4</size>
-                <_longname>AGE</_longname>
+                <size>5</size>
+                <_longname>AGE years</_longname>
+            </column>
+            <column>
+                <_attribute>Age Months</_attribute>
+                <size>5</size>
+                <_longname>AGE months</_longname>
             </column>
             <column>
                 <_attribute>Sex</_attribute>


### PR DESCRIPTION
The UK 1921 census form has separate columns for a persons age in  years and months.
Store these are separate columns in the gramps form definition.
The existing gramps UK1921 form Age column name has not been renamed to maintain backwards compatibility.

We have no way to know how someone may have encoded the years and months columns from the printed form into the single column in the gramps form. This makes it challenging to migrate existing data to the new structure. 