### PR TITLE
Date Calculator Enhancements

### DIFF
--- a/DateCalculator/DateCalculator.py
+++ b/DateCalculator/DateCalculator.py
@@ -79,14 +79,18 @@ class DateCalculator(Gramplet):
         self.result = self.__add_entry(_("Result"))
         self.result.set_editable(False)
 
-        bbox = Gtk.ButtonBox()
+        button_box = Gtk.ButtonBox()
+        button_box.set_layout(Gtk.ButtonBoxStyle.START)
+        button_box.set_spacing(6)
+        button_box.set_border_width(12)
+
         apply_button = Gtk.Button(label=_("Calculate"))
         apply_button.connect('clicked', self.apply_clicked)
-        bbox.pack_start(apply_button, False, False, 6)
+        button_box.add(apply_button)
         clear_button = Gtk.Button(label=_("Clear"))
         clear_button.connect('clicked', self.clear_clicked)
-        bbox.pack_start(clear_button, False, False, 6)
-        self.top.pack_start(bbox, False, False, 6)
+        button_box.add(clear_button)
+        self.top.pack_start(button_box, False, False, 6)
 
         self.top.show_all()
         self.clear_clicked(None)

--- a/DateCalculator/DateCalculator.py
+++ b/DateCalculator/DateCalculator.py
@@ -36,6 +36,7 @@ from gi.repository import Gtk
 #
 #------------------------------------------------------------------------
 from gramps.gen.plug import Gramplet
+from gramps.gen.datehandler import displayer
 from gramps.gen.lib import Date
 from gramps.gui.utils import text_to_clipboard
 
@@ -186,6 +187,7 @@ class DateCalculator(Gramplet):
         if result:
             if isinstance(result, Date):                
                 result.set_quality(Date.QUAL_CALCULATED)
+                result = displayer.display(result)
             self.result.set_text(str(result))
 
     def copy_clicked(self, obj):

--- a/DateCalculator/DateCalculator.py
+++ b/DateCalculator/DateCalculator.py
@@ -74,9 +74,9 @@ class DateCalculator(Gramplet):
         self.top = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self.top.set_border_width(6)
 
-        self.entry1 = self.__add_text_view(_("Expression 1: Reference Date or Date Range"), _("a valid Gramps date"))
-        self.entry2 = self.__add_text_view(_("Expression 2: Date or offset ±y or ±y, m, d"), _("1. a Date\n2. a positive or negative number, representing years\n3. a positive or negative list of values, representing years, months, days"))
-        self.result = self.__add_text_view(_("Result"))
+        self.entry1 = self.__add_entry(_("Expression 1: Reference Date or Date Range"), _("a valid Gramps date"))
+        self.entry2 = self.__add_entry(_("Expression 2: Date or offset ±y or ±y, m, d"), _("1. a Date\n2. a positive or negative number, representing years\n3. a positive or negative list of values, representing years, months, days"))
+        self.result = self.__add_entry(_("Result"))
 
         bbox = Gtk.ButtonBox()
         apply_button = Gtk.Button(label=_("Calculate"))
@@ -91,29 +91,24 @@ class DateCalculator(Gramplet):
         self.clear_clicked(None)
         return self.top
 
-    def __add_text_view(self, name, tooltip = ""):
+    def __add_entry(self, name, tooltip = ""):
         """
         Add a text view to the interface.
         """
         label = Gtk.Label(halign=Gtk.Align.START)
         label.set_markup('<b>%s</b>' % name)
         self.top.pack_start(label, False, False, 6)
-        swin = Gtk.ScrolledWindow()
-        swin.set_shadow_type(Gtk.ShadowType.IN)
-        tview = Gtk.TextView()
-        tview.set_tooltip_text(tooltip)
-        swin.add(tview)
-        self.top.pack_start(swin, True, True, 6)
-        return tview.get_buffer()
+        entry = Gtk.Entry()
+        entry.set_tooltip_text(tooltip)
+        self.top.pack_start(entry, False, False, 6)
+        return entry
 
     def apply_clicked(self, obj):
         """
         Method that is run when you click the Calculate button.
         """
-        text1 = str(self.entry1.get_text(self.entry1.get_start_iter(),
-                                         self.entry1.get_end_iter(), False))
-        text2 = str(self.entry2.get_text(self.entry2.get_start_iter(),
-                                         self.entry2.get_end_iter(), False))
+        text1 = str(self.entry1.get_text())
+        text2 = str(self.entry2.get_text())
         neg1 = False
         neg2 = False
         if text1.startswith("-"):

--- a/DateCalculator/DateCalculator.py
+++ b/DateCalculator/DateCalculator.py
@@ -183,10 +183,5 @@ class DateCalculator(Gramplet):
         self.entry1.set_text("")
         self.entry2.set_text("")
         self.result.set_text(
-            _("Enter an expression in the entries above and click Calculate.\n\n"
-              "An expression can be:\n\n"
-              "1. a valid Gramps date\n"
-              "2. a positive or negative number, representing years\n"
-              "3. a positive or negative tuple, representing (years, months, days)\n\n"
-              "Note that at least one expression must be a date."
+            _("Enter an expression in the entries above and click Calculate."
           ))

--- a/DateCalculator/DateCalculator.py
+++ b/DateCalculator/DateCalculator.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2010       Jakim Friant
 # Copyright (c) 2015       Douglas S. Blank <doug.blank@gmail.com>
 # Copyright (c) 2020       Jan Sparreboom <jan@sparreboom.net>
+# Copyright (c) 2024       Steve Youngs <steve@youngs.cc>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -73,8 +74,8 @@ class DateCalculator(Gramplet):
         self.top = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self.top.set_border_width(6)
 
-        self.entry1 = self.__add_text_view(_("Expression 1"))
-        self.entry2 = self.__add_text_view(_("Expression 2"))
+        self.entry1 = self.__add_text_view(_("Expression 1: Reference Date or Date Range"))
+        self.entry2 = self.__add_text_view(_("Expression 2: Date or offset ±y or ±y, m, d"))
         self.result = self.__add_text_view(_("Result"))
 
         bbox = Gtk.ButtonBox()

--- a/DateCalculator/DateCalculator.py
+++ b/DateCalculator/DateCalculator.py
@@ -37,6 +37,7 @@ from gi.repository import Gtk
 #------------------------------------------------------------------------
 from gramps.gen.plug import Gramplet
 from gramps.gen.lib import Date
+from gramps.gui.utils import text_to_clipboard
 
 #------------------------------------------------------------------------
 #
@@ -87,6 +88,9 @@ class DateCalculator(Gramplet):
         apply_button = Gtk.Button(label=_("Calculate"))
         apply_button.connect('clicked', self.apply_clicked)
         button_box.add(apply_button)
+        copy_button = Gtk.Button(label=_("Copy"))
+        copy_button.connect('clicked', self.copy_clicked)
+        button_box.add(copy_button)
         clear_button = Gtk.Button(label=_("Clear"))
         clear_button.connect('clicked', self.clear_clicked)
         button_box.add(clear_button)
@@ -178,6 +182,9 @@ class DateCalculator(Gramplet):
                 self.result.set_text(_("Error: at least one expression must be a date"))
             elif isinstance(val2, int):
                 self.result.set_text(_("Error: at least one expression must be a date"))
+
+    def copy_clicked(self, obj):
+        text_to_clipboard(self.result.get_text())
 
     def clear_clicked(self, obj):
         self.entry1.set_text("")

--- a/DateCalculator/DateCalculator.py
+++ b/DateCalculator/DateCalculator.py
@@ -184,6 +184,8 @@ class DateCalculator(Gramplet):
             elif isinstance(val2, int):
                 result = _("Error: at least one expression must be a date")
         if result:
+            if isinstance(result, Date):                
+                result.set_quality(Date.QUAL_CALCULATED)
             self.result.set_text(str(result))
 
     def copy_clicked(self, obj):

--- a/DateCalculator/DateCalculator.py
+++ b/DateCalculator/DateCalculator.py
@@ -74,8 +74,8 @@ class DateCalculator(Gramplet):
         self.top = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self.top.set_border_width(6)
 
-        self.entry1 = self.__add_text_view(_("Expression 1: Reference Date or Date Range"))
-        self.entry2 = self.__add_text_view(_("Expression 2: Date or offset ±y or ±y, m, d"))
+        self.entry1 = self.__add_text_view(_("Expression 1: Reference Date or Date Range"), _("a valid Gramps date"))
+        self.entry2 = self.__add_text_view(_("Expression 2: Date or offset ±y or ±y, m, d"), _("1. a Date\n2. a positive or negative number, representing years\n3. a positive or negative list of values, representing years, months, days"))
         self.result = self.__add_text_view(_("Result"))
 
         bbox = Gtk.ButtonBox()
@@ -91,7 +91,7 @@ class DateCalculator(Gramplet):
         self.clear_clicked(None)
         return self.top
 
-    def __add_text_view(self, name):
+    def __add_text_view(self, name, tooltip = ""):
         """
         Add a text view to the interface.
         """
@@ -101,6 +101,7 @@ class DateCalculator(Gramplet):
         swin = Gtk.ScrolledWindow()
         swin.set_shadow_type(Gtk.ShadowType.IN)
         tview = Gtk.TextView()
+        tview.set_tooltip_text(tooltip)
         swin.add(tview)
         self.top.pack_start(swin, True, True, 6)
         return tview.get_buffer()

--- a/DateCalculator/DateCalculator.py
+++ b/DateCalculator/DateCalculator.py
@@ -134,7 +134,7 @@ class DateCalculator(Gramplet):
                 if not val1.is_valid():
                     raise Exception()
             except:
-                self.result.set_text(_("Error: invalid entry for expression 1"))
+                self.result.set_text(_("Error: invalid date for expression 1"))
                 return
         try:
             val2 = eval(text2)
@@ -144,44 +144,47 @@ class DateCalculator(Gramplet):
                 if not val2.is_valid():
                     raise Exception()
             except:
-                self.result.set_text(_("Error: invalid entry for expression 2"))
+                self.result.set_text(_("Error: invalid offset for expression 2"))
                 return
+        result = None
         if isinstance(val1, Date):
             if isinstance(val2, Date):
                 if neg1:
-                    self.result.set_text(str(val2 - val1))
+                    result = val2 - val1
                 else:
-                    self.result.set_text(str(val1 - val2))
+                    result = val1 - val2
             elif isinstance(val2, tuple):
                 if neg2:
-                    self.result.set_text(str(val1 - val2))
+                    result = val1 - val2
                 else:
-                    self.result.set_text(str(val1 + val2))
+                    result = val1 + val2
             elif isinstance(val2, int):
                 if neg2:
-                    self.result.set_text(str(val1 - val2))
+                    result = val1 - val2
                 else:
-                    self.result.set_text(str(val1 + val2))
+                    result = val1 + val2
         elif isinstance(val1, tuple):
             if isinstance(val2, Date):
                 if neg1:
-                    self.result.set_text(str(val2 - val1))
+                    result = val2 - val1
                 else:
-                    self.result.set_text(str(val2 + val1))
+                    result = val2 + val1
             elif isinstance(val2, tuple):
-                self.result.set_text(_("Error: at least one expression must be a date"))
+                result = _("Error: at least one expression must be a date")
             elif isinstance(val2, int):
-                self.result.set_text(_("Error: at least one expression must be a date"))
+                result = _("Error: at least one expression must be a date")
         elif isinstance(val1, int):
             if isinstance(val2, Date):
                 if neg1:
-                    self.result.set_text(str(val2 - val1))
+                    result = val2 - val1
                 else:
-                    self.result.set_text(str(val2 + val1))
+                    result = val2 + val1
             elif isinstance(val2, tuple):
-                self.result.set_text(_("Error: at least one expression must be a date"))
+                result = _("Error: at least one expression must be a date")
             elif isinstance(val2, int):
-                self.result.set_text(_("Error: at least one expression must be a date"))
+                result = _("Error: at least one expression must be a date")
+        if result:
+            self.result.set_text(str(result))
 
     def copy_clicked(self, obj):
         text_to_clipboard(self.result.get_text())

--- a/DateCalculator/DateCalculator.py
+++ b/DateCalculator/DateCalculator.py
@@ -77,6 +77,7 @@ class DateCalculator(Gramplet):
         self.entry1 = self.__add_entry(_("Expression 1: Reference Date or Date Range"), _("a valid Gramps date"))
         self.entry2 = self.__add_entry(_("Expression 2: Date or offset ±y or ±y, m, d"), _("1. a Date\n2. a positive or negative number, representing years\n3. a positive or negative list of values, representing years, months, days"))
         self.result = self.__add_entry(_("Result"))
+        self.result.set_editable(False)
 
         bbox = Gtk.ButtonBox()
         apply_button = Gtk.Button(label=_("Calculate"))

--- a/DateCalculator/DateCalculator.py
+++ b/DateCalculator/DateCalculator.py
@@ -23,29 +23,30 @@
 DateCalculator does date math.
 """
 
-#------------------------------------------------------------------------
+# ------------------------------------------------------------------------
 #
 # Python modules
 #
-#------------------------------------------------------------------------
+# ------------------------------------------------------------------------
 from gi.repository import Gtk
 
-#------------------------------------------------------------------------
+# ------------------------------------------------------------------------
 #
 # GRAMPS modules
 #
-#------------------------------------------------------------------------
+# ------------------------------------------------------------------------
 from gramps.gen.plug import Gramplet
 from gramps.gen.datehandler import displayer
 from gramps.gen.lib import Date
 from gramps.gui.utils import text_to_clipboard
 
-#------------------------------------------------------------------------
+# ------------------------------------------------------------------------
 #
 # Internationalisation
 #
-#------------------------------------------------------------------------
+# ------------------------------------------------------------------------
 from gramps.gen.const import GRAMPS_LOCALE as glocale
+
 try:
     trans = glocale.get_addon_translator(__file__)
 except ValueError:
@@ -55,15 +56,17 @@ ngettext = trans.ngettext
 
 from gramps.gen.datehandler import parser
 
-#------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------
 #
 # Classes
 #
-#------------------------------------------------------------------------
+# ------------------------------------------------------------------------
 class DateCalculator(Gramplet):
     """
     Gramplet that computes date math.
     """
+
     def init(self):
         self.gui.WIDGET = self.build_gui()
         self.gui.get_container_widget().remove(self.gui.textview)
@@ -76,8 +79,15 @@ class DateCalculator(Gramplet):
         self.top = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
         self.top.set_border_width(6)
 
-        self.entry1 = self.__add_entry(_("Expression 1: Reference Date or Date Range"), _("a valid Gramps date"))
-        self.entry2 = self.__add_entry(_("Expression 2: Date or offset ±y or ±y, m, d"), _("1. a Date\n2. a positive or negative number, representing years\n3. a positive or negative list of values, representing years, months, days"))
+        self.entry1 = self.__add_entry(
+            _("Expression 1: Reference Date or Date Range"), _("a valid Gramps date")
+        )
+        self.entry2 = self.__add_entry(
+            _("Expression 2: Date or offset ±y or ±y, m, d"),
+            _(
+                "1. a Date\n2. a positive or negative number, representing years\n3. a positive or negative list of values, representing years, months, days"
+            ),
+        )
         self.result = self.__add_entry(_("Result"))
         self.result.set_editable(False)
 
@@ -87,13 +97,13 @@ class DateCalculator(Gramplet):
         button_box.set_border_width(12)
 
         apply_button = Gtk.Button(label=_("Calculate"))
-        apply_button.connect('clicked', self.apply_clicked)
+        apply_button.connect("clicked", self.apply_clicked)
         button_box.add(apply_button)
         copy_button = Gtk.Button(label=_("Copy"))
-        copy_button.connect('clicked', self.copy_clicked)
+        copy_button.connect("clicked", self.copy_clicked)
         button_box.add(copy_button)
         clear_button = Gtk.Button(label=_("Clear"))
-        clear_button.connect('clicked', self.clear_clicked)
+        clear_button.connect("clicked", self.clear_clicked)
         button_box.add(clear_button)
         self.top.pack_start(button_box, False, False, 6)
 
@@ -101,12 +111,12 @@ class DateCalculator(Gramplet):
         self.clear_clicked(None)
         return self.top
 
-    def __add_entry(self, name, tooltip = ""):
+    def __add_entry(self, name, tooltip=""):
         """
         Add a text view to the interface.
         """
         label = Gtk.Label(halign=Gtk.Align.START)
-        label.set_markup('<b>%s</b>' % name)
+        label.set_markup("<b>%s</b>" % name)
         self.top.pack_start(label, False, False, 6)
         entry = Gtk.Entry()
         entry.set_tooltip_text(tooltip)
@@ -185,7 +195,7 @@ class DateCalculator(Gramplet):
             elif isinstance(val2, int):
                 result = _("Error: at least one expression must be a date")
         if result:
-            if isinstance(result, Date):                
+            if isinstance(result, Date):
                 result.set_quality(Date.QUAL_CALCULATED)
                 result = displayer.display(result)
             self.result.set_text(str(result))
@@ -197,5 +207,5 @@ class DateCalculator(Gramplet):
         self.entry1.set_text("")
         self.entry2.set_text("")
         self.result.set_text(
-            _("Enter an expression in the entries above and click Calculate."
-          ))
+            _("Enter an expression in the entries above and click Calculate.")
+        )


### PR DESCRIPTION
Changes to the date calculator gramplet as discussed in discourse [here](https://gramps.discourse.group/t/update-to-uk1921-form/6581/2?u=stevey) and bug [#12345](https://gramps-project.org/bugs/view.php?id=12345)

In summary:
- add tooltips to the entry widgets
- use Gtk.Entry instead of Gtk.TextView for a more compact display
- use displayer to format the result to match users configuration
- set the qualifier on the result to calculated
- add a copy button for easier copying to the clipboard

credit to the commenters for their ideas.

![image](https://github.com/user-attachments/assets/d3f04a2b-ead4-4f2d-82ed-b76966c59353)
.