### PR TITLE
Form: Sync Event and Citation dates on save

### DIFF
--- a/Form/editform.py
+++ b/Form/editform.py
@@ -326,7 +326,6 @@ class EditForm(ManagedWindow):
         if form_date is not None:
             date_text.set_text(displayer.display(form_date))
             self.event.set_date_object(form_date)
-            self.citation.set_date_object(form_date)
             date_text.set_editable(False)
             date_button.set_sensitive(False)
         else:
@@ -358,6 +357,7 @@ class EditForm(ManagedWindow):
         """
         Called when the user clicks the OK button.
         """
+        self.citation.set_date_object(self.event.get_date_object())
         with DbTxn(self.get_menu_title(), self.db) as trans:
             if not self.event.get_handle():
                 self.db.add_event(self.event, trans)


### PR DESCRIPTION
Currently the date of the event object created by the form is set based on the form.
The date of the citation object is sometimes set.
This PR aligns the behaviour so that the citation date is always set

Currently there are two different behaviours:
1. if the form definition defined the date
  the event and citation objects had the same date as the user is not able to edit the date in the form
  therefore, they were always synced
2. if the form definition did not define a date
  the event date was set based on the form dialog. 
  the citation date was never set.

With this change, the citation date is aligned to the event date when saving the form