### PR TITLE
Tentative fix for crash in Form editor

### DIFF
--- a/Form/editform.py
+++ b/Form/editform.py
@@ -324,7 +324,7 @@ class EditForm(ManagedWindow):
         if not event.get_handle():
             form_reference = get_form_reference(form_id)
             if form_reference:
-                ref_entry = self.widgets['ref_entry']
+                ref_entry = self.widgets["ref_entry"]
                 ref_entry.set_text(form_reference)
 
         # Set date

--- a/Form/editform.py
+++ b/Form/editform.py
@@ -384,6 +384,9 @@ class EditForm(ManagedWindow):
         self.close()
         self.callback()
 
+    def clean_up(self):
+        self.gallery_list.clean_up()
+
     def close(self, *args):
         """
         Close the editor window.
@@ -395,7 +398,6 @@ class EditForm(ManagedWindow):
         self._config.set("interface.form-horiz-position", width)
         self._config.set("interface.form-vert-position", height)
         self._config.save()
-        self.gallery_list.clean_up()
         ManagedWindow.close(self)
 
     def help_clicked(self, obj):


### PR DESCRIPTION
Gramps 5.2, introduced a regression when closing the EditForm dialog, if an image from the gallery had been selected.
This is logged in [mantis](https://gramps-project.org/bugs/view.php?id=13326) and discussed in the forum [here](https://gramps.discourse.group/t/repeatable-unexpected-error-gallery-in-forms/6436/8) and [here](https://gramps.discourse.group/t/error-gallerytab-object-has-no-attribute-iconlist/6675/7).

**Minimal steps to reproduce**
1. install the Forms addon
2. configure at least one Source to be a form
3. create a new form
4. in the form dialog, switch to the gallery tab
5. add an image
6. select the image you just added
7. click Cancel on the Form dialog

It can also be reproduced by opening an existing form with an image and following steps 4, 6 and 7

**Investigation**
I suspect the problem is related to the order in which `EditForm.close()` is destroying objects. Namely `self.gallery_list.clean_up()` is called, leaving the GalleryTab object in an "unexpected" state, before `ManagedWindow.close(self)` is called (which in turn triggers calls into GalleryTab, resulting in the error)

**Tentative Fix**
This PR moves the call to `self.gallery_list.clean_up()` into `EditForm.clean_up`. At face value this seems like a sensible thing to do, and it fixes the error. I'd appreciate a review from someone that understands the object lifetimes of a ManagedWindow

Gramps 5.1.6 works correctly. The modified code is unchanged since 5.1.6.