### PR TITLE
Update GedcomExtensions plugin to unblock GEDCOM exports with patronymic names

### DIFF
--- a/GedcomExtensions/GedcomExtensions.py
+++ b/GedcomExtensions/GedcomExtensions.py
@@ -174,6 +174,8 @@ class GedcomWriterOptionBox(WriterOptionBox):
         self.include_witnesses_check = Gtk.CheckButton(_("Include witnesses"))
         self.include_media_check = Gtk.CheckButton(_("Include media"))
 
+        hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+        label = Gtk.Label(label=_("Patronymic names:"))
         self.process_patronymic_list = Gtk.ComboBoxText()
         self.process_patronymic_list.append_text(_("Don't change"))
         self.process_patronymic_list.append_text(_("Add Patronymic name after Given name"))
@@ -187,7 +189,10 @@ class GedcomWriterOptionBox(WriterOptionBox):
         # Add to gui:
         option_box.pack_start(self.include_witnesses_check, False, False, 0)
         option_box.pack_start(self.include_media_check, False, False, 0)
-        option_box.pack_start(self.process_patronymic_list, False, False, 0)
+
+        hbox.pack_start(label, False, False, 0)
+        hbox.pack_start(self.process_patronymic_list, False, False, 0)
+        option_box.pack_start(hbox, False, False, 0)
 
         return option_box
 

--- a/GedcomExtensions/po/da-local.po
+++ b/GedcomExtensions/po/da-local.po
@@ -62,3 +62,7 @@ msgstr "Tilføj Patronymisk navn efter Fornavn"
 #: GedcomExtensions/GedcomExtensions.py:180
 msgid "Ignore Patronymic name"
 msgstr "Ignorer Patronymisk navn"
+
+#: GedcomExtensions/GedcomExtensions.py
+msgid "Patronymic names:"
+msgstr "Patronymiske navne:"

--- a/GedcomExtensions/po/da-local.po
+++ b/GedcomExtensions/po/da-local.po
@@ -50,3 +50,15 @@ msgstr "Kunne ikke danne %s"
 #: GedcomExtensions/GedcomExtensions.py:150
 msgid "Export failed"
 msgstr "Eksporten mislykkedes"
+
+#: GedcomExtensions/GedcomExtensions.py:178
+msgid "Don't change"
+msgstr "Ændr ikke"
+
+#: GedcomExtensions/GedcomExtensions.py:179
+msgid "Add Patronymic name after Given name"
+msgstr "Tilføj Patronymisk navn efter Fornavn"
+
+#: GedcomExtensions/GedcomExtensions.py:180
+msgid "Ignore Patronymic name"
+msgstr "Ignorer Patronymisk navn"

--- a/GedcomExtensions/po/de-local.po
+++ b/GedcomExtensions/po/de-local.po
@@ -69,3 +69,7 @@ msgstr "Patronym nach Vorname hinzufügen"
 #: GedcomExtensions/GedcomExtensions.py:180
 msgid "Ignore Patronymic name"
 msgstr "Patronym ignorieren"
+
+#: GedcomExtensions/GedcomExtensions.py
+msgid "Patronymic names:"
+msgstr "Patronymische Namen:"

--- a/GedcomExtensions/po/de-local.po
+++ b/GedcomExtensions/po/de-local.po
@@ -57,3 +57,15 @@ msgstr "Konnte %s nicht erstellen"
 #: GedcomExtensions/GedcomExtensions.py:154
 msgid "Export failed"
 msgstr "Export fehlgeschlagen"
+
+#: GedcomExtensions/GedcomExtensions.py:178
+msgid "Don't change"
+msgstr "Nicht ändern"
+
+#: GedcomExtensions/GedcomExtensions.py:179
+msgid "Add Patronymic name after Given name"
+msgstr "Patronym nach Vorname hinzufügen"
+
+#: GedcomExtensions/GedcomExtensions.py:180
+msgid "Ignore Patronymic name"
+msgstr "Patronym ignorieren"

--- a/GedcomExtensions/po/fi-local.po
+++ b/GedcomExtensions/po/fi-local.po
@@ -68,3 +68,7 @@ msgstr "Lisää Isännimi Etunimen jälkeen"
 #: GedcomExtensions/GedcomExtensions.py:180
 msgid "Ignore Patronymic name"
 msgstr "Ohita Isännimi"
+
+#: GedcomExtensions/GedcomExtensions.py
+msgid "Patronymic names:"
+msgstr "Isännimet:"

--- a/GedcomExtensions/po/fi-local.po
+++ b/GedcomExtensions/po/fi-local.po
@@ -56,3 +56,15 @@ msgstr "Ei voitu luoda %s"
 #: GedcomExtensions.py:154
 msgid "Export failed"
 msgstr "Vienti epäonnistui"
+
+#: GedcomExtensions/GedcomExtensions.py:178
+msgid "Don't change"
+msgstr "Älä muuta"
+
+#: GedcomExtensions/GedcomExtensions.py:179
+msgid "Add Patronymic name after Given name"
+msgstr "Lisää Isännimi Etunimen jälkeen"
+
+#: GedcomExtensions/GedcomExtensions.py:180
+msgid "Ignore Patronymic name"
+msgstr "Ohita Isännimi"

--- a/GedcomExtensions/po/fr-local.po
+++ b/GedcomExtensions/po/fr-local.po
@@ -75,3 +75,7 @@ msgstr "Ajouter le nom patronymique après le prénom"
 #: GedcomExtensions/GedcomExtensions.py:180
 msgid "Ignore Patronymic name"
 msgstr "Ignorer le nom patronymique"
+
+#: GedcomExtensions/GedcomExtensions.py
+msgid "Patronymic names:"
+msgstr "Noms patronymiques:"

--- a/GedcomExtensions/po/fr-local.po
+++ b/GedcomExtensions/po/fr-local.po
@@ -64,3 +64,14 @@ msgstr "Impossible de créer %s"
 msgid "Export failed"
 msgstr "L'exportation a échoué"
 
+#: GedcomExtensions/GedcomExtensions.py:178
+msgid "Don't change"
+msgstr "Ne pas changer"
+
+#: GedcomExtensions/GedcomExtensions.py:179
+msgid "Add Patronymic name after Given name"
+msgstr "Ajouter le nom patronymique après le prénom"
+
+#: GedcomExtensions/GedcomExtensions.py:180
+msgid "Ignore Patronymic name"
+msgstr "Ignorer le nom patronymique"

--- a/GedcomExtensions/po/hr-local.po
+++ b/GedcomExtensions/po/hr-local.po
@@ -51,3 +51,15 @@ msgstr "Nije moguće stvoriti %s"
 #: GedcomExtensions/GedcomExtensions.py:154
 msgid "Export failed"
 msgstr "Izvoz neuspio"
+
+#: GedcomExtensions/GedcomExtensions.py:178
+msgid "Don't change"
+msgstr "Ne mijenjaj"
+
+#: GedcomExtensions/GedcomExtensions.py:179
+msgid "Add Patronymic name after Given name"
+msgstr "Dodaj Očinsko ime nakon Imena"
+
+#: GedcomExtensions/GedcomExtensions.py:180
+msgid "Ignore Patronymic name"
+msgstr "Zanemari Očinsko ime"

--- a/GedcomExtensions/po/hr-local.po
+++ b/GedcomExtensions/po/hr-local.po
@@ -63,3 +63,7 @@ msgstr "Dodaj Očinsko ime nakon Imena"
 #: GedcomExtensions/GedcomExtensions.py:180
 msgid "Ignore Patronymic name"
 msgstr "Zanemari Očinsko ime"
+
+#: GedcomExtensions/GedcomExtensions.py
+msgid "Patronymic names:"
+msgstr "Očinska imena:"

--- a/GedcomExtensions/po/nl-local.po
+++ b/GedcomExtensions/po/nl-local.po
@@ -49,3 +49,15 @@ msgstr "Kan %s niet maken"
 #: GedcomExtensions/GedcomExtensions.py:154
 msgid "Export failed"
 msgstr "Export is mislukt"
+
+#: GedcomExtensions/GedcomExtensions.py:178
+msgid "Don't change"
+msgstr "Niet veranderen"
+
+#: GedcomExtensions/GedcomExtensions.py:179
+msgid "Add Patronymic name after Given name"
+msgstr "Voeg Patroniem toe na Voornaam"
+
+#: GedcomExtensions/GedcomExtensions.py:180
+msgid "Ignore Patronymic name"
+msgstr "Negeer Patroniem"

--- a/GedcomExtensions/po/nl-local.po
+++ b/GedcomExtensions/po/nl-local.po
@@ -61,3 +61,7 @@ msgstr "Voeg Patroniem toe na Voornaam"
 #: GedcomExtensions/GedcomExtensions.py:180
 msgid "Ignore Patronymic name"
 msgstr "Negeer Patroniem"
+
+#: GedcomExtensions/GedcomExtensions.py
+msgid "Patronymic names:"
+msgstr "Patroniemen:"

--- a/GedcomExtensions/po/pt_PT-local.po
+++ b/GedcomExtensions/po/pt_PT-local.po
@@ -61,3 +61,7 @@ msgstr "Adicionar Nome Patronímico após o Primeiro Nome"
 #: GedcomExtensions/GedcomExtensions.py:180
 msgid "Ignore Patronymic name"
 msgstr "Ignorar Nome Patronímico"
+
+#: GedcomExtensions/GedcomExtensions.py
+msgid "Patronymic names:"
+msgstr "Nomes Patronímicos:"

--- a/GedcomExtensions/po/pt_PT-local.po
+++ b/GedcomExtensions/po/pt_PT-local.po
@@ -49,3 +49,15 @@ msgstr "Impossível criar %s"
 #: GedcomExtensions/GedcomExtensions.py:154
 msgid "Export failed"
 msgstr "A exportação falhou"
+
+#: GedcomExtensions/GedcomExtensions.py:178
+msgid "Don't change"
+msgstr "Não alterar"
+
+#: GedcomExtensions/GedcomExtensions.py:179
+msgid "Add Patronymic name after Given name"
+msgstr "Adicionar Nome Patronímico após o Primeiro Nome"
+
+#: GedcomExtensions/GedcomExtensions.py:180
+msgid "Ignore Patronymic name"
+msgstr "Ignorar Nome Patronímico"

--- a/GedcomExtensions/po/ru-local.po
+++ b/GedcomExtensions/po/ru-local.po
@@ -65,3 +65,7 @@ msgstr "Добавить Отчество после Имени"
 #: GedcomExtensions/GedcomExtensions.py:180
 msgid "Ignore Patronymic name"
 msgstr "Игнорировать Отчество"
+
+#: GedcomExtensions/GedcomExtensions.py
+msgid "Patronymic names:"
+msgstr "Отчества:"

--- a/GedcomExtensions/po/ru-local.po
+++ b/GedcomExtensions/po/ru-local.po
@@ -53,3 +53,15 @@ msgstr "Ошибка при создании %s"
 #: GedcomExtensions/GedcomExtensions.py:154
 msgid "Export failed"
 msgstr "Ошибка при экспорте"
+
+#: GedcomExtensions/GedcomExtensions.py:178
+msgid "Don't change"
+msgstr "Не изменять"
+
+#: GedcomExtensions/GedcomExtensions.py:179
+msgid "Add Patronymic name after Given name"
+msgstr "Добавить Отчество после Имени"
+
+#: GedcomExtensions/GedcomExtensions.py:180
+msgid "Ignore Patronymic name"
+msgstr "Игнорировать Отчество"

--- a/GedcomExtensions/po/sv-local.po
+++ b/GedcomExtensions/po/sv-local.po
@@ -62,3 +62,7 @@ msgstr "Lägg till Patronymiskt namn efter Förnamn"
 #: GedcomExtensions/GedcomExtensions.py:180
 msgid "Ignore Patronymic name"
 msgstr "Ignorera Patronymiskt namn"
+
+#: GedcomExtensions/GedcomExtensions.py
+msgid "Patronymic names:"
+msgstr "Patronymiska namn:"

--- a/GedcomExtensions/po/sv-local.po
+++ b/GedcomExtensions/po/sv-local.po
@@ -50,3 +50,15 @@ msgstr "Kunde inte skapa %s"
 #: GedcomExtensions/GedcomExtensions.py:154
 msgid "Export failed"
 msgstr "Exportering misslyckades"
+
+#: GedcomExtensions/GedcomExtensions.py:178
+msgid "Don't change"
+msgstr "Ändra inte"
+
+#: GedcomExtensions/GedcomExtensions.py:179
+msgid "Add Patronymic name after Given name"
+msgstr "Lägg till Patronymiskt namn efter Förnamn"
+
+#: GedcomExtensions/GedcomExtensions.py:180
+msgid "Ignore Patronymic name"
+msgstr "Ignorera Patronymiskt namn"

--- a/GedcomExtensions/po/template.pot
+++ b/GedcomExtensions/po/template.pot
@@ -50,14 +50,18 @@ msgstr ""
 msgid "Export failed"
 msgstr ""
 
-#: GedcomExtensions/GedcomExtensions.py:178
+#: GedcomExtensions/GedcomExtensions.py
 msgid "Don't change"
 msgstr ""
 
-#: GedcomExtensions/GedcomExtensions.py:179
+#: GedcomExtensions/GedcomExtensions.py
 msgid "Add Patronymic name after Given name"
 msgstr ""
 
-#: GedcomExtensions/GedcomExtensions.py:180
+#: GedcomExtensions/GedcomExtensions.py
 msgid "Ignore Patronymic name"
+msgstr ""
+
+#: GedcomExtensions/GedcomExtensions.py
+msgid "Patronymic names:"
 msgstr ""

--- a/GedcomExtensions/po/template.pot
+++ b/GedcomExtensions/po/template.pot
@@ -49,3 +49,15 @@ msgstr ""
 #: GedcomExtensions/GedcomExtensions.py:150
 msgid "Export failed"
 msgstr ""
+
+#: GedcomExtensions/GedcomExtensions.py:178
+msgid "Don't change"
+msgstr ""
+
+#: GedcomExtensions/GedcomExtensions.py:179
+msgid "Add Patronymic name after Given name"
+msgstr ""
+
+#: GedcomExtensions/GedcomExtensions.py:180
+msgid "Ignore Patronymic name"
+msgstr ""


### PR DESCRIPTION
Fix for "0013546: Gramps produces unusable GEDCOM when patronymic names are used"
https://gramps-project.org/bugs/view.php?id=13546

This adds options
1. Don't change Gramps export
2. Export Patronymic after given name, instead of adding it to the list of surnames
3. Ignore Patronymic names on export

### Testing
Sample person
![image](https://github.com/user-attachments/assets/1766ad27-3f3f-4807-b641-093ad1fcad70)

1. Don't change Gramps export
```
0 HEAD
1 SOUR Gramps
2 VERS AIO64-5.2.3-r1-aa03f5a
2 NAME Gramps
1 DATE 2 JAN 2025
2 TIME 22:00:48
1 SUBM @SUBM@
1 FILE C:\Users\x\Downloads\test_noop.ged2
1 COPR Copyright (c) 2025 .
1 GEDC
2 VERS 5.5.1
2 FORM LINEAGE-LINKED
1 CHAR UTF-8
1 LANG English
0 @SUBM@ SUBM
1 NAME
0 @I0000@ INDI
1 NAME Fyodor /Dostoevsky Mikhailovich/
2 TYPE birth
2 GIVN Fyodor
2 SURN Dostoevsky, Mikhailovich
1 SEX M
1 CHAN
2 DATE 2 JAN 2025
3 TIME 21:57:36
0 TRLR
```

2. Export Patronymic after given name, instead of adding it to the list of surnames
```
0 HEAD
1 SOUR Gramps
2 VERS AIO64-5.2.3-r1-aa03f5a
2 NAME Gramps
1 DATE 2 JAN 2025
2 TIME 22:01:10
1 SUBM @SUBM@
1 FILE C:\Users\x\Downloads\test_add_to_given_name.ged2
1 COPR Copyright (c) 2025 .
1 GEDC
2 VERS 5.5.1
2 FORM LINEAGE-LINKED
1 CHAR UTF-8
1 LANG English
0 @SUBM@ SUBM
1 NAME
0 @I0000@ INDI
1 NAME Fyodor Mikhailovich /Dostoevsky/
2 TYPE birth
2 GIVN Fyodor Mikhailovich
2 SURN Dostoevsky
1 SEX M
1 CHAN
2 DATE 2 JAN 2025
3 TIME 21:57:36
0 TRLR
```
3. Ignore Patronymic names on export
```
0 HEAD
1 SOUR Gramps
2 VERS AIO64-5.2.3-r1-aa03f5a
2 NAME Gramps
1 DATE 2 JAN 2025
2 TIME 22:01:27
1 SUBM @SUBM@
1 FILE C:\Users\x\Downloads\test_ignore_patronymic.ged2
1 COPR Copyright (c) 2025 .
1 GEDC
2 VERS 5.5.1
2 FORM LINEAGE-LINKED
1 CHAR UTF-8
1 LANG English
0 @SUBM@ SUBM
1 NAME
0 @I0000@ INDI
1 NAME Fyodor /Dostoevsky/
2 TYPE birth
2 GIVN Fyodor
2 SURN Dostoevsky
1 SEX M
1 CHAN
2 DATE 2 JAN 2025
3 TIME 21:57:36
0 TRLR
```


### Background from the bug

Ex-USSR / Eastern European / Russian Empire / etc uses patronymic names (derived from the father's name) between the given and last names.

Example: Фёдор Михайлович Достоевский (Fyodor Mikhailovich Dostoevsky)

In Gramps the patronymic name goes into the surnames list marked as "patronymic". Gramps handles it properly by switching the "name format" in Preferences.

So for the example above:

    Given: Фёдор
    Surname (inherited, primary): Достоевский
    Surname (patronymic): Михайлович

Exporting the DB to GEDCOM to be imported into Geni, FamilySearch, etc, produces a broken file that injects patronymic names as last names during the import. Gramps export doesn't obey the "Name format:" setting in Preferences.

```
1 NAME Фёдор /Достоевский Михайлович/
2 TYPE birth
2 GIVN Фёдор
2 SURN Достоевский, Михайлович
1 SEX M
```

GEDCOM specs don't cover patronymic names, but there are options:

    1. Gramps allows to configure of how patronymic names are exported.
    3. Gramps follows the "Name format:" setting in Preferences.
    5. Patronymic names are ignored at export: `GIVN Фёдор`, `SURN Достоевский`
    6. Patronymic names are added to the given name: `GIVN Фёдор Михайлович`, `SURN Достоевский`