### PR TITLE
GedcomExt: Change defaults from extra options from ON to OFF

### DIFF
--- a/GedcomExtensions/GedcomExtensions.py
+++ b/GedcomExtensions/GedcomExtensions.py
@@ -65,8 +65,8 @@ class GedcomWriterExtension(exportgedcom.GedcomWriter):
             self.include_media = option_box.include_media
             self.process_patronymic = option_box.process_patronymic
         else:
-            self.include_witnesses = CHECK_ON
-            self.include_media = CHECK_ON
+            self.include_witnesses = CHECK_OFF
+            self.include_media = CHECK_OFF
             self.process_patronymic = PATRONYMIC_NOOP
 
     def _photo(self, photo, level):
@@ -160,9 +160,9 @@ class GedcomWriterOptionBox(WriterOptionBox):
         """
         super(GedcomWriterOptionBox, self).__init__(person, dbstate, uistate,
                                                     track=track, window=window)
-        self.include_witnesses = CHECK_ON
+        self.include_witnesses = CHECK_OFF
         self.include_witnesses_check = None
-        self.include_media = CHECK_ON
+        self.include_media = CHECK_OFF
         self.include_media_check = None
         self.process_patronymic = PATRONYMIC_NOOP
         self.process_patronymic_list = None
@@ -182,8 +182,8 @@ class GedcomWriterOptionBox(WriterOptionBox):
         self.process_patronymic_list.append_text(_("Ignore Patronymic name"))
 
         # Set defaults:
-        self.include_witnesses_check.set_active(CHECK_ON)
-        self.include_media_check.set_active(CHECK_ON)
+        self.include_witnesses_check.set_active(CHECK_OFF)
+        self.include_media_check.set_active(CHECK_OFF)
         self.process_patronymic_list.set_active(PATRONYMIC_NOOP)
 
         # Add to gui:


### PR DESCRIPTION
Bug (tweak): https://gramps-project.org/bugs/view.php?id=13574

[GedcomExtensions](https://github.com/bryndin/addons-source/tree/maintenance/gramps52/GedcomExtensions) provides tools to enhance the default GEDCOM export. Users decide what tools they need. By default, GedcomExtensions must behave exactly like the vanilla exporter, and users can enable what they need. Thus, I'm changing the defaults for some features from ON to OFF.

**Change: "Include witnesses" and "Include media" checkboxes are disabled upon start**

Behavior before the change:
![image](https://github.com/user-attachments/assets/9c9f76ce-a1d5-430f-bd4d-710152cbafa6)

After the change:
![after](https://github.com/user-attachments/assets/d46096e4-8b2a-4f26-99f3-121df702e650)
