### PR TITLE
[GedcomExtensions] Allow exporting only one type of surnames

### DIFF
--- a/GedcomExtensions/GedcomExtensions.py
+++ b/GedcomExtensions/GedcomExtensions.py
@@ -48,6 +48,8 @@ CHECK_ON = 1
 PATRONYMIC_NOOP = 0
 PATRONYMIC_ADD = 1
 PATRONYMIC_IGNORE = 2
+SURNAME_FILTER_NOOP = 0
+# the rest of surname types come from NameOriginType
 
 def normalize(name):
     return name.strip().replace("/", "?")
@@ -64,10 +66,12 @@ class GedcomWriterExtension(exportgedcom.GedcomWriter):
             self.include_witnesses = option_box.include_witnesses
             self.include_media = option_box.include_media
             self.process_patronymic = option_box.process_patronymic
+            self.filter_surname = option_box.filter_surname
         else:
             self.include_witnesses = CHECK_ON
             self.include_media = CHECK_ON
             self.process_patronymic = PATRONYMIC_NOOP
+            self.filter_surname = SURNAME_FILTER_NOOP
 
     def _photo(self, photo, level):
         """
@@ -130,16 +134,33 @@ class GedcomWriterExtension(exportgedcom.GedcomWriter):
         name.set_surname_list(surnames)
         return name
 
+    def keep_one_type_of_surname(self, name, type_to_keep):
+        """
+        Keep only one type of surnames.
+
+        Example:  Maria (given) Skłodowska (inherited) Curie (taken)
+                  => noop => Maria (given) Skłodowska (inherited) Curie (taken)
+                  => keep inherited => Maria (given) Skłodowska (inherited)
+                  => keep taken => Maria (given) Curie (taken)
+        """
+        surnames = [s for s in name.get_surname_list() if s.get_origintype() == type_to_keep]
+        name.set_surname_list(surnames)
+        return name
+
     def _person_name(self, name, attr_nick):
         """
         Overloaded name-handling method to handle patronymic names.
         """
-
         # TODO: Should Matronymic names be handled similarly?
         if self.process_patronymic == PATRONYMIC_IGNORE:
             name = self.remove_patronymic_name(name)
         elif self.process_patronymic == PATRONYMIC_ADD:
             name = self.move_patronymic_name_to_given_name(name)
+
+        # surname filtering must happen after the patronymic processing
+        # as "patronymic" is a type of surname
+        if self.filter_surname != SURNAME_FILTER_NOOP:
+            name = self.keep_one_type_of_surname(name, self.filter_surname)
 
         super(GedcomWriterExtension, self)._person_name(name, attr_nick)
 
@@ -166,6 +187,8 @@ class GedcomWriterOptionBox(WriterOptionBox):
         self.include_media_check = None
         self.process_patronymic = PATRONYMIC_NOOP
         self.process_patronymic_list = None
+        self.filter_surname = SURNAME_FILTER_NOOP
+        self.filter_surname_list = None
 
     def get_option_box(self):
         option_box = super(GedcomWriterOptionBox, self).get_option_box()
@@ -181,10 +204,19 @@ class GedcomWriterOptionBox(WriterOptionBox):
         self.process_patronymic_list.append_text(_("Add Patronymic name after Given name"))
         self.process_patronymic_list.append_text(_("Ignore Patronymic name"))
 
+        hbox2 = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+        label2 = Gtk.Label(label=_("Keep one type of surnames:"))
+        self.filter_surname_list = Gtk.ComboBoxText()
+        self.filter_surname_list.append_text(_("Don't change"))
+        type_names = NameOriginType().get_standard_names()
+        for name in type_names:
+            self.filter_surname_list.append_text(name)
+
         # Set defaults:
         self.include_witnesses_check.set_active(CHECK_ON)
         self.include_media_check.set_active(CHECK_ON)
         self.process_patronymic_list.set_active(PATRONYMIC_NOOP)
+        self.filter_surname_list.set_active(SURNAME_FILTER_NOOP)
 
         # Add to gui:
         option_box.pack_start(self.include_witnesses_check, False, False, 0)
@@ -193,6 +225,10 @@ class GedcomWriterOptionBox(WriterOptionBox):
         hbox.pack_start(label, False, False, 0)
         hbox.pack_start(self.process_patronymic_list, False, False, 0)
         option_box.pack_start(hbox, False, False, 0)
+
+        hbox2.pack_start(label2, False, False, 0)
+        hbox2.pack_start(self.filter_surname_list, False, False, 0)
+        option_box.pack_start(hbox2, False, False, 0)
 
         return option_box
 
@@ -207,6 +243,8 @@ class GedcomWriterOptionBox(WriterOptionBox):
             self.include_media = self.include_media_check.get_active()
         if self.process_patronymic_list:
             self.process_patronymic = self.process_patronymic_list.get_active()
+        if self.filter_surname_list:
+            self.filter_surname = self.filter_surname_list.get_active()
 
 def export_data(database, filename, user, option_box=None):
     """

--- a/GedcomExtensions/GedcomExtensions.py
+++ b/GedcomExtensions/GedcomExtensions.py
@@ -205,7 +205,7 @@ class GedcomWriterOptionBox(WriterOptionBox):
         self.process_patronymic_list.append_text(_("Ignore Patronymic name"))
 
         hbox2 = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
-        label2 = Gtk.Label(label=_("Keep one type of surnames:"))
+        label2 = Gtk.Label(label=_("Type of surname:"))
         self.filter_surname_list = Gtk.ComboBoxText()
         self.filter_surname_list.append_text(_("Don't change"))
         type_names = NameOriginType().get_standard_names()

--- a/GedcomExtensions/po/da-local.po
+++ b/GedcomExtensions/po/da-local.po
@@ -66,3 +66,7 @@ msgstr "Ignorer Patronymisk navn"
 #: GedcomExtensions/GedcomExtensions.py
 msgid "Patronymic names:"
 msgstr "Patronymiske navne:"
+
+#: GedcomExtensions/GedcomExtensions.py:208
+msgid "Keep one type of surnames:"
+msgstr "Behold én type efternavne:"

--- a/GedcomExtensions/po/da-local.po
+++ b/GedcomExtensions/po/da-local.po
@@ -68,5 +68,5 @@ msgid "Patronymic names:"
 msgstr "Patronymiske navne:"
 
 #: GedcomExtensions/GedcomExtensions.py:208
-msgid "Keep one type of surnames:"
-msgstr "Behold én type efternavne:"
+msgid "Type of surname:"
+msgstr "Type af efternavn:"

--- a/GedcomExtensions/po/de-local.po
+++ b/GedcomExtensions/po/de-local.po
@@ -73,3 +73,7 @@ msgstr "Patronym ignorieren"
 #: GedcomExtensions/GedcomExtensions.py
 msgid "Patronymic names:"
 msgstr "Patronymische Namen:"
+
+#: GedcomExtensions/GedcomExtensions.py:208
+msgid "Keep one type of surnames:"
+msgstr "Behalte einen Typ von Nachnamen:"

--- a/GedcomExtensions/po/de-local.po
+++ b/GedcomExtensions/po/de-local.po
@@ -75,5 +75,5 @@ msgid "Patronymic names:"
 msgstr "Patronymische Namen:"
 
 #: GedcomExtensions/GedcomExtensions.py:208
-msgid "Keep one type of surnames:"
-msgstr "Behalte einen Typ von Nachnamen:"
+msgid "Type of surname:"
+msgstr "Art des Nachnamens:"

--- a/GedcomExtensions/po/fi-local.po
+++ b/GedcomExtensions/po/fi-local.po
@@ -72,3 +72,7 @@ msgstr "Ohita Isännimi"
 #: GedcomExtensions/GedcomExtensions.py
 msgid "Patronymic names:"
 msgstr "Isännimet:"
+
+#: GedcomExtensions/GedcomExtensions.py:208
+msgid "Keep one type of surnames:"
+msgstr "Pidä yksi sukunimityyppi:"

--- a/GedcomExtensions/po/fi-local.po
+++ b/GedcomExtensions/po/fi-local.po
@@ -74,5 +74,5 @@ msgid "Patronymic names:"
 msgstr "Isännimet:"
 
 #: GedcomExtensions/GedcomExtensions.py:208
-msgid "Keep one type of surnames:"
-msgstr "Pidä yksi sukunimityyppi:"
+msgid "Type of surname:"
+msgstr "Sukunimityyppi:"

--- a/GedcomExtensions/po/fr-local.po
+++ b/GedcomExtensions/po/fr-local.po
@@ -79,3 +79,7 @@ msgstr "Ignorer le nom patronymique"
 #: GedcomExtensions/GedcomExtensions.py
 msgid "Patronymic names:"
 msgstr "Noms patronymiques:"
+
+#: GedcomExtensions/GedcomExtensions.py:208
+msgid "Keep one type of surnames:"
+msgstr "Conserver un type de noms de famille:"

--- a/GedcomExtensions/po/fr-local.po
+++ b/GedcomExtensions/po/fr-local.po
@@ -81,5 +81,5 @@ msgid "Patronymic names:"
 msgstr "Noms patronymiques:"
 
 #: GedcomExtensions/GedcomExtensions.py:208
-msgid "Keep one type of surnames:"
-msgstr "Conserver un type de noms de famille:"
+msgid "Type of surname:"
+msgstr "Type de nom de famille:"

--- a/GedcomExtensions/po/hr-local.po
+++ b/GedcomExtensions/po/hr-local.po
@@ -67,3 +67,7 @@ msgstr "Zanemari Očinsko ime"
 #: GedcomExtensions/GedcomExtensions.py
 msgid "Patronymic names:"
 msgstr "Očinska imena:"
+
+#: GedcomExtensions/GedcomExtensions.py:208
+msgid "Keep one type of surnames:"
+msgstr "Zadrži jedan tip prezimena:"

--- a/GedcomExtensions/po/hr-local.po
+++ b/GedcomExtensions/po/hr-local.po
@@ -69,5 +69,5 @@ msgid "Patronymic names:"
 msgstr "Očinska imena:"
 
 #: GedcomExtensions/GedcomExtensions.py:208
-msgid "Keep one type of surnames:"
-msgstr "Zadrži jedan tip prezimena:"
+msgid "Type of surname:"
+msgstr "Vrsta prezimena:"

--- a/GedcomExtensions/po/nl-local.po
+++ b/GedcomExtensions/po/nl-local.po
@@ -65,3 +65,7 @@ msgstr "Negeer Patroniem"
 #: GedcomExtensions/GedcomExtensions.py
 msgid "Patronymic names:"
 msgstr "Patroniemen:"
+
+#: GedcomExtensions/GedcomExtensions.py:208
+msgid "Keep one type of surnames:"
+msgstr "Behoud één type achternamen:"

--- a/GedcomExtensions/po/nl-local.po
+++ b/GedcomExtensions/po/nl-local.po
@@ -67,5 +67,5 @@ msgid "Patronymic names:"
 msgstr "Patroniemen:"
 
 #: GedcomExtensions/GedcomExtensions.py:208
-msgid "Keep one type of surnames:"
-msgstr "Behoud één type achternamen:"
+msgid "Type of surname:"
+msgstr "Type achternaam:"

--- a/GedcomExtensions/po/pt_PT-local.po
+++ b/GedcomExtensions/po/pt_PT-local.po
@@ -65,3 +65,7 @@ msgstr "Ignorar Nome Patronímico"
 #: GedcomExtensions/GedcomExtensions.py
 msgid "Patronymic names:"
 msgstr "Nomes Patronímicos:"
+
+#: GedcomExtensions/GedcomExtensions.py:208
+msgid "Keep one type of surnames:"
+msgstr "Manter um tipo de apelidos:"

--- a/GedcomExtensions/po/pt_PT-local.po
+++ b/GedcomExtensions/po/pt_PT-local.po
@@ -67,5 +67,5 @@ msgid "Patronymic names:"
 msgstr "Nomes Patronímicos:"
 
 #: GedcomExtensions/GedcomExtensions.py:208
-msgid "Keep one type of surnames:"
-msgstr "Manter um tipo de apelidos:"
+msgid "Type of surname:"
+msgstr "Tipo de apelido:"

--- a/GedcomExtensions/po/ru-local.po
+++ b/GedcomExtensions/po/ru-local.po
@@ -71,5 +71,5 @@ msgid "Patronymic names:"
 msgstr "Отчества:"
 
 #: GedcomExtensions/GedcomExtensions.py:208
-msgid "Keep one type of surnames:"
-msgstr "Сохранить один тип фамилий:"
+msgid "Type of surname:"
+msgstr "Тип фамилии:"

--- a/GedcomExtensions/po/ru-local.po
+++ b/GedcomExtensions/po/ru-local.po
@@ -69,3 +69,7 @@ msgstr "Игнорировать Отчество"
 #: GedcomExtensions/GedcomExtensions.py
 msgid "Patronymic names:"
 msgstr "Отчества:"
+
+#: GedcomExtensions/GedcomExtensions.py:208
+msgid "Keep one type of surnames:"
+msgstr "Сохранить один тип фамилий:"

--- a/GedcomExtensions/po/sv-local.po
+++ b/GedcomExtensions/po/sv-local.po
@@ -66,3 +66,7 @@ msgstr "Ignorera Patronymiskt namn"
 #: GedcomExtensions/GedcomExtensions.py
 msgid "Patronymic names:"
 msgstr "Patronymiska namn:"
+
+#: GedcomExtensions/GedcomExtensions.py:208
+msgid "Keep one type of surnames:"
+msgstr "Behåll en typ av efternamn:"

--- a/GedcomExtensions/po/sv-local.po
+++ b/GedcomExtensions/po/sv-local.po
@@ -68,5 +68,5 @@ msgid "Patronymic names:"
 msgstr "Patronymiska namn:"
 
 #: GedcomExtensions/GedcomExtensions.py:208
-msgid "Keep one type of surnames:"
-msgstr "Behåll en typ av efternamn:"
+msgid "Type of surname:"
+msgstr "Typ av efternamn:"

--- a/GedcomExtensions/po/template.pot
+++ b/GedcomExtensions/po/template.pot
@@ -65,3 +65,7 @@ msgstr ""
 #: GedcomExtensions/GedcomExtensions.py:223
 msgid "Export failed"
 msgstr ""
+
+#: GedcomExtensions/GedcomExtensions.py:208
+msgid "Keep one type of surnames:"
+msgstr ""

--- a/GedcomExtensions/po/template.pot
+++ b/GedcomExtensions/po/template.pot
@@ -67,5 +67,5 @@ msgid "Export failed"
 msgstr ""
 
 #: GedcomExtensions/GedcomExtensions.py:208
-msgid "Keep one type of surnames:"
+msgid "Type of surname:"
 msgstr ""


### PR DESCRIPTION
Bug: https://gramps-project.org/bugs/view.php?id=13575

In Gramps surnames can be tagged with "inherited", "taken", "patronymic" etc. That tagging is not supported by GEDCOM and is lost during the export. The surnames end up space separated and create confusion when imported to other services (e.g. Geni, FamilySearch, etc.)

Example:
	Maria (given) Skłodowska (inherited surname) Curie (taken surname)
	```
	0 @I0003@ INDI
	1 NAME Maria /Skłodowska Curie/
	2 TYPE birth
	2 GIVN Maria
	2 SURN Skłodowska, Curie
	```
	
	Fyodor (given), Dostoevsky(inherited surname) Mikhailovich (patronymic surname)
	```
	0 @I0004@ INDI
	1 NAME Fyodor /Dostoevsky Mikhailovich/
	2 TYPE birth
	2 GIVN Fyodor
	2 SURN Dostoevsky, Mikhailovich
	```

It's customary in gene research to only use "maiden" names and many services expect that.  Thus Gramps needs an option to export only one type of surname, e.g. `inherited`

	Maria (given) Skłodowska (inherited surname) Curie (taken surname)
	```
	0 @I0003@ INDI
	1 NAME Maria /Skłodowska/
	2 TYPE birth
	2 GIVN Maria
	2 SURN Skłodowska
	```
	
	Fyodor (given), Dostoevsky(inherited surname) Mikhailovich (patronymic surname)
	```
	0 @I0004@ INDI
	1 NAME Fyodor /Dostoevsky/
	2 TYPE birth
	2 GIVN Fyodor
	2 SURN Dostoevsky
	```
