### PR TITLE
Fix format string with unnamed arguments warnings

### DIFF
--- a/D3Charts/AncestralCollapsibleTree.py
+++ b/D3Charts/AncestralCollapsibleTree.py
@@ -323,7 +323,7 @@ class AncestralCollapsibleTreeReport(Report):
                 fp.write(outstr)
 
         except IOError as msg:
-            ErrorDialog(_("Failed writing %s: %s") % (self.desthtml, str(msg)),
+            ErrorDialog(_("Failure writing {target_path}: {message}").format(target_path=self.desthtml, message=str(msg)),
                         parent=self.user.uistate.window)
             return
 
@@ -768,7 +768,7 @@ class AncestralCollapsibleTreeReport(Report):
                 fp.write('}\n')
 
         except IOError as msg:
-            ErrorDialog(_("Failed writing %s: %s") % (self.destjs, str(msg)),
+            ErrorDialog(_("Failure writing {target_path}: {message}").format(target_path=self.destjs, message=str(msg)),
                         parent=self.user.uistate.window)
             return
 
@@ -782,7 +782,7 @@ class AncestralCollapsibleTreeReport(Report):
                 self.json_filter(self.center_person.get_handle(), 1)
 
         except IOError as msg:
-            ErrorDialog(_("Failed writing %s: %s") % (self.destjson, str(msg)),
+            ErrorDialog(_("Failure writing {target_path}: {message}").format(target_path=self.destjson, message=str(msg)),
                         parent=self.user.uistate.window)
             return
 

--- a/D3Charts/AncestralFanChart.py
+++ b/D3Charts/AncestralFanChart.py
@@ -398,7 +398,7 @@ class AncestralFanChartReport(Report):
                 fp.write(outstr)
 
         except IOError as msg:
-            ErrorDialog(_("Failed writing %s: %s") % (self.desthtml, str(msg)),
+            ErrorDialog(_("Failure writing {target_path}: {message}").format(target_path=self.desthtml, messgae=str(msg)),
                         parent=self.user.uistate.window)
             return
 
@@ -645,7 +645,7 @@ class AncestralFanChartReport(Report):
                     'replace(location);\n')
 
         except IOError as msg:
-            ErrorDialog(_("Failed writing %s: %s") % (self.destjs, str(msg)),
+            ErrorDialog(_("Failure writing {target_path}: {message}").format(target_path=self.destjs, messgae=str(msg)),
                         parent=self.user.uistate.window)
             return
 
@@ -671,7 +671,7 @@ class AncestralFanChartReport(Report):
 
 
         except IOError as msg:
-            ErrorDialog(_("Failed writing %s: %s") % (self.destjson, str(msg)),
+            ErrorDialog(_("Failure writing {target_path}: {message}").format(target_path=self.destjson, message=str(msg)),
                         parent=self.user.uistate.window)
             return
 

--- a/D3Charts/DescendantIndentedTree.py
+++ b/D3Charts/DescendantIndentedTree.py
@@ -1371,8 +1371,7 @@ class DescendantIndentedTreeReport(Report):
                 try:
                     os.mkdir(self.dest_path)
                 except Exception as err:
-                    ErrorDialog(_("Failed to create %s: %s") %
-                                (self.dest_path, str(err)),
+                    ErrorDialog(_("Failed to create {target_path}: {message}").format(target_path=self.dest_path, message=str(err)),
                                 parent=self.user.uistate.window)
                     return
             else:
@@ -1497,7 +1496,7 @@ class DescendantIndentedTreeReport(Report):
                 fp.write(outstr)
 
         except IOError as msg:
-            ErrorDialog(_("Failed writing %s: %s") % (self.desthtml, str(msg)),
+            ErrorDialog(_("Failure writing {target_path}: {message}").(target_path=self.desthtml, message=str(msg)),
                         parent=self.user.uistate.window)
             return
 
@@ -1560,15 +1559,15 @@ class DescendantIndentedTreeReport(Report):
         try:
             self.write_js(self.destjs, self.contraction)
         except IOError as msg:
-            ErrorDialog(_("Failed writing %s: %s") % (self.destjs, str(msg)),
+            ErrorDialog(_("Failure writing {target_path}: {message}").format(target_path=self.destjs, message=str(msg)),
                         parent=self.user.uistate.window)
 
         # Generate <destexpanded>.js customizing based on options selected
         try:
             self.write_js(self.destexpandedjs, 99)
         except IOError as msg:
-            ErrorDialog(_("Failed writing %s: %s") % (self.destexpandedjs,
-                        str(msg)), parent=self.user.uistate.window)
+            ErrorDialog(_("Failure writing {target_path}: {message}").format(target_path=self.destexpandedjs,
+                        message=str(msg)), parent=self.user.uistate.window)
             return
 
         # Generate <dest>.css options selected such as font-size
@@ -1674,7 +1673,7 @@ class DescendantIndentedTreeReport(Report):
                 fp.write('}\n\n')
 
         except IOError as msg:
-            ErrorDialog(_("Failed writing %s: %s") % (self.destcss, str(msg)),
+            ErrorDialog(_("Failure writing {target_path}: {message}").format(target_path=self.destcss, message=str(msg)),
                         parent=self.user.uistate.window)
             return
 
@@ -1694,7 +1693,7 @@ class DescendantIndentedTreeReport(Report):
                 recurse.recurse(generation, self.center_person, None)
 
         except IOError as msg:
-            ErrorDialog(_("Failed writing %s: %s") % (self.destjson, str(msg)),
+            ErrorDialog(_("Failure writing {target_path}: {message}").format(target_path=self.destjson, message=str(msg)),
                         parent=self.user.uistate.window)
             return
 

--- a/D3Charts/po/template.pot
+++ b/D3Charts/po/template.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-16 15:10-0800\n"
+"POT-Creation-Date: 2025-03-13 23:29+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,33 +17,33 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: D3Charts/AncestralCollapsibleTree.py:124
-#: D3Charts/DescendantIndentedTree.py:914 D3Charts/AncestralFanChart.py:120
+#: D3Charts/AncestralCollapsibleTree.py:124 D3Charts/AncestralFanChart.py:120
+#: D3Charts/DescendantIndentedTree.py:914
 #, python-format
 msgid "Person %s is not in the Database"
 msgstr ""
 
 #: D3Charts/AncestralCollapsibleTree.py:326
 #: D3Charts/AncestralCollapsibleTree.py:771
-#: D3Charts/AncestralCollapsibleTree.py:785
-#: D3Charts/DescendantIndentedTree.py:1500
-#: D3Charts/DescendantIndentedTree.py:1563
-#: D3Charts/DescendantIndentedTree.py:1570
-#: D3Charts/DescendantIndentedTree.py:1677
-#: D3Charts/DescendantIndentedTree.py:1697 D3Charts/AncestralFanChart.py:401
+#: D3Charts/AncestralCollapsibleTree.py:785 D3Charts/AncestralFanChart.py:401
 #: D3Charts/AncestralFanChart.py:648 D3Charts/AncestralFanChart.py:674
-#, python-format
-msgid "Failed writing %s: %s"
+#: D3Charts/DescendantIndentedTree.py:1499
+#: D3Charts/DescendantIndentedTree.py:1562
+#: D3Charts/DescendantIndentedTree.py:1569
+#: D3Charts/DescendantIndentedTree.py:1676
+#: D3Charts/DescendantIndentedTree.py:1696
+#, python-brace-format
+msgid "Failure writing {target_path}: {message}"
 msgstr ""
 
-#: D3Charts/AncestralCollapsibleTree.py:345
-#: D3Charts/DescendantIndentedTree.py:1519 D3Charts/AncestralFanChart.py:420
+#: D3Charts/AncestralCollapsibleTree.py:345 D3Charts/AncestralFanChart.py:420
+#: D3Charts/DescendantIndentedTree.py:1518
 #, python-format
 msgid "Failed to create directory structure : %s"
 msgstr ""
 
-#: D3Charts/AncestralCollapsibleTree.py:368
-#: D3Charts/DescendantIndentedTree.py:1555 D3Charts/AncestralFanChart.py:443
+#: D3Charts/AncestralCollapsibleTree.py:368 D3Charts/AncestralFanChart.py:443
+#: D3Charts/DescendantIndentedTree.py:1554
 #, python-format
 msgid "Failed to copy web files : %s"
 msgstr ""
@@ -52,13 +52,13 @@ msgstr ""
 msgid "Ancestral Collapsible Tree Options"
 msgstr ""
 
-#: D3Charts/AncestralCollapsibleTree.py:818
-#: D3Charts/DescendantIndentedTree.py:1787 D3Charts/AncestralFanChart.py:709
+#: D3Charts/AncestralCollapsibleTree.py:818 D3Charts/AncestralFanChart.py:709
+#: D3Charts/DescendantIndentedTree.py:1786
 msgid "Center Person"
 msgstr ""
 
-#: D3Charts/AncestralCollapsibleTree.py:819
-#: D3Charts/DescendantIndentedTree.py:1788 D3Charts/AncestralFanChart.py:710
+#: D3Charts/AncestralCollapsibleTree.py:819 D3Charts/AncestralFanChart.py:710
+#: D3Charts/DescendantIndentedTree.py:1787
 msgid "The center person for the report"
 msgstr ""
 
@@ -74,13 +74,13 @@ msgstr ""
 msgid "Select the format to display names"
 msgstr ""
 
-#: D3Charts/AncestralCollapsibleTree.py:840
-#: D3Charts/DescendantIndentedTree.py:1804 D3Charts/AncestralFanChart.py:723
+#: D3Charts/AncestralCollapsibleTree.py:840 D3Charts/AncestralFanChart.py:723
+#: D3Charts/DescendantIndentedTree.py:1803
 msgid "Include Generations"
 msgstr ""
 
-#: D3Charts/AncestralCollapsibleTree.py:841
-#: D3Charts/DescendantIndentedTree.py:1806 D3Charts/AncestralFanChart.py:724
+#: D3Charts/AncestralCollapsibleTree.py:841 D3Charts/AncestralFanChart.py:724
+#: D3Charts/DescendantIndentedTree.py:1805
 msgid "The number of generations to include in the report"
 msgstr ""
 
@@ -116,481 +116,39 @@ msgstr ""
 msgid "RGB-color for female expandable box background."
 msgstr ""
 
-#: D3Charts/AncestralCollapsibleTree.py:865
-#: D3Charts/DescendantIndentedTree.py:1824 D3Charts/AncestralFanChart.py:737
+#: D3Charts/AncestralCollapsibleTree.py:865 D3Charts/AncestralFanChart.py:737
+#: D3Charts/DescendantIndentedTree.py:1823
 msgid "Destination"
 msgstr ""
 
-#: D3Charts/AncestralCollapsibleTree.py:867
-#: D3Charts/DescendantIndentedTree.py:1826 D3Charts/AncestralFanChart.py:739
+#: D3Charts/AncestralCollapsibleTree.py:867 D3Charts/AncestralFanChart.py:739
+#: D3Charts/DescendantIndentedTree.py:1825
 msgid "The destination path for generated files."
 msgstr ""
 
-#: D3Charts/AncestralCollapsibleTree.py:871
-#: D3Charts/DescendantIndentedTree.py:1830 D3Charts/AncestralFanChart.py:743
+#: D3Charts/AncestralCollapsibleTree.py:871 D3Charts/AncestralFanChart.py:743
+#: D3Charts/DescendantIndentedTree.py:1829
 msgid "Filename"
 msgstr ""
 
-#: D3Charts/AncestralCollapsibleTree.py:872
-#: D3Charts/DescendantIndentedTree.py:1831 D3Charts/AncestralFanChart.py:744
+#: D3Charts/AncestralCollapsibleTree.py:872 D3Charts/AncestralFanChart.py:744
+#: D3Charts/DescendantIndentedTree.py:1830
 msgid "The destination file name for html content."
 msgstr ""
 
-#: D3Charts/AncestralFanChart.gpr.py:23
-msgid "Ancestral Fan Chart"
+#: D3Charts/AncestralCollapsibleTree.gpr.py:23
+msgid "Ancestral Collapsible Tree"
 msgstr ""
 
-#: D3Charts/AncestralFanChart.gpr.py:33
+#: D3Charts/AncestralCollapsibleTree.gpr.py:33
 msgid ""
 "Generates a web page with a graphical representation of ancestors (SVG) "
-"represented as a Fan Chart from the D3.js JavaScript library."
+"represented as a Collapsible Tree Layout from the D3.js JavaScript library."
 msgstr ""
 
-#: D3Charts/DescendantIndentedTree.py:673
-#, python-format
-msgid "See %(reference)s : %(spouse)s"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:744
-#: D3Charts/DescendantIndentedTree.py:811
-#, python-format
-msgid "%s sp."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:764
-msgid "Generating report..."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:909
 #: D3Charts/DescendantIndentedTree.gpr.py:23
+#: D3Charts/DescendantIndentedTree.py:909
 msgid "Descendant Indented Tree"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1364
-msgid "Invalid Destination Directory"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1365
-#, python-format
-msgid ""
-"Destinaton diretory %s does not exist\n"
-"Do you want to attempt to create it?"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1368
-#: D3Charts/DescendantIndentedTree.py:1394
-msgid "_Yes"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1369
-#: D3Charts/DescendantIndentedTree.py:1395
-msgid "_No"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1374
-#, python-format
-msgid "Failed to create %s: %s"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1382
-msgid "Permission problem"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1383
-#, python-format
-msgid ""
-"You do not have permission to write under the directory %s\n"
-"\n"
-"Please select another directory or correct the permissions."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1390
-msgid "File already exists"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1391
-#, python-format
-msgid ""
-"Destination file %s already exists.\n"
-"Do you want to overwrite it?"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1446
-msgid "Default View"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1449
-msgid "Expand All"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1784
-msgid "Report Options"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1793
-msgid "Numbering system"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1795
-msgid "Simple numbering"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1796
-msgid "d'Aboville numbering"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1797
-msgid "Henry numbering"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1798
-msgid "de Villiers/Pama numbering"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1799
-msgid "Meurgey de Tupigny numbering"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1800
-msgid "Record (Modified Register) numbering"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1801
-msgid "The numbering system to be used"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1811
-msgid "Include contraction level"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1813
-msgid "The number of descendant levels to contract on initial display."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1818
-msgid "Font size"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1820
-msgid "The font size in pixels for each node."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1837
-msgid "Content"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1839
-msgid "Show marriage info"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1840
-msgid "Whether to show marriage information in the report."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1843
-msgid "Show divorce info"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1844
-msgid "Whether to show divorce information in the report."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1847
-msgid "Show duplicate trees"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1848
-msgid "Whether to show duplicate family trees in the report."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1852
-msgid "Expanded Row Background Color"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1853
-msgid "RGB-color for expanded row background."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1856
-msgid "Expandable Background Color"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1858
-msgid "RGB-color for expandable row background."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1861
-msgid "Non-Expandable Background Color"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1863
-msgid "RGB-color for non-expandable row background."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1867
-msgid "Include records marked private"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1869
-msgid "Whether to include private objects."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1872
-msgid "Living People"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1875
-msgid "Exclude"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1877
-msgid "Include Last Name Only"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1879
-msgid "Include Full Name Only"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1880
-msgid "Include"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1881
-msgid "How to handle living people."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1886
-msgid "Years from death to consider living"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1888
-msgid "Whether or not to include people who may have recently died."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1896
-msgid "Navigation"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1898
-msgid "Contraction/Expansion mechanism"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1901
-msgid "Entire node."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1902
-msgid "Arrow images at start of node."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1903
-msgid "Plus/Minus images at start of node."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1904
-#: D3Charts/DescendantIndentedTree.py:1933
-msgid "Where to click to expand/contract nodes."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1908
-msgid "Auto-generate HREF links for nodes"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1910
-msgid "Whether to auto-generate HTML links for each node on the report."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1916
-msgid "URL prefix path."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1918
-msgid "URL prefix to apply to each auto-generated HREF link."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1924
-msgid "URL file extension"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1926
-msgid "No file extension."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1927
-msgid ".html"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1928
-msgid ".htm"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1929
-msgid ".shtml"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1930
-msgid ".php"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1931
-msgid ".php3"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1932
-msgid ".cgi"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1938
-msgid "URL file name delimeter"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1940
-msgid "Remove all whitespace."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1941
-msgid "Replace whitespace with dash(-)."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1942
-msgid "Replace whitespace with underscore(_)"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1943
-msgid "What to use as file name delimiter replacing whitespace."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1948
-msgid "Generations to generate HREF links"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1950
-msgid "The number of generations to generate HREF links."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1956
-msgid "Exclude persons who died before (years)"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1959
-msgid ""
-"Whether to generate links for people who died in infancy, -1 excludes nobody."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1965
-msgid "Exclude center person"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1966
-msgid "Whether or not to generate links for center person."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1971
-msgid "Exclude Spouses"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1972
-msgid "Whether or not to generate links for spouses."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1979
-msgid "Biography Content"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1981
-msgid "Show biography tooltips"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1982
-msgid "Whether to show biography tooltips when hovering over a node."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1987
-msgid "Use callname for common name"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1988
-msgid "Whether to use the call name as the first name."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1992
-msgid "Use full dates instead of only the year"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1995
-msgid "Whether to use full dates instead of just year."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:1999
-msgid "Compute death age"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:2000
-msgid "Whether to compute a person's age at death."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:2004
-msgid "Include Photo/Images from Gallery"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:2006
-msgid "Whether to include images."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:2009
-msgid "Use complete sentences"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:2011
-msgid "Whether to use complete sentences or succinct language."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:2014
-msgid "Replace missing places with ______"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:2016
-msgid "Whether to replace missing Places with blanks."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:2020
-msgid "Replace missing dates with ______"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:2022
-msgid "Whether to replace missing Dates with blanks."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:2026
-msgid "Text Color"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:2028
-msgid "RGB-color for biography text."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:2031
-msgid "Background Color"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:2033
-msgid "RGB-color for biography tooltip."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:2036
-msgid "Header Font size"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:2038
-msgid "The font size in pixels for biography header text."
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:2044
-msgid "Body Font size"
-msgstr ""
-
-#: D3Charts/DescendantIndentedTree.py:2046
-msgid "The font size in pixels for biography body text."
 msgstr ""
 
 #: D3Charts/DescendantIndentedTree.gpr.py:33
@@ -620,12 +178,454 @@ msgstr ""
 msgid "RGB-color for maternal box background."
 msgstr ""
 
-#: D3Charts/AncestralCollapsibleTree.gpr.py:23
-msgid "Ancestral Collapsible Tree"
+#: D3Charts/AncestralFanChart.gpr.py:23
+msgid "Ancestral Fan Chart"
 msgstr ""
 
-#: D3Charts/AncestralCollapsibleTree.gpr.py:33
+#: D3Charts/AncestralFanChart.gpr.py:33
 msgid ""
 "Generates a web page with a graphical representation of ancestors (SVG) "
-"represented as a Collapsible Tree Layout from the D3.js JavaScript library."
+"represented as a Fan Chart from the D3.js JavaScript library."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:673
+#, python-format
+msgid "See %(reference)s : %(spouse)s"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:744
+#: D3Charts/DescendantIndentedTree.py:811
+#, python-format
+msgid "%s sp."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:764
+msgid "Generating report..."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1364
+msgid "Invalid Destination Directory"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1365
+#, python-format
+msgid ""
+"Destinaton diretory %s does not exist\n"
+"Do you want to attempt to create it?"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1368
+#: D3Charts/DescendantIndentedTree.py:1393
+msgid "_Yes"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1369
+#: D3Charts/DescendantIndentedTree.py:1394
+msgid "_No"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1374
+#, python-brace-format
+msgid "Failed to create {target_path}: {message}"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1381
+msgid "Permission problem"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1382
+#, python-format
+msgid ""
+"You do not have permission to write under the directory %s\n"
+"\n"
+"Please select another directory or correct the permissions."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1389
+msgid "File already exists"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1390
+#, python-format
+msgid ""
+"Destination file %s already exists.\n"
+"Do you want to overwrite it?"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1445
+msgid "Default View"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1448
+msgid "Expand All"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1783
+msgid "Report Options"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1792
+msgid "Numbering system"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1794
+msgid "Simple numbering"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1795
+msgid "d'Aboville numbering"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1796
+msgid "Henry numbering"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1797
+msgid "de Villiers/Pama numbering"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1798
+msgid "Meurgey de Tupigny numbering"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1799
+msgid "Record (Modified Register) numbering"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1800
+msgid "The numbering system to be used"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1810
+msgid "Include contraction level"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1812
+msgid "The number of descendant levels to contract on initial display."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1817
+msgid "Font size"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1819
+msgid "The font size in pixels for each node."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1836
+msgid "Content"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1838
+msgid "Show marriage info"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1839
+msgid "Whether to show marriage information in the report."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1842
+msgid "Show divorce info"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1843
+msgid "Whether to show divorce information in the report."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1846
+msgid "Show duplicate trees"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1847
+msgid "Whether to show duplicate family trees in the report."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1851
+msgid "Expanded Row Background Color"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1852
+msgid "RGB-color for expanded row background."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1855
+msgid "Expandable Background Color"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1857
+msgid "RGB-color for expandable row background."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1860
+msgid "Non-Expandable Background Color"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1862
+msgid "RGB-color for non-expandable row background."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1866
+msgid "Include records marked private"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1868
+msgid "Whether to include private objects."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1871
+msgid "Living People"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1874
+msgid "Exclude"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1876
+msgid "Include Last Name Only"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1878
+msgid "Include Full Name Only"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1879
+msgid "Include"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1880
+msgid "How to handle living people."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1885
+msgid "Years from death to consider living"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1887
+msgid "Whether or not to include people who may have recently died."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1895
+msgid "Navigation"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1897
+msgid "Contraction/Expansion mechanism"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1900
+msgid "Entire node."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1901
+msgid "Arrow images at start of node."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1902
+msgid "Plus/Minus images at start of node."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1903
+#: D3Charts/DescendantIndentedTree.py:1932
+msgid "Where to click to expand/contract nodes."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1907
+msgid "Auto-generate HREF links for nodes"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1909
+msgid "Whether to auto-generate HTML links for each node on the report."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1915
+msgid "URL prefix path."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1917
+msgid "URL prefix to apply to each auto-generated HREF link."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1923
+msgid "URL file extension"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1925
+msgid "No file extension."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1926
+msgid ".html"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1927
+msgid ".htm"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1928
+msgid ".shtml"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1929
+msgid ".php"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1930
+msgid ".php3"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1931
+msgid ".cgi"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1937
+msgid "URL file name delimeter"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1939
+msgid "Remove all whitespace."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1940
+msgid "Replace whitespace with dash(-)."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1941
+msgid "Replace whitespace with underscore(_)"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1942
+msgid "What to use as file name delimiter replacing whitespace."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1947
+msgid "Generations to generate HREF links"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1949
+msgid "The number of generations to generate HREF links."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1955
+msgid "Exclude persons who died before (years)"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1958
+msgid ""
+"Whether to generate links for people who died in infancy, -1 excludes nobody."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1964
+msgid "Exclude center person"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1965
+msgid "Whether or not to generate links for center person."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1970
+msgid "Exclude Spouses"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1971
+msgid "Whether or not to generate links for spouses."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1978
+msgid "Biography Content"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1980
+msgid "Show biography tooltips"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1981
+msgid "Whether to show biography tooltips when hovering over a node."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1986
+msgid "Use callname for common name"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1987
+msgid "Whether to use the call name as the first name."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1991
+msgid "Use full dates instead of only the year"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1994
+msgid "Whether to use full dates instead of just year."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1998
+msgid "Compute death age"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:1999
+msgid "Whether to compute a person's age at death."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:2003
+msgid "Include Photo/Images from Gallery"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:2005
+msgid "Whether to include images."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:2008
+msgid "Use complete sentences"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:2010
+msgid "Whether to use complete sentences or succinct language."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:2013
+msgid "Replace missing places with ______"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:2015
+msgid "Whether to replace missing Places with blanks."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:2019
+msgid "Replace missing dates with ______"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:2021
+msgid "Whether to replace missing Dates with blanks."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:2025
+msgid "Text Color"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:2027
+msgid "RGB-color for biography text."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:2030
+msgid "Background Color"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:2032
+msgid "RGB-color for biography tooltip."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:2035
+msgid "Header Font size"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:2037
+msgid "The font size in pixels for biography header text."
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:2043
+msgid "Body Font size"
+msgstr ""
+
+#: D3Charts/DescendantIndentedTree.py:2045
+msgid "The font size in pixels for biography body text."
 msgstr ""


### PR DESCRIPTION
Fixes [#13661](https://gramps-project.org/bugs/view.php?id=13661).

Note:  I used the string "Failure writing {target_path}: {message}" instead of "Failed writing {target_path}: {message}" because it already existed in DenominoViso.