### PR TITLE
Some fixes and enhancements for the make file

### DIFF
--- a/make.py
+++ b/make.py
@@ -275,7 +275,7 @@ def strip_header(po_file):
     out_file = ""
     if not os.path.isfile(po_file):
         return out_file
-    with open(po_file, "r") as in_file:
+    with open(po_file, "r", encoding="utf-8") as in_file:
         for line in in_file:
             if not header:
                 out_file += line
@@ -289,8 +289,8 @@ def aggregate_pot():
     Aggregate the template files for all addons into a single file without
     strings that are already present in core Gramps.
     """
-    args = ["touch", "po/template.pot"]
-    call(args)
+    f = open("po/template.pot", "w")
+    f.close()
 
     args = ["xgettext", "-j", "-o", "po/template.pot"]
     args.extend(glob.glob("*/po/template.pot"))
@@ -514,7 +514,9 @@ elif command == "update":
         f'"{addon}/po/{locale}-local.po" '
     )
     # Get all of the addon strings out of the catalog:
-    system(f"touch {addon}/po/{locale}-temp.po")
+    f = open(f"{addon}/po/{locale}-temp.po", "w")
+    f.close()
+
     system(
         f"msggrep --location={addon}/* "
         f'"{addon}/po/{locale}-global.po" '
@@ -574,9 +576,14 @@ elif command == "as-needed":
 
     languages = get_all_languages()
     listings = {lang: [] for lang in languages}
-    dirs = [
-        file for file in glob.glob("*") if os.path.isdir(file) and file != "__pycache__"
-    ]
+    if len(sys.argv) == 3 or addon == "all":
+        dirs = [
+            file
+            for file in glob.glob("*")
+            if os.path.isdir(file) and file != "__pycache__"
+        ]
+    else:
+        dirs = [addon]
     for addon in sorted(dirs):
         todo = False
         for po in glob.glob(f"{addon}/po/*-local.po"):

--- a/make.py
+++ b/make.py
@@ -70,6 +70,7 @@ command = sys.argv[2]
 if len(sys.argv) >= 4:
     addon = sys.argv[3]
 
+
 def system(scmd, **kwargs):
     """
     Replace and call system with scmd.
@@ -250,6 +251,7 @@ def build_addon(addon):
     if files:
         do_tar(files)
 
+
 def check_gramps_path(command):
     try:
         sys.path.insert(0, GRAMPSPATH)
@@ -263,6 +265,7 @@ def check_gramps_path(command):
             % (os.path.abspath(GRAMPSPATH), gramps_version, command)
         )
         exit()
+
 
 def strip_header(po_file):
     """
@@ -317,7 +320,7 @@ def extract_po(addon):
     if not os.path.exists(pot):
         return
     for lang in get_all_languages():
-        #print (lang)
+        # print (lang)
         po = os.path.join(po_dir, f"{lang}-local.po")
         if os.path.exists(f"po/{lang}.po"):
             old_file = strip_header(po)
@@ -336,6 +339,7 @@ def extract_po(addon):
             if new_file and old_file == new_file:
                 args = ["git", "restore", po]
                 call(args)
+
 
 if command == "clean":
     if len(sys.argv) == 3:
@@ -396,18 +400,18 @@ elif command == "init":
                 continue  # skip this one if not listed
 
             mkdir(f"{addon}/po")
-            fnames = ' '.join(glob.glob(f"{addon}/*.py"))
+            fnames = " ".join(glob.glob(f"{addon}/*.py"))
             system(
                 f"xgettext --language=Python --keyword=_ --keyword=N_"
                 f" --from-code=UTF-8"
                 f' -o "{addon}/po/template.pot" {fnames} '
             )
-            fnames = ' '.join(glob.glob("%s/*.glade" % addon))
+            fnames = " ".join(glob.glob("%s/*.glade" % addon))
             if fnames:
                 system(
                     "xgettext -j --add-comments -L Glade "
                     f'--from-code=UTF-8 -o "{addon}/po/template.pot" '
-                    f'{fnames}'
+                    f"{fnames}"
                 )
 
             # scan for xml files and get translation text where the tag
@@ -510,9 +514,7 @@ elif command == "update":
         f'"{addon}/po/{locale}-local.po" '
     )
     # Get all of the addon strings out of the catalog:
-    system(
-        f"touch {addon}/po/{locale}-temp.po"
-    )
+    system(f"touch {addon}/po/{locale}-temp.po")
     system(
         f"msggrep --location={addon}/* "
         f'"{addon}/po/{locale}-global.po" '
@@ -721,18 +723,18 @@ elif command == "as-needed":
         cleanup(addon)
         if todo:  # make an updated pot file
             mkdir("%(addon)s/po")
-            fnames = ' '.join(glob.glob(f"{addon}/*.py"))
+            fnames = " ".join(glob.glob(f"{addon}/*.py"))
             system(
                 "xgettext --language=Python --keyword=_ --keyword=N_"
                 " --from-code=UTF-8"
                 f' -o "{addon}/po/temp.pot" {fnames} '
             )
-            fnames = ' '.join(glob.glob(f"{addon}/*.glade"))
+            fnames = " ".join(glob.glob(f"{addon}/*.glade"))
             if fnames:
                 system(
                     "xgettext -j --add-comments -L Glade "
                     f'--from-code=UTF-8 -o "{addon}/po/temp.pot" '
-                    f'{fnames}'
+                    f"{fnames}"
                 )
 
             # scan for xml files and get translation text where the tag
@@ -1023,10 +1025,10 @@ elif command == "aggregate-pot":
     aggregate_pot()
 
 elif command == "extract-po":
-    for addon in [file for file in glob.glob("*")
-                  if os.path.isdir(file)
-                  and file != "po"]:
-        print (addon)
+    for addon in [
+        file for file in glob.glob("*") if os.path.isdir(file) and file != "po"
+    ]:
+        print(addon)
         extract_po(addon)
 
 else:


### PR DESCRIPTION
Been looking at the translation automation in make.
Big one, it looks like the extracted po files don't contain .pot msgid strings that should be satisfied from the Gramps main translations.  You stripped those out of the overall pot, to reduce translation work, good.
But when you did the extraction of main po files to individual addons, the Gramps strings were not included.

A smaller issue, Windows system (mine at least) doesn't include a "touch" command.
Also on Windows, you have to specify utf8 when opening a file or you get errors due to default code page.

I also added the ability to do a single file "as-needed", but may still want to enhance further with updated po etc. when the Weblate changes settle down.

I suspect that some of the other commands will fail for the 'all' when they hit the new po directory, but have not yet tested and fixed these.