### PR TITLE
Fix second run (gramps60)

### DIFF
--- a/lxml/lxmlGramplet.py
+++ b/lxml/lxmlGramplet.py
@@ -358,7 +358,10 @@ class lxmlGramplet(Gramplet):
 
         # GtkTextView ; buffer limitation ...
 
-        #self.text.set_text(_('Parsing file...'))
+        if isinstance(self.text, list):
+            pass
+        else:
+            self.text.set_text(_('Parsing file...'))
 
         #LOG.info(etree.tostring(root, pretty_print=True))
 
@@ -540,7 +543,10 @@ class lxmlGramplet(Gramplet):
 
         # GtkTextView
 
-        self.text.set_text(header + file_info + period + counters + libs)
+        if isinstance(self.text, list):
+            pass
+        else:
+            self.text.set_text(header + file_info + period + counters + libs)
 
         LOG.info('### NEW FILES ###')
         LOG.info('content parsed and copied')


### PR DESCRIPTION
same as #685 but for gramps60
self.text will be a list after the first run (list of media object references). So, we are no more able to run a second pass after the first one. It does not make sense to re-run the gramplet, but this PR should fix this issue.