### PR TITLE
Fix reference to _format_source_text in DetailedDescendantReport with Images

### DIFF
--- a/DetDescendantReport-images/detdescendantreporti.py
+++ b/DetDescendantReport-images/detdescendantreporti.py
@@ -68,7 +68,7 @@ from gramps.gen.plug.report import MenuReportOptions
 from gramps.gen.plug.report import stdoptions
 from gramps.plugins.lib.libnarrate import Narrator
 from gramps.gen.display.place import displayer as place_displayer
-
+from gramps.gen.lib import Citation
 #------------------------------------------------------------------------
 #
 # Constants
@@ -1049,7 +1049,7 @@ class DetailedDescendantReportI(Report):
             first = True
 
             doc.start_paragraph('Endnotes-Source', "%d." % cindex)
-            doc.write_text(endnotes._format_source_text(source, elocale), links=links)
+            doc.write_text(_format_source_text(source, elocale), links=links)
             doc.end_paragraph()
 
             if printnotes:
@@ -1062,7 +1062,7 @@ class DetailedDescendantReportI(Report):
             for key, ref in citation.get_ref_list():
                 # translators: needed for French, ignore otherwise
                 doc.start_paragraph('Endnotes-Ref', trans_text('%s:') % key)
-                doc.write_text(endnotes._format_ref_text(ref, key, elocale), links=links)
+                doc.write_text(_format_ref_text(ref, key, elocale), links=links)
                 doc.end_paragraph()
 
                 if printnotes:
@@ -1072,7 +1072,67 @@ class DetailedDescendantReportI(Report):
                     if self.addimages:
                         self.write_images(ref_plist)
 
+def _format_source_text(source, elocale):
+    if not source:
+        return ""
 
+    trans_text = elocale.translation.gettext
+    # trans_text is a defined keyword (see po/update_po.py, po/genpot.sh)
+
+    src_txt = ""
+
+    if source.get_author():
+        src_txt += source.get_author()
+
+    if source.get_title():
+        if src_txt:
+            # Translators: needed for Arabic, ignore otherwise
+            src_txt += trans_text(", ")
+        # Translators: used in French+Russian, ignore otherwise
+        src_txt += trans_text('"%s"') % source.get_title()
+
+    if source.get_publication_info():
+        if src_txt:
+            # Translators: needed for Arabic, ignore otherwise
+            src_txt += trans_text(", ")
+        src_txt += source.get_publication_info()
+
+    if source.get_abbreviation():
+        if src_txt:
+            # Translators: needed for Arabic, ignore otherwise
+            src_txt += trans_text(", ")
+        src_txt += "(%s)" % source.get_abbreviation()
+
+    return src_txt
+
+
+def _format_ref_text(ref, key, elocale):
+    if not ref:
+        return ""
+
+    ref_txt = ""
+
+    datepresent = False
+    date = ref.get_date_object()
+    if date is not None and not date.is_empty():
+        datepresent = True
+    if datepresent:
+        if ref.get_page():
+            ref_txt = "%s - %s" % (ref.get_page(), elocale.get_date(date))
+        else:
+            ref_txt = elocale.get_date(date)
+    else:
+        ref_txt = ref.get_page()
+
+    # Print only confidence level if it is not Normal
+    if ref.get_confidence_level() != Citation.CONF_NORMAL:
+        ref_txt += (
+            " ["
+            + elocale.translation.gettext(conf_strings[ref.get_confidence_level()])
+            + "]"
+        )
+
+    return ref_txt
 #------------------------------------------------------------------------
 #
 # DetDescendantOptions


### PR DESCRIPTION
Added _format_source_text and _format_ref_text since calling protected procedure is not part of public API