### PR TITLE
Update WWII Draft Reg form based on PR 542

### DIFF
--- a/Form/form_us.xml
+++ b/Form/form_us.xml
@@ -8011,50 +8011,106 @@ Birth, Death, Marriage
                 <_attribute>Date of Registration</_attribute>
             </column>
         </section>
-    <!--
-    WWII Draft Registration
-    https://familysearch.org/search/collection/1861144
-    -->
-    </form>
+<!--
+WWII Draft Registration
+D.S.S. Form 1
+-->
     <form id='USWWIIDRC' type='Military Registration' title='World War II Draft Registration Card' date='1942-04-27'>
         <heading>
             <_attribute>Serial Number</_attribute>
-        </heading><heading>
+        </heading>
+        <heading>
             <_attribute>Order Number</_attribute>
         </heading>
         <section role='Primary' type='person' title='Registrant'>
             <column>
+                <_attribute>Registration Card</_attribute>
+                <_longname>Found in lower left corner
+      D.S.S. Form 1
+        (Men 21 - 31)
+      D.S.S. Form 1 (Rev. 6-9-41)
+        (Men who turned 21 since 1st registration)
+      D.S.S. Form 1 (Rev. 1/1/42)
+        (Men born Feb 17, 1897 to Dec 31 1921)
+      D.S.S. Form 1 (Rev. 4/1/42)
+        (Men 45-64)
+      D.S.S. Form 1 (Rev. 6/1/42)
+        (Men 18-20)
+      D.S.S. Form 1 (Rev. 11/16/42)
+        (Men who turned 18 since
+         previous registration)</_longname>
+            </column>
+            <column>
                 <_attribute>Name</_attribute>
+                <_longname>(1) First, Middle, Last</_longname>
             </column>
             <column>
                 <_attribute>Place of Residence</_attribute>
+                <_longname>(2) Address or Place of Residence
+ No. and street or R.F.D. No., Town, County, State</_longname>
             </column>
             <column>
                 <_attribute>Mailing Address</_attribute>
+                <_longname> Not used on D.S.S. Form 1
+ (3) Used on all other forms</_longname>
             </column>
             <column>
                 <_attribute>Telephone</_attribute>
+                <_longname>(3) On D.S.S. Form 1
+(4) On all other forms</_longname>
             </column>
             <column>
                 <_attribute>Age in years</_attribute>
+                <_longname>(4) On D.S.S. Form 1
+(5) On all other forms</_longname>
             </column>
             <column>
                 <_attribute>Date of Birth</_attribute>
+                <_longname>(Below Age in Years)</_longname>
             </column>
             <column>
                 <_attribute>Place of Birth</_attribute>
+                <_longname>(5) On D.S.S. Form 1
+(6) On all other forms</_longname>
+            </column>
+            <column>
+                <_attribute>Country of Citizenship</_attribute>
+                <_longname>(6) On D.S.S. Form 1
+Not used on other forms</_longname>
             </column>
             <column>
                 <_attribute>Who will always know your address (Name &amp; Address)</_attribute>
+                <_longname>(7 &amp; 9) On D.S.S. Form 1
+(7) On all but D.S.S. Form 1 (Rev. 6-9-41)
+(8) On D.S.S. Form 1 (Rev. 6-9-41)</_longname>
+            </column>
+            <column>
+                <_attribute>Relationship </_attribute>
+                <_longname>(8) Only on D.S.S. Form 1</_longname>
+            </column>
+            <column>
+                <_attribute>Occupation </_attribute>
+                <_longname>(7) Only on D.S.S. Form 1 (Rev. 6-9-41)</_longname>
             </column>
             <column>
                 <_attribute>Employer&apos;s Name &amp; address</_attribute>
+                <_longname>(10) On D.S.S. Form 1
+(9) On D.S.S. Form 1 (Rev. 6-9-41)
+(8) on all others forms</_longname>
             </column>
             <column>
                 <_attribute>Place of employment or business</_attribute>
+                <_longname>(11) On D.S.S. Form 1
+(10) On D.S.S. Form 1 (Rev. 6-9-41)
+(9) on all others forms</_longname>
             </column>
             <column>
                 <_attribute>Race</_attribute>
+                <_longname>White
+Negro
+Oriental
+Indian
+Filipino</_longname>
             </column>
             <column>
                 <_attribute>Height</_attribute>
@@ -8064,12 +8120,31 @@ Birth, Death, Marriage
             </column>
             <column>
                 <_attribute>Complexion</_attribute>
+                <_longname>Sallow
+Light
+Ruddy
+Dark
+Freckled
+Light brown
+Dark brown
+Black</_longname>
             </column>
             <column>
                 <_attribute>Eyes</_attribute>
+                <_longname>Blue
+Gray
+Hazel
+Brown
+Black</_longname>
             </column>
             <column>
                 <_attribute>Hair</_attribute>
+                <_longname>Blonde
+Red
+Brown
+Black
+Gray
+Bald</_longname>
             </column>
             <column>
                 <_attribute>Other characteristics</_attribute>


### PR DESCRIPTION
This PR replaces [542](https://github.com/gramps-project/addons-source/pull/542) with similar changes to the US WWII Draft Registration Form for the gramps60 branch. It rebases the changes (fixing some previous typos). It is backward compatible and does not break current usage.

The intention is to CLOSE [312](https://github.com/gramps-project/addons-source/pull/312), [542](https://github.com/gramps-project/addons-source/pull/542), and [546](https://github.com/gramps-project/addons-source/pull/546). This PR covers the Draft changes. The 1950 US Census changes will be discarded as they break current users.

