### PR TITLE
Adapt PostgreSQL addon for Gramps 6.0

### DIFF
--- a/PostgreSQL/postgresql.py
+++ b/PostgreSQL/postgresql.py
@@ -190,6 +190,34 @@ class Connection:
                               "WHERE table_name=%s;", [table])
         return self.fetchone()[0] != 0
 
+
+    def column_exists(self, table, column):
+        """
+        Test whether the specified SQL column exists in the specified table.
+        :param table: table name to check.
+        :type table: str
+        :param column: column name to check.
+        :type column: str
+        :returns: True if the column exists, False otherwise.
+        :rtype: bool
+        """
+        self.__cursor.execute(
+            "SELECT COUNT(*) FROM information_schema.columns "
+            "WHERE table_name = %s AND column_name = %s",
+            (table, column),
+        )
+        return self.fetchone()[0] != 0
+
+
+    def drop_column(self, table_name, column_name):
+        """Drop a column from a table.
+        :param table_name: name of the table to drop the column from.
+        :type table_name: str
+        :param column_name: name of the column to drop.
+        :type column_name: str
+        """
+        self.execute(f"ALTER TABLE {table_name} DROP COLUMN {column_name};")
+
     def close(self):
         self.__connection.close()
 


### PR DESCRIPTION
A Gramps Web user noticed that the PostgreSQL addon has not been adapted for Gramps 6.0 yet. (https://github.com/gramps-project/gramps-web-api/issues/637)

Note: this is not the SharedPostgreSQL addon that has been specifically develeoped for Gramps Web, but the old single-tree PostgreSQL addon.

Related discussion: https://github.com/gramps-project/gramps-web-api/issues/596#issuecomment-2623802281

Note that **I have not tested this change myself**.

The `drop_column` function is simple enough; the `column_exists` function has been copied over (and is identical to) the SharedPostgreSQL addon (which I have tested).

@dnightbane would you be able to test this?

CC @dsblank, @Nick-Hall 