### PR TITLE
Add one time retry on exception when file upload

### DIFF
--- a/GrampsWebSync/webapihandler.py
+++ b/GrampsWebSync/webapihandler.py
@@ -368,6 +368,11 @@ class WebApiHandler:
                 self.fetch_token()
                 return self._upload_file(url=url, fobj=fobj, retry=False)
             raise
+        except (URLError, socket.timeout) as exc:
+            if retry:
+                sleep(1)
+                return self._upload_file(url=url, fobj=fobj, retry=False)
+            raise
 
 
 def transaction_to_json(


### PR DESCRIPTION
In some cases, file uploads may fail due to temporary network issues or a restart of one of the pods running Gramps Web. When this happens, the entire sync process fails, requiring a full restart. This involves refetching remote data, comparing changes, and attempting to re-upload missing files — a time-consuming process, especially with large trees (as in my case).

This PR adds a one-time retry on network-related exceptions during file upload to mitigate such temporary issues and improve reliability.