### PR TITLE
Fix use_json_data in SharedPostgreSQL

### DIFF
--- a/SharedPostgreSQL/shareddbapi.py
+++ b/SharedPostgreSQL/shareddbapi.py
@@ -92,8 +92,12 @@ class SharedDBAPI(DbGeneric):
         # if the database has been converted to use JSON data
         if not self.dbapi.column_exists("metadata", "json_data"):
             return False
-        # but even if it does, it could be that the specific tree
-        # is not converted yet.
+        # if the column exists, but the tree ID is not in the trees
+        # table yet, the tree is still empty, so we are OK
+        if not self.dbapi._get_treeid():
+            return True
+        # if the column exists and the tree does too, it could be
+        # that this specific tree is not converted yet.
         return self.dbapi._schema_version_exists()
 
     def upgrade_table_for_json_data(self, table_name):


### PR DESCRIPTION
Another small fix needed to make SharedPostgreSQL work fully with Gramps 6.0.

The issue here was that, if the tree has not been populated yet, `_schema_version_exists` would fail with an error.

@GaryGriffin it would be great if you could merge the fix swiftly, as usual :pray: Thanks!