### PR TITLE
Gedcom 7 import addon

### DIFF
--- a/ImportGedcom7/MANIFEST
+++ b/ImportGedcom7/MANIFEST
@@ -1,0 +1,1 @@
+ImportGedcom7/README.md

--- a/ImportGedcom7/README.md
+++ b/ImportGedcom7/README.md
@@ -1,0 +1,37 @@
+# GEDCOM 7 Import
+
+Imports [GEDCOM 7](https://gedcom.io/) files into Gramps.
+
+GEDCOM 7 is a substantial revision of the GEDCOM standard and is not backwards
+compatible with GEDCOM 5.5.1, so it needs an importer of its own. Gramps' built-in
+GEDCOM importer continues to handle 5.5.1 and earlier files.
+
+## Requirements
+
+This addon requires the [gramps-gedcom7](https://github.com/DavidMStraub/gramps-gedcom7)
+Python library, which does the actual parsing and conversion:
+
+```bash
+pip install gramps-gedcom7
+```
+
+The Plugin Manager can also install it for you when you install this addon.
+
+## File extension
+
+The addon registers the `.ged7` extension. GEDCOM 7 files produced by other
+applications usually carry the same `.ged` extension as GEDCOM 5.5.1 files,
+which Gramps routes to its built-in GEDCOM 5.5.1 importer — so **rename a
+GEDCOM 7 file to `.ged7` before importing it**.
+
+GEDCOM ZIP packages (`.gdz`) are not supported yet; unpack them and import the
+GEDCOM file they contain.
+
+## Status
+
+The underlying conversion covers the vast majority of GEDCOM 7 and has been
+tested against real-world files. The addon itself is registered as beta because
+it is new; as with any conversion tool, check the results after importing.
+
+Please report problems, ideally with a sample file, at the
+[gramps-gedcom7 issue tracker](https://github.com/DavidMStraub/gramps-gedcom7/issues).

--- a/ImportGedcom7/import_gedcom7.py
+++ b/ImportGedcom7/import_gedcom7.py
@@ -1,0 +1,7 @@
+from gramps_gedcom7 import import_gedcom, ImportSettings
+
+
+def import_data(database, filename, user):
+    """Import a GEDCOM file into a Gramps database with user context."""
+    settings = ImportSettings()
+    import_gedcom(input_file=filename, db=database, settings=settings)

--- a/ImportGedcom7/import_gedcom7.py
+++ b/ImportGedcom7/import_gedcom7.py
@@ -1,7 +1,116 @@
-from gramps_gedcom7 import import_gedcom, ImportSettings
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2025 David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Import a GEDCOM 7 file into Gramps."""
+
+# -------------------------------------------------------------------------
+#
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import logging
+
+# -------------------------------------------------------------------------
+#
+# Gramps modules
+#
+# -------------------------------------------------------------------------
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+from gramps.gen.errors import DbError
+from gramps.gen.utils.libformatting import ImportInfo
+
+# -------------------------------------------------------------------------
+#
+# GEDCOM 7 library
+#
+# -------------------------------------------------------------------------
+from gramps_gedcom7 import ImportSettings, import_gedcom
+
+try:
+    _trans = glocale.get_addon_translator(__file__)
+except ValueError:
+    _trans = glocale.translation
+_ = _trans.gettext
+
+LOG = logging.getLogger(".ImportGedcom7")
+
+
+def _object_counts(database):
+    """Return the number of objects of each type, keyed by display label."""
+    return {
+        label: getattr(database, method)()
+        for label, method in (
+            (_("People"), "get_number_of_people"),
+            (_("Families"), "get_number_of_families"),
+            (_("Events"), "get_number_of_events"),
+            (_("Places"), "get_number_of_places"),
+            (_("Sources"), "get_number_of_sources"),
+            (_("Citations"), "get_number_of_citations"),
+            (_("Repositories"), "get_number_of_repositories"),
+            (_("Media"), "get_number_of_media"),
+            (_("Notes"), "get_number_of_notes"),
+            (_("Tags"), "get_number_of_tags"),
+        )
+    }
+
+
+def _import_statistics(before, after):
+    """Return the number of objects added, omitting types with no additions."""
+    added = {
+        label: after[label] - before[label]
+        for label in after
+        if after[label] > before[label]
+    }
+    return added or {_("Results"): _("No objects were imported")}
 
 
 def import_data(database, filename, user):
-    """Import a GEDCOM file into a Gramps database with user context."""
+    """Import a GEDCOM 7 file into a Gramps database.
+
+    :returns: an :class:`ImportInfo` with the object counts, or None if the
+              file could not be imported. Gramps treats None as a failure.
+    """
+    # A fresh ImportSettings per import: the library records HEAD.PLAC.FORM on
+    # it, so a shared instance would leak that default into the next import.
     settings = ImportSettings()
-    import_gedcom(input_file=filename, db=database, settings=settings)
+    before = _object_counts(database)
+    try:
+        import_gedcom(input_file=filename, db=database, settings=settings)
+    except OSError as err:
+        user.notify_error(_("%s could not be opened") % filename, str(err))
+        return None
+    except ValueError as err:
+        # raised for invalid UTF-8 and for GEDCOM 7 parse errors
+        user.notify_error(
+            _("Invalid GEDCOM 7 file"),
+            _("%s could not be imported") % filename + "\n" + str(err),
+        )
+        return None
+    except DbError as err:
+        user.notify_db_error(str(err.value))
+        return None
+    except Exception as err:
+        LOG.error("Failed to import GEDCOM 7 file.", exc_info=True)
+        user.notify_error(
+            _("Error reading GEDCOM 7 file"),
+            _("%s could not be imported") % filename + "\n" + str(err),
+        )
+        return None
+    return ImportInfo(_import_statistics(before, _object_counts(database)))

--- a/ImportGedcom7/importgedcom7.gpr.py
+++ b/ImportGedcom7/importgedcom7.gpr.py
@@ -1,0 +1,32 @@
+# Copyright (C) 2025 David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Import a Gedcom 7 file into Gramps."""
+
+register(
+    IMPORT,
+    id="im_ged7",
+    name=_("GEDCOM 7"),
+    description=_("Import GEDCOM 7 files"),
+    version = "0.1.0",
+    gramps_target_version="6.0",
+    status=BETA,
+    fname="import_gedcom7.py",
+    import_function="import_data",
+    extension="ged7",
+    requires_mod=["gramps_gedcom7"],
+)

--- a/ImportGedcom7/importgedcom7.gpr.py
+++ b/ImportGedcom7/importgedcom7.gpr.py
@@ -29,4 +29,6 @@ register(
     import_function="import_data",
     extension="ged7",
     requires_mod=["gramps_gedcom7"],
+    authors=["David Straub"],
+    authors_email=["straub@protonmail.com"],
 )

--- a/ImportGedcom7/po/template.pot
+++ b/ImportGedcom7/po/template.pot
@@ -1,0 +1,92 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-12 22:55+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ImportGedcom7/importgedcom7.gpr.py:23
+msgid "GEDCOM 7"
+msgstr ""
+
+#: ImportGedcom7/importgedcom7.gpr.py:24
+msgid "Import GEDCOM 7 files"
+msgstr ""
+
+#: ImportGedcom7/import_gedcom7.py:60
+msgid "People"
+msgstr ""
+
+#: ImportGedcom7/import_gedcom7.py:61
+msgid "Families"
+msgstr ""
+
+#: ImportGedcom7/import_gedcom7.py:62
+msgid "Events"
+msgstr ""
+
+#: ImportGedcom7/import_gedcom7.py:63
+msgid "Places"
+msgstr ""
+
+#: ImportGedcom7/import_gedcom7.py:64
+msgid "Sources"
+msgstr ""
+
+#: ImportGedcom7/import_gedcom7.py:65
+msgid "Citations"
+msgstr ""
+
+#: ImportGedcom7/import_gedcom7.py:66
+msgid "Repositories"
+msgstr ""
+
+#: ImportGedcom7/import_gedcom7.py:67
+msgid "Media"
+msgstr ""
+
+#: ImportGedcom7/import_gedcom7.py:68
+msgid "Notes"
+msgstr ""
+
+#: ImportGedcom7/import_gedcom7.py:69
+msgid "Tags"
+msgstr ""
+
+#: ImportGedcom7/import_gedcom7.py:81
+msgid "Results"
+msgstr ""
+
+#: ImportGedcom7/import_gedcom7.py:81
+msgid "No objects were imported"
+msgstr ""
+
+#: ImportGedcom7/import_gedcom7.py:97
+#, python-format
+msgid "%s could not be opened"
+msgstr ""
+
+#: ImportGedcom7/import_gedcom7.py:102
+msgid "Invalid GEDCOM 7 file"
+msgstr ""
+
+#: ImportGedcom7/import_gedcom7.py:103 ImportGedcom7/import_gedcom7.py:113
+#, python-format
+msgid "%s could not be imported"
+msgstr ""
+
+#: ImportGedcom7/import_gedcom7.py:112
+msgid "Error reading GEDCOM 7 file"
+msgstr ""

--- a/ImportGedcom7/tests/test_import_gedcom7.py
+++ b/ImportGedcom7/tests/test_import_gedcom7.py
@@ -1,0 +1,124 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2025 David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Tests for the GEDCOM 7 importer."""
+
+import os
+import sys
+import tempfile
+import unittest
+
+ADDON_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ADDON_DIR not in sys.path:
+    sys.path.insert(0, ADDON_DIR)
+
+try:
+    import gramps_gedcom7  # noqa: F401
+except ImportError as err:
+    raise unittest.SkipTest("gramps_gedcom7 not available: %s" % err)
+
+from gramps.gen.db.utils import make_database
+
+from ImportGedcom7.import_gedcom7 import import_data
+
+GEDCOM = """0 HEAD
+1 GEDC
+2 VERS 7.0
+0 @I1@ INDI
+1 NAME John /Doe/
+1 SEX M
+0 @I2@ INDI
+1 NAME Jane /Doe/
+1 SEX F
+0 @F1@ FAM
+1 HUSB @I1@
+1 WIFE @I2@
+0 TRLR
+"""
+
+
+class MockUser:
+    """Records the errors an importer reports instead of displaying them."""
+
+    def __init__(self):
+        self.errors = []
+
+    def notify_error(self, title, error=""):
+        self.errors.append((title, error))
+
+    def notify_db_error(self, error):
+        self.errors.append(("db error", error))
+
+
+class TestImportGedcom7(unittest.TestCase):
+    def setUp(self):
+        self.db = make_database("sqlite")
+        self.db.load(tempfile.mkdtemp(prefix="importgedcom7_"))
+        self.user = MockUser()
+        self.tmpdir = tempfile.mkdtemp(prefix="importgedcom7_files_")
+
+    def tearDown(self):
+        self.db.close()
+
+    def _write(self, name, content, mode="w"):
+        path = os.path.join(self.tmpdir, name)
+        with open(path, mode) as file:
+            file.write(content)
+        return path
+
+    def test_import(self):
+        path = self._write("test.ged7", GEDCOM)
+        info = import_data(self.db, path, self.user)
+        self.assertEqual(self.user.errors, [])
+        # Gramps treats a None result as a failed import
+        self.assertIsNotNone(info)
+        self.assertEqual(self.db.get_number_of_people(), 2)
+        self.assertEqual(self.db.get_number_of_families(), 1)
+
+    def test_import_info_reports_counts(self):
+        path = self._write("test.ged7", GEDCOM)
+        info = import_data(self.db, path, self.user)
+        text = info.info_text()
+        self.assertIn("2", text)
+        self.assertIn("1", text)
+
+    def test_invalid_file(self):
+        path = self._write("invalid.ged7", "this is not a GEDCOM file\n")
+        info = import_data(self.db, path, self.user)
+        self.assertIsNone(info)
+        self.assertEqual(len(self.user.errors), 1)
+        self.assertEqual(self.db.get_number_of_people(), 0)
+
+    def test_invalid_encoding(self):
+        path = self._write(
+            "latin1.ged7", "0 HEAD\n1 NOTE \xe9\n".encode("latin-1"), "wb"
+        )
+        info = import_data(self.db, path, self.user)
+        self.assertIsNone(info)
+        self.assertEqual(len(self.user.errors), 1)
+
+    def test_missing_file(self):
+        info = import_data(self.db, os.path.join(self.tmpdir, "nope.ged7"), self.user)
+        self.assertIsNone(info)
+        self.assertEqual(len(self.user.errors), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This is a draft of an import addon for Gedcom 7 files based on the [standalone library](https://github.com/DavidMStraub/gramps-gedcom7). The implementation is not complete yet, but ready for testing & feedback.

Two problems regarding the plugin (i.e., independent of the library):

- When using `ged` as extension, the plugin is always overruled by the core Gedcom (6) plugin. That's why I had to change the extension to `ged7`, but that's an ugly hack. Is there a way around it?
- I added `gramps_gedcom7` (with underscore) to `requires_mod` because that's the module that is required, but there are two problems with this:
    - The package is called `gramps-gedcom7` (with hyphen) and there is currently no way to specify that in the `gpr` file
    - There is currently no way to specify a target version of a pip package.

To install the required package, use

```bash
python -m pip install --upgrade gramps-gedcom7
```