### PR TITLE
Add better error handling to GrampWebSync

### DIFF
--- a/GrampsWebSync/grampswebsync.py
+++ b/GrampsWebSync/grampswebsync.py
@@ -363,9 +363,9 @@ class GrampsWebSyncTool(BatchTool, ManagedWindow):
             if exc.code == 401:
                 self.loginpage.show_error(_("Authentication failed. Please check your username and password."))
             elif exc.code == 403:
-                self.loginpage.show_error(_("Access forbidden. Please check your server permissions."))
+                self.loginpage.show_error(_("Access forbidden. Please check username and password."))
             elif exc.code == 404:
-                self.loginpage.show_error(_("Server not found. Please check the URL."))
+                self.loginpage.show_error(_("GrampsWeb service not found. Please check the URL."))
             else:
                 self.loginpage.show_error(_("Server error %s. Please check your connection.") % exc.code)
             return False
@@ -761,15 +761,6 @@ class LoginPage(Page):
         self.url.connect("changed", self.on_entry_changed)
         self.username.connect("changed", self.on_entry_changed)
         self.password.connect("changed", self.on_entry_changed)
-
-        # Connect Enter key to advance page
-        self.password.connect("activate", self.on_password_activate)
-
-    def on_password_activate(self, widget):
-        """Handle Enter key press in password field."""
-        if self.complete:
-            # Try to advance to next page
-            self.assistant.next_page()
 
     def show_error(self, message: str):
         """Display an error message on the login page."""

--- a/GrampsWebSync/grampswebsync.py
+++ b/GrampsWebSync/grampswebsync.py
@@ -493,7 +493,8 @@ class GrampsWebSyncTool(BatchTool, ManagedWindow):
         if db2 is None:
             self.handle_error(_("Failed importing downloaded XML file."))
             return
-        LOG.debug("Successfully imported Gramps XML file.")
+        else:
+            LOG.debug("Successfully imported Gramps XML file.")
         path.unlink()  # delete temporary file
         self.db2 = db2
         self.diff_progress_page.label.set_text(_("Comparing local and remote data..."))
@@ -760,7 +761,7 @@ class LoginPage(Page):
         self.error_label = Gtk.Label()
         self.error_label.set_line_wrap(True)
         self.error_label.set_max_width_chars(60)
-        self.error_label.set_markup('<span color="red"><b>Error:</b> </span>')
+        self.error_label.get_style_context().add_class('error')
         self.error_label.set_no_show_all(True)  # Don't show when show_all() is called
         self.error_label.hide()
         grid.attach(self.error_label, 0, 3, 2, 1)
@@ -772,7 +773,7 @@ class LoginPage(Page):
 
     def show_error(self, message: str):
         """Display an error message on the login page."""
-        self.error_label.set_markup(f'<span color="red"><b>Error:</b> {message}</span>')
+        self.error_label.set_markup(f'<b>Error:</b> {message}')
         self.error_label.show()
         self.update_complete()
 

--- a/GrampsWebSync/grampswebsync.py
+++ b/GrampsWebSync/grampswebsync.py
@@ -767,48 +767,29 @@ class LoginPage(Page):
         self.error_label.hide()
         grid.attach(self.error_label, 0, 3, 2, 1)
 
-        # Retry button - initially hidden
-        self.retry_button = Gtk.Button(label=_("Test Connection"))
-        self.retry_button.connect("clicked", self.on_retry_clicked)
-        self.retry_button.set_no_show_all(True)  # Don't show when show_all() is called
-        self.retry_button.hide()
-        grid.attach(self.retry_button, 1, 4, 1, 1)
-
         # Connect entry change events
         self.url.connect("changed", self.on_entry_changed)
         self.username.connect("changed", self.on_entry_changed)
         self.password.connect("changed", self.on_entry_changed)
 
-        # Connect Enter key to test connection
+        # Connect Enter key to advance page
         self.password.connect("activate", self.on_password_activate)
 
     def on_password_activate(self, widget):
         """Handle Enter key press in password field."""
         if self.complete:
-            # Simulate clicking "Test Connection" or moving to next page
-            if self.retry_button.get_visible():
-                self.on_retry_clicked(None)
-            else:
-                # Try to advance to next page
-                self.assistant.next_page()
-
-    def on_retry_clicked(self, button):
-        """Handle retry button click."""
-        self.clear_error()
-        # Trigger moving to the next page, which will test the connection
-        self.assistant.next_page()
+            # Try to advance to next page
+            self.assistant.next_page()
 
     def show_error(self, message: str):
         """Display an error message on the login page."""
         self.error_label.set_markup(f'<span color="red"><b>Error:</b> {message}</span>')
         self.error_label.show()
-        self.retry_button.show()
         self.update_complete()
 
     def clear_error(self):
         """Clear any displayed error message."""
         self.error_label.hide()
-        self.retry_button.hide()
         self.update_complete()
 
     @property

--- a/GrampsWebSync/grampswebsync.py
+++ b/GrampsWebSync/grampswebsync.py
@@ -352,12 +352,6 @@ class GrampsWebSyncTool(BatchTool, ManagedWindow):
     def test_connection(self, url: str, username: str, password: str) -> bool:
         """Test the connection and authentication. Return True if successful."""
         try:
-            # Sanitize URL first
-            url = self.sanitize_url(url)
-            if url is None:
-                self.loginpage.show_error(_("Invalid URL provided."))
-                return False
-
             # Try to create API handler
             self._api = WebApiHandler(url, username, password, None)
 

--- a/GrampsWebSync/grampswebsync.py
+++ b/GrampsWebSync/grampswebsync.py
@@ -237,14 +237,12 @@ class GrampsWebSyncTool(BatchTool, ManagedWindow):
         self.assistant.set_page_title(page, title)
         self.assistant.set_page_type(page, page_type)
 
-
     def handle_done_syncing_dbs(self):
         """Handle the completion of syncing the databases."""
         self.save_timestamp()
         self.sync_progress_page.handle_done_syncing_dbs()
         self.files_missing_local = self.get_missing_files_local()
         self.assistant.next_page()
-
 
     def prepare(self, assistant, page):
         """Run page preparation code."""
@@ -468,7 +466,7 @@ class GrampsWebSyncTool(BatchTool, ManagedWindow):
         LOG.error(message)
         self.conclusion.error = True
         self.assistant.next_page()
-        self.conclusion.label.set_text(message)  #
+        self.conclusion.label.set_text(message)
         self.conclusion.set_complete()
 
     def handle_unchanged(self):
@@ -493,8 +491,7 @@ class GrampsWebSyncTool(BatchTool, ManagedWindow):
         if db2 is None:
             self.handle_error(_("Failed importing downloaded XML file."))
             return
-        else:
-            LOG.debug("Successfully imported Gramps XML file.")
+        LOG.debug("Successfully imported Gramps XML file.")
         path.unlink()  # delete temporary file
         self.db2 = db2
         self.diff_progress_page.label.set_text(_("Comparing local and remote data..."))

--- a/GrampsWebSync/grampswebsync.py
+++ b/GrampsWebSync/grampswebsync.py
@@ -369,6 +369,14 @@ class GrampsWebSyncTool(BatchTool, ManagedWindow):
                 self.loginpage.show_error(
                     _("GrampsWeb service not found. Please check the URL.")
                 )
+            elif exc.code == 429:
+                self.loginpage.show_error(
+                    _("Too many requests, please try again in a few seconds.")
+                )
+            elif exc.code == 503:
+                self.loginpage.show_error(
+                    _("GrampsWeb tree is disabled.")
+                )
             else:
                 self.loginpage.show_error(
                     _("Server error %s. Please check your connection.") % exc.code

--- a/GrampsWebSync/grampswebsync.py
+++ b/GrampsWebSync/grampswebsync.py
@@ -84,7 +84,6 @@ def get_password(service: str, username: str) -> str | None:
         return None
     return keyring.get_password(service, username)
 
-
 def set_password(service: str, username: str, password: str) -> None:
     """If keyring is installed, store the user's password."""
     try:
@@ -287,7 +286,7 @@ class GrampsWebSyncTool(BatchTool, ManagedWindow):
                     self.handle_error(
                         _("Unexpected error while applying changes.") + f" {e}"
                     )
-                
+
             # now, get missing media files
         elif page == self.file_confirmation:
             if self.files_missing_local:
@@ -361,18 +360,28 @@ class GrampsWebSyncTool(BatchTool, ManagedWindow):
 
         except HTTPError as exc:
             if exc.code == 401:
-                self.loginpage.show_error(_("Authentication failed. Please check your username and password."))
+                self.loginpage.show_error(
+                    _("Authentication failed. Please check your username and password.")
+                )
             elif exc.code == 403:
-                self.loginpage.show_error(_("Access forbidden. Please check username and password."))
+                self.loginpage.show_error(
+                    _("Access forbidden. Please check username and password.")
+                )
             elif exc.code == 404:
-                self.loginpage.show_error(_("GrampsWeb service not found. Please check the URL."))
+                self.loginpage.show_error(
+                    _("GrampsWeb service not found. Please check the URL.")
+                )
             else:
-                self.loginpage.show_error(_("Server error %s. Please check your connection.") % exc.code)
+                self.loginpage.show_error(
+                    _("Server error %s. Please check your connection.") % exc.code
+                )
             return False
         except URLError:
-            self.loginpage.show_error(_("Connection failed. Please check the URL and your internet connection."))
+            self.loginpage.show_error(
+                _("Connection failed. Please check the URL and your internet connection.")
+            )
             return False
-        except ValueError as e:
+        except ValueError:
             self.loginpage.show_error(_("Invalid server response. Please check the URL."))
             return False
         except Exception as e:
@@ -484,8 +493,7 @@ class GrampsWebSyncTool(BatchTool, ManagedWindow):
         if db2 is None:
             self.handle_error(_("Failed importing downloaded XML file."))
             return
-        else:
-            LOG.debug("Successfully imported Gramps XML file.")
+        LOG.debug("Successfully imported Gramps XML file.")
         path.unlink()  # delete temporary file
         self.db2 = db2
         self.diff_progress_page.label.set_text(_("Comparing local and remote data..."))


### PR DESCRIPTION
@DavidMStraub 
The current GrampsWebSync essentially crashes when provided a bad username or password and even offers to send a crash report.  This seems less than ideal.  I'm neither a python novice nor an expert, but somewhere in between and haven't played with gramps plugins before.  So hopefully I'm coloring within the lines here.  Full disclosure I used an AI as an experiment to see how far that would get me, but I've personally reviewed all changes and take responsibility for them. 

I used Anthropic's Claude Sonnet 4 AI to produce a first pass using the prompt:
Using the code at https://raw.githubusercontent.com/hdholm/addons-source/refs/heads/maintenance/gramps60/GrampsWebSync/grampswebsync.py as a starting point modify the code to report errors such as login failures directly on the login page in class LoginPage and provide the abilty to retry with a different password and/or user name.
commit 6e37f19fd18279595d4c1420e12cb7c640b24c24

I followed up with a prompt:
Building on that code, remove the need for the test connection button, just use the next button.  But keep the logic for the
error messages.
ommit e508f4bdbbdbf4a682e4e713f61d0b561b823be7

The rest of the commits are not AI generated and are me cleaning up the AI's misunderstanding of how the credentials were managed and it's gratuitous changes in some places as well as  some cleanup - particularly error messages that didn't necessarily reflect the cause of the error. I tried to use pylint and made a number of changes it suggested, but the vast majority were in code that wasn't added here, so I mostly left that as is.

I haven't really played with translation before and I DID change some strings, so if there are things I need to do to accommodate that please let me know.