### PR TITLE
Fix duplicate message definitions in PostgreSQLEnhanced template.pot

### DIFF
--- a/PostgreSQLEnhanced/po/template.pot
+++ b/PostgreSQLEnhanced/po/template.pot
@@ -124,9 +124,6 @@ msgstr ""
 msgid "Migration completed!"
 msgstr ""
 
-#: migration.py:302
-msgid "Starting upgrade..."
-msgstr ""
 
 #: migration.py:320
 #, python-format
@@ -156,8 +153,4 @@ msgstr ""
 
 #: schema.py:246
 msgid "PostgreSQL Enhanced schema created successfully"
-msgstr ""
-
-#: connection.py:113
-msgid "psycopg3 is required for PostgreSQL Enhanced support. Install with: pip install 'psycopg[binary]'"
 msgstr ""


### PR DESCRIPTION
This PR fixes the duplicate message definitions in the PostgreSQLEnhanced addon's template.pot file that were causing the publish step to fail after PR #750 was merged.

## Changes
- Remove duplicate 'Starting upgrade...' message (was at lines 94 and 128)
- Remove duplicate 'psycopg3 is required...' message (was at lines 33 and 162)

## Context
PR #750 was merged in commit 4b9a47c before the template.pot fix was applied. This PR applies just the template.pot fix to resolve the publish step failure.

Fixes the error reported by @GaryGriffin in #750 (comment)