### PR TITLE
Initiate variable to avoid unhandled exception

### DIFF
--- a/D3Charts/AncestralCollapsibleTree.py
+++ b/D3Charts/AncestralCollapsibleTree.py
@@ -101,6 +101,7 @@ class AncestralCollapsibleTreeReport(Report):
         """
         Report.__init__(self, database, options, user)
 
+        self.user = user
         self.map = {}
 
         menu = options.menu

--- a/D3Charts/AncestralFanChart.py
+++ b/D3Charts/AncestralFanChart.py
@@ -99,6 +99,7 @@ class AncestralFanChartReport(Report):
         """
         Report.__init__(self, database, options, user)
 
+        self.user = user
         self.map = {}
 
         menu = options.menu


### PR DESCRIPTION
Commit 756f4af5576fc1f33bca9824d51f37003fc66daa referenced the user parameter that was passed in but not initialized/stored locally, leading to an unhandled exception. This change copies the parameter in the init method, making it available for subsequent use.

For the user it means that when full path to the report's destination folder doesn't exist, a dialog will show that error instead of Gramps ending up with an unhandled exception.

Fixes [#13932](https://gramps-project.org/bugs/view.php?id=13932)