### PR TITLE
[GetGOV] Fix empty date ranges

### DIFF
--- a/GetGOV/getgov.py
+++ b/GetGOV/getgov.py
@@ -560,4 +560,4 @@ class GetGOV(Gramplet):
         else:
             date_str = ""
 
-        return parser.parse(date_str) if date_str else None
+        return parser.parse(date_str)


### PR DESCRIPTION
For empty date ranges send an empty string to the date parser instead of using a NoneType as date.

Fixes [#13937](https://gramps-project.org/bugs/view.php?id=13937).