### PR TITLE
Fix registration file to point to the correct help URL for Media Browser addon

### DIFF
--- a/MediaBrowser/MediaBrowser.gpr.py
+++ b/MediaBrowser/MediaBrowser.gpr.py
@@ -38,5 +38,5 @@ register(
     gramplet="MediaBrowser",
     gramplet_title=_("Browser"),
     navtypes=["Person"],
-    help_url="Addon:MediaMerge",
+    help_url="Addon:MediaBrowserGramplet",
 )


### PR DESCRIPTION
Help URL in the registration file was pointing to a different addon's help URL. This has been fixed so that it points to the URL for Media Browser's help URL.

Fixes [#0013959](https://gramps-project.org/bugs/view.php?id=13959)