### PR TITLE
Fix unhandled exception when omit duplicate option is used with index of names

### DIFF
--- a/DescendantBooks/DetailedDescendantBookReport.py
+++ b/DescendantBooks/DetailedDescendantBookReport.py
@@ -353,6 +353,11 @@ class DetailedDescendantBookReport(Report):
         self.ca = CollectAscendants(self.database, self.user, self.title)
         self.ascendants = self.ca.collect_data(self.filter, self.center_person)
 
+        # Initialize attributes used for indexing and references
+        self.report_app_ref = {}
+        self.index_of_dates = {}
+        self.index_of_places = {}
+
         if self.dubperson:
             if len(self.ascendants) > 1:
                 self.user.begin_progress(self.title,
@@ -362,10 +367,7 @@ class DetailedDescendantBookReport(Report):
             # Need to do two runs of generations,
             # 1st run gets references for all people/mates in report
             # 2nd run actually generates the report and includes the references
-            self.report_app_ref = {}
             self.report_count = 0
-            self.index_of_dates = {}
-            self.index_of_places = {}
             self.phandle = 0 # person handle used by append_event to retrieve name and references to the current person
             for asc_handle in self.ascendants:
                 if len(self.ascendants) > 1:


### PR DESCRIPTION
The issue was that report_app_ref, index_of_dates, and index_of_places were only initialized when the dubperson (i.e. omit duplicates) option was enabled, but they were accessed unconditionally in methods like write_index_of_names, append_event, and write_report_ref. This lead to an `AttributeError` when later code tried to access them.

AI was asked to analyze the call stack and fix the issue. Validation and verification of fix was performed by me.

Generated-by: Cline v3.27.0; x-ai/grok-code-fast-1

Fixes #[12859](https://gramps-project.org/bugs/view.php?id=12859), #[12857](https://gramps-project.org/bugs/view.php?id=12857)

@Nick-Hall Please review acknowledgement of AI use