### PR TITLE
Fix old style translation context in the Network Chart report

### DIFF
--- a/NetworkChart/NetworkChart.py
+++ b/NetworkChart/NetworkChart.py
@@ -130,9 +130,9 @@ class NetworkChartReport(Report):
 
         stdoptions.run_name_format_option(self, menu)
 
-        self._born = self._("birth abbreviation|b.") + ' '
-        self._died = self._("death abbreviation|d.") + ' '
-        self._marr = self._("marriage abbreviation|m.") + ' '
+        self._born = self._("b.", "birth abbreviation") + ' '
+        self._died = self._("d.", "death abbreviation") + ' '
+        self._marr = self._("m.", "marriage abbreviation") + ' '
         self._unk = self._('Unknown')
 
         self.font_chart = menu.get_option_by_name(

--- a/NetworkChart/po/template.pot
+++ b/NetworkChart/po/template.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-16 15:10-0800\n"
+"POT-Creation-Date: 2025-09-09 18:33+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,16 +17,27 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: NetworkChart/NetworkChart.gpr.py:24
+msgid "Network Chart"
+msgstr ""
+
+#: NetworkChart/NetworkChart.gpr.py:35
+msgid "Generates a family network chart."
+msgstr ""
+
 #: NetworkChart/NetworkChart.py:133
-msgid "birth abbreviation|b."
+msgctxt "birth abbreviation"
+msgid "b."
 msgstr ""
 
 #: NetworkChart/NetworkChart.py:134
-msgid "death abbreviation|d."
+msgctxt "death abbreviation"
+msgid "d."
 msgstr ""
 
 #: NetworkChart/NetworkChart.py:135
-msgid "marriage abbreviation|m."
+msgctxt "marriage abbreviation"
+msgid "m."
 msgstr ""
 
 #: NetworkChart/NetworkChart.py:136
@@ -256,7 +267,6 @@ msgstr ""
 msgid "RGB-color for Female box background."
 msgstr ""
 
-# added:
 #: NetworkChart/NetworkChart.py:1026
 msgid "Female Background Alpha"
 msgstr ""
@@ -311,8 +321,8 @@ msgstr ""
 
 #: NetworkChart/NetworkChart.py:1056
 msgid ""
-"RGB-color for the highlighted path between two individuals.  If the graph."
-"inverts, reverse the order to change."
+"RGB-color for the highlighted path between two individuals.  If the "
+"graph.inverts, reverse the order to change."
 msgstr ""
 
 #: NetworkChart/NetworkChart.py:1061
@@ -569,12 +579,4 @@ msgstr ""
 
 #: NetworkChart/NetworkChart.py:1243
 msgid "Enable/disable confirmation of file overwrite."
-msgstr ""
-
-#: NetworkChart/NetworkChart.gpr.py:24
-msgid "Network Chart"
-msgstr ""
-
-#: NetworkChart/NetworkChart.gpr.py:35
-msgid "Generates a family network chart."
 msgstr ""

--- a/make.py
+++ b/make.py
@@ -402,7 +402,7 @@ elif command == "init":
             mkdir(f"{addon}/po")
             fnames = " ".join(glob.glob(f"{addon}/*.py"))
             system(
-                f"xgettext --language=Python --keyword=_ --keyword=N_"
+                f"xgettext --language=Python --keyword=_ --keyword=_:1,2c --keyword=N_"
                 f" --from-code=UTF-8 --add-comments=Translators"
                 f' -o "{addon}/po/template.pot" {fnames} '
             )
@@ -732,8 +732,8 @@ elif command == "as-needed":
             mkdir("%(addon)s/po")
             fnames = " ".join(glob.glob(f"{addon}/*.py"))
             system(
-                "xgettext --language=Python --keyword=_ --keyword=N_"
-                " --from-code=UTF-8"
+                "xgettext --language=Python --keyword=_ --keyword=_:1,2c --keyword=N_"
+                " --from-code=UTF-8 --add-comments=Translators"
                 f' -o "{addon}/po/temp.pot" {fnames} '
             )
             fnames = " ".join(glob.glob(f"{addon}/*.glade"))


### PR DESCRIPTION
This report was still using the old vertical bar format for translation context.

See the [Change layout of nodes on the Network Chart addon](https://gramps.discourse.group/t/change-layout-of-nodes-on-the-network-chart-addon/8524) topic on Discourse for details.

Also fix `xgettext` to add translation context and comments.  The second parameter of the `_` function was not being processed and the comments were missing when run with "as-needed".