### PR TITLE
Heatmap Web Report - Make it usable from CLI

### DIFF
--- a/Heatmap/heatmap.gpr.py
+++ b/Heatmap/heatmap.gpr.py
@@ -33,6 +33,6 @@ register(
     category=CATEGORY_WEB,
     reportclass="ReportClass",
     optionclass="ReportOptions",
-    report_modes=[REPORT_MODE_GUI],
+    report_modes=[REPORT_MODE_GUI, REPORT_MODE_CLI],
     help_url="Addon:HeatmapWebReport",
 )


### PR DESCRIPTION
Heatmap used to be called on CLI[1] but not anymore. See https://gramps-project.org/bugs/view.php?id=13990 : it's not registered to be used through the CLI.
This restores that feature

[1] See https://gramps-project.org/bugs/view.php?id=12813