### PR TITLE
Gramps Web Sync: make error message a bit more helpful

### DIFF
--- a/GrampsWebSync/grampswebsync.py
+++ b/GrampsWebSync/grampswebsync.py
@@ -554,7 +554,7 @@ class GrampsWebSyncTool(BatchTool, ManagedWindow):
             self.handle_error(_("URL error while connecting to server."))
             return None
         except ValueError as exc:
-            self.handle_error(_("Unable to synchronize changes to server: {exc}"))
+            self.handle_error(f"{_('Unable to synchronize changes to server.')} ({exc})")
             return None
 
     def save_credentials(self) -> None:

--- a/GrampsWebSync/grampswebsync.py
+++ b/GrampsWebSync/grampswebsync.py
@@ -553,8 +553,8 @@ class GrampsWebSyncTool(BatchTool, ManagedWindow):
         except URLError:
             self.handle_error(_("URL error while connecting to server."))
             return None
-        except ValueError:
-            self.handle_error(_("Error while parsing response from server."))
+        except ValueError as exc:
+            self.handle_error(_("Unable to synchronize changes to server: {exc}"))
             return None
 
     def save_credentials(self) -> None:

--- a/GrampsWebSync/po/template.pot
+++ b/GrampsWebSync/po/template.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-06 08:58-0800\n"
+"POT-Creation-Date: 2025-10-11 21:37+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,8 +17,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: GrampsWebSync/grampswebsync.gpr.py:29 GrampsWebSync/grampswebsync.py:117
-#: GrampsWebSync/grampswebsync.py:210
+#: GrampsWebSync/grampswebsync.gpr.py:29 GrampsWebSync/grampswebsync.py:116
+#: GrampsWebSync/grampswebsync.py:209
 msgid "Gramps Web Sync"
 msgstr ""
 
@@ -26,27 +26,27 @@ msgstr ""
 msgid "Synchronizes a local database with a Gramps Web instance."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:126
+#: GrampsWebSync/grampswebsync.py:125
 msgid "Introduction"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:137
+#: GrampsWebSync/grampswebsync.py:136
 msgid "Login"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:143 GrampsWebSync/grampswebsync.py:169
+#: GrampsWebSync/grampswebsync.py:142 GrampsWebSync/grampswebsync.py:168
 msgid "Progress Information"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:148
+#: GrampsWebSync/grampswebsync.py:147
 msgid "Final confirmation"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:155 GrampsWebSync/grampswebsync.py:173
+#: GrampsWebSync/grampswebsync.py:154 GrampsWebSync/grampswebsync.py:172
 msgid "Summary"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:162
+#: GrampsWebSync/grampswebsync.py:161
 msgid "Media Files"
 msgstr ""
 
@@ -54,98 +54,136 @@ msgstr ""
 msgid "Your user does not have sufficient server permissions to use sync."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:268
+#: GrampsWebSync/grampswebsync.py:269
 msgid "Fetching remote data..."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:284
+#: GrampsWebSync/grampswebsync.py:285
 msgid "Unexpected error while applying changes."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:322
+#: GrampsWebSync/grampswebsync.py:323
 msgid "Media files are in sync."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:331
+#: GrampsWebSync/grampswebsync.py:332
 #, python-format
 msgid "Successfully downloaded %s media files."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:334
+#: GrampsWebSync/grampswebsync.py:335
 #, python-format
 msgid "Encountered %s errors during download."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:340
+#: GrampsWebSync/grampswebsync.py:341
 #, python-format
 msgid "Successfully uploaded %s media files."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:343
+#: GrampsWebSync/grampswebsync.py:344
 #, python-format
 msgid "Encountered %s errors during upload."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:389 GrampsWebSync/grampswebsync.py:410
+#: GrampsWebSync/grampswebsync.py:362
+msgid "Authentication failed. Please check your username and password."
+msgstr ""
+
+#: GrampsWebSync/grampswebsync.py:366
+msgid "Access forbidden. Please check username and password."
+msgstr ""
+
+#: GrampsWebSync/grampswebsync.py:370
+msgid "GrampsWeb service not found. Please check the URL."
+msgstr ""
+
+#: GrampsWebSync/grampswebsync.py:374
+msgid "Too many requests, please try again in a few seconds."
+msgstr ""
+
+#: GrampsWebSync/grampswebsync.py:378
+msgid "GrampsWeb tree is disabled."
+msgstr ""
+
+#: GrampsWebSync/grampswebsync.py:382
+#, python-format
+msgid "Server error %s. Please check your connection."
+msgstr ""
+
+#: GrampsWebSync/grampswebsync.py:387
+msgid "Connection failed. Please check the URL and your internet connection."
+msgstr ""
+
+#: GrampsWebSync/grampswebsync.py:391
+msgid "Invalid server response. Please check the URL."
+msgstr ""
+
+#: GrampsWebSync/grampswebsync.py:394
+#, python-format
+msgid "Unexpected error: %s"
+msgstr ""
+
+#: GrampsWebSync/grampswebsync.py:438 GrampsWebSync/grampswebsync.py:459
 msgid "Error accessing media object."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:451
+#: GrampsWebSync/grampswebsync.py:500
 msgid "Failed importing downloaded XML file."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:457
+#: GrampsWebSync/grampswebsync.py:505
 msgid "Comparing local and remote data..."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:489
+#: GrampsWebSync/grampswebsync.py:537
 msgid "Server authorization error."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:492
+#: GrampsWebSync/grampswebsync.py:540
 msgid "Server authorization error: insufficient permissions."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:495
+#: GrampsWebSync/grampswebsync.py:543
 msgid "Error: URL not found."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:499
+#: GrampsWebSync/grampswebsync.py:547
 msgid "Unable to synchronize changes to server: objects have been modified."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:503
+#: GrampsWebSync/grampswebsync.py:551
 #, python-format
 msgid "Error %s while connecting to server."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:506
+#: GrampsWebSync/grampswebsync.py:554
 msgid "URL error while connecting to server."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:509
-msgid "Error while parsing response from server."
+#: GrampsWebSync/grampswebsync.py:557
+msgid "Unable to synchronize changes to server."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:537
+#: GrampsWebSync/grampswebsync.py:585
 msgid "Continue without transport encryption?"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:539
+#: GrampsWebSync/grampswebsync.py:587
 msgid ""
 "You have specified a URL with http scheme. If you continue, your password "
 "will be sent in clear text over the network. Use only for local testing!"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:544
+#: GrampsWebSync/grampswebsync.py:592
 msgid "Continue with HTTP"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:545
+#: GrampsWebSync/grampswebsync.py:593
 msgid "Use HTTPS"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:663
+#: GrampsWebSync/grampswebsync.py:711
 msgid ""
 "This tool allows to synchronize the currently opened family tree with a "
 "remote family tree served by Gramps Web.\n"
@@ -161,101 +199,101 @@ msgid ""
 "option to make manual modifications, use the Import Merge Tool instead."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:690
+#: GrampsWebSync/grampswebsync.py:738
 msgid "Server URL: "
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:699
+#: GrampsWebSync/grampswebsync.py:747
 msgid "Username: "
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:707
+#: GrampsWebSync/grampswebsync.py:755
 msgid "Password: "
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:774
+#: GrampsWebSync/grampswebsync.py:847
 msgid "Bidirectional Synchronization"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:783
+#: GrampsWebSync/grampswebsync.py:856
 msgid "Reset remote to local"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:791
+#: GrampsWebSync/grampswebsync.py:864
 msgid "Reset local to remote"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:799
+#: GrampsWebSync/grampswebsync.py:872
 msgid "Merge"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:824
+#: GrampsWebSync/grampswebsync.py:897
 msgid "Local changes"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:825 GrampsWebSync/grampswebsync.py:830
+#: GrampsWebSync/grampswebsync.py:898 GrampsWebSync/grampswebsync.py:903
 msgid "Added"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:826 GrampsWebSync/grampswebsync.py:831
+#: GrampsWebSync/grampswebsync.py:899 GrampsWebSync/grampswebsync.py:904
 msgid "Deleted"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:827 GrampsWebSync/grampswebsync.py:832
-#: GrampsWebSync/grampswebsync.py:834
+#: GrampsWebSync/grampswebsync.py:900 GrampsWebSync/grampswebsync.py:905
+#: GrampsWebSync/grampswebsync.py:907
 msgid "Modified"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:829
+#: GrampsWebSync/grampswebsync.py:902
 msgid "Remote changes"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:834
+#: GrampsWebSync/grampswebsync.py:907
 msgid "Simultaneous changes"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:891
+#: GrampsWebSync/grampswebsync.py:964
 msgid "Fetching information about media files..."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:912
+#: GrampsWebSync/grampswebsync.py:985
 msgid "Both trees are the same."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:918
+#: GrampsWebSync/grampswebsync.py:991
 msgid "Applying changes to local database ..."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:920
+#: GrampsWebSync/grampswebsync.py:993
 msgid "No changes to apply to local database."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:923
+#: GrampsWebSync/grampswebsync.py:996
 msgid "Applying changes to remote database ..."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:926
+#: GrampsWebSync/grampswebsync.py:999
 msgid "No changes to apply to remote database."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:933
+#: GrampsWebSync/grampswebsync.py:1006
 msgid "Successfully applied changes to local database."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:962
+#: GrampsWebSync/grampswebsync.py:1035
 msgid "Missing locally"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:965
+#: GrampsWebSync/grampswebsync.py:1038
 msgid "Missing remotely"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:1003
+#: GrampsWebSync/grampswebsync.py:1076
 #, python-format
 msgid "Downloading %s media file(s)"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:1011
+#: GrampsWebSync/grampswebsync.py:1084
 #, python-format
 msgid "Uploading %s media file(s)"
 msgstr ""

--- a/GrampsWebSync/po/template.pot
+++ b/GrampsWebSync/po/template.pot
@@ -68,23 +68,31 @@ msgstr ""
 
 #: GrampsWebSync/grampswebsync.py:332
 #, python-format
-msgid "Successfully downloaded %s media files."
-msgstr ""
+msgid "Successfully downloaded %s media file."
+msgid_plural "Successfully downloaded %s media files."
+msgstr[0] ""
+msgstr[1] ""
 
 #: GrampsWebSync/grampswebsync.py:335
 #, python-format
-msgid "Encountered %s errors during download."
-msgstr ""
+msgid "Encountered %s error during download."
+msgid_plural "Encountered %s errors during download."
+msgstr[0] ""
+msgstr[1] ""
 
 #: GrampsWebSync/grampswebsync.py:341
 #, python-format
-msgid "Successfully uploaded %s media files."
-msgstr ""
+msgid "Successfully uploaded %s media file."
+msgid_plural "Successfully uploaded %s media files."
+msgstr[0] ""
+msgstr[1] ""
 
 #: GrampsWebSync/grampswebsync.py:344
 #, python-format
-msgid "Encountered %s errors during upload."
-msgstr ""
+msgid "Encountered %s error during upload."
+msgid_plural "Encountered %s errors during upload."
+msgstr[0] ""
+msgstr[1] ""
 
 #: GrampsWebSync/grampswebsync.py:362
 msgid "Authentication failed. Please check your username and password."
@@ -290,10 +298,14 @@ msgstr ""
 
 #: GrampsWebSync/grampswebsync.py:1076
 #, python-format
-msgid "Downloading %s media file(s)"
-msgstr ""
+msgid "Downloading %s media file"
+msgid_plural "Downloading %s media files"
+msgstr[0] ""
+msgstr[1] ""
 
 #: GrampsWebSync/grampswebsync.py:1084
 #, python-format
-msgid "Uploading %s media file(s)"
-msgstr ""
+msgid "Uploading %s media file"
+msgid_plural "Uploading %s media files"
+msgstr[0] ""
+msgstr[1] ""


### PR DESCRIPTION
Making the error message a bit more helpful to ease problems such as this one:
https://github.com/DavidMStraub/gramps-web-sync/issues/39