### PR TITLE
JSON import: do not return None on success

### DIFF
--- a/JSON/JSONImport.py
+++ b/JSON/JSONImport.py
@@ -49,6 +49,7 @@ from gramps.gen.lib import (
 )
 from gramps.gen.lib.json_utils import string_to_object
 from gramps.gen.const import GRAMPS_LOCALE as glocale
+from gramps.gen.utils.libformatting import ImportInfo
 
 _ = glocale.translation.sgettext
 
@@ -95,6 +96,10 @@ def importData(db, filename, user):
                     line = fp.readline()
     except EnvironmentError as err:
         user.notify_error(_("%s could not be opened\n") % filename, str(err))
+        return None
+    finally:
+        db.enable_signals()
 
-    db.enable_signals()
     db.request_rebuild()
+
+    return ImportInfo({_("Results"): _("done")})


### PR DESCRIPTION
The JSON import function `importData` always returns `None`. As a consequence, when using `gramps.gen.db.utils.import_from_filename` with a JSON file, it's impossible to distinguish whether the import failed or succeeded, as this function interprets falsey return values of import functions as indicating failure (which is indeed the case for the core importers like Gramps XML). To solve that, I added a return of `ImportInfo` on success, as is done for several core plugins.