### PR TITLE
Chatwithtree markdown rendering

### DIFF
--- a/ChatWithTree/ChatWithTree.gpr.py
+++ b/ChatWithTree/ChatWithTree.gpr.py
@@ -8,7 +8,7 @@ register(
     id="ChatWithTree",  # Unique ID for your addon
     name=_("Chat With Tree Interactive Addon"),  # Display name in Gramps, translatable
     description=_("Chat With Tree with the help of AI Large Language Model, needs litellm module"),
-    version = '0.0.27',
+    version = '0.0.28',
     gramps_target_version="6.0",  # Specify the Gramps version you are targeting
     status=STABLE,
     audience = EVERYONE,

--- a/ChatWithTree/ChatWithTree.gpr.py
+++ b/ChatWithTree/ChatWithTree.gpr.py
@@ -8,17 +8,17 @@ register(
     id="ChatWithTree",  # Unique ID for your addon
     name=_("Chat With Tree Interactive Addon"),  # Display name in Gramps, translatable
     description=_("Chat With Tree with the help of AI Large Language Model, needs litellm module"),
-    version = '0.0.28',
+    version = '0.0.27',
     gramps_target_version="6.0",  # Specify the Gramps version you are targeting
     status=STABLE,
-    audience = EVERYONE,
+    audience=EVERYONE,
     fname="ChatWithTree.py",  # The main Python file for your Gramplet
     # The 'gramplet' argument points to the class name in your main file
     gramplet="ChatWithTreeClass",
     gramplet_title=_("Chat With Tree"),
     authors = ["Melle Koning"],
     authors_email = ["mellekoning@gmail.com"],
-    height=18,
+    height=500,
      # addon needs litellm python module
     requires_mod=['litellm'],
     navtypes=["Dashboard"],

--- a/ChatWithTree/ChatWithTree.py
+++ b/ChatWithTree/ChatWithTree.py
@@ -19,6 +19,7 @@
 #
 # ChatWithTree.py
 import logging
+import re
 
 import gi
 from AsyncChatService import AsyncChatService
@@ -195,6 +196,40 @@ class ChatWithTreeClass(Gramplet):
         style_context = self.chat_listbox.get_style_context()
         style_context.add_class("message-box")
 
+    def _markdown_to_pango(self, text):
+        """
+        Converts basic Markdown to Pango Markup.
+        The LLM's replies may contain simple Markdown formatting.
+        """
+        # Escape special characters (crucial for Pango)
+        text = text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+        # Render Headers (### Header)
+        text = re.sub(r'^####\s+(.*?)$', r'\n<b>\1</b>',
+                      text, flags=re.MULTILINE)
+        text = re.sub(r'^###\s+(.*?)$', r'\n<b><big>\1</big></b>',
+                      text, flags=re.MULTILINE)
+        text = re.sub(r'^##\s+(.*?)$', r'\n<b><span size="large">\1</span></b>',
+                      text, flags=re.MULTILINE)
+        text = re.sub(r'^#\s+(.*?)$', r'\n<b><span size="x-large">\1</span></b>',
+                      text, flags=re.MULTILINE)
+
+        # Bold: **text** -> <b>text</b>
+        text = re.sub(r'\*\*(.*?)\*\*', r'<b>\1</b>', text)
+
+        # Italics: *text* -> <i>text</i>
+        text = re.sub(r'\*(.*?)\*', r'<i>\1</i>', text)
+
+        # Inline Code: `text` -> monospace with subtle background
+        text = re.sub(r'`(.*?)`',
+                      r'<span font_family="monospace" background="#eeeeee">\1</span>',
+                      text)
+
+        # Lists: Replace leading dashes/asterisks with bullet points
+        text = re.sub(r'^(\s*)[\-\*]\s+', r'\1• ', text, flags=re.MULTILINE)
+
+        return text
+
     def _add_message_row(self, text: str, reply_type: YieldType):
         """
         Creates a new message "balloon" widget and adds it to the listbox.
@@ -208,10 +243,19 @@ class ChatWithTreeClass(Gramplet):
         message_box.get_style_context().add_class("message-box")
 
         # Create the label for the text.
-        message_label = Gtk.Label(label=text)
+        message_label = Gtk.Label()
+
+        # Decide whether to render Markdown
+        if reply_type in (YieldType.USER, YieldType.PARTIAL, YieldType.FINAL):
+            message_label.set_markup(self._markdown_to_pango(text))
+        else:
+            # Tool calls remain plain text
+            message_label.set_text(text)
+
         message_label.set_halign(Gtk.Align.START)
         message_label.set_line_wrap(True)
         message_label.set_max_width_chars(80)
+        message_label.set_selectable(True)
         message_box.pack_start(message_label, True, True, 0)
 
         if reply_type == YieldType.USER:
@@ -255,7 +299,7 @@ class ChatWithTreeClass(Gramplet):
 
         This method runs repeatedly via GLib.idle_add until the job is done.
         """
-        # 1. Safety check
+        # Safety check
         if self.chat_service is None:
             LOG.error("Chat service is unexpectedly None in _check_queue_for_reply.")
             return GLib.SOURCE_REMOVE
@@ -275,7 +319,6 @@ class ChatWithTreeClass(Gramplet):
                     # after job completion). Stop the idle handler.
                     return GLib.SOURCE_REMOVE
 
-            # --- 2. Process and Update UI ---
             # If we reached here, 'reply' is a valid (type, content) tuple
             reply_type, content = reply
 

--- a/ChatWithTree/ChatWithTreeBot.py
+++ b/ChatWithTree/ChatWithTreeBot.py
@@ -114,7 +114,7 @@ source genealogy program.
 Your primary goal is to assist the user by providing accurate and relevant
 genealogical information.
 
-**Crucial Guidelines for Tool Usage and Output:**
+**Guidelines for Tool Usage and Output:**
 
 1.  **Prioritize User Response:** Always aim to provide a direct answer to the
 user's query as soon as you have sufficient information.
@@ -128,13 +128,10 @@ user's query as soon as you have sufficient information.
     * **Assess Tool Results:** After each tool call, carefully evaluate its output.
       Did it provide the expected information?
       Is it sufficient to progress towards the user's goal?
-    * **Tool use** Use many tool calls in one try as you can, but do not call the
+    * **Tool use** Use as many tool calls in one try as you can, but do not call the
     same tool with the same arguments more than once.
-5.  **Graceful Exit with Partial Results:**
-    * **Summarize Findings:** Synthesize all the information you have gathered
+5.  **Summarize Findings:** Respond in markdown format all information you have gathered
     and clearly state what you found and what information you were unable to obtain.
-
-You can get the start point of the genealogy tree using the `start_point` tool.
 """
 
 GRAMPS_AI_MODEL_NAME = os.environ.get("GRAMPS_AI_MODEL_NAME")
@@ -288,7 +285,7 @@ class ChatBot(IChatLogic):
         seed: int,
     ) -> Any:
         response = litellm.completion(
-            model=GRAMPS_AI_MODEL_NAME,  # self.model,
+            model=GRAMPS_AI_MODEL_NAME,
             messages=all_messages,
             seed=seed,
             tools=tool_definitions,


### PR DESCRIPTION
This renders any markdown formatting returned by the LLM into GTK Pango formatting, which means it shows actual **bold text** and _italic text_ and some 

### headings

where possible.

As an example, a question to get some contents from a LLM model about the place of when a family lived in Rotterdam:

This was after setting a free available model:

`/setmodel openrouter/nvidia/nemotron-3-nano-30b-a3b:free
`
<img width="800" height="705" alt="Screenshot from 2025-12-28 20-12-54" src="https://github.com/user-attachments/assets/9a1a6502-0541-41cc-a793-99556f6129d6" />
<img width="689" height="732" alt="Screenshot from 2025-12-28 20-13-32" src="https://github.com/user-attachments/assets/44a696bd-2edd-41d8-a6c1-82f5148e9e9a" />


I have several questions about support for the gramplet:
1. I updated the version number in the `ChatWithTree.gpr.py` file, via running the `make.py gramps60 build ChatWithTree` command, but I do not even know if that was necessary. Is it?
2. After running that make.py command, a new tar.gz version is created in the `/addons` repository: Do I need to create another pull request for that update, or should I not worry about it has it is part of a generic build of gramps?
3. Maybe in general I am missing these support steps for keeping the addon updated - what is the best place to find it on the gramps wiki? I am willing to help add what I found myself, like how I test the Gramplet with my installed version of Gramps on my linux machine, by copying over files after a code change. Let me know where I can help extending the docs.

