### PR TITLE
ChatWithTree: render markdown and add gramps links

### DIFF
--- a/ChatWithTree/AsyncChatService.py
+++ b/ChatWithTree/AsyncChatService.py
@@ -21,15 +21,12 @@ import logging
 import queue
 import traceback
 from concurrent.futures import ThreadPoolExecutor
-from typing import Iterator, Optional, Tuple
+from typing import Iterator, Optional
 
-from chatwithllm import YieldType
+from chatwithllm import ChatResponse, ReplyItem, YieldType
 from ChatWithTreeBot import ChatBot
 
 logger = logging.getLogger("AsyncChatService")
-
-# Alias for the yielded items from the ChatBot generator
-ReplyItem = Tuple[YieldType, str]
 
 
 class AsyncChatService:
@@ -105,10 +102,11 @@ class AsyncChatService:
 
         except Exception as e:
             tb = traceback.format_exc()
-            self.result_queue.put((
-                YieldType.FINAL,
-                f"ERROR: {type(e).__name__}: {e}\n{tb}"
-            ))
+            error_text = f"ERROR: {type(e).__name__}: {e}\n{tb}"
+            error_response = ChatResponse(text=error_text)
+
+            # Use the NamedTuple constructor
+            self.result_queue.put(ReplyItem(type=YieldType.FINAL, data=error_response))
         finally:
             # Always put the sentinel and set status to finished
             self.result_queue.put(None)  # Sentinel: None signals job completion

--- a/ChatWithTree/ChatWithTree.gpr.py
+++ b/ChatWithTree/ChatWithTree.gpr.py
@@ -11,14 +11,14 @@ register(
     version = '0.0.27',
     gramps_target_version="6.0",  # Specify the Gramps version you are targeting
     status=STABLE,
-    audience = EVERYONE,
+    audience=EVERYONE,
     fname="ChatWithTree.py",  # The main Python file for your Gramplet
     # The 'gramplet' argument points to the class name in your main file
     gramplet="ChatWithTreeClass",
     gramplet_title=_("Chat With Tree"),
     authors = ["Melle Koning"],
     authors_email = ["mellekoning@gmail.com"],
-    height=18,
+    height=500,
      # addon needs litellm python module
     requires_mod=['litellm'],
     navtypes=["Dashboard"],

--- a/ChatWithTree/ChatWithTree.py
+++ b/ChatWithTree/ChatWithTree.py
@@ -19,13 +19,16 @@
 #
 # ChatWithTree.py
 import logging
+import re
+from typing import Optional
 
 import gi
 from AsyncChatService import AsyncChatService
-from chatwithllm import YieldType
+from chatwithllm import ChatResponse, ReplyItem, YieldType
 from gi.repository import Gdk, GLib, Gtk
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 from gramps.gen.plug import Gramplet
+from gramps.gui.editors import EditFamily, EditPerson
 
 LOG = logging.getLogger(".")
 LOG.debug("loading chatwithtree")
@@ -94,9 +97,11 @@ class ChatWithTreeClass(Gramplet):
             try:
                 active_db_name = self.dbstate.db.get_dbname()
                 if active_db_name:
-                    self._add_message_row(_(f"Database change detected\
-                                            Database {active_db_name}."
-                                            ""), YieldType.PARTIAL)
+                    dbChangeMessage = ReplyItem(
+                        type=YieldType.PARTIAL,
+                        data=ChatResponse(
+                            text=_(f"Database change detected {active_db_name}.")))
+                    self._add_message_row(dbChangeMessage)
                     self.chat_service = AsyncChatService(active_db_name)
             except Exception as e:
                 # Catch the likely TypeError or any other startup error
@@ -152,11 +157,12 @@ class ChatWithTreeClass(Gramplet):
         vbox.pack_start(input_hbox, False, False, 0)
 
         # Add the initial message to the list box.
-        self._add_message_row(_(
-            "Chat with Tree initialized. \
-                Type /help for help."),
-            YieldType.PARTIAL
-            )
+        initMessage = ReplyItem(
+            type=YieldType.PARTIAL,
+            data=ChatResponse(text=_(
+                "Chat with Tree initialized. \
+                Type /help for help.")))
+        self._add_message_row(initMessage)
 
         return vbox
 
@@ -181,9 +187,13 @@ class ChatWithTreeClass(Gramplet):
         .tree-reply-box {
             background-color: #d1e2f4; /* Light blue for replies */
         }
+        .error-reply-box {
+            background-color: #f4e2d1; /* Light red for errors */
+        }
         .tree-toolcall-box {
             background-color: #fce8b2; /* Light yellow for tool calls */
         }
+
         """
         css_provider.load_from_data(css.encode('utf-8'))
         screen = Gdk.Screen.get_default()
@@ -195,7 +205,82 @@ class ChatWithTreeClass(Gramplet):
         style_context = self.chat_listbox.get_style_context()
         style_context.add_class("message-box")
 
-    def _add_message_row(self, text: str, reply_type: YieldType):
+    def _markdown_to_pango(self, text, entities=None):
+        """
+        Converts Markdown to Pango and safely injects entity links
+        without nesting tags.
+        """
+        # 1. Normalize and Escape (Must be first)
+        text = text.replace('\u202f', ' ').replace('\u00a0', ' ')
+        text = text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+        placeholders = {}
+        linked_handles = set()
+
+        if entities:
+            # Sort by name length descending to handle "John Smith" before "John"
+            sorted_entities = sorted(entities, key=lambda x: len(x.name), reverse=True)
+
+            for i, entity in enumerate(sorted_entities):
+                link_uri = f"{entity.entity_type}:{entity.handle}"
+
+                # Create unique keys for this specific entity
+                name_key = f"##NAME_{i}##"
+                handle_key = f"##HNDL_{i}##"
+
+                # --- Pass 1: Replace raw text with placeholders ---
+                # We replace the literal handle and literal name in the text
+                if entity.handle in text:
+                    text = text.replace(entity.handle, handle_key)
+                    # Store the final Pango version for later
+                    linkref = (
+                        f'<a href="{link_uri}">'
+                        f'<span font_family="monospace">{entity.handle}</span>'
+                        '</a>')
+                    placeholders[handle_key] = linkref
+                    linked_handles.add(entity.handle)
+
+                if entity.name in text:
+                    text = text.replace(entity.name, name_key)
+                    placeholders[name_key] = (
+                         f'<a href="{link_uri}"><b>{entity.name}</b></a>'
+                    )
+                    linked_handles.add(entity.handle)
+
+        # 2. Render Markdown (Bold, Italics, etc.)
+        # Because we use placeholders like ##NAME_0##, Markdown regex won't
+        # find names/handles and accidentally break them.
+        text = re.sub(r'^####\s+(.*?)$', r'\n<b>\1</b>', text, flags=re.MULTILINE)
+        text = re.sub(r'^###\s+(.*?)$',
+                      r'\n<b><big>\1</big></b>', text, flags=re.MULTILINE)
+        text = re.sub(r'^##\s+(.*?)$',
+                      r'\n<b><span size="large">\1</span></b>',
+                      text, flags=re.MULTILINE)
+        text = re.sub(r'^#\s+(.*?)$',
+                      r'\n<b><span size="x-large">\1</span></b>',
+                      text, flags=re.MULTILINE)
+        text = re.sub(r'\*\*(.*?)\*\*', r'<b>\1</b>', text)
+        text = re.sub(r'\*(.*?)\*', r'<i>\1</i>', text)
+        text = re.sub(r'`(.*?)`',
+                      r'<span font_family="monospace" background="#eeeeee">\1</span>',
+                      text)
+        text = re.sub(r'^(\s*)[\-\*]\s+', r'\1• ', text, flags=re.MULTILINE)
+
+        # 3. Final Pass: Swap placeholders back for real Pango Links
+        for key, pango_html in placeholders.items():
+            text = text.replace(key, pango_html)
+
+        unlinked = [e for e in entities if e.handle not in linked_handles]
+
+        if unlinked:
+            text += "\n---\n<i>Related Records:</i>"
+            for e in unlinked:
+                link_uri = f"{e.entity_type}:{e.handle}"
+                text += f'\n• <a href="{link_uri}"><b>{e.name}</b></a>'
+
+        return text
+
+    def _add_message_row(self, reply: ReplyItem) -> Gtk.Label:
         """
         Creates a new message "balloon" widget and adds it to the listbox.
         """
@@ -208,23 +293,40 @@ class ChatWithTreeClass(Gramplet):
         message_box.get_style_context().add_class("message-box")
 
         # Create the label for the text.
-        message_label = Gtk.Label(label=text)
+        message_label = Gtk.Label()
+
+        # Decide whether to render Markdown
+        if reply.type in (YieldType.USER, YieldType.PARTIAL, YieldType.FINAL):
+            message_label.set_markup(
+                self._markdown_to_pango(reply.data.text, reply.data.metadata)
+                )
+            if reply.data.has_links:
+                message_label.connect("activate-link", self.on_handle_clicked)
+        else:
+            # Tool calls and errors remain plain text
+            message_label.set_text(reply.data.text)
+
         message_label.set_halign(Gtk.Align.START)
         message_label.set_line_wrap(True)
         message_label.set_max_width_chars(80)
+        message_label.set_selectable(True)
         message_box.pack_start(message_label, True, True, 0)
 
-        if reply_type == YieldType.USER:
+        if reply.type == YieldType.USER:
             message_box.get_style_context().add_class("user-message-box")
             # Align the message balloon to the right.
             hbox.set_halign(Gtk.Align.END)
-        elif reply_type in (YieldType.PARTIAL, YieldType.TOOL_CALL):
+        elif reply.type in (YieldType.PARTIAL, YieldType.TOOL_CALL):
             message_box.get_style_context().add_class("tree-toolcall-box")
             # Align the message balloon to the left.
             hbox.set_halign(Gtk.Align.CENTER)
 
-        elif reply_type == YieldType.FINAL:
+        elif reply.type == YieldType.FINAL:
             message_box.get_style_context().add_class("tree-reply-box")
+            # Align the message balloon to the left.
+            hbox.set_halign(Gtk.Align.START)
+        elif reply.type == YieldType.ERROR:
+            message_box.get_style_context().add_class("error-reply-box")
             # Align the message balloon to the left.
             hbox.set_halign(Gtk.Align.START)
 
@@ -236,6 +338,30 @@ class ChatWithTreeClass(Gramplet):
         self.chat_listbox.show_all()
 
         return message_label
+
+    def on_handle_clicked(self, label, uri):
+        try:
+            # uri is "Person:f51cfe..." or "Family:f51cfe..."
+            etype, handle = uri.split(":", 1)
+            db = self.dbstate.db
+
+            if etype == "Person":
+                person = db.get_person_from_handle(handle)
+                if person:
+                    # Open the Person Editor
+                    EditPerson(self.dbstate, self.uistate, [], person)
+
+            elif etype == "Family":
+                family = db.get_family_from_handle(handle)
+                if family:
+                    # Open the Family Editor
+                    EditFamily(self.dbstate, self.uistate, [], family)
+
+        except Exception as e:
+            # We use LOG.error as per your existing pattern
+            LOG.error(f"Failed to open editor for {uri}: {e}")
+
+        return True
 
     def scroll_to_bottom(self):
         """
@@ -255,7 +381,7 @@ class ChatWithTreeClass(Gramplet):
 
         This method runs repeatedly via GLib.idle_add until the job is done.
         """
-        # 1. Safety check
+        # Safety check
         if self.chat_service is None:
             LOG.error("Chat service is unexpectedly None in _check_queue_for_reply.")
             return GLib.SOURCE_REMOVE
@@ -263,7 +389,7 @@ class ChatWithTreeClass(Gramplet):
         try:
             # Non-blocking attempt to get the next result from the worker thread's queue.
             # This result will be ReplyItem or None (the sentinel).
-            reply = self.chat_service.get_next_result_from_queue()
+            reply: Optional[ReplyItem] = self.chat_service.get_next_result_from_queue()
 
             if reply is None:
                 # Queue is empty. Check the status of the background job.
@@ -275,28 +401,24 @@ class ChatWithTreeClass(Gramplet):
                     # after job completion). Stop the idle handler.
                     return GLib.SOURCE_REMOVE
 
-            # --- 2. Process and Update UI ---
-            # If we reached here, 'reply' is a valid (type, content) tuple
-            reply_type, content = reply
+            # If we reached here, 'reply' is of type ReplyItem tuple
+            if reply.type == YieldType.PARTIAL:
+                self._add_message_row(reply)
 
-            if reply_type == YieldType.PARTIAL:
-                self._add_message_row(content, reply_type)
-
-            elif reply_type == YieldType.TOOL_CALL:
+            elif reply.type == YieldType.TOOL_CALL:
                 # Append to an existing label for streaming effect, or create a new one
                 if self.current_tool_call_label is None:
                     self.current_tool_call_label = self._add_message_row(
-                        content,
-                        reply_type
+                        reply
                     )
-                else:
+                else:   # This is a subsequent tool call. Update the existing label.
                     existing_text = self.current_tool_call_label.get_text()
-                    # Append new content
-                    self.current_tool_call_label.set_text(existing_text + " " + content)
+                    self.current_tool_call_label.set_text(
+                        existing_text + " " + reply.data.text)
 
-            elif reply_type == YieldType.FINAL:
+            elif reply.type == YieldType.FINAL or reply.type == YieldType.ERROR:
                 # Final reply from the chatbot.
-                self._add_message_row(content, reply_type)
+                self._add_message_row(reply)
 
             # Since we successfully retrieved and processed an item,
             # we immediately check the queue again for the next item.
@@ -306,7 +428,10 @@ class ChatWithTreeClass(Gramplet):
             # Handle unexpected errors on the main GTK thread
             error_message = f"Critical UI Error: {type(e).__name__} - {e}"
             LOG.error(error_message, exc_info=True)
-            self._add_message_row(f"Application Error. {error_message}", YieldType.FINAL)
+            exceptionReply = ReplyItem(
+                type=YieldType.ERROR,
+                data=ChatResponse(text=f"Application Error. {error_message}"))
+            self._add_message_row(exceptionReply)
 
             return GLib.SOURCE_REMOVE    # Stop the process on error
 
@@ -318,26 +443,29 @@ class ChatWithTreeClass(Gramplet):
         # This handles the case where the addon is loaded for the first time
         # on an already running Gramps session.
         if self.chat_service is None:
-            self._add_message_row(
-                _("The ChatWithTree addon is not yet initialized. \
-                  Please reload Gramps or select a database."),
-                YieldType.FINAL
-            )
+            notInitializedMessage = ReplyItem(
+                type=YieldType.FINAL,
+                data=ChatResponse(text=_(
+                  "The ChatWithTree addon is not yet initialized. \
+                    Please reload Gramps or select a database.")))
+            self._add_message_row(notInitializedMessage)
             return
 
         if self.chat_service.is_processing():
-            self._add_message_row(
-                _("The chatbot is currently processing a query. Please wait."),
-                YieldType.PARTIAL
-            )
+            processingMessage = ReplyItem(
+                type=YieldType.PARTIAL,
+                data=ChatResponse(text=_(
+                  "The chatbot is currently processing a query. Please wait.")))
+            self._add_message_row(processingMessage)
             return
         # Normal handling of user input
         user_input = self.input_entry.get_text()
         self.input_entry.set_text("")
         if user_input.strip():
-            # Add the user's message to the chat.
-            self._add_message_row(f"{user_input}", YieldType.USER)
-
+            userMessage = ReplyItem(
+                type=YieldType.USER,
+                data=ChatResponse(text=f"{user_input}"))
+            self._add_message_row(userMessage)
             # Now, schedule the reply-getting logic to run when the main loop is idle.
             # Run the asynchronous processing for this single query
             try:
@@ -351,40 +479,12 @@ class ChatWithTreeClass(Gramplet):
 
             except Exception as e:
                 LOG.error(f"Error running async query: {e}")
-                self._add_message_row(
-                     _("An error occurred while processing your query."),
-                     YieldType.FINAL
-                )
+                exceptionMsg = ReplyItem(
+                    type=YieldType.ERROR,
+                    data=ChatResponse(
+                        text=_("An error occurred while processing your query.")))
+                self._add_message_row(exceptionMsg)
                 return
-
-    async def process_query_async(self, query):
-        """
-        Asynchronously processes a single query and prints the replies as they come in.
-        """
-        # The ChatThreading service handles all the threading and queues.
-        # We just iterate over the async generator it returns.
-        async for reply in self.chat_service.get_reply_stream(query):
-            reply_type, content = reply
-            if reply_type == YieldType.PARTIAL:
-                # sometimes there is no content in the partial yield
-                # if there is, it is usually an explained strategy what the
-                # model will do to achieve the final result
-                self._add_message_row(content, reply_type)
-            if reply_type == YieldType.TOOL_CALL:
-                if self.current_tool_call_label is None:
-                    self.current_tool_call_label = self._add_message_row(
-                        content,
-                        reply_type
-                        )
-                else:
-                    # This is a subsequent tool call. Update the existing label.
-                    # We append the new content to the existing label.
-                    existing_text = self.current_tool_call_label.get_text()
-                    self.current_tool_call_label.set_text(existing_text + " " + content)
-            elif reply_type == YieldType.FINAL:
-                # Final reply from the chatbot
-                # We let the iterator SENTINEL take care of returning Glib.SOURCE_REMOVE
-                self._add_message_row(content, reply_type)
 
     def main(self):
         """

--- a/ChatWithTree/ChatWithTreeBot.py
+++ b/ChatWithTree/ChatWithTreeBot.py
@@ -26,10 +26,13 @@ import sys
 import time
 from typing import Any, Dict, Iterator, List, Optional, Pattern, Tuple
 
-from chatwithllm import IChatLogic, YieldType
+from chatwithllm import (ChatResponse, EntityMetadata, IChatLogic, ReplyItem,
+                         YieldType)
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 from gramps.gen.db.utils import open_database
+from gramps.gen.display.name import displayer as name_displayer
 from gramps.gen.display.place import displayer as place_displayer
+from gramps.gen.lib import Person
 from gramps.gen.simple import SimpleAccess
 from litellm_utils import function_to_litellm_definition
 
@@ -114,7 +117,7 @@ source genealogy program.
 Your primary goal is to assist the user by providing accurate and relevant
 genealogical information.
 
-**Crucial Guidelines for Tool Usage and Output:**
+**Guidelines for Tool Usage and Output:**
 
 1.  **Prioritize User Response:** Always aim to provide a direct answer to the
 user's query as soon as you have sufficient information.
@@ -128,13 +131,11 @@ user's query as soon as you have sufficient information.
     * **Assess Tool Results:** After each tool call, carefully evaluate its output.
       Did it provide the expected information?
       Is it sufficient to progress towards the user's goal?
-    * **Tool use** Use many tool calls in one try as you can, but do not call the
+    * **Tool use** Use as many tool calls in one try as you can, but do not call the
     same tool with the same arguments more than once.
-5.  **Graceful Exit with Partial Results:**
-    * **Summarize Findings:** Synthesize all the information you have gathered
+5.  **Summarize Findings:** Respond in markdown format prefer lists above tables to
+    display all information you have gathered
     and clearly state what you found and what information you were unable to obtain.
-
-You can get the start point of the genealogy tree using the `start_point` tool.
 """
 
 GRAMPS_AI_MODEL_NAME = os.environ.get("GRAMPS_AI_MODEL_NAME")
@@ -149,6 +150,8 @@ class ChatBot(IChatLogic):
     def __init__(self, database_name: str):
         self.database_name = database_name
         self.limit_loop = 6  # Default tool-calling loop limit
+        # The collector for the current conversation turn
+        self.current_entities: dict[str, EntityMetadata] = {}
         self.reset_chat_history()
         self.tool_map = {
             "start_point": self.start_point,
@@ -185,27 +188,45 @@ class ChatBot(IChatLogic):
             raise Exception(f"Unable to open database {self.database_name}")
         self.sa = SimpleAccess(self.db)
 
+    def _reply(self, y_type: YieldType, text: str, metadata=None) -> ReplyItem:
+        """Helper to ensure we always yield a valid NamedTuple ReplyItem."""
+        return ReplyItem(type=y_type,
+                         data=ChatResponse(text=text, metadata=metadata or []))
+
+    def _register_entity(self, handle: str, name: str, etype: str):
+        """Adds an entity to the current session if not already present."""
+        if handle not in self.current_entities:
+            self.current_entities[handle] = EntityMetadata(
+                handle=handle,
+                name=name,
+                entity_type=etype
+            )
+
     def reset_chat_history(self) -> None:
         """Resets the chat message history to its initial state."""
         self.messages: List[Dict[str, Any]] = [
             {"role": "system", "content": SYSTEM_PROMPT}]
 
-    def command_handle_help(self, message: str) -> Iterator[Tuple[YieldType, str]]:
+    def command_handle_help(self, message: str) -> Iterator[ReplyItem]:
         '''
         returns the helptext to the user including
         the current model name and model url
         '''
-        yield (YieldType.FINAL, f"{HELP_TEXT}"
-               f"\nGRAMPS_AI_MODEL_NAME: {GRAMPS_AI_MODEL_NAME}"
-               f"\nGRAMPS_AI_MODEL_URL: {GRAMPS_AI_MODEL_URL}")
+        yield self._reply(
+            YieldType.FINAL,
+            f"{HELP_TEXT}"
+            f"\nGRAMPS_AI_MODEL_NAME: {GRAMPS_AI_MODEL_NAME}"
+            f"\nGRAMPS_AI_MODEL_URL: {GRAMPS_AI_MODEL_URL}")
 
-    def command_handle_history(self, message: str) -> Iterator[Tuple[YieldType, str]]:
+    def command_handle_history(self, message: str) -> Iterator[ReplyItem]:
         '''
         returns the full chat history to the user
         '''
-        yield (YieldType.FINAL, json.dumps(self.messages, indent=4, sort_keys=True))
+        yield self._reply(
+            YieldType.FINAL,
+            json.dumps(self.messages, indent=4, sort_keys=True))
 
-    def command_handle_setmodel(self, message: str) -> Iterator[Tuple[YieldType, str]]:
+    def command_handle_setmodel(self, message: str) -> Iterator[ReplyItem]:
         '''
         sets the model name to use for the LLM
         usage: /setmodel <model_name>
@@ -214,14 +235,14 @@ class ChatBot(IChatLogic):
         global GRAMPS_AI_MODEL_NAME
         parts = message.split(' ', 1)
         if len(parts) != 2 or not parts[1].strip():
-            yield (YieldType.FINAL, "Usage: /setmodel <model_name>")
+            yield self._reply(YieldType.FINAL, "Usage: /setmodel <model_name>")
             return
         new_model_name = parts[1].strip()
         GRAMPS_AI_MODEL_NAME = new_model_name
         self.reset_chat_history()   # Reset history when model changes
-        yield (YieldType.FINAL, f"Model name set to: {GRAMPS_AI_MODEL_NAME}")
+        yield self._reply(YieldType.FINAL, f"Model name set to: {GRAMPS_AI_MODEL_NAME}")
 
-    def command_handle_setlimit(self, message: str) -> Iterator[Tuple[YieldType, str]]:
+    def command_handle_setlimit(self, message: str) -> Iterator[ReplyItem]:
         '''
         sets the tool-calling loop limit.
         usage: /setlimit <number>
@@ -229,34 +250,38 @@ class ChatBot(IChatLogic):
         '''
         parts = message.split(' ', 1)
         if len(parts) != 2 or not parts[1].strip():
-            yield (YieldType.FINAL, "Usage: /setlimit <number between 6 and 20>")
+            yield self._reply(
+                YieldType.FINAL,
+                "Usage: /setlimit <number between 6 and 20>")
             return
         try:
             new_limit = int(parts[1].strip())
             if 6 <= new_limit <= 20:
                 self.limit_loop = new_limit
-                yield (
+                yield self._reply(
                         YieldType.FINAL,
                         f"Tool-calling loop limit set to: {self.limit_loop}"
                       )
             else:
-                yield (
-                        YieldType.FINAL,
+                yield self._reply(
+                        YieldType.ERROR,
                         "Error: Limit must be an integer between 6 and 20."
                       )
         except ValueError:
-            yield (
-                    YieldType.FINAL,
+            yield self._reply(
+                    YieldType.ERROR,
                     "Error: Invalid number provided. Please enter an integer."
                   )
 
     # The implementation of the IChatLogic interface
-    def get_reply(self, message: str) -> Iterator[Tuple[YieldType, str]]:
+    def get_reply(self, message: str) -> Iterator[ReplyItem]:
         """
         Processes the message and returns a reply.
         """
         # Strip leading/trailing whitespace
         message = message.strip()
+        # Reset the collector for the new prompt
+        self.current_entities = {}
 
         if message.startswith('/'):
             # Split the message into command and arguments (if any)
@@ -270,16 +295,16 @@ class ChatBot(IChatLogic):
                 yield from commandhandler(message)
             else:
                 # Handle unknown command
-                yield (YieldType.FINAL, f"Unknown command: {command_key}")
+                yield self._reply(YieldType.ERROR, f"Unknown command: {command_key}")
             return    # prevent command to be sent to LLM
         if GRAMPS_AI_MODEL_NAME:
             # yield from returns all yields from the calling func
             yield from self.get_chatbot_response(message)
         else:
-            yield (YieldType.FINAL,
-                   "Error: ensure to set GRAMPS_AI_MODEL_NAME\
-                    and GRAMPS_AI_MODEL_URL environment variables.\
-                    or use the /setmodel <model_name> command.")
+            yield self._reply(YieldType.ERROR,
+                              "Error: ensure to set GRAMPS_AI_MODEL_NAME\
+                              and GRAMPS_AI_MODEL_URL environment variables.\
+                              or use the /setmodel <model_name> command.")
 
     def _llm_complete(
         self,
@@ -288,7 +313,7 @@ class ChatBot(IChatLogic):
         seed: int,
     ) -> Any:
         response = litellm.completion(
-            model=GRAMPS_AI_MODEL_NAME,  # self.model,
+            model=GRAMPS_AI_MODEL_NAME,
             messages=all_messages,
             seed=seed,
             tools=tool_definitions,
@@ -300,7 +325,7 @@ class ChatBot(IChatLogic):
         self,
         user_input: str,
         seed: int = 42,
-    ) -> Iterator[Tuple[YieldType, str]]:
+    ) -> Iterator[ReplyItem]:
         self.messages.append({"role": "user", "content": user_input})
         yield from self._llm_loop(seed)
 
@@ -339,7 +364,7 @@ class ChatBot(IChatLogic):
             }
         )
 
-    def _llm_loop(self, seed: int) -> Iterator[Tuple[YieldType, str]]:
+    def _llm_loop(self, seed: int) -> Iterator[ReplyItem]:
         # Tool-calling loop
         final_response = "I was unable to find the desired information."
         sys.stdout.flush()
@@ -370,11 +395,11 @@ class ChatBot(IChatLogic):
                 if (hasattr(msg, 'reasoning_content') and
                         msg.reasoning_content and
                         len(msg.reasoning_content) > 3):
-                    yield (YieldType.PARTIAL, msg.reasoning_content)
+                    yield self._reply(YieldType.PARTIAL, msg.reasoning_content)
                 elif msg.content and len(msg.content) > 3:
-                    yield (YieldType.PARTIAL, msg.content)
+                    yield self._reply(YieldType.PARTIAL, msg.content)
                 for tool_call in msg["tool_calls"]:
-                    yield (YieldType.TOOL_CALL, tool_call['function']['name'])
+                    yield self._reply(YieldType.TOOL_CALL, tool_call['function']['name'])
                     self.execute_tool(tool_call)
             else:
                 final_response = response.choices[0].message.content
@@ -408,7 +433,9 @@ class ChatBot(IChatLogic):
            ):
             final_response = self.messages[-1]["content"]
 
-        yield (YieldType.FINAL, final_response)
+        # Convert collected dict values to a list for the metadata field
+        metadata_list = list(self.current_entities.values())
+        yield self._reply(YieldType.FINAL, final_response, metadata=metadata_list)
 
     # Tools:
     def get_person(self, person_handle: str) -> Dict[str, Any]:
@@ -421,6 +448,15 @@ class ChatBot(IChatLogic):
         if person_obj.get_privacy():
             return {"error": "Person data is private and cannot be accessed."}
         data = dict(self.db.get_raw_person_data(person_handle))
+        # The idea is that the LLM can use the 'full_name' field
+        # to refer to the person in answers
+        name1 = name_displayer.display(person_obj)
+        data['full_name'] = name1
+        self._register_entity(
+            handle=person_handle,
+            name=name1,
+            etype=Person.__name__    # "Person"
+        )
         notes = []
         for note_handle in person_obj.get_note_list():
             note_obj = self.db.get_note_from_handle(note_handle)
@@ -439,9 +475,8 @@ class ChatBot(IChatLogic):
         whose mother you want to find.
         """
         person_obj = self.db.get_person_from_handle(person_handle)
-        obj = self.sa.mother(person_obj)
-        data = dict(self.db.get_raw_person_data(obj.handle))
-        return data
+        mother_obj = self.sa.mother(person_obj)
+        return self.get_person(mother_obj.handle)
 
     def get_family(self, family_handle: str) -> Dict[str, Any]:
         """
@@ -480,8 +515,7 @@ class ChatBot(IChatLogic):
         * Use this tool to get the first person in the genealogy tree.
 
         The result of start_point contains values for:
-        * The "first_name" contains the first name of this person.
-        * The "surname_list" and then "surname" contains the last name(s) of this person.
+        * The "full_name" contains the name of this person.
         * The "handle" is the key that looks like a hash string for this person
         to use for other tool calls.
         * "family_list" is a list of handles where this person is a parent.
@@ -490,8 +524,8 @@ class ChatBot(IChatLogic):
         """
         obj = self.db.get_default_person()
         if obj:
-            data = dict(self.db.get_raw_person_data(obj.handle))
-            return data
+            return self.get_person(obj.handle)
+
         return None
 
     def get_children_of_person(
@@ -528,9 +562,8 @@ class ChatBot(IChatLogic):
         for the person whose father you want to find.
         """
         person_obj = self.db.get_person_from_handle(person_handle)
-        obj = self.sa.father(person_obj)
-        data = dict(self.db.get_raw_person_data(obj.handle))
-        return data
+        father_obj = self.sa.father(person_obj)
+        return self.get_person(father_obj.handle)
 
     def get_person_birth_date(self, person_handle: str) -> str:
         """

--- a/ChatWithTree/chatwithllm.py
+++ b/ChatWithTree/chatwithllm.py
@@ -19,8 +19,9 @@
 #
 import abc
 import time
+from dataclasses import dataclass, field
 from enum import Enum, auto
-from typing import Iterator, Tuple
+from typing import Iterator, List, NamedTuple
 
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 
@@ -32,10 +33,40 @@ _ = glocale.get_addon_translator(__file__).gettext
 
 
 class YieldType(Enum):
-    PARTIAL = auto()
-    TOOL_CALL = auto()
-    FINAL = auto()
-    USER = auto()
+    USER = auto()        # Prompt from the user
+    PARTIAL = auto()     # Streaming chunks from the LLM
+    TOOL_CALL = auto()   # Indicator of a gramps tool call
+    FINAL = auto()       # The complete response
+    ERROR = auto()       # For structured error reporting
+
+
+@dataclass
+class EntityMetadata:
+    handle: str
+    name: str
+    entity_type: str  # "Person" or "Family"
+
+
+@dataclass
+class ChatResponse:
+    """
+    The primary data container for all chatbot yields.
+    """
+    text: str
+    metadata: List[EntityMetadata] = field(default_factory=list)
+
+    # Helper property for partial and final yields
+    @property
+    def has_links(self) -> bool:
+        return len(self.metadata) > 0
+
+
+# The ReplyItem NamedTuple defines
+# the contract between the ChatWithTree GUI class
+# and the ChatWithTreeBot class for the yielded responses.
+class ReplyItem(NamedTuple):
+    type: YieldType
+    data: ChatResponse
 
 
 # ==============================================================================
@@ -47,7 +78,7 @@ class IChatLogic(abc.ABC):
     Any class that processes a message and returns a reply must implement this.
     """
     @abc.abstractmethod
-    def get_reply(self, message: str) -> Iterator[Tuple[YieldType, str]]:
+    def get_reply(self, message: str) -> Iterator[ReplyItem]:
         """
         Processes a user message and returns a reply string.
         """
@@ -74,7 +105,7 @@ class ChatWithLLM(IChatLogic):
         """
         pass
 
-    def get_reply(self, message: str) -> Iterator[Tuple[YieldType, str]]:
+    def get_reply(self, message: str) -> Iterator[ReplyItem]:
         """
         Processes the message and yields parts of the reply.
 
@@ -88,6 +119,6 @@ class ChatWithLLM(IChatLogic):
         reversed_message = _("Tree: '{}'").format(message[::-1])
 
         for char in reversed_message:
-            yield (YieldType.PARTIAL, char)
+            yield (YieldType.PARTIAL, ChatResponse(text=char))
             time.sleep(0.05)    # Simulate a slight delay, like a real-time stream
-        yield (YieldType.FINAL, reversed_message)
+        yield (YieldType.FINAL, ChatResponse(text=reversed_message))


### PR DESCRIPTION
This contains two updates to the ChatWithTree gramps addon:

- Rendering the responses from LLMs into Markdown
- Any persons that can be found in the final response (or their handles) get clickable links to open the Gramps Edit window (visible via underlining these)

If persons that were retrieved using any of the get_person, get_father, get_mother tools could not be found, these are added at the bottom of the final response text.

An example screenshot below clarifies the added feature:

<img width="1560" height="873" alt="grampsclickablerelatedrecords" src="https://github.com/user-attachments/assets/4736da9d-04d8-436a-9eba-488a70a4b141" />

The model accessed a few persons. Dina, the start point of this test tree, was not matched / found in the text of the final LLM response and was then added by the code to the bottom of the LLM response with the `Related Records` heading. 

