### PR TITLE
Show translation status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-addons-source [![Build Status](https://travis-ci.org/gramps-project/addons-source.svg?branch=master)](https://travis-ci.org/gramps-project/addons-source)
+addons-source [![Build Status](https://travis-ci.org/gramps-project/addons-source.svg?branch=master)](https://travis-ci.org/gramps-project/addons-source) <a href="https://hosted.weblate.org/engage/gramps-project/">
+<img src="https://hosted.weblate.org/widget/gramps-project/addons/svg-badge.svg" alt="Translation status" />
+</a>
 =============
 
 Source code of contributed third-party addons for the [Gramps genealogy program](https://github.com/gramps-project/gramps).


### PR DESCRIPTION
Include a badge showing percentage of strings translated. Gramps' addons component is found at: https://hosted.weblate.org/projects/gramps-project/addons/