### PR TITLE
Add User-Agent header to API requests

### DIFF
--- a/GrampsWebSync/webapihandler.py
+++ b/GrampsWebSync/webapihandler.py
@@ -150,7 +150,7 @@ class WebApiHandler:
         LOG.debug("Fetching metadata from the server")
         req = Request(
             f"{self.url}/metadata/",
-            headers={"Authorization": f"Bearer {self.access_token}"},
+            headers={"Authorization": f"Bearer {self.access_token}", "User-Agent": "GrampsWebSync"},
         )
         with urlopen(req, context=self._ctx) as res:
             self._metadata = json.load(res)
@@ -162,7 +162,7 @@ class WebApiHandler:
         req = Request(
             f"{self.url}/token/",
             data=data.encode(),
-            headers={"Content-Type": "application/json"},
+            headers={"Content-Type": "application/json", "User-Agent": "GrampsWebSync"},
         )
         try:
             with urlopen(req, context=self._ctx) as res:
@@ -225,6 +225,7 @@ class WebApiHandler:
                 headers={
                     "Content-Type": "application/json",
                     "Authorization": f"Bearer {self.access_token}",
+                    "User-Agent": "GrampsWebSync"
                 },
             )
             json_response: dict | None = None
@@ -260,7 +261,7 @@ class WebApiHandler:
         endpoint = f"{self.url}/tasks/{task_id}"
         req = Request(
             endpoint,
-            headers={"Authorization": f"Bearer {self.access_token}"},
+            headers={"Authorization": f"Bearer {self.access_token}", "User-Agent": "GrampsWebSync"},
         )
         try:
             with urlopen(req, context=self._ctx) as res:
@@ -286,7 +287,7 @@ class WebApiHandler:
         """Get a list of remote media objects with missing files."""
         req = Request(
             f"{self.url}/media/?filemissing=1",
-            headers={"Authorization": f"Bearer {self.access_token}"},
+            headers={"Authorization": f"Bearer {self.access_token}", "User-Agent": "GrampsWebSync"},
         )
         try:
             with urlopen(req, context=self._ctx) as res:
@@ -305,11 +306,11 @@ class WebApiHandler:
     ):
         """Download a file."""
         if token_url:
-            req = Request(f"{url}?jwt={self.access_token}")
+            req = Request(f"{url}?jwt={self.access_token}", headers={"User-Agent": "GrampsWebSync"})
         else:
             req = Request(
                 url,
-                headers={"Authorization": f"Bearer {self.access_token}"},
+                headers={"Authorization": f"Bearer {self.access_token}", "User-Agent": "GrampsWebSync"},
             )
         try:
             with urlopen(req, context=self._ctx) as res:
@@ -356,7 +357,7 @@ class WebApiHandler:
         req = Request(
             url,
             data=fobj,
-            headers={"Authorization": f"Bearer {self.access_token}"},
+            headers={"Authorization": f"Bearer {self.access_token}", "User-Agent": "GrampsWebSync"},
             method="PUT",
         )
         try:


### PR DESCRIPTION
Without providing a user agent, cloudflare, which runs in front of my gramps web instance, returns an error [1010](https://developers.cloudflare.com/support/troubleshooting/http-status-codes/cloudflare-1xxx-errors/error-1010/) which results in a 403 access denied