### PR TITLE
GrampsWebSync: Add Cloudflare Zero Trust service token support

### DIFF
--- a/GrampsWebSync/grampswebsync.py
+++ b/GrampsWebSync/grampswebsync.py
@@ -111,6 +111,8 @@ class GrampsWebSyncTool(BatchTool, ManagedWindow):
         self.config.register("credentials.url", "")
         self.config.register("credentials.username", "")
         self.config.register("credentials.timestamp", 0)
+        self.config.register("credentials.cf_client_id", "")
+        self.config.register("credentials.cf_client_secret", "")
         self.config.load()
 
         self.assistant = Gtk.Assistant()
@@ -128,11 +130,15 @@ class GrampsWebSyncTool(BatchTool, ManagedWindow):
         self.url = self.config.get("credentials.url")
         self.username = self.config.get("credentials.username")
         self.password = self.get_password()
+        self.cf_client_id = self.config.get("credentials.cf_client_id")
+        self.cf_client_secret = self.config.get("credentials.cf_client_secret")
         self.loginpage = LoginPage(
             self.assistant,
             url=self.url,
             username=self.username,
             password=self.password,
+            cf_client_id=self.cf_client_id,
+            cf_client_secret=self.cf_client_secret,
         )
         self.add_page(self.loginpage, Gtk.AssistantPageType.CONTENT, _("Login"))
 
@@ -349,11 +355,21 @@ class GrampsWebSyncTool(BatchTool, ManagedWindow):
 
             self.conclusion.set_complete()
 
+    def _get_cf_headers(self) -> dict[str, str]:
+        """Build Cloudflare Access headers from login page fields."""
+        headers = {}
+        cf_id = self.loginpage.cf_client_id.get_text().strip()
+        cf_secret = self.loginpage.cf_client_secret.get_text().strip()
+        if cf_id and cf_secret:
+            headers["CF-Access-Client-Id"] = cf_id
+            headers["CF-Access-Client-Secret"] = cf_secret
+        return headers
+
     def test_connection(self, url: str, username: str, password: str) -> bool:
         """Test the connection and authentication. Return True if successful."""
         try:
             # Try to create API handler
-            self._api = WebApiHandler(url, username, password, None)
+            self._api = WebApiHandler(url, username, password, None, extra_headers=self._get_cf_headers())
 
             # Test the connection by making a simple API call
             self.api.get_permissions()
@@ -594,6 +610,8 @@ class GrampsWebSyncTool(BatchTool, ManagedWindow):
             self.config.set("credentials.timestamp", 0)
         self.config.set("credentials.url", url)
         self.config.set("credentials.username", username)
+        self.config.set("credentials.cf_client_id", self.loginpage.cf_client_id.get_text().strip())
+        self.config.set("credentials.cf_client_secret", self.loginpage.cf_client_secret.get_text().strip())
         set_password(url, username, password)
         self.config.save()
 
@@ -754,7 +772,7 @@ class IntroductionPage(Page):
 class LoginPage(Page):
     """A page to provide server credentials."""
 
-    def __init__(self, assistant, url, username, password):
+    def __init__(self, assistant, url, username, password, cf_client_id="", cf_client_secret=""):
         super().__init__(assistant)
         self.set_spacing(12)
 
@@ -790,6 +808,29 @@ class LoginPage(Page):
         self.password.set_input_purpose(Gtk.InputPurpose.PASSWORD)
         grid.attach(self.password, 1, 2, 1, 1)
 
+        # Cloudflare Access fields (optional)
+        cf_label = Gtk.Label()
+        cf_label.set_markup("<i>" + _("Cloudflare Access (optional):") + "</i>")
+        cf_label.set_margin_top(12)
+        grid.attach(cf_label, 0, 3, 2, 1)
+
+        label = Gtk.Label(label=_("CF Client ID: "))
+        grid.attach(label, 0, 4, 1, 1)
+        self.cf_client_id = Gtk.Entry()
+        if cf_client_id:
+            self.cf_client_id.set_text(cf_client_id)
+        self.cf_client_id.set_hexpand(True)
+        grid.attach(self.cf_client_id, 1, 4, 1, 1)
+
+        label = Gtk.Label(label=_("CF Client Secret: "))
+        grid.attach(label, 0, 5, 1, 1)
+        self.cf_client_secret = Gtk.Entry()
+        if cf_client_secret:
+            self.cf_client_secret.set_text(cf_client_secret)
+        self.cf_client_secret.set_hexpand(True)
+        self.cf_client_secret.set_visibility(False)
+        grid.attach(self.cf_client_secret, 1, 5, 1, 1)
+
         # Error message label - initially hidden
         self.error_label = Gtk.Label()
         self.error_label.set_line_wrap(True)
@@ -797,7 +838,7 @@ class LoginPage(Page):
         self.error_label.get_style_context().add_class("error")
         self.error_label.set_no_show_all(True)  # Don't show when show_all() is called
         self.error_label.hide()
-        grid.attach(self.error_label, 0, 3, 2, 1)
+        grid.attach(self.error_label, 0, 6, 2, 1)
 
         # Connect entry change events
         self.url.connect("changed", self.on_entry_changed)

--- a/GrampsWebSync/webapihandler.py
+++ b/GrampsWebSync/webapihandler.py
@@ -99,6 +99,7 @@ class WebApiHandler:
         username: str,
         password: str,
         download_callback: Callable | None = None,
+        extra_headers: dict[str, str] | None = None,
     ) -> None:
         """Initialize given URL, user name, and password."""
         self.url = url.rstrip("/")
@@ -106,6 +107,7 @@ class WebApiHandler:
         self.password = password
         self._access_token: str | None = None
         self.download_callback = download_callback
+        self._extra_headers = extra_headers or {}
         # Determine the appropriate SSL context based on platform
         self._ctx = (
             create_macos_ssl_context() if platform.system() == "Darwin" else None
@@ -114,6 +116,10 @@ class WebApiHandler:
         # get and cache the access token
         self.fetch_token()
         self._metadata: dict | None = None
+
+    def _headers(self, headers: dict[str, str]) -> dict[str, str]:
+        """Merge extra headers (e.g. Cloudflare Access) into request headers."""
+        return {**self._extra_headers, **headers}
 
     @property
     def access_token(self) -> str:
@@ -150,7 +156,7 @@ class WebApiHandler:
         LOG.debug("Fetching metadata from the server")
         req = Request(
             f"{self.url}/metadata/",
-            headers={"Authorization": f"Bearer {self.access_token}", "User-Agent": "GrampsWebSync"},
+            headers=self._headers({"Authorization": f"Bearer {self.access_token}", "User-Agent": "GrampsWebSync"}),
         )
         with urlopen(req, context=self._ctx) as res:
             self._metadata = json.load(res)
@@ -162,7 +168,7 @@ class WebApiHandler:
         req = Request(
             f"{self.url}/token/",
             data=data.encode(),
-            headers={"Content-Type": "application/json", "User-Agent": "GrampsWebSync"},
+            headers=self._headers({"Content-Type": "application/json", "User-Agent": "GrampsWebSync"}),
         )
         try:
             with urlopen(req, context=self._ctx) as res:
@@ -222,11 +228,11 @@ class WebApiHandler:
             req = Request(
                 endpoint,
                 data=data,
-                headers={
+                headers=self._headers({
                     "Content-Type": "application/json",
                     "Authorization": f"Bearer {self.access_token}",
                     "User-Agent": "GrampsWebSync"
-                },
+                }),
             )
             json_response: dict | None = None
             with urlopen(req, context=self._ctx) as res:
@@ -261,7 +267,7 @@ class WebApiHandler:
         endpoint = f"{self.url}/tasks/{task_id}"
         req = Request(
             endpoint,
-            headers={"Authorization": f"Bearer {self.access_token}", "User-Agent": "GrampsWebSync"},
+            headers=self._headers({"Authorization": f"Bearer {self.access_token}", "User-Agent": "GrampsWebSync"}),
         )
         try:
             with urlopen(req, context=self._ctx) as res:
@@ -287,7 +293,7 @@ class WebApiHandler:
         """Get a list of remote media objects with missing files."""
         req = Request(
             f"{self.url}/media/?filemissing=1",
-            headers={"Authorization": f"Bearer {self.access_token}", "User-Agent": "GrampsWebSync"},
+            headers=self._headers({"Authorization": f"Bearer {self.access_token}", "User-Agent": "GrampsWebSync"}),
         )
         try:
             with urlopen(req, context=self._ctx) as res:
@@ -306,11 +312,11 @@ class WebApiHandler:
     ):
         """Download a file."""
         if token_url:
-            req = Request(f"{url}?jwt={self.access_token}", headers={"User-Agent": "GrampsWebSync"})
+            req = Request(f"{url}?jwt={self.access_token}", headers=self._headers({"User-Agent": "GrampsWebSync"}))
         else:
             req = Request(
                 url,
-                headers={"Authorization": f"Bearer {self.access_token}", "User-Agent": "GrampsWebSync"},
+                headers=self._headers({"Authorization": f"Bearer {self.access_token}", "User-Agent": "GrampsWebSync"}),
             )
         try:
             with urlopen(req, context=self._ctx) as res:
@@ -357,7 +363,7 @@ class WebApiHandler:
         req = Request(
             url,
             data=fobj,
-            headers={"Authorization": f"Bearer {self.access_token}", "User-Agent": "GrampsWebSync"},
+            headers=self._headers({"Authorization": f"Bearer {self.access_token}", "User-Agent": "GrampsWebSync"}),
             method="PUT",
         )
         try:


### PR DESCRIPTION
## Summary

- Adds optional `CF-Access-Client-Id` and `CF-Access-Client-Secret` header support to `WebApiHandler` so users behind Cloudflare Zero Trust can sync with their Gramps Web instance
- Two new optional fields on the login page ("Cloudflare Access") are persisted across sessions via the existing config manager
- All HTTP requests route through a new `_headers()` method that merges any extra headers (e.g. Cloudflare Access) into each request

## Cloudflare setup

1. In the Cloudflare One dashboard, go to **Access controls > Service credentials > Service Tokens**
2. Select **Create Service Token**, give it a name, and choose a duration. Copy the Client Secret immediately -- Cloudflare only displays it once
3. In the Access policy for your Gramps Web application, add a rule with the **Service Auth** action so the token is accepted without an identity provider login
4. Enter the Client ID and Client Secret in the Gramps Web Sync login page under "Cloudflare Access (optional)"

## Test plan

- [x] Verify sync works without CF fields populated (no regression)
- [x] Verify CF credentials are saved and restored across sessions
- [x] Verify sync works with a Gramps Web instance behind Cloudflare Zero Trust using a valid service token

🤖 Generated with [Claude Code](https://claude.com/claude-code) Opus 4.6 with the prompt 

"Add Cloudflare Zero Trust service token support to GrampsWebSync. Add optional CF-Access-Client-Id and CF-Access-Client-Secret fields to the login page, persist them across sessions using the existing config manager, and include them as headers on all HTTP requests made by WebApiHandler."