### PR TITLE
Gramps Web Sync: Add missing force parameter

### DIFF
--- a/GrampsWebSync/webapihandler.py
+++ b/GrampsWebSync/webapihandler.py
@@ -213,12 +213,13 @@ class WebApiHandler:
             background = api_version and parse_version(api_version) >= (2, 7)
             data = json.dumps(payload).encode()
             endpoint = f"{self.url}/transactions/"
+            params = []
             if force:
-                endpoint = f"{endpoint}?force=1"
-                if background:
-                    endpoint = f"{endpoint}&background=1"
-            elif background:
-                endpoint = f"{endpoint}?background=1"
+                params.append("force=1")
+            if background:
+                params.append("background=1")
+            if params:
+                endpoint = f"{endpoint}?{'&'.join(params)}"
             req = Request(
                 endpoint,
                 data=data,


### PR DESCRIPTION
Investigating an issue reported by a user, I realized the `force` parameter (which needs to be passed to the API) is not appended to the URL when using background tasks `background=1`. This is a bug and is fixed by this PR.