### PR TITLE
Ensure unicode characters can be written to file

### DIFF
--- a/MediaVerify/MediaVerify.py
+++ b/MediaVerify/MediaVerify.py
@@ -27,7 +27,6 @@
 #
 #-------------------------------------------------------------------------
 import os
-import io
 
 #-------------------------------------------------------------------------
 #
@@ -210,7 +209,7 @@ class MediaVerify(tool.Tool, ManagedWindow):
                 chooser.destroy()
                 return
         try:
-            with io.open(filename, 'w') as report_file:
+            with open(filename, 'w', encoding='utf-8') as report_file:
                 for title, model in zip(self.titles, self.models):
                     self.export_page(report_file, title, model)
         except IOError as err:


### PR DESCRIPTION
In some regions, e.g. Western Europe, Windows uses different encodings as default (e.g. cp1252) which doesn't handle unicode characters. To ensure that unicode characters can be written to files without an throwing an exception, we specify UTF-8 encoding when opening the file for write.

Fixes #[14057](https://gramps-project.org/bugs/view.php?id=14057)