### PR TITLE
Gramps Web Sync: log errors as warnings, always force

### DIFF
--- a/GrampsWebSync/grampswebsync.py
+++ b/GrampsWebSync/grampswebsync.py
@@ -480,7 +480,7 @@ class GrampsWebSyncTool(BatchTool, ManagedWindow):
 
     def handle_error(self, message):
         """Handle an error message during sync."""
-        LOG.error(message)
+        LOG.warning(message)
         self.conclusion.error = True
         self.assistant.next_page()
         self.conclusion.label.set_text(message)
@@ -644,11 +644,12 @@ class GrampsWebSyncTool(BatchTool, ManagedWindow):
                     LOG.debug("No changes to apply to local database.")
                 self.sync.commit_actions(actions, trans1, trans2)
                 self.sync_progress_page.handle_local_sync_complete(actions)
-                # force the sync if mode is reset
-                force = self.confirmation.sync_mode in {
-                    MODE_RESET_TO_LOCAL,
-                    MODE_RESET_TO_REMOTE,
-                }
+                # force the sync for all modes: the server-side "object has changed"
+                # check compares against the XML-round-tripped object, which often
+                # differs from the live server object due to serialization artifacts,
+                # causing false-positive 409 conflicts even when no real concurrent
+                # edit has occurred.
+                force = True
                 lang = self.api.get_lang()
                 payload = transaction_to_json(trans2, lang)
         GLib.idle_add(self.async_commit_actions_to_remote, payload, force)

--- a/GrampsWebSync/webapihandler.py
+++ b/GrampsWebSync/webapihandler.py
@@ -270,8 +270,8 @@ class WebApiHandler:
                 if task_status["state"] == "SUCCESS":
                     return True
                 if task_status["state"] in {"FAILURE", "REVOKED"}:
-                    LOG.error(f"Server task failed: {task_status}")
-                    raise ValueError(task_status.get("info", "Server task failed"))
+                    LOG.warning(f"Server task failed: {task_status}")
+                    raise ValueError(str(task_status.get("info", "Server task failed")))
                 if progress_callback:
                     try:
                         progress = task_status["result_object"]["progress"]
@@ -280,13 +280,13 @@ class WebApiHandler:
                     progress_callback(progress)
                 return False
         except HTTPError as e:
-            LOG.error(f"HTTPError while fetching task status: {e.code} - {e.reason}")
+            LOG.warning(f"HTTPError while fetching task status: {e.code} - {e.reason}")
             raise ValueError(f"HTTP Error: {e.code} - {e.reason}")
         except URLError as e:
-            LOG.error(f"URLError while fetching task status: {e.reason}")
+            LOG.warning(f"URLError while fetching task status: {e.reason}")
             raise ValueError(f"URL Error: {e.reason}")
         except socket.timeout as e:
-            LOG.error(f"Timeout while fetching task status: {e}")
+            LOG.warning(f"Timeout while fetching task status: {e}")
             raise ValueError("Connection timed out while fetching task status.")
 
     def get_missing_files(self, retry: bool = True) -> list:


### PR DESCRIPTION
Two of the most frequently reported issues with the sync addon are unexpcted "crashes" (i.e. popping up of the Gramps error reporting dialog) and sync failures because of reported conflicts ("object has changed").

See e.g. https://github.com/gramps-project/gramps-web-docs/issues/75

This PR hopefully fixes both:

- the "crashes" are caused by `LOG.error` calls, which are meant to ease debugging, but are redundant as the error state is handled by the addon itself. It wasn't taken into account that those log calls trigger the Gramps error reporting dialog. Solution: demote them to `LOG.warning`
- the 409 CONFLICT errors are always due to XML round-trip (export and import again) inconcistencies between desktop and server which can have multiple causes. But they can be easily solved by just always using the `force` query parameter. Omitting it was meant to prevent accidentally overwriting changes happening between the start of the sync addon and the final sync confirmation, but it leads to way more problems than it prevents.