### PR TITLE
Wrap label vaue to ensure it is a string

### DIFF
--- a/TimelinePedigreeView/TimelinePedigreeView.py
+++ b/TimelinePedigreeView/TimelinePedigreeView.py
@@ -705,7 +705,7 @@ class TimelinePedigreeView(NavigationView):
                 if Tick[1] > 0 and Tick[1] < RequiredWidth:
                     self.gtklayout_lines.append([Tick[1], int(5*TimeLineHeight/8), Tick[1], int(7*TimeLineHeight/8), 1])
                     if Tick[0]:
-                        label = Gtk.Label(label=Tick[0])
+                        label = Gtk.Label(label=str(Tick[0]))
                         label.set_justify(Gtk.Justification.CENTER)
                         label.show()
                         layout_widget.put(label, int(Tick[1]-label.get_preferred_size()[0].width/2), 1*TimeLineHeight/4)


### PR DESCRIPTION
The argument `label` to Gtk.Label must be of type string. In recent versions of Python and/or PyGObject, this check has become stricter and as a result is throwing an exception instead of silently converting to a string. So now we explicitly convert to string.

Fixes #[14181](https://gramps-project.org/bugs/view.php?id=14181)