### PR TITLE
Form: fix crash and surface clear errors for malformed XML (bug 11707)

### DIFF
--- a/Form/editform.py
+++ b/Form/editform.py
@@ -28,7 +28,10 @@ Form editor.
 # Python modules
 # -------------------------------------------------------------------------
 from gi.repository import Gdk
+import logging
 import pickle
+
+LOG = logging.getLogger(".FormGramplet")
 
 # ------------------------------------------------------------------------
 #
@@ -77,6 +80,7 @@ from form import (
     get_section_columns,
     get_form_citation,
 )
+from form_validator import split_family_title
 from entrygrid import EntryGrid
 
 # ------------------------------------------------------------------------
@@ -113,6 +117,12 @@ class EditForm(ManagedWindow):
         self.event = event
         self.citation = citation
         self.callback = callback
+
+        LOG.debug(
+            "Opening EditForm for event %s, citation %s",
+            event.get_handle() or "<new>",
+            citation.get_handle() or "<new>",
+        )
 
         ManagedWindow.__init__(self, uistate, track, citation)
 
@@ -391,10 +401,10 @@ class EditForm(ManagedWindow):
         """
         Close the editor window.
         """
-        (width, height) = self.window.get_size()
+        width, height = self.window.get_size()
         self._config.set("interface.form-width", width)
         self._config.set("interface.form-height", height)
-        (width, height) = self.window.get_position()
+        width, height = self.window.get_position()
         self._config.set("interface.form-horiz-position", width)
         self._config.set("interface.form-vert-position", height)
         self._config.save()
@@ -700,7 +710,7 @@ class MultiSection(Gtk.Box):
         self, widget, context, pos_x, pos_y, sel_data, info, time
     ):
         if sel_data and sel_data.get_data():
-            (drag_type, idval, handle, val) = pickle.loads(sel_data.get_data())
+            drag_type, idval, handle, val = pickle.loads(sel_data.get_data())
             person = self.db.get_person_from_handle(handle)
             if person:
                 self.__person_added(person)
@@ -972,7 +982,7 @@ class PersonSection(Gtk.Box):
         self, widget, context, pos_x, pos_y, sel_data, info, time
     ):
         if sel_data and sel_data.get_data():
-            (drag_type, idval, handle, val) = pickle.loads(sel_data.get_data())
+            drag_type, idval, handle, val = pickle.loads(sel_data.get_data())
             person = self.db.get_person_from_handle(handle)
             if person:
                 self.__added(person)
@@ -1102,7 +1112,15 @@ class FamilySection(Gtk.Box):
         hbox = Gtk.Box()
 
         title = get_section_title(form_id, section)
-        title1, title2 = title.split("/")
+        title1, title2 = split_family_title(title)
+        if not title2:
+            LOG.warning(
+                "FamilySection for form '%s' section '%s' has title '%s' "
+                "without the expected 'X/Y' separator; second label will be empty",
+                form_id,
+                section,
+                title,
+            )
 
         label = Gtk.Label(label="<b>%s</b>" % title1)
         label.set_use_markup(True)
@@ -1158,7 +1176,7 @@ class FamilySection(Gtk.Box):
         self, widget, context, pos_x, pos_y, sel_data, info, time
     ):
         if sel_data and sel_data.get_data():
-            (drag_type, idval, handle, val) = pickle.loads(sel_data.get_data())
+            drag_type, idval, handle, val = pickle.loads(sel_data.get_data())
             family = self.db.get_family_from_handle(handle)
             if family:
                 self.__added(family)

--- a/Form/form.py
+++ b/Form/form.py
@@ -22,6 +22,7 @@
 """
 Form definitions.
 """
+
 # ---------------------------------------------------------------
 #
 # Python imports
@@ -29,6 +30,8 @@ Form definitions.
 # ---------------------------------------------------------------
 import os
 import xml.dom.minidom
+import xml.parsers.expat
+import logging
 
 # ---------------------------------------------------------------
 #
@@ -37,8 +40,14 @@ import xml.dom.minidom
 # ---------------------------------------------------------------
 from gramps.gen.datehandler import parser
 from gramps.gen.config import config
-from gramps.gui.dialog import ErrorDialog, WarningDialog
-import logging
+from gramps.gui.dialog import ErrorDialog
+
+# ---------------------------------------------------------------
+#
+# Gramps specific
+#
+# ---------------------------------------------------------------
+from form_validator import validate_form_dom, validate_form_element
 
 LOG = logging.getLogger(".FormGramplet")
 
@@ -111,7 +120,14 @@ class Form:
     A class to read form definitions from an XML file.
     """
 
-    def __init__(self):
+    def __init__(self, definition_dir=None):
+        """
+        :param definition_dir: optional override for the directory the
+            loader scans for ``form_*.xml`` / ``custom.xml`` files.
+            Defaults to the directory containing this module. Exposed
+            primarily so tests can point the loader at an isolated
+            temporary directory.
+        """
         self.__references = {}
         self.__dates = {}
         self.__headings = {}
@@ -122,27 +138,88 @@ class Form:
         self.__names = {}
         self.__section_types = {}
 
+        base_dir = definition_dir or os.path.dirname(__file__)
+        LOG.debug("Loading form definitions from %s", base_dir)
         for file_name in definition_files:
-            full_path = os.path.join(os.path.dirname(__file__), file_name)
+            full_path = os.path.join(base_dir, file_name)
             if os.path.exists(full_path):
-                try:
-                    self.__load_definitions(full_path)
-                except Exception as e:
-                    WarningDialog(
-                        _("Failed to load Form definition file:\n%s\n") % full_path,
-                    )
-                    LOG.warning(
-                        "\nERROR: failed to load Form definition file.\n%s\nException:\n%s",
-                        full_path,
-                        str(e),
-                    )
+                self.__load_file(full_path)
+            else:
+                LOG.debug("Form definition file not present: %s", full_path)
+        LOG.info(
+            "Loaded %d form definition(s) from %s",
+            len(self.__names),
+            base_dir,
+        )
 
-    def __load_definitions(self, definition_file):
-        dom = xml.dom.minidom.parse(definition_file)
+    def __load_file(self, full_path):
+        """
+        Parse and validate a single form definition file, then load any
+        well-formed ``<form>`` elements it contains.
+
+        Parse errors and structural validation errors are reported to the
+        user through an :class:`ErrorDialog` and logged; malformed forms
+        are skipped while valid forms from the same file are still loaded.
+        """
+        LOG.debug("Parsing form definition file %s", full_path)
+        try:
+            dom = xml.dom.minidom.parse(full_path)
+        except xml.parsers.expat.ExpatError as exc:
+            ErrorDialog(
+                _("XML syntax error in Form definition file"),
+                "%s\n\n%s" % (full_path, exc),
+            )
+            LOG.warning(
+                "XML syntax error in Form definition file %s: %s",
+                full_path,
+                exc,
+            )
+            return
+        except Exception as exc:
+            ErrorDialog(
+                _("Failed to read Form definition file"),
+                "%s\n\n%s" % (full_path, exc),
+            )
+            LOG.warning("Failed to read Form definition file %s: %s", full_path, exc)
+            return
+
+        errors = validate_form_dom(dom)
+        if errors:
+            ErrorDialog(
+                _("Invalid Form definition file"),
+                "%s\n\n%s" % (full_path, "\n".join(errors)),
+            )
+            LOG.warning(
+                "Invalid Form definition file %s:\n%s",
+                full_path,
+                "\n".join(errors),
+            )
+
+        try:
+            self.__load_definitions(dom)
+        finally:
+            dom.unlink()
+
+    def __load_definitions(self, dom):
         top = dom.getElementsByTagName("forms")
+        if not top:
+            return
 
         for form in top[0].getElementsByTagName("form"):
+            if validate_form_element(form):
+                # Errors for this form were already surfaced by the
+                # file-level validator — skip it so __load_definitions
+                # never touches a malformed element.
+                skipped_id = (
+                    form.attributes["id"].value
+                    if "id" in form.attributes
+                    else "<missing id>"
+                )
+                LOG.debug("Skipping invalid <form> '%s'", skipped_id)
+                continue
+
             id = form.attributes["id"].value
+            LOG.debug("Loading form '%s'", id)
             self.__names[id] = form.attributes["title"].value
             self.__types[id] = form.attributes["type"].value
             if "reference" in form.attributes:
@@ -194,7 +271,6 @@ class Form:
                     self.__columns[id][role].append(
                         (attr_text, long_text, int(size_text))
                     )
-        dom.unlink()
 
     def get_form_ids(self):
         """Return a list of ids for all form definitions."""
@@ -205,7 +281,7 @@ class Form:
         return self.__names[form_id]
 
     def get_reference(self, form_id):
-        """ Return the reference for a given form. """
+        """Return the reference for a given form."""
         return self.__references[form_id]
 
     def get_date(self, form_id):
@@ -258,11 +334,13 @@ def get_form_title(form_id):
     """
     return FORM.get_title(form_id)
 
+
 def get_form_reference(form_id):
     """
     Return the reference for a given form.
     """
     return FORM.get_reference(form_id)
+
 
 def get_form_date(form_id):
     """

--- a/Form/form_validator.py
+++ b/Form/form_validator.py
@@ -1,0 +1,169 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Eduard Ralph
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Pure-Python validation for Form addon XML definition files.
+
+Kept free of GTK/Gramps imports so it can be unit-tested without a GUI
+environment.
+"""
+
+# ------------------------
+# Python modules
+# ------------------------
+import xml.dom.minidom
+import xml.parsers.expat
+
+VALID_SECTION_TYPES = frozenset({"person", "family", "multi"})
+REQUIRED_FORM_ATTRS = ("id", "title", "type")
+
+
+def split_family_title(title: str) -> tuple[str, str]:
+    """
+    Split a family-section title of the form ``'X/Y'`` into ``(X, Y)``.
+
+    Falls back gracefully when the separator is absent or the input is
+    empty, so callers never raise ``ValueError`` on malformed XML.
+
+    :param title: the raw title string from the XML (may be empty)
+    :returns: a two-tuple of title parts; the second element is empty
+              when the title contains no ``'/'``
+    """
+    if not title:
+        return "", ""
+    parts = title.split("/", 1)
+    if len(parts) == 2:
+        return parts[0], parts[1]
+    return parts[0], ""
+
+
+def validate_form_element(form) -> list[str]:
+    """
+    Validate a single ``<form>`` DOM element against the form schema.
+
+    :param form: a DOM element for a single form definition
+    :returns: a list of human-readable error messages scoped to this
+              form; empty when the form is valid
+    """
+    errors: list[str] = []
+
+    form_id = form.attributes["id"].value if "id" in form.attributes else "<missing id>"
+    for required in REQUIRED_FORM_ATTRS:
+        if required not in form.attributes:
+            errors.append(
+                "Form '%s': missing required attribute '%s'" % (form_id, required)
+            )
+
+    for section in form.getElementsByTagName("section"):
+        role = section.attributes["role"].value if "role" in section.attributes else ""
+        if not role:
+            errors.append(
+                "Form '%s': <section> is missing required attribute 'role'" % form_id
+            )
+            continue
+
+        if "type" not in section.attributes:
+            errors.append(
+                "Form '%s': section '%s' is missing required attribute 'type'"
+                % (form_id, role)
+            )
+            continue
+
+        section_type = section.attributes["type"].value
+        if not section_type:
+            errors.append(
+                "Form '%s': section '%s' has an empty 'type' attribute"
+                % (form_id, role)
+            )
+            continue
+
+        if section_type not in VALID_SECTION_TYPES:
+            errors.append(
+                "Form '%s': section '%s' has invalid type '%s' "
+                "(expected one of: %s)"
+                % (
+                    form_id,
+                    role,
+                    section_type,
+                    ", ".join(sorted(VALID_SECTION_TYPES)),
+                )
+            )
+            continue
+
+        title = (
+            section.attributes["title"].value if "title" in section.attributes else ""
+        )
+        if section_type == "family":
+            parts = title.split("/")
+            if len(parts) != 2 or not parts[0].strip() or not parts[1].strip():
+                errors.append(
+                    "Form '%s': family section '%s' requires a title "
+                    "of the form 'Name1/Name2' (got '%s')" % (form_id, role, title)
+                )
+
+    return errors
+
+
+def validate_form_dom(dom: xml.dom.minidom.Document) -> list[str]:
+    """
+    Validate the structure of a parsed form definitions DOM.
+
+    Checks that:
+
+    * a ``<forms>`` root element exists;
+    * each ``<form>`` element has ``id``, ``title`` and ``type`` attributes;
+    * each ``<section>`` element has non-empty ``role`` and ``type``
+      attributes;
+    * each section's ``type`` is one of ``person``, ``family`` or ``multi``;
+    * ``family``-type sections declare a title of the form ``'X/Y'`` with
+      two non-empty parts.
+
+    :param dom: a parsed ``xml.dom.minidom.Document``
+    :returns: a list of human-readable error messages; empty when the
+              document is valid
+    """
+    top = dom.getElementsByTagName("forms")
+    if not top:
+        return ["Missing <forms> root element"]
+
+    errors: list[str] = []
+    for form in top[0].getElementsByTagName("form"):
+        errors.extend(validate_form_element(form))
+    return errors
+
+
+def parse_and_validate(path: str) -> tuple[xml.dom.minidom.Document | None, list[str]]:
+    """
+    Parse ``path`` as XML and validate it against the form schema.
+
+    :param path: filesystem path to a form definitions XML file
+    :returns: a ``(dom, errors)`` tuple. When parsing fails, ``dom`` is
+              ``None`` and ``errors`` contains a single description of
+              the syntax error. When parsing succeeds, ``dom`` is the
+              parsed document and ``errors`` lists any structural
+              problems (empty when the file is valid).
+    """
+    try:
+        dom = xml.dom.minidom.parse(path)
+    except xml.parsers.expat.ExpatError as exc:
+        return None, ["XML syntax error: %s" % exc]
+    except (OSError, ValueError) as exc:
+        return None, ["Failed to read file: %s" % exc]
+    return dom, validate_form_dom(dom)

--- a/Form/po/template.pot
+++ b/Form/po/template.pot
@@ -9045,3 +9045,15 @@ msgstr ""
 #: Form/form_fr.xml.h:144
 msgid "Arrived since"
 msgstr ""
+
+#: Form/form.py:154
+msgid "XML syntax error in Form definition file"
+msgstr ""
+
+#: Form/form.py:165
+msgid "Failed to read Form definition file"
+msgstr ""
+
+#: Form/form.py:176
+msgid "Invalid Form definition file"
+msgstr ""

--- a/Form/tests/test_form_validator.py
+++ b/Form/tests/test_form_validator.py
@@ -1,0 +1,385 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Eduard Ralph
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Unit tests for ``form_validator`` — the pure-Python validation layer
+for Form addon XML definition files.
+
+These tests do not touch Gramps or GTK, so they run in every CI job.
+
+Run with::
+
+    python3 -m unittest Form.tests.test_form_validator -v
+"""
+
+# ------------------------
+# Python modules
+# ------------------------
+import os
+import sys
+import tempfile
+import textwrap
+import unittest
+import xml.dom.minidom
+
+# ------------------------
+# Gramps specific
+# ------------------------
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from form_validator import (
+    parse_and_validate,
+    split_family_title,
+    validate_form_dom,
+    VALID_SECTION_TYPES,
+)
+
+
+def _dom_from_string(xml_text: str) -> xml.dom.minidom.Document:
+    """Parse an XML string into a DOM for validator testing."""
+    return xml.dom.minidom.parseString(xml_text)
+
+
+# ---------------------------------------------------------------------------
+# split_family_title — belt-and-braces helper used by FamilySection
+# ---------------------------------------------------------------------------
+class TestSplitFamilyTitle(unittest.TestCase):
+    """
+    Regression coverage for Gramps bug 11707 — ``FamilySection`` used to
+    crash with ``ValueError: not enough values to unpack (expected 2,
+    got 1)`` when a form's ``<section type='family'>`` title did not
+    contain a ``/`` separator.
+    """
+
+    def test_two_parts(self):
+        self.assertEqual(split_family_title("Groom/Bride"), ("Groom", "Bride"))
+
+    def test_no_separator_returns_empty_second(self):
+        self.assertEqual(split_family_title("Couple"), ("Couple", ""))
+
+    def test_empty_string_returns_two_empties(self):
+        self.assertEqual(split_family_title(""), ("", ""))
+
+    def test_only_separator(self):
+        self.assertEqual(split_family_title("/"), ("", ""))
+
+    def test_leading_separator(self):
+        self.assertEqual(split_family_title("/Bride"), ("", "Bride"))
+
+    def test_trailing_separator(self):
+        self.assertEqual(split_family_title("Groom/"), ("Groom", ""))
+
+    def test_multiple_separators_only_split_once(self):
+        self.assertEqual(split_family_title("A/B/C"), ("A", "B/C"))
+
+    def test_whitespace_preserved(self):
+        self.assertEqual(
+            split_family_title(" Groom / Bride "),
+            (" Groom ", " Bride "),
+        )
+
+
+# ---------------------------------------------------------------------------
+# validate_form_dom — happy path
+# ---------------------------------------------------------------------------
+class TestValidateFormDomValid(unittest.TestCase):
+
+    def test_minimal_valid_form(self):
+        dom = _dom_from_string(textwrap.dedent("""\
+            <forms>
+                <form id='F1' type='Census' title='Test Census'>
+                    <section role='Primary' type='multi'/>
+                </form>
+            </forms>
+        """))
+        self.assertEqual(validate_form_dom(dom), [])
+
+    def test_valid_family_section_with_slashed_title(self):
+        dom = _dom_from_string(textwrap.dedent("""\
+            <forms>
+                <form id='F1' type='Marriage' title='Test Marriage'>
+                    <section role='Family' type='family' title='Groom/Bride'/>
+                </form>
+            </forms>
+        """))
+        self.assertEqual(validate_form_dom(dom), [])
+
+    def test_valid_person_section_without_title(self):
+        """Person sections may legitimately omit the title attribute."""
+        dom = _dom_from_string(textwrap.dedent("""\
+            <forms>
+                <form id='F1' type='Census' title='Test'>
+                    <section role='Primary' type='person'/>
+                </form>
+            </forms>
+        """))
+        self.assertEqual(validate_form_dom(dom), [])
+
+    def test_empty_forms_element_is_valid(self):
+        dom = _dom_from_string("<forms/>")
+        self.assertEqual(validate_form_dom(dom), [])
+
+
+# ---------------------------------------------------------------------------
+# validate_form_dom — structural errors
+# ---------------------------------------------------------------------------
+class TestValidateFormDomErrors(unittest.TestCase):
+
+    def test_missing_forms_root(self):
+        dom = _dom_from_string("<other/>")
+        errors = validate_form_dom(dom)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("<forms>", errors[0])
+
+    def test_form_missing_id_attribute(self):
+        dom = _dom_from_string("<forms><form type='Census' title='x'/></forms>")
+        errors = validate_form_dom(dom)
+        self.assertTrue(any("missing required attribute 'id'" in e for e in errors))
+
+    def test_form_missing_title_attribute(self):
+        dom = _dom_from_string("<forms><form id='F1' type='Census'/></forms>")
+        errors = validate_form_dom(dom)
+        self.assertTrue(any("missing required attribute 'title'" in e for e in errors))
+
+    def test_form_missing_type_attribute(self):
+        dom = _dom_from_string("<forms><form id='F1' title='x'/></forms>")
+        errors = validate_form_dom(dom)
+        self.assertTrue(any("missing required attribute 'type'" in e for e in errors))
+
+    def test_section_missing_role_attribute(self):
+        dom = _dom_from_string(textwrap.dedent("""\
+            <forms>
+                <form id='F1' type='Census' title='x'>
+                    <section type='person'/>
+                </form>
+            </forms>
+        """))
+        errors = validate_form_dom(dom)
+        self.assertTrue(any("'role'" in e for e in errors))
+
+    def test_section_empty_role_attribute(self):
+        dom = _dom_from_string(textwrap.dedent("""\
+            <forms>
+                <form id='F1' type='Census' title='x'>
+                    <section role='' type='person'/>
+                </form>
+            </forms>
+        """))
+        errors = validate_form_dom(dom)
+        self.assertTrue(any("'role'" in e for e in errors))
+
+    def test_section_missing_type_attribute(self):
+        dom = _dom_from_string(textwrap.dedent("""\
+            <forms>
+                <form id='F1' type='Census' title='x'>
+                    <section role='Primary'/>
+                </form>
+            </forms>
+        """))
+        errors = validate_form_dom(dom)
+        self.assertTrue(any("'type'" in e for e in errors))
+
+    def test_section_empty_type_attribute(self):
+        dom = _dom_from_string(textwrap.dedent("""\
+            <forms>
+                <form id='F1' type='Census' title='x'>
+                    <section role='Primary' type=''/>
+                </form>
+            </forms>
+        """))
+        errors = validate_form_dom(dom)
+        self.assertTrue(any("'type'" in e for e in errors))
+
+    def test_section_invalid_type(self):
+        dom = _dom_from_string(textwrap.dedent("""\
+            <forms>
+                <form id='F1' type='Census' title='x'>
+                    <section role='Primary' type='bogus'/>
+                </form>
+            </forms>
+        """))
+        errors = validate_form_dom(dom)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("invalid type 'bogus'", errors[0])
+        for valid in VALID_SECTION_TYPES:
+            self.assertIn(valid, errors[0])
+
+    def test_section_type_is_case_sensitive(self):
+        """
+        A real custom.xml in the wild used ``type='Person'`` instead of
+        ``type='person'``. The validator rejects it so the user sees a
+        clear error rather than silently loading a broken form.
+        """
+        dom = _dom_from_string(textwrap.dedent("""\
+            <forms>
+                <form id='AusCemIndex' type='AusCemIndex' title='x'>
+                    <section role='Primary' type='Person'/>
+                </form>
+            </forms>
+        """))
+        errors = validate_form_dom(dom)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("invalid type 'Person'", errors[0])
+
+    def test_family_section_without_title_is_rejected(self):
+        """
+        Reproduction of bug 11707 at the validation layer: a family
+        section without a slashed title produces a clear error instead
+        of a ValueError crash in the GUI.
+        """
+        dom = _dom_from_string(textwrap.dedent("""\
+            <forms>
+                <form id='F1' type='Marriage' title='x'>
+                    <section role='Family' type='family'/>
+                </form>
+            </forms>
+        """))
+        errors = validate_form_dom(dom)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("Name1/Name2", errors[0])
+
+    def test_family_section_with_single_part_title_is_rejected(self):
+        dom = _dom_from_string(textwrap.dedent("""\
+            <forms>
+                <form id='F1' type='Marriage' title='x'>
+                    <section role='Family' type='family' title='Couple'/>
+                </form>
+            </forms>
+        """))
+        errors = validate_form_dom(dom)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("Couple", errors[0])
+
+    def test_family_section_with_blank_part_is_rejected(self):
+        dom = _dom_from_string(textwrap.dedent("""\
+            <forms>
+                <form id='F1' type='Marriage' title='x'>
+                    <section role='Family' type='family' title='Groom/'/>
+                </form>
+            </forms>
+        """))
+        errors = validate_form_dom(dom)
+        self.assertEqual(len(errors), 1)
+
+    def test_family_section_with_three_parts_is_rejected(self):
+        dom = _dom_from_string(textwrap.dedent("""\
+            <forms>
+                <form id='F1' type='Marriage' title='x'>
+                    <section role='Family' type='family' title='A/B/C'/>
+                </form>
+            </forms>
+        """))
+        errors = validate_form_dom(dom)
+        self.assertEqual(len(errors), 1)
+
+    def test_multiple_errors_aggregated(self):
+        dom = _dom_from_string(textwrap.dedent("""\
+            <forms>
+                <form id='F1' type='Census' title='x'>
+                    <section role='A' type='bogus'/>
+                    <section type='person'/>
+                </form>
+                <form title='Unnamed' type='Census'/>
+            </forms>
+        """))
+        errors = validate_form_dom(dom)
+        # 1 for invalid type + 1 for missing role + 1 for missing id
+        self.assertGreaterEqual(len(errors), 3)
+
+
+# ---------------------------------------------------------------------------
+# parse_and_validate — file-level entry point
+# ---------------------------------------------------------------------------
+class TestParseAndValidate(unittest.TestCase):
+
+    def _write(self, content: str) -> str:
+        """Write a temporary XML file and return its path."""
+        fd, path = tempfile.mkstemp(suffix=".xml")
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(content)
+        self.addCleanup(os.remove, path)
+        return path
+
+    def test_valid_file(self):
+        path = self._write(textwrap.dedent("""\
+            <forms>
+                <form id='F1' type='Census' title='x'>
+                    <section role='Primary' type='person'/>
+                </form>
+            </forms>
+        """))
+        dom, errors = parse_and_validate(path)
+        self.assertIsNotNone(dom)
+        self.assertEqual(errors, [])
+
+    def test_xml_syntax_error_reports_cleanly(self):
+        path = self._write("<forms><form><unclosed></forms>")
+        dom, errors = parse_and_validate(path)
+        self.assertIsNone(dom)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("XML syntax error", errors[0])
+
+    def test_missing_file_reports_cleanly(self):
+        dom, errors = parse_and_validate("/nonexistent/path.xml")
+        self.assertIsNone(dom)
+        self.assertEqual(len(errors), 1)
+
+    def test_invalid_structure_returns_errors_and_dom(self):
+        path = self._write(textwrap.dedent("""\
+            <forms>
+                <form id='F1' type='Marriage' title='x'>
+                    <section role='Family' type='family' title='NoSlash'/>
+                </form>
+            </forms>
+        """))
+        dom, errors = parse_and_validate(path)
+        self.assertIsNotNone(dom)
+        self.assertEqual(len(errors), 1)
+
+
+# ---------------------------------------------------------------------------
+# Sanity: the shipped built-in definition files must validate
+# ---------------------------------------------------------------------------
+class TestShippedDefinitionFilesValidate(unittest.TestCase):
+    """
+    Every built-in ``form_*.xml`` file shipped with the addon must pass
+    validation.  If this test fails, the addon would refuse to load one
+    of its own definition files for end users.
+    """
+
+    FORM_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+    def test_all_builtin_form_files_validate(self):
+        import glob
+
+        files = sorted(glob.glob(os.path.join(self.FORM_DIR, "form_*.xml")))
+        self.assertGreater(len(files), 0, "no form_*.xml files discovered")
+        for path in files:
+            with self.subTest(form_file=os.path.basename(path)):
+                dom, errors = parse_and_validate(path)
+                self.assertIsNotNone(dom, f"failed to parse {path}")
+                self.assertEqual(
+                    errors,
+                    [],
+                    f"validation errors in {path}:\n" + "\n".join(errors),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Form/tests/test_integration_form.py
+++ b/Form/tests/test_integration_form.py
@@ -1,0 +1,258 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Eduard Ralph
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Integration tests for the Form addon loader — covers
+``gramps-project/gramps#11707`` (*ValueError: not enough values to
+unpack* when a form's ``<section type='family'>`` title lacks the
+``X/Y`` separator).
+
+Scenarios covered:
+
+* Malformed XML produces an ``ErrorDialog`` rather than a bare traceback.
+* A partially-broken file still loads its well-formed ``<form>`` entries.
+* The shipped built-in definition files load cleanly without any error
+  dialogs being raised.
+
+Run with::
+
+    python3 -m unittest Form.tests.test_integration_form -v
+"""
+
+# ------------------------
+# Python modules
+# ------------------------
+import os
+import shutil
+import sys
+import tempfile
+import textwrap
+import unittest
+from unittest.mock import patch
+
+# ------------------------
+# Gramps modules
+# ------------------------
+try:
+    import gi  # noqa: F401
+    import gramps
+except ImportError as exc:
+    raise unittest.SkipTest(
+        "Form integration tests require 'gi' and 'gramps': %s" % exc
+    )
+
+if "GRAMPS_RESOURCES" not in os.environ:
+    os.environ["GRAMPS_RESOURCES"] = os.path.dirname(os.path.dirname(gramps.__file__))
+
+# ------------------------
+# Gramps specific
+# ------------------------
+ADDON_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ADDON_DIR not in sys.path:
+    sys.path.insert(0, ADDON_DIR)
+
+
+# ---------------------------------------------------------------------------
+# Shared harness
+# ---------------------------------------------------------------------------
+class FormLoaderTestCase(unittest.TestCase):
+    """
+    Base class that imports the Form addon's ``form`` module and
+    redirects its ``ErrorDialog`` to an in-memory list instead of
+    opening a GTK dialog.
+
+    Subclasses access :attr:`shown` to inspect captured dialog calls
+    and use :meth:`_write` to drop XML files into an isolated
+    temporary directory.
+    """
+
+    def setUp(self) -> None:
+        import form
+
+        self.form = form
+        self.shown: list[tuple[str, str]] = []
+
+        def _fake_error_dialog(*args, **kwargs):
+            title = str(args[0]) if args else ""
+            body = str(args[1]) if len(args) > 1 else ""
+            self.shown.append((title, body))
+
+        error_patch = patch.object(form, "ErrorDialog", _fake_error_dialog)
+        error_patch.start()
+        self.addCleanup(error_patch.stop)
+
+        self.tmp_dir = tempfile.mkdtemp(prefix="form-integration-")
+        self.addCleanup(shutil.rmtree, self.tmp_dir, True)
+
+    def _write(self, filename: str, content: str) -> None:
+        """Write an XML fixture into the test's temporary directory."""
+        path = os.path.join(self.tmp_dir, filename)
+        with open(path, "w", encoding="utf-8") as handle:
+            handle.write(content)
+
+    def _patch_definition_files(self, files: list[str]) -> None:
+        """Redirect the loader to the given filenames (inside tmp_dir)."""
+        files_patch = patch.object(self.form, "definition_files", files)
+        files_patch.start()
+        self.addCleanup(files_patch.stop)
+
+
+# ---------------------------------------------------------------------------
+# Error-dialog wiring
+# ---------------------------------------------------------------------------
+class TestErrorDialogWiring(FormLoaderTestCase):
+    """
+    Exercises the four failure modes the loader now surfaces via
+    :class:`ErrorDialog` instead of an unhandled traceback.
+    """
+
+    def test_malformed_xml_shows_error_dialog(self) -> None:
+        """XML syntax errors should raise an ErrorDialog, not a traceback."""
+        self._write("custom.xml", "<forms><form id='F1'><unclosed></forms>")
+        self._patch_definition_files(["custom.xml"])
+
+        instance = self.form.Form(definition_dir=self.tmp_dir)
+
+        self.assertTrue(self.shown, "no ErrorDialog was displayed")
+        title, body = self.shown[0]
+        self.assertIn("XML syntax error", title)
+        self.assertIn("custom.xml", body)
+        self.assertEqual(list(instance.get_form_ids()), [])
+
+    def test_invalid_family_title_shows_error_dialog(self) -> None:
+        """
+        The exact condition from bug 11707 — a family section with a
+        non-``X/Y`` title — must be surfaced as an ErrorDialog at load
+        time rather than an unhandled exception when the user later
+        opens the form.
+        """
+        self._write(
+            "custom.xml",
+            textwrap.dedent("""\
+                <forms>
+                    <form id='F1' type='Marriage' title='Bad Marriage'>
+                        <section role='Family' type='family' title='Couple'/>
+                    </form>
+                </forms>
+                """),
+        )
+        self._patch_definition_files(["custom.xml"])
+
+        self.form.Form(definition_dir=self.tmp_dir)
+
+        self.assertTrue(
+            self.shown, "no ErrorDialog was displayed for invalid family title"
+        )
+        title, body = self.shown[0]
+        self.assertIn("Invalid Form definition file", title)
+        self.assertIn("Name1/Name2", body)
+
+    def test_partially_broken_file_still_loads_valid_forms(self) -> None:
+        """A broken <form> must not stop sibling <form> elements loading."""
+        self._write(
+            "custom.xml",
+            textwrap.dedent("""\
+                <forms>
+                    <form id='GOOD' type='Census' title='Good Census'>
+                        <section role='Primary' type='person'/>
+                    </form>
+                    <form id='BAD' type='Marriage' title='Bad Marriage'>
+                        <section role='Family' type='family' title='Couple'/>
+                    </form>
+                </forms>
+                """),
+        )
+        self._patch_definition_files(["custom.xml"])
+
+        instance = self.form.Form(definition_dir=self.tmp_dir)
+        loaded_ids = list(instance.get_form_ids())
+
+        self.assertIn("GOOD", loaded_ids, "valid form should still load")
+        self.assertNotIn("BAD", loaded_ids, "invalid form should be skipped")
+        self.assertTrue(self.shown, "the broken form should have been reported")
+
+    def test_missing_role_attribute_shows_error_dialog(self) -> None:
+        """A section missing its ``role`` attribute is reported clearly."""
+        self._write(
+            "custom.xml",
+            textwrap.dedent("""\
+                <forms>
+                    <form id='F1' type='Census' title='x'>
+                        <section type='person'/>
+                    </form>
+                </forms>
+                """),
+        )
+        self._patch_definition_files(["custom.xml"])
+
+        self.form.Form(definition_dir=self.tmp_dir)
+
+        self.assertTrue(self.shown)
+        _, body = self.shown[0]
+        self.assertIn("role", body)
+
+    def test_invalid_section_type_shows_error_dialog(self) -> None:
+        """Unknown section types produce a clear error, not a later crash."""
+        self._write(
+            "custom.xml",
+            textwrap.dedent("""\
+                <forms>
+                    <form id='F1' type='Census' title='x'>
+                        <section role='Primary' type='bogus'/>
+                    </form>
+                </forms>
+                """),
+        )
+        self._patch_definition_files(["custom.xml"])
+
+        instance = self.form.Form(definition_dir=self.tmp_dir)
+
+        self.assertTrue(self.shown)
+        _, body = self.shown[0]
+        self.assertIn("bogus", body)
+        self.assertNotIn("F1", list(instance.get_form_ids()))
+
+
+# ---------------------------------------------------------------------------
+# Shipped files load cleanly
+# ---------------------------------------------------------------------------
+class TestShippedFilesLoadCleanly(FormLoaderTestCase):
+    """
+    The built-in definition files that ship with the addon must load
+    without triggering a single ErrorDialog, otherwise end users would
+    see a popup every time they opened Gramps.
+    """
+
+    def test_shipped_files_load_without_errors(self) -> None:
+        instance = self.form.Form()
+
+        self.assertFalse(
+            self.shown,
+            "Built-in definition files triggered ErrorDialog calls:\n"
+            + "\n".join("%s: %s" % (t, b) for t, b in self.shown),
+        )
+        self.assertTrue(
+            list(instance.get_form_ids()),
+            "no forms loaded from built-in definition files",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Fixes the `ValueError: not enough values to unpack (expected 2, got 1)` crash in the Forms addon's `FamilySection` when a `<section type='family'>` title omits the `X/Y` separator ([gramps-project/gramps#11707](https://gramps-project.org/bugs/view.php?id=11707)).
- Adds a pure-Python `form_validator` module so the loader can reject malformed XML up front, with user-facing `ErrorDialog`s naming the file, form, and rule that failed.
- Partially addresses [#11010](https://gramps-project.org/bugs/view.php?id=11010) (request for a user error dialog for unsupported elements) by covering its core ask: clear errors for invalid section types, missing/empty `role`, missing/empty `type`, and XML syntax errors.

## What changed

**Loader (`Form/form.py`)**

- Pre-validates each definition file; syntax errors, missing required attributes, and invalid section types all surface as `ErrorDialog`s with the file path and a precise message.
- Partially-broken files still load their well-formed `<form>` entries — one bad section no longer nukes the whole file.
- Added diagnostic logging: `INFO` count of forms loaded per file, `DEBUG` per file/form trace.

**Validator (`Form/form_validator.py`, new)**

- `split_family_title()` — belt-and-braces helper so `FamilySection` never raises on a malformed title.
- `validate_form_element()` / `validate_form_dom()` — returns a list of human-readable errors; free of GTK/Gramps imports so it runs in any CI job.
- `parse_and_validate()` — file-level entry point that catches both parse and schema errors cleanly.

**Editor (`Form/editform.py`)**

- Uses `split_family_title()` instead of the raw `title.split('/')` that blew up in #11707.
- Added a module logger with `DEBUG` on `EditForm` open and a `WARNING` in `FamilySection` if the title lacks the separator (so future regressions are visible in logs, not just as a traceback).

**Translations (`Form/po/template.pot`)** — three new translatable dialog titles.

## Tests

All green locally (38 passed, 7 subtests):

- `Form/tests/test_form_validator.py` — 32 pure-Python unit tests: every branch of `split_family_title`, every validation rule, `parse_and_validate` file handling, plus a sanity test that every shipped `form_*.xml` passes validation.
- `Form/tests/test_integration_form.py` — 6 integration tests that patch `ErrorDialog` and assert: syntax errors, invalid family titles (the exact #11707 repro), missing `role`, and invalid section types all raise a clear dialog; partially-broken files still load their valid forms; shipped files trigger zero dialogs.

## Test plan

- [x] `python3 -m pytest Form/tests/ -v` — 38 passed
- [x] `python3 -m pytest Form/tests/test_form_validator.py` runs pure Python, no Gramps required
- [x] `ruff check Form/` — clean
- [x] `python3 -m py_compile Form/*.py` — clean
- [x] Manual smoke test in local Gramps 6.0 installation:
  - Shipped forms load with zero dialogs.
  - Dropping a `custom.xml` with an invalid `<section type='Person'>` shows the new ErrorDialog naming the file, form, and rule.
  - Dropping a `custom.xml` with the #11707 family-title repro shows a clear dialog instead of the `ValueError` traceback.
  - Opening a valid form from an existing source round-trips through the editor without regression.

Fixes gramps-project/gramps#11707
Refs gramps-project/gramps#11010
