### PR TITLE
Form: detect empty definition files and warn on column-size mismatches (bug 11010)

### DIFF
--- a/Form/form.py
+++ b/Form/form.py
@@ -47,7 +47,11 @@ from gramps.gui.dialog import ErrorDialog
 # Gramps specific
 #
 # ---------------------------------------------------------------
-from form_validator import validate_form_dom, validate_form_element
+from form_validator import (
+    get_form_warnings,
+    validate_form_dom,
+    validate_form_element,
+)
 
 LOG = logging.getLogger(".FormGramplet")
 
@@ -194,6 +198,9 @@ class Form:
                 full_path,
                 "\n".join(errors),
             )
+
+        for warning in get_form_warnings(dom):
+            LOG.warning("In %s: %s", full_path, warning)
 
         try:
             self.__load_definitions(dom)

--- a/Form/form_validator.py
+++ b/Form/form_validator.py
@@ -127,7 +127,8 @@ def validate_form_dom(dom: xml.dom.minidom.Document) -> list[str]:
 
     Checks that:
 
-    * a ``<forms>`` root element exists;
+    * a ``<forms>`` root element exists and contains at least one
+      ``<form>`` definition;
     * each ``<form>`` element has ``id``, ``title`` and ``type`` attributes;
     * each ``<section>`` element has non-empty ``role`` and ``type``
       attributes;
@@ -144,9 +145,77 @@ def validate_form_dom(dom: xml.dom.minidom.Document) -> list[str]:
         return ["Missing <forms> root element"]
 
     errors: list[str] = []
-    for form in top[0].getElementsByTagName("form"):
+    forms = top[0].getElementsByTagName("form")
+    if not forms:
+        errors.append("<forms> root element contains no <form> definitions")
+    for form in forms:
         errors.extend(validate_form_element(form))
     return errors
+
+
+def get_form_warnings(dom: xml.dom.minidom.Document) -> list[str]:
+    """
+    Collect non-fatal warnings about a parsed form definitions DOM.
+
+    Warnings describe likely authoring mistakes that do not prevent the
+    form from loading. Currently covers Gramps bug 11010's observation
+    that a section's ``<column>`` ``<size>`` values are expected to sum
+    to 100 — sections that declare explicit sizes on every column but do
+    not sum to 100 are reported as warnings so callers can log them
+    without blocking the form from loading.
+
+    Sections without any sized columns, or with only some columns
+    sized, are skipped because the intent is ambiguous.
+
+    :param dom: a parsed ``xml.dom.minidom.Document``
+    :returns: a list of human-readable warning messages; empty when
+              nothing questionable is detected
+    """
+    warnings: list[str] = []
+    top = dom.getElementsByTagName("forms")
+    if not top:
+        return warnings
+
+    for form in top[0].getElementsByTagName("form"):
+        form_id = (
+            form.attributes["id"].value
+            if "id" in form.attributes
+            else "<missing id>"
+        )
+        for section in form.getElementsByTagName("section"):
+            role = (
+                section.attributes["role"].value
+                if "role" in section.attributes
+                else "<missing role>"
+            )
+            columns = section.getElementsByTagName("column")
+            if not columns:
+                continue
+
+            sizes: list[int] = []
+            all_sized = True
+            for column in columns:
+                size_nodes = column.getElementsByTagName("size")
+                if not size_nodes or not size_nodes[0].childNodes:
+                    all_sized = False
+                    break
+                try:
+                    sizes.append(int(size_nodes[0].childNodes[0].data))
+                except ValueError:
+                    all_sized = False
+                    break
+            if not all_sized:
+                continue
+
+            total = sum(sizes)
+            if total != 100:
+                warnings.append(
+                    "Form '%s': section '%s' column sizes sum to %d "
+                    "(expected 100); form will still load but column "
+                    "widths may not render as intended"
+                    % (form_id, role, total)
+                )
+    return warnings
 
 
 def parse_and_validate(path: str) -> tuple[xml.dom.minidom.Document | None, list[str]]:

--- a/Form/tests/test_form_validator.py
+++ b/Form/tests/test_form_validator.py
@@ -44,6 +44,7 @@ import xml.dom.minidom
 # ------------------------
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 from form_validator import (
+    get_form_warnings,
     parse_and_validate,
     split_family_title,
     validate_form_dom,
@@ -131,11 +132,6 @@ class TestValidateFormDomValid(unittest.TestCase):
         """))
         self.assertEqual(validate_form_dom(dom), [])
 
-    def test_empty_forms_element_is_valid(self):
-        dom = _dom_from_string("<forms/>")
-        self.assertEqual(validate_form_dom(dom), [])
-
-
 # ---------------------------------------------------------------------------
 # validate_form_dom — structural errors
 # ---------------------------------------------------------------------------
@@ -146,6 +142,23 @@ class TestValidateFormDomErrors(unittest.TestCase):
         errors = validate_form_dom(dom)
         self.assertEqual(len(errors), 1)
         self.assertIn("<forms>", errors[0])
+
+    def test_empty_forms_element_is_rejected(self):
+        """
+        Regression for Gramps bug 11010 — a file whose ``<forms>`` root
+        contains no ``<form>`` definitions used to load silently, leaving
+        users with no feedback. The validator now reports it as an error.
+        """
+        dom = _dom_from_string("<forms/>")
+        errors = validate_form_dom(dom)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("no <form>", errors[0])
+
+    def test_forms_root_with_only_comments_is_rejected(self):
+        dom = _dom_from_string("<forms><!-- nothing here --></forms>")
+        errors = validate_form_dom(dom)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("no <form>", errors[0])
 
     def test_form_missing_id_attribute(self):
         dom = _dom_from_string("<forms><form type='Census' title='x'/></forms>")
@@ -379,6 +392,126 @@ class TestShippedDefinitionFilesValidate(unittest.TestCase):
                     [],
                     f"validation errors in {path}:\n" + "\n".join(errors),
                 )
+
+
+# ---------------------------------------------------------------------------
+# get_form_warnings — non-fatal authoring warnings (Gramps bug 11010)
+# ---------------------------------------------------------------------------
+class TestGetFormWarnings(unittest.TestCase):
+    """
+    Column sizes are expected to sum to 100. Rather than reject the
+    form, ``get_form_warnings`` flags suspect sections so the caller can
+    log them — 78 shipped definition files currently violate this rule
+    without breaking rendering, so escalating to an error would be
+    user-hostile.
+    """
+
+    def test_section_without_columns_has_no_warning(self):
+        dom = _dom_from_string(textwrap.dedent("""\
+            <forms>
+                <form id='F1' type='Census' title='x'>
+                    <section role='Primary' type='person'/>
+                </form>
+            </forms>
+        """))
+        self.assertEqual(get_form_warnings(dom), [])
+
+    def test_columns_without_any_size_have_no_warning(self):
+        dom = _dom_from_string(textwrap.dedent("""\
+            <forms>
+                <form id='F1' type='Census' title='x'>
+                    <section role='Primary' type='person'>
+                        <column><_attribute>Name</_attribute></column>
+                        <column><_attribute>Age</_attribute></column>
+                    </section>
+                </form>
+            </forms>
+        """))
+        self.assertEqual(get_form_warnings(dom), [])
+
+    def test_columns_summing_to_100_have_no_warning(self):
+        dom = _dom_from_string(textwrap.dedent("""\
+            <forms>
+                <form id='F1' type='Census' title='x'>
+                    <section role='Primary' type='person'>
+                        <column><_attribute>A</_attribute><size>60</size></column>
+                        <column><_attribute>B</_attribute><size>40</size></column>
+                    </section>
+                </form>
+            </forms>
+        """))
+        self.assertEqual(get_form_warnings(dom), [])
+
+    def test_columns_not_summing_to_100_emit_warning(self):
+        dom = _dom_from_string(textwrap.dedent("""\
+            <forms>
+                <form id='F1' type='Census' title='x'>
+                    <section role='Primary' type='person'>
+                        <column><_attribute>A</_attribute><size>25</size></column>
+                    </section>
+                </form>
+            </forms>
+        """))
+        warnings = get_form_warnings(dom)
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("sum to 25", warnings[0])
+        self.assertIn("F1", warnings[0])
+        self.assertIn("Primary", warnings[0])
+
+    def test_partially_sized_columns_have_no_warning(self):
+        """
+        When only some columns declare a ``<size>``, the author's intent
+        is ambiguous (mixed relative/absolute sizing) so the check is
+        skipped to avoid false positives.
+        """
+        dom = _dom_from_string(textwrap.dedent("""\
+            <forms>
+                <form id='F1' type='Census' title='x'>
+                    <section role='Primary' type='person'>
+                        <column><_attribute>A</_attribute><size>25</size></column>
+                        <column><_attribute>B</_attribute></column>
+                    </section>
+                </form>
+            </forms>
+        """))
+        self.assertEqual(get_form_warnings(dom), [])
+
+    def test_warnings_are_independent_of_errors(self):
+        """
+        Warnings are structurally orthogonal to errors: a malformed form
+        still produces warnings for its well-formed sibling.
+        """
+        dom = _dom_from_string(textwrap.dedent("""\
+            <forms>
+                <form id='BAD' type='Marriage' title='x'>
+                    <section role='Family' type='family' title='NoSlash'/>
+                </form>
+                <form id='GOOD' type='Census' title='x'>
+                    <section role='Primary' type='person'>
+                        <column><_attribute>A</_attribute><size>30</size></column>
+                    </section>
+                </form>
+            </forms>
+        """))
+        warnings = get_form_warnings(dom)
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("GOOD", warnings[0])
+
+    def test_multiple_misaligned_sections_all_reported(self):
+        dom = _dom_from_string(textwrap.dedent("""\
+            <forms>
+                <form id='F1' type='Census' title='x'>
+                    <section role='A' type='person'>
+                        <column><_attribute>X</_attribute><size>40</size></column>
+                    </section>
+                    <section role='B' type='person'>
+                        <column><_attribute>Y</_attribute><size>70</size></column>
+                    </section>
+                </form>
+            </forms>
+        """))
+        warnings = get_form_warnings(dom)
+        self.assertEqual(len(warnings), 2)
 
 
 if __name__ == "__main__":

--- a/Form/tests/test_integration_form.py
+++ b/Form/tests/test_integration_form.py
@@ -22,12 +22,16 @@
 Integration tests for the Form addon loader — covers
 ``gramps-project/gramps#11707`` (*ValueError: not enough values to
 unpack* when a form's ``<section type='family'>`` title lacks the
-``X/Y`` separator).
+``X/Y`` separator) and ``gramps-project/gramps#11010`` (empty
+``<forms>`` roots used to load silently, and column-size mismatches
+had no diagnostic).
 
 Scenarios covered:
 
 * Malformed XML produces an ``ErrorDialog`` rather than a bare traceback.
 * A partially-broken file still loads its well-formed ``<form>`` entries.
+* Empty ``<forms>`` roots surface as an ``ErrorDialog`` (bug 11010 item a).
+* Column-size mismatches are logged as WARNINGs only (bug 11010 item b).
 * The shipped built-in definition files load cleanly without any error
   dialogs being raised.
 
@@ -39,6 +43,7 @@ Run with::
 # ------------------------
 # Python modules
 # ------------------------
+import logging
 import os
 import shutil
 import sys
@@ -228,6 +233,75 @@ class TestErrorDialogWiring(FormLoaderTestCase):
         _, body = self.shown[0]
         self.assertIn("bogus", body)
         self.assertNotIn("F1", list(instance.get_form_ids()))
+
+
+# ---------------------------------------------------------------------------
+# Empty / content-less definition files (Gramps bug 11010 item a)
+# ---------------------------------------------------------------------------
+class TestEmptyFormsValidation(FormLoaderTestCase):
+    """
+    A definition file whose ``<forms>`` root contains no ``<form>``
+    children used to load silently. The validator now surfaces it as an
+    ErrorDialog so the user notices the empty file.
+    """
+
+    def test_empty_forms_element_shows_error_dialog(self) -> None:
+        """Empty ``<forms/>`` must raise an ErrorDialog, not load silently."""
+        self._write("custom.xml", "<forms/>")
+        self._patch_definition_files(["custom.xml"])
+
+        instance = self.form.Form(definition_dir=self.tmp_dir)
+
+        self.assertTrue(self.shown, "no ErrorDialog was displayed for empty <forms>")
+        title, body = self.shown[0]
+        self.assertIn("Invalid Form definition file", title)
+        self.assertIn("no <form>", body)
+        self.assertEqual(list(instance.get_form_ids()), [])
+
+
+# ---------------------------------------------------------------------------
+# Column-size warnings (Gramps bug 11010 item b) — WARNING only, not errors
+# ---------------------------------------------------------------------------
+class TestColumnSizeWarnings(FormLoaderTestCase):
+    """
+    Sections whose ``<column>`` sizes do not sum to 100 must be logged
+    as warnings only — 78 shipped forms trip this check, so escalating
+    to an ErrorDialog would harass users on every launch.
+    """
+
+    def test_column_size_sum_warning_is_logged_not_dialog(self) -> None:
+        """Column-size mismatch → WARNING log entry, no ErrorDialog."""
+        self._write(
+            "custom.xml",
+            textwrap.dedent("""\
+                <forms>
+                    <form id='F1' type='Census' title='x'>
+                        <section role='Primary' type='person'>
+                            <column><_attribute>A</_attribute><size>25</size></column>
+                        </section>
+                    </form>
+                </forms>
+                """),
+        )
+        self._patch_definition_files(["custom.xml"])
+
+        with self.assertLogs(".FormGramplet", level=logging.WARNING) as log_ctx:
+            instance = self.form.Form(definition_dir=self.tmp_dir)
+
+        self.assertFalse(
+            self.shown,
+            "column-size mismatch must not produce an ErrorDialog:\n"
+            + "\n".join("%s: %s" % (t, b) for t, b in self.shown),
+        )
+        self.assertIn(
+            "F1",
+            list(instance.get_form_ids()),
+            "the form must still load despite the size mismatch",
+        )
+        self.assertTrue(
+            any("sum to 25" in message for message in log_ctx.output),
+            "expected a column-size warning in the log",
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes [Gramps bug 11010](https://gramps-project.org/bugs/view.php?id=11010).

The Form loader previously accepted form definition files that had a `<forms>` root element with no `<form>` children, silently producing zero usable forms and leaving the user with no feedback. It also had no diagnostic for a common authoring mistake the bug reporter called out — `<column>` `<size>` values are expected to sum to 100.

This change:

- Extends `validate_form_dom` to report `<forms>` roots containing no `<form>` definitions as an error, surfacing them through the same `ErrorDialog` path introduced by bug 11707.
- Adds a non-fatal `get_form_warnings` check that flags sections whose explicitly-sized columns do not sum to 100, and logs the result via `LOG.warning`.
- Leaves the form loading — 78 shipped definition files (Belgian, Canadian, Danish, etc. censuses) currently violate the sum-to-100 rule without breaking rendering (the `size` field is parsed but never read by the layout code), so escalating this to an error would reject working forms. A separate issue will track re-balancing the existing forms; this PR just makes the problem diagnosable for user-authored `custom.xml` files.

## Dependency

Depends on #821 (bug 11707 fix) — introduces `form_validator.py`. GitHub will display both commits until #821 is merged; this PR will auto-rebase to a single commit afterwards.

## Test plan

- [x] `python3 -m pytest Form/tests/ -v` — 48 pass (7 new unit tests for `get_form_warnings`, 1 new unit test for empty `<forms>`, 1 new unit test for comments-only `<forms>`, 2 new integration tests).
- [x] `TestShippedDefinitionFilesValidate` still green — no shipped file is flagged as an error by the new empty-forms rule.
- [x] Manual: shipped-file load produces no `ErrorDialog`, only WARNING-level log entries for the 78 known offenders.