### PR TITLE
TimelinePedigreeView: fix crash on second right-click (bug 0012387)

### DIFF
--- a/TimelinePedigreeView/TimelinePedigreeView.py
+++ b/TimelinePedigreeView/TimelinePedigreeView.py
@@ -1501,7 +1501,6 @@ class TimelinePedigreeView(NavigationView):
         menu.append(item)
 
         # Help menu entry
-        menu.append(item)
         item = Gtk.MenuItem(label=_("About Timeline Pedigree View"))
         item.connect("activate", self.on_help_clicked)
         item.show()


### PR DESCRIPTION
## Summary
- Fixes [bug 0012387](https://gramps-project.org/bugs/view.php?id=12387) (and duplicate [0013463](https://gramps-project.org/bugs/view.php?id=13463)): Gramps crashes on the second right-click in the Timeline Pedigree view.
- `add_settings_to_menu` was appending the same `SeparatorMenuItem` twice. GTK rejected the second append (`Can't set a parent on widget which has a parent`), and the corrupt parent linkage caused a segfault when the previous menu was garbage-collected on the next right-click.
- Removing the stray duplicate append fixes all four context-menu paths (background canvas, person, relation, missing parent) and silences the `GTK_IS_WIDGET` assertion warnings.

## Test plan
- [ ] Open the Timeline Pedigree view on `example.gramps`.
- [ ] Right-click the canvas, change a setting (e.g. untick "Order by Timeline"); menu closes cleanly.
- [ ] Right-click the canvas again — menu opens, no crash, no GTK warnings on the console.
- [ ] Right-click on a person, on a relation line, and on a missing-parent slot — each opens the menu, and a follow-up right-click anywhere does not crash.