### PR TITLE
DataEntryGramplet: fix crash when adding person with no Family Tree open (bug 0012691)

### DIFF
--- a/DataEntryGramplet/DataEntryGramplet.py
+++ b/DataEntryGramplet/DataEntryGramplet.py
@@ -423,6 +423,11 @@ class DataEntryGramplet(Gramplet):
 
     def save_data_edit(self, obj):
         if self._dirty:
+            if not self.dbstate.is_open():
+                from gramps.gui.dialog import ErrorDialog
+                ErrorDialog(_("No Family Tree is open."),
+                            _("Please open a Family Tree to edit data."))
+                return
             # Save the edits ----------------------------------
             person = self._dirty_person
             # First, get the data:
@@ -498,6 +503,10 @@ class DataEntryGramplet(Gramplet):
 
     def add_data_entry(self, obj):
         from gramps.gui.dialog import ErrorDialog
+        if not self.dbstate.is_open():
+            ErrorDialog(_("No Family Tree is open."),
+                        _("Please open a Family Tree before adding a person."))
+            return
         # First, get the data:
         if "," in self.de_widgets["NPName"].get_text():
             surname, firstname = self.de_widgets["NPName"].get_text().split(",", 1)

--- a/DataEntryGramplet/tests/test_data_entry_gramplet.py
+++ b/DataEntryGramplet/tests/test_data_entry_gramplet.py
@@ -35,72 +35,146 @@ spinning up GTK, while still exercising the real guard code paths.
 # ------------------------
 import os
 import sys
+import unittest
+from typing import Any
+from unittest import mock
 
-import pytest
+# The addon imports Gtk at module load — skip cleanly if gi/Gtk are not
+# available. On systems where both GTK3 and GTK4 are present, pin Gtk to
+# 3.0 before any gramps import (mirrors what gramps.grampsapp does at
+# startup); otherwise PyGObject loads GTK4 and the gramps.gui import
+# chain crashes on Gtk.IconSize.MENU (a GTK3-only enum).
+try:
+    import gi
 
-# Gramps is imported by the module under test.
-pytest.importorskip("gramps")
+    gi.require_version("Gtk", "3.0")
+    gi.require_version("Gdk", "3.0")
+except (ImportError, ValueError, AttributeError) as err:
+    raise unittest.SkipTest("GTK 3.0 / PyGObject not available: %s" % err)
 
-
-# ---------------------------------------------------------------------------
-# Make the addon importable and ensure GRAMPS_RESOURCES is set
-# ---------------------------------------------------------------------------
+# ------------------------
+# Gramps modules
+# ------------------------
+# Addon root goes on sys.path so ``from DataEntryGramplet import
+# DataEntryGramplet`` resolves the module-level class. The unittest
+# discovery entrypoint (tests/) lacks an __init__.py, so this
+# ``__file__``-based hack is still the right way to make the addon
+# importable during local and CI runs.
 ADDON_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if ADDON_DIR not in sys.path:
     sys.path.insert(0, ADDON_DIR)
 
-if "GRAMPS_RESOURCES" not in os.environ:
+try:
     import gramps
+except ImportError as err:
+    raise unittest.SkipTest("gramps package not available: %s" % err)
 
+if "GRAMPS_RESOURCES" not in os.environ:
     os.environ["GRAMPS_RESOURCES"] = os.path.dirname(
         os.path.dirname(gramps.__file__)
     )
 
-
 # ------------------------
-# Module under test
+# Gramps specific
 # ------------------------
-import gramps.gui.dialog as gramps_dialog  # noqa: E402
+# The addon module pulls in the full Gramps GUI stack at import time. On
+# environments where GTK is missing or version-mismatched the import
+# fails; skip the whole module cleanly in that case so collection does
+# not surface spurious errors.
+try:
+    import gramps.gui.dialog as gramps_dialog  # noqa: E402
+    from DataEntryGramplet import DataEntryGramplet  # noqa: E402
+except Exception as err:  # noqa: BLE001 — environment guard
+    raise unittest.SkipTest("DataEntryGramplet module unavailable: %s" % err)
 
-from DataEntryGramplet import DataEntryGramplet  # noqa: E402
 
-
-# ---------------------------------------------------------------------------
-# Lightweight stubs — enough surface for the guard paths under test
-# ---------------------------------------------------------------------------
+# ------------------------------------------------------------
+#
+# _FakeDbState
+#
+# ------------------------------------------------------------
 class _FakeDbState:
-    def __init__(self, is_open=True):
+    """Stub for ``Gramplet.dbstate`` — only ``is_open()`` is consulted
+    by the guards under test."""
+
+    def __init__(self, is_open: bool = True) -> None:
+        """
+        :param is_open: Value returned from ``is_open()``.
+        :type is_open: bool
+        """
         self._is_open = is_open
 
-    def is_open(self):
+    def is_open(self) -> bool:
+        """Return the configured open state."""
         return self._is_open
 
 
+# ------------------------------------------------------------
+#
+# _FakeEntry
+#
+# ------------------------------------------------------------
 class _FakeEntry:
-    def __init__(self, text=""):
+    """Stub for ``Gtk.Entry`` — exposes only ``get_text()``."""
+
+    def __init__(self, text: str = "") -> None:
+        """
+        :param text: Value returned from ``get_text()``.
+        :type text: str
+        """
         self._text = text
 
-    def get_text(self):
+    def get_text(self) -> str:
+        """Return the configured text."""
         return self._text
 
 
+# ------------------------------------------------------------
+#
+# _FakeCombo
+#
+# ------------------------------------------------------------
 class _FakeCombo:
-    def __init__(self, active=0):
+    """Stub for ``Gtk.ComboBox`` — exposes only ``get_active()``."""
+
+    def __init__(self, active: int = 0) -> None:
+        """
+        :param active: Value returned from ``get_active()``.
+        :type active: int
+        """
         self._active = active
 
-    def get_active(self):
+    def get_active(self) -> int:
+        """Return the configured active index."""
         return self._active
 
 
 def _make_gramplet(
     *,
-    db_open=True,
-    np_name="",
-    np_gender=2,  # UNKNOWN
-    np_relation=DataEntryGramplet.NO_REL,
-    dirty=False,
-):
-    """Return an instance skipping ``__init__`` so no GTK is required."""
+    db_open: bool = True,
+    np_name: str = "",
+    np_gender: int = 2,  # UNKNOWN
+    np_relation: int = DataEntryGramplet.NO_REL,
+    dirty: bool = False,
+) -> Any:
+    """
+    Build a ``DataEntryGramplet`` via ``__new__`` so its ``__init__``
+    (which pulls in GTK) does not run, then attach just enough state
+    for the isolated guards to execute.
+
+    :param db_open: Whether ``dbstate.is_open()`` reports an open tree.
+    :type db_open: bool
+    :param np_name: Value stored in the Name entry.
+    :type np_name: str
+    :param np_gender: Value stored in the Gender combo (UNKNOWN by default).
+    :type np_gender: int
+    :param np_relation: Value stored in the Relation combo.
+    :type np_relation: int
+    :param dirty: Value of the private ``_dirty`` flag.
+    :type dirty: bool
+    :returns: A stub instance with the minimum attributes set.
+    :rtype: DataEntryGramplet
+    """
     stub = DataEntryGramplet.__new__(DataEntryGramplet)
     stub.dbstate = _FakeDbState(db_open)
     stub._dirty = dirty
@@ -116,108 +190,136 @@ def _make_gramplet(
     return stub
 
 
-@pytest.fixture
-def captured_errors(monkeypatch):
-    """Replace gramps.gui.dialog.ErrorDialog so tests can inspect calls."""
-    shown: list[tuple[str, str]] = []
+# ------------------------------------------------------------
+#
+# _ErrorDialogTestCase
+#
+# ------------------------------------------------------------
+class _ErrorDialogTestCase(unittest.TestCase):
+    """Base class that patches ``gramps.gui.dialog.ErrorDialog`` so
+    tests can inspect calls without opening any GTK dialogs."""
 
-    def _fake(title, body="", *args, **kwargs):
-        shown.append((str(title), str(body)))
+    def setUp(self) -> None:
+        """Install the ErrorDialog capture and reset the buffer."""
+        self.captured_errors: list[tuple[str, str]] = []
 
-    monkeypatch.setattr(gramps_dialog, "ErrorDialog", _fake)
-    return shown
+        def _fake(title: Any, body: Any = "", *_args: Any, **_kwargs: Any) -> None:
+            self.captured_errors.append((str(title), str(body)))
 
-
-# ---------------------------------------------------------------------------
-# Bug 12691 — closed Family Tree must not crash
-# ---------------------------------------------------------------------------
-def test_add_data_entry_with_closed_db_shows_error(captured_errors):
-    """Pressing *Add* with no tree open surfaces an ErrorDialog, not a crash."""
-    stub = _make_gramplet(db_open=False, np_name="Doe, Jane")
-
-    stub.add_data_entry(None)
-
-    assert captured_errors, "ErrorDialog was not displayed"
-    title, body = captured_errors[0]
-    assert "Family Tree" in title
-    assert "open" in body.lower()
+        patcher = mock.patch.object(gramps_dialog, "ErrorDialog", _fake)
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
 
-def test_save_data_edit_with_closed_db_shows_error(captured_errors):
-    """Pressing *Save* while dirty with no tree open must not invoke DbTxn."""
-    stub = _make_gramplet(db_open=False, dirty=True)
+# ------------------------------------------------------------
+#
+# TestBug12691ClosedDb
+#
+# ------------------------------------------------------------
+class TestBug12691ClosedDb(_ErrorDialogTestCase):
+    """Regression coverage for bug 12691 — pressing *Add* or *Save*
+    with no tree open must surface an ErrorDialog instead of crashing
+    inside ``DbTxn`` with ``AttributeError: 'DummyDb' ... get_undodb``."""
 
-    stub.save_data_edit(None)
+    def test_add_data_entry_with_closed_db_shows_error(self) -> None:
+        """*Add* with no tree open surfaces an ErrorDialog, not a crash."""
+        stub = _make_gramplet(db_open=False, np_name="Doe, Jane")
 
-    assert captured_errors, "ErrorDialog was not displayed"
-    title, _body = captured_errors[0]
-    assert "Family Tree" in title
+        stub.add_data_entry(None)
 
+        self.assertTrue(self.captured_errors, "ErrorDialog was not displayed")
+        title, body = self.captured_errors[0]
+        self.assertIn("Family Tree", title)
+        self.assertIn("open", body.lower())
 
-def test_save_data_edit_noop_when_not_dirty(captured_errors):
-    """A *Save* click with nothing pending should be a silent no-op."""
-    stub = _make_gramplet(db_open=True, dirty=False)
+    def test_save_data_edit_with_closed_db_shows_error(self) -> None:
+        """*Save* while dirty with no tree open must not invoke DbTxn."""
+        stub = _make_gramplet(db_open=False, dirty=True)
 
-    stub.save_data_edit(None)
+        stub.save_data_edit(None)
 
-    assert captured_errors == []
-    assert stub._dirty is False
+        self.assertTrue(self.captured_errors, "ErrorDialog was not displayed")
+        title, _body = self.captured_errors[0]
+        self.assertIn("Family Tree", title)
 
+    def test_save_data_edit_noop_when_not_dirty(self) -> None:
+        """A *Save* click with nothing pending should be a silent no-op."""
+        stub = _make_gramplet(db_open=True, dirty=False)
 
-# ---------------------------------------------------------------------------
-# Pre-existing guards — lock them in against regressions
-# ---------------------------------------------------------------------------
-def test_add_data_entry_requires_name(captured_errors):
-    """Empty name with a valid tree should surface the name-required error."""
-    stub = _make_gramplet(db_open=True, np_name="")
+        stub.save_data_edit(None)
 
-    stub.add_data_entry(None)
-
-    assert captured_errors
-    title, _body = captured_errors[0]
-    assert "name" in title.lower()
-
-
-def test_add_data_entry_parent_without_active_person(captured_errors):
-    """Adding as a parent without an active person surfaces a clear error."""
-    stub = _make_gramplet(
-        db_open=True,
-        np_name="Doe, Jane",
-        np_relation=DataEntryGramplet.AS_PARENT,
-    )
-
-    stub.add_data_entry(None)
-
-    assert captured_errors
-    _title, body = captured_errors[0]
-    assert "parent" in body.lower()
+        self.assertEqual(self.captured_errors, [])
+        self.assertFalse(stub._dirty)
 
 
-# ---------------------------------------------------------------------------
-# Plugin registration — catch metadata breakage early
-# ---------------------------------------------------------------------------
-def test_gpr_registration_metadata():
-    """The .gpr.py file must register a single gramplet with expected keys."""
-    gpr_path = os.path.join(ADDON_DIR, "DataEntryGramplet.gpr.py")
-    calls: list[tuple[tuple, dict]] = []
+# ------------------------------------------------------------
+#
+# TestInputGuards
+#
+# ------------------------------------------------------------
+class TestInputGuards(_ErrorDialogTestCase):
+    """Lock in the pre-existing input validators so future refactors
+    cannot silently weaken the guardrails around ``add_data_entry``."""
 
-    namespace = {
-        "register": lambda *args, **kwargs: calls.append((args, kwargs)),
-        "GRAMPLET": "GRAMPLET",
-        "STABLE": "STABLE",
-        "EXPERT": "EXPERT",
-        "_": lambda s: s,
-    }
-    with open(gpr_path, encoding="utf-8") as handle:
-        exec(compile(handle.read(), gpr_path, "exec"), namespace)
+    def test_add_data_entry_requires_name(self) -> None:
+        """Empty name with a valid tree should surface the name-required error."""
+        stub = _make_gramplet(db_open=True, np_name="")
 
-    assert len(calls) == 1, "expected exactly one register() call"
-    args, kwargs = calls[0]
-    assert args == ("GRAMPLET",)
-    assert kwargs["id"] == "Data Entry Gramplet"
-    assert kwargs["gramplet"] == "DataEntryGramplet"
-    assert kwargs["fname"] == "DataEntryGramplet.py"
-    assert kwargs["gramps_target_version"] == "6.0"
-    assert kwargs["status"] == "STABLE"
-    # Navigation type must stay Person — the active object is fetched that way.
-    assert kwargs["navtypes"] == ["Person"]
+        stub.add_data_entry(None)
+
+        self.assertTrue(self.captured_errors)
+        title, _body = self.captured_errors[0]
+        self.assertIn("name", title.lower())
+
+    def test_add_data_entry_parent_without_active_person(self) -> None:
+        """Adding as a parent without an active person surfaces a clear error."""
+        stub = _make_gramplet(
+            db_open=True,
+            np_name="Doe, Jane",
+            np_relation=DataEntryGramplet.AS_PARENT,
+        )
+
+        stub.add_data_entry(None)
+
+        self.assertTrue(self.captured_errors)
+        _title, body = self.captured_errors[0]
+        self.assertIn("parent", body.lower())
+
+
+# ------------------------------------------------------------
+#
+# TestGprRegistration
+#
+# ------------------------------------------------------------
+class TestGprRegistration(unittest.TestCase):
+    """Catch metadata breakage in the plugin registration file early."""
+
+    def test_gpr_registration_metadata(self) -> None:
+        """The .gpr.py file must register a single gramplet with expected keys."""
+        gpr_path = os.path.join(ADDON_DIR, "DataEntryGramplet.gpr.py")
+        calls: list[tuple[tuple, dict]] = []
+
+        namespace: dict[str, Any] = {
+            "register": lambda *args, **kwargs: calls.append((args, kwargs)),
+            "GRAMPLET": "GRAMPLET",
+            "STABLE": "STABLE",
+            "EXPERT": "EXPERT",
+            "_": lambda s: s,
+        }
+        with open(gpr_path, encoding="utf-8") as handle:
+            exec(compile(handle.read(), gpr_path, "exec"), namespace)
+
+        self.assertEqual(len(calls), 1, "expected exactly one register() call")
+        args, kwargs = calls[0]
+        self.assertEqual(args, ("GRAMPLET",))
+        self.assertEqual(kwargs["id"], "Data Entry Gramplet")
+        self.assertEqual(kwargs["gramplet"], "DataEntryGramplet")
+        self.assertEqual(kwargs["fname"], "DataEntryGramplet.py")
+        self.assertEqual(kwargs["gramps_target_version"], "6.0")
+        self.assertEqual(kwargs["status"], "STABLE")
+        # Navigation type must stay Person — the active object is fetched that way.
+        self.assertEqual(kwargs["navtypes"], ["Person"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/DataEntryGramplet/tests/test_data_entry_gramplet.py
+++ b/DataEntryGramplet/tests/test_data_entry_gramplet.py
@@ -1,0 +1,223 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Eduard Ralph
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Tests for the Data Entry Gramplet — covers
+``gramps-project/gramps#12691`` (``AttributeError: 'DummyDb' object
+has no attribute 'get_undodb'`` when the user presses *Add* or *Save*
+without a Family Tree loaded).
+
+The Gramplet subclass requires a live Gramps GUI to instantiate, so
+these tests build a minimal stub via ``__new__`` and invoke the
+mutating callbacks directly. That keeps the tests fast and avoids
+spinning up GTK, while still exercising the real guard code paths.
+"""
+
+# ------------------------
+# Python modules
+# ------------------------
+import os
+import sys
+
+import pytest
+
+# Gramps is imported by the module under test.
+pytest.importorskip("gramps")
+
+
+# ---------------------------------------------------------------------------
+# Make the addon importable and ensure GRAMPS_RESOURCES is set
+# ---------------------------------------------------------------------------
+ADDON_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ADDON_DIR not in sys.path:
+    sys.path.insert(0, ADDON_DIR)
+
+if "GRAMPS_RESOURCES" not in os.environ:
+    import gramps
+
+    os.environ["GRAMPS_RESOURCES"] = os.path.dirname(
+        os.path.dirname(gramps.__file__)
+    )
+
+
+# ------------------------
+# Module under test
+# ------------------------
+import gramps.gui.dialog as gramps_dialog  # noqa: E402
+
+from DataEntryGramplet import DataEntryGramplet  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Lightweight stubs — enough surface for the guard paths under test
+# ---------------------------------------------------------------------------
+class _FakeDbState:
+    def __init__(self, is_open=True):
+        self._is_open = is_open
+
+    def is_open(self):
+        return self._is_open
+
+
+class _FakeEntry:
+    def __init__(self, text=""):
+        self._text = text
+
+    def get_text(self):
+        return self._text
+
+
+class _FakeCombo:
+    def __init__(self, active=0):
+        self._active = active
+
+    def get_active(self):
+        return self._active
+
+
+def _make_gramplet(
+    *,
+    db_open=True,
+    np_name="",
+    np_gender=2,  # UNKNOWN
+    np_relation=DataEntryGramplet.NO_REL,
+    dirty=False,
+):
+    """Return an instance skipping ``__init__`` so no GTK is required."""
+    stub = DataEntryGramplet.__new__(DataEntryGramplet)
+    stub.dbstate = _FakeDbState(db_open)
+    stub._dirty = dirty
+    stub._dirty_person = None
+    stub.de_widgets = {
+        "NPName": _FakeEntry(np_name),
+        "NPGender": _FakeCombo(np_gender),
+        "NPRelation": _FakeCombo(np_relation),
+    }
+    # save_data_edit falls through to self.update() even on the guarded path.
+    stub.update = lambda: None
+    stub.get_active_object = lambda _type: None
+    return stub
+
+
+@pytest.fixture
+def captured_errors(monkeypatch):
+    """Replace gramps.gui.dialog.ErrorDialog so tests can inspect calls."""
+    shown: list[tuple[str, str]] = []
+
+    def _fake(title, body="", *args, **kwargs):
+        shown.append((str(title), str(body)))
+
+    monkeypatch.setattr(gramps_dialog, "ErrorDialog", _fake)
+    return shown
+
+
+# ---------------------------------------------------------------------------
+# Bug 12691 — closed Family Tree must not crash
+# ---------------------------------------------------------------------------
+def test_add_data_entry_with_closed_db_shows_error(captured_errors):
+    """Pressing *Add* with no tree open surfaces an ErrorDialog, not a crash."""
+    stub = _make_gramplet(db_open=False, np_name="Doe, Jane")
+
+    stub.add_data_entry(None)
+
+    assert captured_errors, "ErrorDialog was not displayed"
+    title, body = captured_errors[0]
+    assert "Family Tree" in title
+    assert "open" in body.lower()
+
+
+def test_save_data_edit_with_closed_db_shows_error(captured_errors):
+    """Pressing *Save* while dirty with no tree open must not invoke DbTxn."""
+    stub = _make_gramplet(db_open=False, dirty=True)
+
+    stub.save_data_edit(None)
+
+    assert captured_errors, "ErrorDialog was not displayed"
+    title, _body = captured_errors[0]
+    assert "Family Tree" in title
+
+
+def test_save_data_edit_noop_when_not_dirty(captured_errors):
+    """A *Save* click with nothing pending should be a silent no-op."""
+    stub = _make_gramplet(db_open=True, dirty=False)
+
+    stub.save_data_edit(None)
+
+    assert captured_errors == []
+    assert stub._dirty is False
+
+
+# ---------------------------------------------------------------------------
+# Pre-existing guards — lock them in against regressions
+# ---------------------------------------------------------------------------
+def test_add_data_entry_requires_name(captured_errors):
+    """Empty name with a valid tree should surface the name-required error."""
+    stub = _make_gramplet(db_open=True, np_name="")
+
+    stub.add_data_entry(None)
+
+    assert captured_errors
+    title, _body = captured_errors[0]
+    assert "name" in title.lower()
+
+
+def test_add_data_entry_parent_without_active_person(captured_errors):
+    """Adding as a parent without an active person surfaces a clear error."""
+    stub = _make_gramplet(
+        db_open=True,
+        np_name="Doe, Jane",
+        np_relation=DataEntryGramplet.AS_PARENT,
+    )
+
+    stub.add_data_entry(None)
+
+    assert captured_errors
+    _title, body = captured_errors[0]
+    assert "parent" in body.lower()
+
+
+# ---------------------------------------------------------------------------
+# Plugin registration — catch metadata breakage early
+# ---------------------------------------------------------------------------
+def test_gpr_registration_metadata():
+    """The .gpr.py file must register a single gramplet with expected keys."""
+    gpr_path = os.path.join(ADDON_DIR, "DataEntryGramplet.gpr.py")
+    calls: list[tuple[tuple, dict]] = []
+
+    namespace = {
+        "register": lambda *args, **kwargs: calls.append((args, kwargs)),
+        "GRAMPLET": "GRAMPLET",
+        "STABLE": "STABLE",
+        "EXPERT": "EXPERT",
+        "_": lambda s: s,
+    }
+    with open(gpr_path, encoding="utf-8") as handle:
+        exec(compile(handle.read(), gpr_path, "exec"), namespace)
+
+    assert len(calls) == 1, "expected exactly one register() call"
+    args, kwargs = calls[0]
+    assert args == ("GRAMPLET",)
+    assert kwargs["id"] == "Data Entry Gramplet"
+    assert kwargs["gramplet"] == "DataEntryGramplet"
+    assert kwargs["fname"] == "DataEntryGramplet.py"
+    assert kwargs["gramps_target_version"] == "6.0"
+    assert kwargs["status"] == "STABLE"
+    # Navigation type must stay Person — the active object is fetched that way.
+    assert kwargs["navtypes"] == ["Person"]

--- a/DataEntryGramplet/tests/test_data_entry_gramplet.py
+++ b/DataEntryGramplet/tests/test_data_entry_gramplet.py
@@ -55,11 +55,15 @@ except (ImportError, ValueError, AttributeError) as err:
 # ------------------------
 # Gramps modules
 # ------------------------
-# Addon root goes on sys.path so ``from DataEntryGramplet import
-# DataEntryGramplet`` resolves the module-level class. The unittest
-# discovery entrypoint (tests/) lacks an __init__.py, so this
-# ``__file__``-based hack is still the right way to make the addon
-# importable during local and CI runs.
+# Addon root goes on sys.path so ``from DataEntryGramplet.DataEntryGramplet
+# import DataEntryGramplet`` resolves the class inside the addon module.
+# The fully-qualified form matters: when unittest loads this file as
+# ``DataEntryGramplet.tests.test_...``, the outer ``DataEntryGramplet``
+# is already a namespace package in ``sys.modules``, so a bare
+# ``from DataEntryGramplet import DataEntryGramplet`` would bind the
+# submodule instead of the class. The ``tests/`` directory lacks an
+# __init__.py, so this ``__file__``-based hack is still the right way
+# to make the addon importable during local and CI runs.
 ADDON_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 if ADDON_DIR not in sys.path:
     sys.path.insert(0, ADDON_DIR)
@@ -83,7 +87,7 @@ if "GRAMPS_RESOURCES" not in os.environ:
 # not surface spurious errors.
 try:
     import gramps.gui.dialog as gramps_dialog  # noqa: E402
-    from DataEntryGramplet import DataEntryGramplet  # noqa: E402
+    from DataEntryGramplet.DataEntryGramplet import DataEntryGramplet  # noqa: E402
 except Exception as err:  # noqa: BLE001 — environment guard
     raise unittest.SkipTest("DataEntryGramplet module unavailable: %s" % err)
 


### PR DESCRIPTION
## Summary
- Guard `add_data_entry` and `save_data_edit` on `dbstate.is_open()` so
  clicking *Add* / *Save* with no tree loaded surfaces an ErrorDialog
  instead of crashing with `AttributeError: 'DummyDb' object has no
  attribute 'get_undodb'` from `DbTxn`.
- Add unit tests covering the closed-db guards, pre-existing input
  guards, and `.gpr.py` registration metadata.
- Bump version to 1.0.53.

Fixes https://gramps-project.org/bugs/view.php?id=12691

## Test plan
- [x] `pytest DataEntryGramplet/tests/` — 6 pass, 0 fail
- [x] Tests fail on the unpatched module (verified by reverting fix)
- [ ] Manual: open Gramps with no tree, add Data Entry gramplet, click
      *Add* → confirm ErrorDialog instead of traceback

🤖 Generated with [Claude Code](https://claude.com/claude-code)