### PR TITLE
ImportMerge: fix AttributeError when adding/merging Tag objects (bug 0014056)

### DIFF
--- a/ImportMerge/importmerge.py
+++ b/ImportMerge/importmerge.py
@@ -803,8 +803,8 @@ class ImportMerge(tool.BatchTool, ManagedWindow):
                     continue
                 # now check the missing list for a match
                 changed += self.check_miss(r_objtype, r_hndl, item)
-            # check for GID conflict
-            if item.gramps_id != item1.gramps_id:
+            # check for GID conflict (Tag is a table object without gramps_id)
+            if obj_type != 'Tag' and item.gramps_id != item1.gramps_id:
                 if getattr(self.db1, 'has_' + obj_type.lower() +
                            '_gramps_id')(item.gramps_id):
                     item.gramps_id = getattr(self.db1, 'find_next_' +
@@ -823,9 +823,10 @@ class ImportMerge(tool.BatchTool, ManagedWindow):
                     continue
                 # now check the differences list for a match
                 self.check_diffs(r_objtype, r_hndl, obj_type, item)
-            # check for GID conflict
-            if getattr(self.db1, 'has_' + obj_type.lower() +
-                       '_gramps_id')(item.gramps_id):
+            # check for GID conflict (Tag is a table object without gramps_id)
+            if obj_type != 'Tag' and getattr(
+                    self.db1, 'has_' + obj_type.lower() +
+                    '_gramps_id')(item.gramps_id):
                 item.gramps_id = getattr(self.db1, 'find_next_' +
                                          obj_type.lower() +
                                          '_gramps_id')()

--- a/ImportMerge/tests/test_integration_importmerge.py
+++ b/ImportMerge/tests/test_integration_importmerge.py
@@ -38,10 +38,8 @@ Regression coverage:
 import os
 import shutil
 import tempfile
-import types
+import unittest
 from types import SimpleNamespace
-
-import pytest
 
 # The ImportMerge module imports Gtk at module load — skip the whole file if
 # gi/Gtk aren't available (headless-without-GTK environments). On systems
@@ -49,15 +47,14 @@ import pytest
 # import (mirrors what gramps.grampsapp does at startup); otherwise
 # PyGObject loads GTK4 and the gramps.gui import chain crashes on
 # Gtk.IconSize.MENU (a GTK3-only enum).
-pytest.importorskip("gi")
-import gi  # noqa: E402
-
 try:
+    import gi
+
     gi.require_version("Gtk", "3.0")
     gi.require_version("Gdk", "3.0")
-except (ValueError, AttributeError):
-    pytest.skip(
-        "GTK 3.0 typelib not available", allow_module_level=True
+except (ImportError, ValueError, AttributeError) as err:
+    raise unittest.SkipTest(
+        "GTK 3.0 / PyGObject not available: %s" % err
     )
 
 # ------------------------
@@ -75,47 +72,12 @@ from ImportMerge.importmerge import ImportMerge, S_ADD, S_DIFFERS, A_ADD
 
 def _make_db(suffix):
     """Create a fresh on-disk Gramps SQLite DB inside a temp directory."""
-    tmpdir = tempfile.mkdtemp(prefix=f"gramps_test_{suffix}_")
-    db_path = os.path.join(tmpdir, f"db_{suffix}")
+    tmpdir = tempfile.mkdtemp(prefix="gramps_test_%s_" % suffix)
+    db_path = os.path.join(tmpdir, "db_%s" % suffix)
     os.makedirs(db_path)
     db = make_database("sqlite")
     db.load(db_path, None)
     return db, tmpdir
-
-
-@pytest.fixture
-def db1():
-    """Destination Gramps DB (the one being merged into)."""
-    db, tmpdir = _make_db("db1")
-    yield db
-    try:
-        db.close()
-    except Exception:
-        pass
-    shutil.rmtree(tmpdir, ignore_errors=True)
-
-
-@pytest.fixture
-def db2():
-    """Source Gramps DB (simulates the XML being imported)."""
-    db, tmpdir = _make_db("db2")
-    yield db
-    try:
-        db.close()
-    except Exception:
-        pass
-    shutil.rmtree(tmpdir, ignore_errors=True)
-
-
-def _make_stub(db1, db2):
-    """Stub ``self`` for ``ImportMerge.do_commits`` — no GUI attributes."""
-    return SimpleNamespace(
-        db1=db1,
-        db2=db2,
-        added={},
-        missing={},
-        diffs={},
-    )
 
 
 def _add_tag(db, name):
@@ -127,60 +89,87 @@ def _add_tag(db, name):
     return handle
 
 
-def test_add_tag_does_not_crash(db1, db2):
-    """Regression for bug 0014056 — adding a Tag via do_commits must succeed.
+class ImportMergeTagTestCase(unittest.TestCase):
+    """Regression tests for bug 0014056 (Tag handling in do_commits)."""
 
-    Before the fix, this raised ``AttributeError: 'SQLite' object has no
-    attribute 'has_tag_gramps_id'`` because the generic GID-conflict check
-    didn't special-case Tag (a table object without a gramps_id field).
-    """
-    tag_handle = _add_tag(db2, "Imported")
-    stub = _make_stub(db1, db2)
+    def setUp(self):
+        self.db1, self.tmp1 = _make_db("db1")
+        self.db2, self.tmp2 = _make_db("db2")
 
-    with DbTxn("import merge", db1, batch=True) as trans:
-        ImportMerge.do_commits(stub, S_ADD, "Tag", tag_handle, A_ADD, trans)
+    def tearDown(self):
+        for db in (self.db1, self.db2):
+            try:
+                db.close()
+            except Exception:
+                pass
+        shutil.rmtree(self.tmp1, ignore_errors=True)
+        shutil.rmtree(self.tmp2, ignore_errors=True)
 
-    # Tag should now exist in the destination DB.
-    assert db1.get_number_of_tags() == 1
-    committed = db1.get_tag_from_handle(tag_handle)
-    assert committed is not None
-    assert committed.get_name() == "Imported"
-
-
-def test_differing_tag_does_not_crash(db1, db2):
-    """S_DIFFERS branch must also skip the gramps_id check for Tag.
-
-    Same root cause as the S_ADD path: the GID-conflict block at the end of
-    the S_DIFFERS branch dereferences ``item.gramps_id`` and calls
-    ``has_tag_gramps_id`` — both fail for Tag objects.
-    """
-    tag_handle = _add_tag(db1, "Original")
-    # Same handle in db2 with a different name — simulates S_DIFFERS.
-    tag2 = Tag()
-    tag2.set_handle(tag_handle)
-    tag2.set_name("Modified")
-    with DbTxn("seed db2", db2, batch=True) as trans:
-        db2.add_tag(tag2, trans)
-
-    stub = _make_stub(db1, db2)
-
-    # diff_result is invoked by do_commits on the S_DIFFERS path; stub it to
-    # return the db2 version as the resolved item (action = A_ADD ⇒ "replace").
-    def fake_diff_result(action, obj_type, hndl):
-        item1 = db1.get_tag_from_handle(hndl)
-        item2 = db2.get_tag_from_handle(hndl)
-        return item1, item2, item2
-
-    stub.diff_result = fake_diff_result
-    stub.check_diffs = lambda *a, **kw: False
-    stub.check_added = lambda *a, **kw: False
-    stub.check_miss = lambda *a, **kw: False
-
-    with DbTxn("import merge", db1, batch=True) as trans:
-        ImportMerge.do_commits(
-            stub, S_DIFFERS, "Tag", tag_handle, A_ADD, trans
+    def _make_stub(self):
+        """Stub ``self`` for ``ImportMerge.do_commits`` — no GUI attributes."""
+        return SimpleNamespace(
+            db1=self.db1,
+            db2=self.db2,
+            added={},
+            missing={},
+            diffs={},
         )
 
-    committed = db1.get_tag_from_handle(tag_handle)
-    assert committed is not None
-    assert committed.get_name() == "Modified"
+    def test_add_tag_does_not_crash(self):
+        """Regression for bug 0014056 — adding a Tag via do_commits must succeed.
+
+        Before the fix, this raised ``AttributeError: 'SQLite' object has no
+        attribute 'has_tag_gramps_id'`` because the generic GID-conflict check
+        didn't special-case Tag (a table object without a gramps_id field).
+        """
+        tag_handle = _add_tag(self.db2, "Imported")
+        stub = self._make_stub()
+
+        with DbTxn("import merge", self.db1, batch=True) as trans:
+            ImportMerge.do_commits(
+                stub, S_ADD, "Tag", tag_handle, A_ADD, trans
+            )
+
+        self.assertEqual(self.db1.get_number_of_tags(), 1)
+        committed = self.db1.get_tag_from_handle(tag_handle)
+        self.assertIsNotNone(committed)
+        self.assertEqual(committed.get_name(), "Imported")
+
+    def test_differing_tag_does_not_crash(self):
+        """S_DIFFERS branch must also skip the gramps_id check for Tag.
+
+        Same root cause as the S_ADD path: the GID-conflict block at the end
+        of the S_DIFFERS branch dereferences ``item.gramps_id`` and calls
+        ``has_tag_gramps_id`` — both fail for Tag objects.
+        """
+        tag_handle = _add_tag(self.db1, "Original")
+        tag2 = Tag()
+        tag2.set_handle(tag_handle)
+        tag2.set_name("Modified")
+        with DbTxn("seed db2", self.db2, batch=True) as trans:
+            self.db2.add_tag(tag2, trans)
+
+        stub = self._make_stub()
+
+        def fake_diff_result(action, obj_type, hndl):
+            item1 = self.db1.get_tag_from_handle(hndl)
+            item2 = self.db2.get_tag_from_handle(hndl)
+            return item1, item2, item2
+
+        stub.diff_result = fake_diff_result
+        stub.check_diffs = lambda *a, **kw: False
+        stub.check_added = lambda *a, **kw: False
+        stub.check_miss = lambda *a, **kw: False
+
+        with DbTxn("import merge", self.db1, batch=True) as trans:
+            ImportMerge.do_commits(
+                stub, S_DIFFERS, "Tag", tag_handle, A_ADD, trans
+            )
+
+        committed = self.db1.get_tag_from_handle(tag_handle)
+        self.assertIsNotNone(committed)
+        self.assertEqual(committed.get_name(), "Modified")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ImportMerge/tests/test_integration_importmerge.py
+++ b/ImportMerge/tests/test_integration_importmerge.py
@@ -1,0 +1,173 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Eduard Ralph
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Integration tests for the Import and Merge tool.
+
+These tests exercise ``ImportMerge.do_commits`` against a real Gramps SQLite
+database.  We call the method unbound with a stub ``self`` so the GUI
+(ManagedWindow + Gtk dialog) doesn't need to be instantiated — the data-path
+logic is what we're verifying.
+
+Regression coverage:
+
+* Gramps bug 0014056 — Adding a Tag via the Import Merge tool raised
+  ``AttributeError: 'SQLite' object has no attribute 'has_tag_gramps_id'``
+  because Tag is a table object and has no gramps_id.
+"""
+
+# ------------------------
+# Python modules
+# ------------------------
+import os
+import shutil
+import tempfile
+import types
+from types import SimpleNamespace
+
+import pytest
+
+# The ImportMerge module imports Gtk at module load — skip the whole file if
+# gi/Gtk aren't available (headless-without-GTK environments).
+pytest.importorskip("gi")
+
+# ------------------------
+# Gramps modules
+# ------------------------
+from gramps.gen.db import DbTxn
+from gramps.gen.db.utils import make_database
+from gramps.gen.lib import Tag
+
+# ------------------------
+# Gramps specific
+# ------------------------
+from ImportMerge.importmerge import ImportMerge, S_ADD, S_DIFFERS, A_ADD
+
+
+def _make_db(suffix):
+    """Create a fresh on-disk Gramps SQLite DB inside a temp directory."""
+    tmpdir = tempfile.mkdtemp(prefix=f"gramps_test_{suffix}_")
+    db_path = os.path.join(tmpdir, f"db_{suffix}")
+    os.makedirs(db_path)
+    db = make_database("sqlite")
+    db.load(db_path, None)
+    return db, tmpdir
+
+
+@pytest.fixture
+def db1():
+    """Destination Gramps DB (the one being merged into)."""
+    db, tmpdir = _make_db("db1")
+    yield db
+    try:
+        db.close()
+    except Exception:
+        pass
+    shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+@pytest.fixture
+def db2():
+    """Source Gramps DB (simulates the XML being imported)."""
+    db, tmpdir = _make_db("db2")
+    yield db
+    try:
+        db.close()
+    except Exception:
+        pass
+    shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def _make_stub(db1, db2):
+    """Stub ``self`` for ``ImportMerge.do_commits`` — no GUI attributes."""
+    return SimpleNamespace(
+        db1=db1,
+        db2=db2,
+        added={},
+        missing={},
+        diffs={},
+    )
+
+
+def _add_tag(db, name):
+    """Add a Tag to ``db`` and return its handle."""
+    tag = Tag()
+    tag.set_name(name)
+    with DbTxn("add tag", db, batch=True) as trans:
+        handle = db.add_tag(tag, trans)
+    return handle
+
+
+def test_add_tag_does_not_crash(db1, db2):
+    """Regression for bug 0014056 — adding a Tag via do_commits must succeed.
+
+    Before the fix, this raised ``AttributeError: 'SQLite' object has no
+    attribute 'has_tag_gramps_id'`` because the generic GID-conflict check
+    didn't special-case Tag (a table object without a gramps_id field).
+    """
+    tag_handle = _add_tag(db2, "Imported")
+    stub = _make_stub(db1, db2)
+
+    with DbTxn("import merge", db1, batch=True) as trans:
+        ImportMerge.do_commits(stub, S_ADD, "Tag", tag_handle, A_ADD, trans)
+
+    # Tag should now exist in the destination DB.
+    assert db1.get_number_of_tags() == 1
+    committed = db1.get_tag_from_handle(tag_handle)
+    assert committed is not None
+    assert committed.get_name() == "Imported"
+
+
+def test_differing_tag_does_not_crash(db1, db2):
+    """S_DIFFERS branch must also skip the gramps_id check for Tag.
+
+    Same root cause as the S_ADD path: the GID-conflict block at the end of
+    the S_DIFFERS branch dereferences ``item.gramps_id`` and calls
+    ``has_tag_gramps_id`` — both fail for Tag objects.
+    """
+    tag_handle = _add_tag(db1, "Original")
+    # Same handle in db2 with a different name — simulates S_DIFFERS.
+    tag2 = Tag()
+    tag2.set_handle(tag_handle)
+    tag2.set_name("Modified")
+    with DbTxn("seed db2", db2, batch=True) as trans:
+        db2.add_tag(tag2, trans)
+
+    stub = _make_stub(db1, db2)
+
+    # diff_result is invoked by do_commits on the S_DIFFERS path; stub it to
+    # return the db2 version as the resolved item (action = A_ADD ⇒ "replace").
+    def fake_diff_result(action, obj_type, hndl):
+        item1 = db1.get_tag_from_handle(hndl)
+        item2 = db2.get_tag_from_handle(hndl)
+        return item1, item2, item2
+
+    stub.diff_result = fake_diff_result
+    stub.check_diffs = lambda *a, **kw: False
+    stub.check_added = lambda *a, **kw: False
+    stub.check_miss = lambda *a, **kw: False
+
+    with DbTxn("import merge", db1, batch=True) as trans:
+        ImportMerge.do_commits(
+            stub, S_DIFFERS, "Tag", tag_handle, A_ADD, trans
+        )
+
+    committed = db1.get_tag_from_handle(tag_handle)
+    assert committed is not None
+    assert committed.get_name() == "Modified"

--- a/ImportMerge/tests/test_integration_importmerge.py
+++ b/ImportMerge/tests/test_integration_importmerge.py
@@ -44,8 +44,21 @@ from types import SimpleNamespace
 import pytest
 
 # The ImportMerge module imports Gtk at module load — skip the whole file if
-# gi/Gtk aren't available (headless-without-GTK environments).
+# gi/Gtk aren't available (headless-without-GTK environments). On systems
+# where both GTK3 and GTK4 are present, pin Gtk to 3.0 before any gramps
+# import (mirrors what gramps.grampsapp does at startup); otherwise
+# PyGObject loads GTK4 and the gramps.gui import chain crashes on
+# Gtk.IconSize.MENU (a GTK3-only enum).
 pytest.importorskip("gi")
+import gi  # noqa: E402
+
+try:
+    gi.require_version("Gtk", "3.0")
+    gi.require_version("Gdk", "3.0")
+except (ValueError, AttributeError):
+    pytest.skip(
+        "GTK 3.0 typelib not available", allow_module_level=True
+    )
 
 # ------------------------
 # Gramps modules

--- a/ImportMerge/tests/test_integration_importmerge.py
+++ b/ImportMerge/tests/test_integration_importmerge.py
@@ -59,6 +59,7 @@ except (ImportError, ValueError, AttributeError) as err:
 # Gramps modules
 # ------------------------
 from gramps.gen.db import DbTxn
+from gramps.gen.db.base import DbReadBase
 from gramps.gen.db.utils import make_database
 from gramps.gen.lib import Tag
 
@@ -68,8 +69,13 @@ from gramps.gen.lib import Tag
 from ImportMerge.importmerge import ImportMerge, S_ADD, S_DIFFERS, A_ADD
 
 
-def _make_db(suffix):
-    """Create a fresh on-disk Gramps SQLite DB inside a temp directory."""
+def _make_db(suffix: str) -> tuple[DbReadBase, str]:
+    """Create a fresh on-disk Gramps SQLite DB inside a temp directory.
+
+    :param suffix: Short label used in the temp-directory prefix.
+    :returns: A ``(db, tmpdir)`` tuple — the caller owns ``tmpdir`` and must
+        remove it.
+    """
     tmpdir = tempfile.mkdtemp(prefix="gramps_test_%s_" % suffix)
     db_path = os.path.join(tmpdir, "db_%s" % suffix)
     os.makedirs(db_path)
@@ -78,8 +84,13 @@ def _make_db(suffix):
     return db, tmpdir
 
 
-def _add_tag(db, name):
-    """Add a Tag to ``db`` and return its handle."""
+def _add_tag(db: DbReadBase, name: str) -> str:
+    """Add a Tag to ``db`` and return its handle.
+
+    :param db: The database to add the tag to.
+    :param name: The tag name.
+    :returns: The handle of the newly-created tag.
+    """
     tag = Tag()
     tag.set_name(name)
     with DbTxn("add tag", db, batch=True) as trans:
@@ -87,14 +98,19 @@ def _add_tag(db, name):
     return handle
 
 
+# ------------------------------------------------------------
+#
+# ImportMergeTagTestCase
+#
+# ------------------------------------------------------------
 class ImportMergeTagTestCase(unittest.TestCase):
     """Regression tests for bug 0014056 (Tag handling in do_commits)."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.db1, self.tmp1 = _make_db("db1")
         self.db2, self.tmp2 = _make_db("db2")
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         for db in (self.db1, self.db2):
             try:
                 db.close()
@@ -103,7 +119,7 @@ class ImportMergeTagTestCase(unittest.TestCase):
         shutil.rmtree(self.tmp1, ignore_errors=True)
         shutil.rmtree(self.tmp2, ignore_errors=True)
 
-    def _make_stub(self):
+    def _make_stub(self) -> SimpleNamespace:
         """Stub ``self`` for ``ImportMerge.do_commits`` — no GUI attributes."""
         return SimpleNamespace(
             db1=self.db1,
@@ -113,7 +129,7 @@ class ImportMergeTagTestCase(unittest.TestCase):
             diffs={},
         )
 
-    def test_add_tag_does_not_crash(self):
+    def test_add_tag_does_not_crash(self) -> None:
         """Regression for bug 0014056 — adding a Tag via do_commits must succeed.
 
         Before the fix, this raised ``AttributeError: 'SQLite' object has no
@@ -131,7 +147,7 @@ class ImportMergeTagTestCase(unittest.TestCase):
         self.assertIsNotNone(committed)
         self.assertEqual(committed.get_name(), "Imported")
 
-    def test_differing_tag_does_not_crash(self):
+    def test_differing_tag_does_not_crash(self) -> None:
         """S_DIFFERS branch must also skip the gramps_id check for Tag.
 
         Same root cause as the S_ADD path: the GID-conflict block at the end
@@ -147,7 +163,9 @@ class ImportMergeTagTestCase(unittest.TestCase):
 
         stub = self._make_stub()
 
-        def fake_diff_result(action, obj_type, hndl):
+        def fake_diff_result(
+            action: int, obj_type: str, hndl: str
+        ) -> tuple[Tag | None, Tag | None, Tag | None]:
             item1 = self.db1.get_tag_from_handle(hndl)
             item2 = self.db2.get_tag_from_handle(hndl)
             return item1, item2, item2

--- a/ImportMerge/tests/test_integration_importmerge.py
+++ b/ImportMerge/tests/test_integration_importmerge.py
@@ -53,9 +53,7 @@ try:
     gi.require_version("Gtk", "3.0")
     gi.require_version("Gdk", "3.0")
 except (ImportError, ValueError, AttributeError) as err:
-    raise unittest.SkipTest(
-        "GTK 3.0 / PyGObject not available: %s" % err
-    )
+    raise unittest.SkipTest("GTK 3.0 / PyGObject not available: %s" % err)
 
 # ------------------------
 # Gramps modules
@@ -126,9 +124,7 @@ class ImportMergeTagTestCase(unittest.TestCase):
         stub = self._make_stub()
 
         with DbTxn("import merge", self.db1, batch=True) as trans:
-            ImportMerge.do_commits(
-                stub, S_ADD, "Tag", tag_handle, A_ADD, trans
-            )
+            ImportMerge.do_commits(stub, S_ADD, "Tag", tag_handle, A_ADD, trans)
 
         self.assertEqual(self.db1.get_number_of_tags(), 1)
         committed = self.db1.get_tag_from_handle(tag_handle)
@@ -162,9 +158,7 @@ class ImportMergeTagTestCase(unittest.TestCase):
         stub.check_miss = lambda *a, **kw: False
 
         with DbTxn("import merge", self.db1, batch=True) as trans:
-            ImportMerge.do_commits(
-                stub, S_DIFFERS, "Tag", tag_handle, A_ADD, trans
-            )
+            ImportMerge.do_commits(stub, S_DIFFERS, "Tag", tag_handle, A_ADD, trans)
 
         committed = self.db1.get_tag_from_handle(tag_handle)
         self.assertIsNotNone(committed)


### PR DESCRIPTION
## Summary
Fixes [bug 0014056](https://gramps-project.org/bugs/view.php?id=14056) — *Import and Merge tool* crashes with `AttributeError: 'SQLite' object has no attribute 'has_tag_gramps_id'` when the user selects *Add* (or hits a GID conflict) on a `Tag` row.

`Tag` is a table object and, unlike primary objects, does not have a `gramps_id` field — there is no `has_tag_gramps_id` / `find_next_tag_gramps_id` on the database. The generic `getattr(self.db1, 'has_' + obj_type.lower() + '_gramps_id')` lookup in `do_commits` therefore raised before the commit could complete.

## Changes
- Guard both GID-conflict branches in [`ImportMerge/importmerge.py`](https://github.com/gramps-project/addons-source/blob/maintenance/gramps60/ImportMerge/importmerge.py) (`S_ADD` and `S_DIFFERS`) so they skip `Tag`.
- Bump `version` in `importmerge.gpr.py` (`0.0.25` → `0.0.26`).
- Add an integration test exercising both branches via the real Gramps SQLite backend; the test fails without the guard and passes with it.

Confirmed by upstream maintainers (Nick_H, dstraub) in the bug thread: tags are table objects without a Gramps ID, so the generic lookup is invalid for them.

## Test plan
- [x] `python3 -m pytest ImportMerge/tests/test_integration_importmerge.py -v` passes
- [x] Reverting the guard makes the new tests fail with the original `AttributeError`
- [ ] Manual verification with the steps from the bug report (Gramps Sample tree, sort by Object descending, *Add* a Tag row, *Done*, *Save*) — completes without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)