### PR TITLE
Allow newer versions of GExiv2.

### DIFF
--- a/EditExifMetadata/editexifmetadata.py
+++ b/EditExifMetadata/editexifmetadata.py
@@ -41,7 +41,11 @@ getcontext().prec = 6
 # -----------------------------------------------------------------------------
 from gi.repository import Gtk, GdkPixbuf
 import gi
-gi.require_version('GExiv2', '0.10')
+repository = gi.Repository.get_default()
+v_array = repository.enumerate_versions("GExiv2")
+    if not v_array:
+        raise ValueError("GExiv2 is not installed")
+    gi.require_version("GExiv2", v_array[-1])
 from gi.repository import GExiv2
 # -----------------------------------------------------------------------------
 # GRAMPS modules

--- a/PrerequisitesCheckerGramplet/PrerequisitesCheckerGramplet.py
+++ b/PrerequisitesCheckerGramplet/PrerequisitesCheckerGramplet.py
@@ -1286,8 +1286,9 @@ class PrerequisitesCheckerGramplet(Gramplet):
             import gi
 
             repository = gi.Repository.get_default()
-            if repository.enumerate_versions("GExiv2"):
-                gi.require_version("GExiv2", "0.10")
+            v_array = repository.enumerate_versions("GExiv2")
+            if v_array:
+                gi.require_version("GExiv2", v_array[-1])
                 from gi.repository import GExiv2
 
                 try:
@@ -1299,8 +1300,8 @@ class PrerequisitesCheckerGramplet(Gramplet):
 
         except ImportError:
             gexiv2_str = _("not found")
-        except ValueError:
-            gexiv2_str = "not new enough"
+        except ValueError as err:
+            gexiv2_str = f"Version error: {err}"
 
         try:
             vers_str = Popen(["exiv2", "-V"], stdout=PIPE).communicate(input=None)[0]


### PR DESCRIPTION
GExiv2's import is currently locked at version 0.10 from 2019. While I can't say that it's completely unavailable, it certainly isn't widely available anymore: The current release is 0.16.0 and most distributions (including UCRT64) [provide either that or 0.14.x.](https://repology.org/project/gexiv2/versions).

[Companion Gramps PR](https://github.com/gramps-project/gramps/pull/2271) 