### PR TITLE
Update unittests for 6.1

### DIFF
--- a/CalculateEstimatedDates/tests/test_calculate_estimated_dates.py
+++ b/CalculateEstimatedDates/tests/test_calculate_estimated_dates.py
@@ -250,7 +250,7 @@ class TestGprRegistration(unittest.TestCase):
         self.assertEqual(args, ("TOOL",))
         self.assertEqual(kwargs["id"], "calculateestimateddates")
         self.assertEqual(kwargs["fname"], "CalculateEstimatedDates.py")
-        self.assertEqual(kwargs["gramps_target_version"], "6.0")
+        self.assertEqual(kwargs["gramps_target_version"], "6.1")
         self.assertEqual(kwargs["status"], "STABLE")
         self.assertEqual(kwargs["toolclass"], "CalcToolManagedWindow")
         self.assertEqual(kwargs["optionclass"], "CalcEstDateOptions")

--- a/DataEntryGramplet/tests/test_data_entry_gramplet.py
+++ b/DataEntryGramplet/tests/test_data_entry_gramplet.py
@@ -319,7 +319,7 @@ class TestGprRegistration(unittest.TestCase):
         self.assertEqual(kwargs["id"], "Data Entry Gramplet")
         self.assertEqual(kwargs["gramplet"], "DataEntryGramplet")
         self.assertEqual(kwargs["fname"], "DataEntryGramplet.py")
-        self.assertEqual(kwargs["gramps_target_version"], "6.0")
+        self.assertEqual(kwargs["gramps_target_version"], "6.1")
         self.assertEqual(kwargs["status"], "STABLE")
         # Navigation type must stay Person — the active object is fetched that way.
         self.assertEqual(kwargs["navtypes"], ["Person"])

--- a/Sqlite/tests/test_sqlite.py
+++ b/Sqlite/tests/test_sqlite.py
@@ -1,3 +1,17 @@
+# The Sqlite module imports Gtk at module load — skip the whole file if
+# gi/Gtk aren't available (headless-without-GTK environments). On systems
+# where both GTK3 and GTK4 are present, pin Gtk to 3.0 before any gramps
+# import (mirrors what gramps.grampsapp does at startup); otherwise
+# PyGObject loads GTK4 and the gramps.gui import chain crashes on
+# Gtk.IconSize.MENU (a GTK3-only enum).
+try:
+    import gi
+
+    gi.require_version("Gtk", "3.0")
+    gi.require_version("Gdk", "3.0")
+except (ImportError, ValueError, AttributeError) as err:
+    raise unittest.SkipTest("GTK 3.0 / PyGObject not available: %s" % err)
+
 from gramps.gen.db.utils import make_database
 from gramps.plugins.importer.importxml import importData as importXML
 from gramps.cli.user import User

--- a/TMGimporter/tests/test_integration.py
+++ b/TMGimporter/tests/test_integration.py
@@ -11,6 +11,21 @@ it defaults to the RELPH backup used during development.  Tests are skipped
 automatically when the file is not present.
 """
 
+# The TMGimporter module imports Gtk at module load — skip the whole file if
+# gi/Gtk aren't available (headless-without-GTK environments). On systems
+# where both GTK3 and GTK4 are present, pin Gtk to 3.0 before any gramps
+# import (mirrors what gramps.grampsapp does at startup); otherwise
+# PyGObject loads GTK4 and the gramps.gui import chain crashes on
+# Gtk.IconSize.MENU (a GTK3-only enum).
+try:
+    import gi
+
+    gi.require_version("Gtk", "3.0")
+    gi.require_version("Gdk", "3.0")
+except (ImportError, ValueError, AttributeError) as err:
+    raise unittest.SkipTest("GTK 3.0 / PyGObject not available: %s" % err)
+
+
 import os
 import sys
 import shutil

--- a/TMGimporter/tests/test_libtmg.py
+++ b/TMGimporter/tests/test_libtmg.py
@@ -9,6 +9,22 @@ Gramps must be installed.  The DBF-dependent import functions are tested by
 patching the module-level table globals so no real .dbf files are needed.
 """
 
+# The TMGimporter module imports Gtk at module load — skip the whole file if
+# gi/Gtk aren't available (headless-without-GTK environments). On systems
+# where both GTK3 and GTK4 are present, pin Gtk to 3.0 before any gramps
+# import (mirrors what gramps.grampsapp does at startup); otherwise
+# PyGObject loads GTK4 and the gramps.gui import chain crashes on
+# Gtk.IconSize.MENU (a GTK3-only enum).
+try:
+    import gi
+
+    gi.require_version("Gtk", "3.0")
+    gi.require_version("Gdk", "3.0")
+except (ImportError, ValueError, AttributeError) as err:
+    raise unittest.SkipTest("GTK 3.0 / PyGObject not available: %s" % err)
+
+
+
 import sys
 import os
 import tempfile

--- a/WebSearch/tests/test_filetable.py
+++ b/WebSearch/tests/test_filetable.py
@@ -37,6 +37,22 @@ Mocks are used to avoid real file operations during tests.
 Each test ensures that the file table behaves correctly according to its configuration.
 """
 
+# The TMGimporter module imports Gtk at module load — skip the whole file if
+# gi/Gtk aren't available (headless-without-GTK environments). On systems
+# where both GTK3 and GTK4 are present, pin Gtk to 3.0 before any gramps
+# import (mirrors what gramps.grampsapp does at startup); otherwise
+# PyGObject loads GTK4 and the gramps.gui import chain crashes on
+# Gtk.IconSize.MENU (a GTK3-only enum).
+try:
+    import gi
+
+    gi.require_version("Gtk", "3.0")
+    gi.require_version("Gdk", "3.0")
+except (ImportError, ValueError, AttributeError) as err:
+    raise unittest.SkipTest("GTK 3.0 / PyGObject not available: %s" % err)
+
+
+
 import unittest
 import os
 

--- a/WebSearch/tests/test_filetable.py
+++ b/WebSearch/tests/test_filetable.py
@@ -51,10 +51,19 @@ try:
 except (ImportError, ValueError, AttributeError) as err:
     raise unittest.SkipTest("GTK 3.0 / PyGObject not available: %s" % err)
 
-
-
-import unittest
 import os
+
+import sys
+import unittest
+
+# Make sure addon modules are importable from the parent directory
+# (matches the convention used by TMGimporter/Form tests). Required when
+# the test is loaded via its dotted path — e.g.
+# `python3 -m unittest WebSearch.tests.test_filetable` from
+# addons-source/, the form used by addons-source's own ci.yml — where
+# `models`/`constants`/`db_file_table` are otherwise resolved against
+# the addons-source root rather than against `WebSearch/`.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from models import DBFileTableConfig
 from constants import DuplicateHandlingMode, DB_FILE_TABLE_DIR

--- a/WebSearch/tests/test_filetable.py
+++ b/WebSearch/tests/test_filetable.py
@@ -37,24 +37,25 @@ Mocks are used to avoid real file operations during tests.
 Each test ensures that the file table behaves correctly according to its configuration.
 """
 
-# The TMGimporter module imports Gtk at module load — skip the whole file if
+import os
+import sys
+import unittest
+
+# The WebSearch module imports Gtk at module load — skip the whole file if
 # gi/Gtk aren't available (headless-without-GTK environments). On systems
 # where both GTK3 and GTK4 are present, pin Gtk to 3.0 before any gramps
 # import (mirrors what gramps.grampsapp does at startup); otherwise
 # PyGObject loads GTK4 and the gramps.gui import chain crashes on
 # Gtk.IconSize.MENU (a GTK3-only enum).
+
 try:
     import gi
-
     gi.require_version("Gtk", "3.0")
     gi.require_version("Gdk", "3.0")
 except (ImportError, ValueError, AttributeError) as err:
     raise unittest.SkipTest("GTK 3.0 / PyGObject not available: %s" % err)
 
-import os
 
-import sys
-import unittest
 
 # Make sure addon modules are importable from the parent directory
 # (matches the convention used by TMGimporter/Form tests). Required when


### PR DESCRIPTION
Update to fix gramps_version (from 6.0 to 6.1) and add Gtk 3.0 check