### PR TITLE
WebSearch: fix bare imports in test_filetable for dotted-path loading

### DIFF
--- a/WebSearch/tests/test_filetable.py
+++ b/WebSearch/tests/test_filetable.py
@@ -37,8 +37,18 @@ Mocks are used to avoid real file operations during tests.
 Each test ensures that the file table behaves correctly according to its configuration.
 """
 
-import unittest
 import os
+import sys
+import unittest
+
+# Make sure addon modules are importable from the parent directory
+# (matches the convention used by TMGimporter/Form tests). Required when
+# the test is loaded via its dotted path — e.g.
+# `python3 -m unittest WebSearch.tests.test_filetable` from
+# addons-source/, the form used by addons-source's own ci.yml — where
+# `models`/`constants`/`db_file_table` are otherwise resolved against
+# the addons-source root rather than against `WebSearch/`.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from models import DBFileTableConfig
 from constants import DuplicateHandlingMode, DB_FILE_TABLE_DIR


### PR DESCRIPTION
## Summary

`WebSearch/tests/test_filetable.py` (added in WebSearch 1.10.7, commit e3750a0a) imports `models`, `constants` and `db_file_table` without a package prefix:

```python
from models import DBFileTableConfig
from constants import DuplicateHandlingMode, DB_FILE_TABLE_DIR
from db_file_table import DBFileTable, DuplicateEntryError
```

Those resolve only when `WebSearch/` itself is on `sys.path` — i.e. when the test is loaded via `unittest discover` from inside `tests/`. Under the **dotted-path** invocation that fork CI's `unit-test-linux` job uses (`python3 -m unittest WebSearch.tests.test_filetable` from the addons-source root, with `PYTHONPATH=.`), the imports look for a top-level `models` module and the test module fails to load:

```
ImportError: Failed to import test module: test_filetable
ModuleNotFoundError: No module named 'models'
```

This is the same package-shadowing class of bug as 0012691 — the dotted-path loader is what surfaces it; `discover` from `tests/` hides it.

## Fix

Add the `sys.path.insert(0, …parent dir…)` prologue that `TMGimporter/tests/test_libtmg.py` and `Form/tests/test_form_validator.py` already use for sibling-module imports — the established in-tree convention for this exact case. No behavioural change beyond the imports.

## Verification

- Repro: `cd addons-source && PYTHONPATH=. python3 -m unittest -v WebSearch.tests.test_filetable` -> ImportError / ModuleNotFoundError.
- After this patch: `Ran 28 tests in 0.008s -- OK`.

Reproduced & verified in a sibling testbed (gramps-testbed) that runs every addon's `tests/test_*.py` via the dotted-path form, which is how this trap surfaces in the first place.

## Remarks

This is one of the fixes required for the CI PR I've proposed to run clean on the repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)