### PR TITLE
Query: fix missing closing paren in QueryQuickview (line 347)

### DIFF
--- a/Query/QueryQuickview.py
+++ b/Query/QueryQuickview.py
@@ -344,7 +344,7 @@ class DBI(object):
         table = Table()
         self.sdb = SimpleAccess(self.database)
         self.process_table(table) # a class that has .row(1, 2, 3, ...)
-        print(_("{rows:d} rows processed in {secs} seconds.\n").format(rows=self.select, secs=time.time() - start_time)
+        print(_("{rows:d} rows processed in {secs} seconds.\n").format(rows=self.select, secs=time.time() - start_time))
         return table
 
     def eval(self):


### PR DESCRIPTION
## Summary

`Query/QueryQuickview.py:347` is missing the closing `)` of the surrounding `print(...)` call. Python rejects the file at parse time:

```
File "Query/QueryQuickview.py", line 347
    print(_("{rows:d} rows processed in {secs} seconds.\n").format(rows=self.select, secs=time.time() - start_time)
         ^
SyntaxError: '(' was never closed
```

## Provenance

The bug was introduced by 81094b74 ("Fix format string with unnamed arguments warning", fixes #13664, 2025-03-13) when converting `%`-formatting to `.format()`. The original code had a trailing `))` that closed both the inner `_(...)` and the outer `print(...)`; the rewrite left only one `)` on this line.

A second hunk in the same commit converted a sibling `return _("…") % (…)` expression on line 364, which doesn't need an outer paren — that one was unaffected. The bug is isolated to line 347.

## Why nobody noticed

There's no compile-check job currently configured on `maintenance/gramps60`, so the file has been broken at module-import time for ~14 months without surfacing. It would only manifest at runtime if a user actually invoked `Query Quickview`, since Python defers `SyntaxError` on uncompiled `.pyc`-less modules until import.

## Fix

```diff
-        print(_("{rows:d} rows processed in {secs} seconds.\n").format(rows=self.select, secs=time.time() - start_time)
+        print(_("{rows:d} rows processed in {secs} seconds.\n").format(rows=self.select, secs=time.time() - start_time))
```

One character. No behavioural change beyond `print()` actually completing.

## Verification

- Repro on the un-fixed tree:
  ```
  $ python3 -m py_compile Query/QueryQuickview.py
    File "Query/QueryQuickview.py", line 347
      print(_("{rows:d} rows processed in {secs} seconds.\n")…
           ^
  SyntaxError: '(' was never closed
  ```
- After this patch:
  ```
  $ python3 -m py_compile Query/QueryQuickview.py
    (no output, exit 0)
  ```
- Full per-addon compile loop on `Query/` (the same shape as a compile-check workflow): every `.py` in `Query/` (excluding `.gpr.py`) compiles cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)