### PR TITLE
HouseTimelineGramplet: escape backslash in ASCII-art string

### DIFF
--- a/HouseTimelineGramplet/housetimeline.py
+++ b/HouseTimelineGramplet/housetimeline.py
@@ -190,7 +190,7 @@ class HouseTimelineGramplet(Gramplet):
         elif house_type == "002":
             self.append_text(
                 " .___. \n" +
-                "/ \___\\ \n" +
+                "/ \\___\\ \n" +
                 "|_|_#_| \n" +
                 "                        \n"
             )


### PR DESCRIPTION
## Summary

`HouseTimelineGramplet/housetimeline.py:193` has an unescaped backslash followed by an underscore (`\_`) inside a regular (non-raw) string literal. Python 3.12+ emits a `SyntaxWarning`:

```
HouseTimelineGramplet/housetimeline.py:193: SyntaxWarning: invalid escape sequence '\_'
  "/ \___\\ \n" +
```

The backslash is intended literally — the line is part of an ASCII-art house drawing for `house_type == "002"`. Escape it explicitly so the emitted string is byte-for-byte unchanged (`/ \___\ ` followed by a newline) but the source parses without warning.

## Fix

```diff
-                "/ \___\\ \n" +
+                "/ \\___\\ \n" +
```

The string the gramplet displays is identical:

```
$ python3 -c "print(repr('/ \\\\___\\\\ \n'))"
'/ \\___\\ \n'
```

(`'\\___\\'` in repr ↔ `\___\` in actual string content — one backslash, three underscores, one backslash.)

## Verification

- Before: `python3 -m py_compile HouseTimelineGramplet/housetimeline.py` → `SyntaxWarning: invalid escape sequence '\_'`
- After: `python3 -W error::SyntaxWarning -m py_compile HouseTimelineGramplet/housetimeline.py` exits 0 with no output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)