### PR TITLE
Themes: use raw string for Windows registry path with backslash

### DIFF
--- a/Themes/themes.py
+++ b/Themes/themes.py
@@ -263,7 +263,7 @@ class MyPrefs(GrampsPreferences):
                                               shell=True)
             else:
                 txt = subprocess.check_output(
-                    'reg delete HKCU\Environment /v GTK_OVERLAY_SCROLLING /f',
+                    r'reg delete HKCU\Environment /v GTK_OVERLAY_SCROLLING /f',
                     shell=True)
         except subprocess.CalledProcessError:
             print("Cannot set environment variable GTK_OVERLAY_SCROLLING")
@@ -314,7 +314,7 @@ class MyPrefs(GrampsPreferences):
                 Screen.get_default(), MyPrefs.provider)
         try:
             txt = subprocess.check_output(
-                'reg delete HKCU\Environment /v GTK_OVERLAY_SCROLLING /f',
+                r'reg delete HKCU\Environment /v GTK_OVERLAY_SCROLLING /f',
                  shell=True)
         except subprocess.CalledProcessError:
             pass


### PR DESCRIPTION
## Summary

`Themes/themes.py:266` and `:317` both contain:

```python
'reg delete HKCU\Environment /v GTK_OVERLAY_SCROLLING /f'
```

The backslash before `Environment` is intended literally — it's a Windows registry path passed to `subprocess.check_output(..., shell=True)`. In a regular string literal, Python 3.12+ emits `SyntaxWarning`:

```
Themes/themes.py:266: SyntaxWarning: invalid escape sequence '\E'
Themes/themes.py:317: SyntaxWarning: invalid escape sequence '\E'
```

Both lines are byte-identical apart from indentation.

## Fix

Convert each to a raw string literal (`r'...'`) — the standard idiom for Windows paths and registry keys. The string is otherwise free of escape sequences (no `\n`, `\t`, etc.), so raw is fully equivalent to the previous content with the warning silenced:

```diff
-                    'reg delete HKCU\Environment /v GTK_OVERLAY_SCROLLING /f',
+                    r'reg delete HKCU\Environment /v GTK_OVERLAY_SCROLLING /f',
```

(Same change at line 317.)

## Verification

- Before: `python3 -m py_compile Themes/themes.py` → two `SyntaxWarning: invalid escape sequence '\E'`.
- After: `python3 -W error::SyntaxWarning -m py_compile Themes/themes.py` exits 0.
- The `subprocess.check_output(...)` argument is byte-identical to before — `reg.exe` still receives `HKCU\Environment` verbatim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)