### PR TITLE
lxml: use == not is when comparing os.name to a string literal

### DIFF
--- a/lxml/lxmlGramplet.py
+++ b/lxml/lxmlGramplet.py
@@ -397,7 +397,7 @@ class lxmlGramplet(Gramplet):
             os.system(f'xmllint')
 
         try:
-            if os.name is 'nt':
+            if os.name == 'nt':
                 os.system(f'xmllint --relaxng {rng} --noout {filename} {options}')
                 LOG.debug('xmllint (relaxng) : %s' % filename)
             else:
@@ -755,7 +755,7 @@ class lxmlGramplet(Gramplet):
 
         dtd = os.path.join(USER_PLUGINS, 'lxml', 'grampsxml.dtd')
         try:
-            if os.name is 'nt':
+            if os.name == 'nt':
                 os.system(f'xmllint --dtdvalid {dtd} {filename} {options}')
             else:
                 os.system(f'xmllint --dtdvalid file://{dtd} {filename} {options}')


### PR DESCRIPTION
## Summary

`lxml/lxmlGramplet.py:400` and `:758` both use `is` to compare `os.name` against the string literal `'nt'`:

```python
if os.name is 'nt':
```

Python 3.12+ emits a `SyntaxWarning` on this idiom:

```
lxml/lxmlGramplet.py:400: SyntaxWarning: "is" with 'str' literal. Did you mean "=="?
lxml/lxmlGramplet.py:758: SyntaxWarning: "is" with 'str' literal. Did you mean "=="?
```

`is` checks object identity, not equality. The expression *happens* to evaluate as expected on CPython today because short strings get interned during compilation — but that's an implementation detail of the interpreter, not a language guarantee. The right test is value equality.

## Fix

```diff
-            if os.name is 'nt':
+            if os.name == 'nt':
```

(Same change on both lines.)

This also brings the file's own style into self-consistency: two other call sites comparing `os.name` to a literal in this file (`lxmlGramplet.py:161` and `:181`) already use `==`:

```
161:        if os.name == 'nt' or sys.platform == "darwin":
181:        if os.name == 'nt' or sys.platform == "darwin":
400:            if os.name == 'nt':       ← was `is`, now `==`
758:            if os.name == 'nt':       ← was `is`, now `==`
```

## Verification

- Before: `python3 -m py_compile lxml/lxmlGramplet.py` → two `SyntaxWarning: "is" with 'str' literal`.
- After: `python3 -W error::SyntaxWarning -m py_compile lxml/lxmlGramplet.py` exits 0.
- Behaviour at runtime is unchanged on CPython (interning makes `is` and `==` agree for `'nt'` today); the patch makes that agreement explicit and removes the language-level warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)