### PR TITLE
AnniversariesGramplet: add po/template.pot (backport from gramps61)

### DIFF
--- a/AnniversariesGramplet/po/template.pot
+++ b/AnniversariesGramplet/po/template.pot
@@ -1,0 +1,47 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-05-03 15:04-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: AnniversariesGramplet/AnniversariesGramplet.py:51
+msgid "Double-click on a row to edit the event."
+msgstr ""
+
+#: AnniversariesGramplet/AnniversariesGramplet.py:56
+msgid "Date"
+msgstr ""
+
+#: AnniversariesGramplet/AnniversariesGramplet.py:58
+msgid "Participant"
+msgstr ""
+
+#: AnniversariesGramplet/AnniversariesGramplet.py:59
+msgid "Age"
+msgstr ""
+
+#: AnniversariesGramplet/AnniversariesGramplet.py:61
+msgid "Event Type"
+msgstr ""
+
+#: AnniversariesGramplet/AnniversariesGramplet.gpr.py:24
+#: AnniversariesGramplet/AnniversariesGramplet.gpr.py:32
+msgid "Anniversaries"
+msgstr ""
+
+#: AnniversariesGramplet/AnniversariesGramplet.gpr.py:25
+msgid "A gramplet that displays the anniversaries of events"
+msgstr ""


### PR DESCRIPTION
## Summary

Backports `AnniversariesGramplet/po/template.pot` from `maintenance/gramps61` (added there by @GaryGriffin's [#831](https://github.com/gramps-project/addons-source/pull/831) "Update template.pot for 6.1", merged 2026-05-08) to `maintenance/gramps60`.

The addon registers a translation-marked name and description in its `.gpr.py` but ships no `po/` subtree, so Weblate has nothing to track on `maintenance/gramps60`. This file backfills that gap.

## Why the gramps61 file works as-is on gramps60

The only diff in `AnniversariesGramplet/` between the two branches is a `gramps_target_version` bump (6.0 → 6.1) and a version string update — no translatable strings have changed:

```
$ git diff upstream/maintenance/gramps60 upstream/maintenance/gramps61 -- AnniversariesGramplet/ ':!AnniversariesGramplet/po/'
 AnniversariesGramplet/AnniversariesGramplet.gpr.py | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```

`AnniversariesGramplet.py` is byte-identical, and the .gpr.py's `_("…")` markers are at the same line numbers in both branches.

## Verification

- `msgfmt --output-file=/dev/null AnniversariesGramplet/po/template.pot` exits 0 (parses cleanly).
- Every `#:` line reference in the .pot points at a line containing a `_(...)` translation marker in the gramps60 sources.

## Scope

Per addons-source convention, one PR per addon directory. The other three addons that #831 covered (`ArchiveAssist`, `GrampsChat`, `GrampyScript`) get parallel single-file PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)