### PR TITLE
GrampsChat: add po/template.pot (backport from gramps61)

### DIFF
--- a/GrampsChat/po/template.pot
+++ b/GrampsChat/po/template.pot
@@ -1,0 +1,26 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-05-03 15:05-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: GrampsChat/GrampsChat.gpr.py:4 GrampsChat/GrampsChat.gpr.py:9
+msgid "GrampsChat"
+msgstr ""
+
+#: GrampsChat/GrampsChat.gpr.py:5
+msgid "AI Chatbot Gramplet (requires connecting to an LLM service)"
+msgstr ""


### PR DESCRIPTION
## Summary

Backports `GrampsChat/po/template.pot` from `maintenance/gramps61` (added there by @GaryGriffin's [#831](https://github.com/gramps-project/addons-source/pull/831), merged 2026-05-08) to `maintenance/gramps60`.

The addon registers translation-marked text in its `.gpr.py` but ships no `po/` subtree, so Weblate has nothing to track on `maintenance/gramps60`. This file backfills that gap.

## Why the gramps61 file works as-is on gramps60

```
$ git diff upstream/maintenance/gramps60 upstream/maintenance/gramps61 -- GrampsChat/ ':!GrampsChat/po/'
 GrampsChat/GrampsChat.gpr.py | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```

Only `gramps_target_version` (6.0 → 6.1) and version-string differences. No translatable strings changed.

## Verification

- `msgfmt --output-file=/dev/null GrampsChat/po/template.pot` exits 0.
- Every `#:` line reference points at a line containing a `_(...)` translation marker in gramps60 sources.

## Scope

Per addons-source convention, one PR per addon directory. The other three addons that #831 covered get parallel single-file PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)