### PR TITLE
GrampyScript: add po/template.pot (backport from gramps61)

### DIFF
--- a/GrampyScript/po/template.pot
+++ b/GrampyScript/po/template.pot
@@ -1,0 +1,108 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-05-03 15:05-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: GrampyScript/GrampyScript.gpr.py:23 GrampyScript/GrampyScript.gpr.py:32
+msgid "Gram.py Script"
+msgstr ""
+
+#: GrampyScript/GrampyScript.gpr.py:24
+msgid "Run a special Gramps Python script"
+msgstr ""
+
+#: GrampyScript/GrampyScript.py:91
+msgid "Load query from a .script file"
+msgstr ""
+
+#: GrampyScript/GrampyScript.py:97 GrampyScript/GrampyScript.py:127
+#: GrampyScript/GrampyScript.py:147
+msgid "_Cancel"
+msgstr ""
+
+#: GrampyScript/GrampyScript.py:97
+msgid "Load"
+msgstr ""
+
+#: GrampyScript/GrampyScript.py:121
+msgid "Save query to a .script file"
+msgstr ""
+
+#: GrampyScript/GrampyScript.py:127 GrampyScript/GrampyScript.py:147
+#: GrampyScript/GrampyScript.py:304
+msgid "Save"
+msgstr ""
+
+#: GrampyScript/GrampyScript.py:141
+msgid "Download results as a CSV file"
+msgstr ""
+
+#: GrampyScript/GrampyScript.py:300
+msgid "Script"
+msgstr ""
+
+#: GrampyScript/GrampyScript.py:302
+msgid "New"
+msgstr ""
+
+#: GrampyScript/GrampyScript.py:303
+msgid "Open..."
+msgstr ""
+
+#: GrampyScript/GrampyScript.py:305
+msgid "Save as..."
+msgstr ""
+
+#: GrampyScript/GrampyScript.py:317
+msgid "Data"
+msgstr ""
+
+#: GrampyScript/GrampyScript.py:319
+msgid "Save as CSV"
+msgstr ""
+
+#: GrampyScript/GrampyScript.py:320
+msgid "Copy to clipboard"
+msgstr ""
+
+#: GrampyScript/GrampyScript.py:382
+msgid "Table"
+msgstr ""
+
+#: GrampyScript/GrampyScript.py:386
+msgid "Output"
+msgstr ""
+
+#: GrampyScript/GrampyScript.py:395
+msgid "Chart"
+msgstr ""
+
+#: GrampyScript/GrampyScript.py:400
+msgid "Execute <Alt+Enter>"
+msgstr ""
+
+#: GrampyScript/GrampyScript.py:402
+msgid "Execute the script"
+msgstr ""
+
+#: GrampyScript/GrampyScript.py:416
+msgid "Ready..."
+msgstr ""
+
+#: GrampyScript/GrampyScript.py:1028
+msgid "Gram.py Script Edited Data"
+msgstr ""


### PR DESCRIPTION
## Summary

Backports `GrampyScript/po/template.pot` from `maintenance/gramps61` (added there by @GaryGriffin's [#831](https://github.com/gramps-project/addons-source/pull/831), merged 2026-05-08) to `maintenance/gramps60`.

The addon registers translation-marked text but shipped without a `po/` subtree, so Weblate has nothing to track on `maintenance/gramps60`. This file backfills that gap.

## Why the gramps61 file works as-is on gramps60

```
$ git diff upstream/maintenance/gramps60 upstream/maintenance/gramps61 -- GrampyScript/ ':!GrampyScript/po/'
 GrampyScript/GrampyScript.gpr.py | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```

Only `gramps_target_version` (6.0 → 6.1) and version-string differences. No translatable strings changed.

## Verification

- `msgfmt --output-file=/dev/null GrampyScript/po/template.pot` exits 0.
- Every `#:` line reference points at a line containing a `_(...)` translation marker in gramps60 sources.

## Scope

Per addons-source convention, one PR per addon directory. The other three addons that #831 covered get parallel single-file PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)