### PR TITLE
AnniversariesGramplet: import WindowActiveError

### DIFF
--- a/AnniversariesGramplet/AnniversariesGramplet.py
+++ b/AnniversariesGramplet/AnniversariesGramplet.py
@@ -26,6 +26,7 @@ from gramps.gen.lib.date import Today
 from gramps.gen.utils.db import get_participant_from_event
 from gramps.gen.datehandler import get_date
 from gramps.gen.config import config
+from gramps.gen.errors import WindowActiveError
 from gramps.gui.editors import EditEvent
 
 from gramps.gen.const import GRAMPS_LOCALE as glocale


### PR DESCRIPTION
## Summary

`AnniversariesGramplet/AnniversariesGramplet.py:103` references `WindowActiveError` in an `except` clause but never imports it. Ruff (rule `F821`) flags this:

```
F821 Undefined name `WindowActiveError`
   --> AnniversariesGramplet/AnniversariesGramplet.py:103:20
    |
101 |                 event = self.dbstate.db.get_event_from_handle(handle)
102 |                 EditEvent(self.dbstate, self.uistate, [], event)
103 |             except WindowActiveError:
    |                    ^^^^^^^^^^^^^^^^^
104 |                 pass
    |
```

The exception is raised by `gramps.gui.editors.EditEvent` when the editor is already open for the same handle; `WindowActiveError` lives in `gramps.gen.errors`. Without the import, the `except` clause would trigger `NameError` if an editor were already open — a real (if rare) runtime bug masked today only because that path is uncommon.

## Fix

Add the missing import alongside the other `gramps.gen.*` imports:

```diff
 from gramps.gen.config import config
+from gramps.gen.errors import WindowActiveError
 from gramps.gui.editors import EditEvent
```

One-line change, no behavioural impact under normal use; fixes the `NameError` on the active-editor path.

## Verification

- `ruff check --select=E9,F63,F7,F82 --no-fix --exclude='*.gpr.py' AnniversariesGramplet/` → "All checks passed!" (was 1 F821).
- `python3 -m py_compile AnniversariesGramplet/AnniversariesGramplet.py` exits 0.
- Sweep across the entire addons-source tree confirms exactly one F821 was removed (from 78 → 77 sites) — no other addon affected.

## Scope

Per addons-source convention, one PR per addon directory. This is the first of an upstream-friendly per-addon series clearing the lint backlog (the same set PR #820's body originally enumerated). Each subsequent PR will be similarly minimal and addon-scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)