### PR TITLE
DenominoViso: import reduce from functools

### DIFF
--- a/DenominoViso/DenominoViso.py
+++ b/DenominoViso/DenominoViso.py
@@ -130,6 +130,7 @@ from urllib.request import pathname2url
 from xml.sax.saxutils import escape, quoteattr
 from math import sin,cos,exp,sqrt,e,pi
 import codecs
+from functools import reduce
 
 #-------------------------------------------------------------------------
 #


### PR DESCRIPTION
## Summary

`DenominoViso/DenominoViso.py:1714` calls `reduce(tmpfunc, …)` but never imports it. `reduce` was a Python 2 builtin, removed from the Python 3 builtin namespace and relocated to `functools.reduce`. Without the import, the call raises `NameError` whenever the witness-array formatting branch is reached. Ruff (F821) flags this:

```
F821 Undefined name `reduce`
   --> DenominoViso/DenominoViso.py:1714:19
```

## Fix

```diff
 from math import sin,cos,exp,sqrt,e,pi
 import codecs
+from functools import reduce
```

No behavioural change beyond fixing the latent `NameError` on the affected formatting path.

## Verification

- `ruff check --select=E9,F63,F7,F82 --no-fix --exclude='*.gpr.py' DenominoViso/` → All checks passed.
- `python3 -m py_compile DenominoViso/DenominoViso.py` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)