### PR TITLE
DescendantsLines: import reduce from functools

### DIFF
--- a/DescendantsLines/ft.py
+++ b/DescendantsLines/ft.py
@@ -31,6 +31,7 @@ import gzip
 import xml.dom.minidom
 import getopt
 import sys
+from functools import reduce
 #-------------------------------------------------------------------------
 #
 # variables


### PR DESCRIPTION
## Summary

`DescendantsLines/ft.py` calls `reduce(...)` at lines 185, 195, 352, and 358 but never imports it. `reduce` was a Python 2 builtin, removed from the Python 3 builtin namespace and relocated to `functools.reduce`. Without the import, every call raises `NameError`. Ruff (F821) flags all four sites.

## Fix

```diff
 import cairo
 import gtk
 import gzip
 import xml.dom.minidom
 import getopt
 import sys
+from functools import reduce
```

No behavioural change beyond fixing the latent `NameError` on these four call sites.

## Note on file scope

`ft.py` is a Py2-era helper that also references the long-gone `gtk` module (PyGTK, dropped in Gramps 4.x's PyGObject migration). This PR addresses only the four `reduce` lint sites; the broader `gtk`-import question is a separate cleanup outside this PR's scope.

## Verification

- `ruff check --select=E9,F63,F7,F82 --no-fix --exclude='*.gpr.py' DescendantsLines/` → All checks passed.
- `ast.parse('DescendantsLines/ft.py')` succeeds (the file's syntax is valid; the `gtk` import would still fail at runtime, but that pre-existed this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)