### PR TITLE
DynamicWeb: drop Python 2 compatibility branches

### DIFF
--- a/DynamicWeb/dynamicweb.py
+++ b/DynamicWeb/dynamicweb.py
@@ -123,14 +123,9 @@ import codecs
 import tarfile
 import tempfile
 
-if sys.version_info[0] < 3:
-    from cStringIO import StringIO
+from io import StringIO
 
-    string_types = basestring
-else:
-    from io import StringIO
-
-    string_types = str
+string_types = str
 from unicodedata import normalize
 from collections import defaultdict, OrderedDict
 from xml.sax.saxutils import escape

--- a/DynamicWeb/run_dynamicweb.py
+++ b/DynamicWeb/run_dynamicweb.py
@@ -44,9 +44,6 @@ gramps_path = os.environ["GRAMPS_RESOURCES"]
 if (not os.path.exists(gramps_path)): raise Exception("Gramps path GRAMPS_RESOURCES not found")
 sys.path.insert(1, gramps_path)
 
-if sys.version_info[0] < 3:
-    reload(sys)
-    sys.setdefaultencoding('utf8')
 from dynamicweb import *
 from dynamicweb import _
 from report_sets import *


### PR DESCRIPTION
## Summary

Two Py2-only code paths in DynamicWeb reference names that no longer exist on Python 3, and ruff (F821) flags them:

```
F821 Undefined name `basestring`
   --> DynamicWeb/dynamicweb.py:129:20
F821 Undefined name `reload`
   --> DynamicWeb/run_dynamicweb.py:48:5
```

Both sit inside `if sys.version_info[0] < 3:` blocks. On Python 3 the other branch always runs, so the `basestring`/`reload` references are dead code that only ever ran on Python 2.

## Fix

`dynamicweb.py` — collapse the if/else so only the Py3 imports remain:

```diff
-if sys.version_info[0] < 3:
-    from cStringIO import StringIO
-
-    string_types = basestring
-else:
-    from io import StringIO
-
-    string_types = str
+from io import StringIO
+
+string_types = str
```

`run_dynamicweb.py` — delete the Py2-only `reload`/`setdefaultencoding` block:

```diff
-if sys.version_info[0] < 3:
-    reload(sys)
-    sys.setdefaultencoding('utf8')
 from dynamicweb import *
```

## Behavioural impact

- On Python 3 — byte-identical (the dropped branches were never taken).
- On Python 2 — changes (`from cStringIO import StringIO` no longer happens). Not a concern: Gramps 6.0 is Python 3 only at the project level, so Py2 support is already gone.

## Verification

- `ruff check --select=E9,F63,F7,F82 --no-fix --exclude='*.gpr.py' DynamicWeb/` → All checks passed.
- `python3 -m py_compile DynamicWeb/dynamicweb.py` exits 0.
- `ast.parse` on `run_dynamicweb.py` succeeds (the file's other concerns — script-style `from dynamicweb import *` etc. — are outside this PR's scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)