### PR TITLE
LinesOfDescendency: import ReportError

### DIFF
--- a/LinesOfDescendency/lines-of-descendency.py
+++ b/LinesOfDescendency/lines-of-descendency.py
@@ -97,11 +97,13 @@ class LinesOfDescendency(Report):
         menu = options.menu
         pid  = menu.get_option_by_name('pid').get_value()
         self.descendent = database.get_person_from_gramps_id(pid)
+        if (self.descendent == None) :
+            raise ReportError(_("Person %s is not in the Database") % pid )
         self.descendent_handle = self.descendent.get_handle()
         ancestor = menu.get_option_by_name('ancestor').get_value()
         self.ancestor = database.get_person_from_gramps_id(ancestor)
-        if (self.descendent == None) :
-            raise ReportError(_("Person %s is not in the Database") % pid )
+        if (self.ancestor == None) :
+            raise ReportError(_("Person %s is not in the Database") % ancestor )
 
     def write_path(self, path):
         gen = 1

--- a/LinesOfDescendency/lines-of-descendency.py
+++ b/LinesOfDescendency/lines-of-descendency.py
@@ -27,6 +27,7 @@
 #
 
 from gramps.gen.const import GRAMPS_LOCALE as glocale
+from gramps.gen.errors import ReportError
 try:
     _trans = glocale.get_addon_translator(__file__)
 except ValueError:

--- a/LinesOfDescendency/tests/test_linesofdescendency_guards.py
+++ b/LinesOfDescendency/tests/test_linesofdescendency_guards.py
@@ -1,0 +1,131 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Gramps Development Team
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Regression test for the descendent/ancestor guards in
+``LinesOfDescendency.__init__``.
+
+``__init__`` looks up two people by Gramps ID::
+
+    self.descendent = database.get_person_from_gramps_id(pid)
+    ...
+    self.ancestor = database.get_person_from_gramps_id(ancestor)
+
+A Gramps ID that is not in the database makes the lookup return
+``None``. Historically the only guard was ``if self.descendent == None``
+placed *after* ``self.descendent.get_handle()`` — so a missing
+descendent raised ``AttributeError`` before the guard could run, the
+missing-ancestor case was never guarded at all, and ``ReportError`` was
+not even imported (the guard would itself have raised ``NameError``).
+
+These tests drive ``__init__`` with a mock options/database and assert
+that a missing descendent *or* a missing ancestor raises
+``ReportError`` naming the offending ID. ``Report.__init__`` (the base
+class) is stubbed, so no real Gramps report backend is needed.
+"""
+
+import importlib.util
+import os
+import unittest
+from unittest import mock
+
+# The addon module's filename contains a hyphen, so it cannot be loaded
+# with a normal `import` statement / dotted path — it is loaded directly
+# from its file location instead.
+_IMPL_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "lines-of-descendency.py",
+)
+
+
+def _load_impl():
+    """Load and return the lines-of-descendency.py module by file path."""
+    spec = importlib.util.spec_from_file_location(
+        "linesofdescendency_impl", _IMPL_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_options(pid, ancestor_id):
+    """Build a mock options object exposing the 'pid'/'ancestor' menu options."""
+    options = mock.MagicMock()
+    values = {"pid": pid, "ancestor": ancestor_id}
+
+    def get_option_by_name(name):
+        opt = mock.MagicMock()
+        opt.get_value.return_value = values[name]
+        return opt
+
+    options.menu.get_option_by_name.side_effect = get_option_by_name
+    return options
+
+
+class TestLinesOfDescendencyGuards(unittest.TestCase):
+    """Cover the missing-person guards in LinesOfDescendency.__init__."""
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            cls.impl = _load_impl()
+        except ImportError as err:
+            raise unittest.SkipTest("Gramps not importable: %s" % err)
+        cls.LinesOfDescendency = cls.impl.LinesOfDescendency
+        cls.ReportError = cls.impl.ReportError
+
+    def _build(self, descendent, ancestor, pid="I9999", ancestor_id="I0001"):
+        """Instantiate the report against a database returning the given people.
+
+        ``Report.__init__`` is stubbed so no real report backend is needed.
+        """
+        database = mock.MagicMock()
+        people = {pid: descendent, ancestor_id: ancestor}
+        database.get_person_from_gramps_id.side_effect = lambda gid: people[gid]
+        options = _make_options(pid, ancestor_id)
+        with mock.patch.object(self.impl, "Report"):
+            return self.LinesOfDescendency(database, options, mock.MagicMock())
+
+    def test_missing_descendent_raises_report_error(self):
+        """A descendent ID absent from the database raises ReportError."""
+        with self.assertRaises(self.ReportError) as ctx:
+            self._build(descendent=None, ancestor=mock.MagicMock())
+        self.assertIn("I9999", str(ctx.exception))
+
+    def test_missing_ancestor_raises_report_error(self):
+        """An ancestor ID absent from the database raises ReportError.
+
+        Before the fix this case was not guarded at all.
+        """
+        with self.assertRaises(self.ReportError) as ctx:
+            self._build(descendent=mock.MagicMock(), ancestor=None)
+        self.assertIn("I0001", str(ctx.exception))
+
+    def test_both_present_does_not_raise(self):
+        """With both people present, __init__ completes without error."""
+        report = self._build(
+            descendent=mock.MagicMock(), ancestor=mock.MagicMock()
+        )
+        self.assertIsNotNone(report.descendent)
+        self.assertIsNotNone(report.ancestor)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Root cause

`LinesOfDescendency.__init__` looks up two people by Gramps ID and was mishandling the not-found case three ways:

1. `ReportError` was used but never imported — Ruff F821; the `raise` would itself have hit `NameError`.
2. The `if self.descendent == None` guard sat **after** `self.descendent.get_handle()`, so a missing descendent raised `AttributeError` before the guard could run — the guard was unreachable.
3. The `ancestor` lookup had no guard at all — a missing ancestor surfaced later as an unrelated error.

(2) and (3) were raised by @GaryGriffin in review; the first revision of this PR only added the import.

## Fix

```diff
 from gramps.gen.const import GRAMPS_LOCALE as glocale
+from gramps.gen.errors import ReportError
```

```diff
         self.descendent = database.get_person_from_gramps_id(pid)
+        if (self.descendent == None) :
+            raise ReportError(_("Person %s is not in the Database") % pid )
         self.descendent_handle = self.descendent.get_handle()
         ancestor = menu.get_option_by_name('ancestor').get_value()
         self.ancestor = database.get_person_from_gramps_id(ancestor)
-        if (self.descendent == None) :
-            raise ReportError(_("Person %s is not in the Database") % pid )
+        if (self.ancestor == None) :
+            raise ReportError(_("Person %s is not in the Database") % ancestor )
```

The descendent guard moves above `get_handle()`; a symmetric guard is added for `ancestor`. `ReportError` is imported for both raises.

## Verified against

- `gramps-project/gramps` `gramps/gen/errors.py` — `ReportError` is defined there.

## Test

Adds `LinesOfDescendency/tests/test_linesofdescendency_guards.py` (3 tests): a missing descendent or a missing ancestor must raise `ReportError` naming the offending ID; `__init__` completes cleanly when both are present. It drives `__init__` with a mock options/database and stubs `Report.__init__`. The addon module's filename has a hyphen, so the test loads it by file path via `importlib`.

Run with the dotted-path form CI uses:

```
python3 -m unittest LinesOfDescendency.tests.test_linesofdescendency_guards
```

- **Fixed tree**: 3 tests, OK.
- **Pre-fix tree**: fails — `ReportError` was not importable, and with the guard after `get_handle()` a missing descendent raised `AttributeError` rather than `ReportError`.

Also: `ruff check --select=E9,F63,F7,F82 --no-fix --exclude="*.gpr.py" LinesOfDescendency/` passes; `python3 -m py_compile` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)