### PR TITLE
MongoDB: initialise gettext _ from glocale

### DIFF
--- a/MongoDB/mongodb.py
+++ b/MongoDB/mongodb.py
@@ -50,6 +50,12 @@ from gramps.gen.utils.configmanager import ConfigManager
 from gramps.gen.config import config
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 
+try:
+    _trans = glocale.get_addon_translator(__file__)
+except ValueError:
+    _trans = glocale.translation
+_ = _trans.gettext
+
 LOG = logging.getLogger(".mongodb")
 _LOG = logging.getLogger(DBLOGNAME)
 


### PR DESCRIPTION
## Summary

`MongoDB/mongodb.py:84` calls `_("Database version")` in `get_summary`, but the file imports `GRAMPS_LOCALE` without ever binding the `_` gettext shortcut. Ruff (F821) flags it:

```
F821 Undefined name `_`
   --> MongoDB/mongodb.py:84:13
```

The addon ships a `po/` subtree (da-local.po, de-local.po, fi-local.po and others), so the standard Gramps addon-translator pattern is the right fit.

## Fix

Add the standard addon-translator block right after the existing `from gramps.gen.const import GRAMPS_LOCALE as glocale` import:

```diff
 from gramps.gen.const import GRAMPS_LOCALE as glocale

+try:
+    _trans = glocale.get_addon_translator(__file__)
+except ValueError:
+    _trans = glocale.translation
+_ = _trans.gettext
+
 LOG = logging.getLogger(".mongodb")
```

No behavioural change beyond fixing the latent `NameError` on `get_summary`.

## Verification

- `ruff check --select=E9,F63,F7,F82 --no-fix --exclude="*.gpr.py" MongoDB/` → All checks passed.
- `python3 -m py_compile MongoDB/mongodb.py` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)