### PR TITLE
PersonEverything: import ReportError

### DIFF
--- a/PersonEverything/PersonEverything.py
+++ b/PersonEverything/PersonEverything.py
@@ -37,6 +37,7 @@ Reports/Text Reports/Person Everything Report.
 #
 #------------------------------------------------------------------------
 from gramps.gen.const import GRAMPS_LOCALE as glocale
+from gramps.gen.errors import ReportError
 import copy
 import string
 


### PR DESCRIPTION
## Summary

`PersonEverything/PersonEverything.py:111` raises `ReportError(_("Person %s is not in the Database") % pid)` but never imports it. Ruff (F821) flags it:

```
F821 Undefined name `ReportError`
   --> PersonEverything/PersonEverything.py:111:19
```

`ReportError` lives in `gramps.gen.errors`. Without the import, the raise itself triggers `NameError` instead of the intended "Person not in database" message.

## Fix

```diff
 from gramps.gen.const import GRAMPS_LOCALE as glocale
+from gramps.gen.errors import ReportError
 import copy
 import string
```

## Verification

- `ruff check --select=E9,F63,F7,F82 --no-fix --exclude="*.gpr.py" PersonEverything/` → All checks passed.
- `python3 -m py_compile PersonEverything/PersonEverything.py` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)