### PR TITLE
PostgreSQLEnhanced: import time

### DIFF
--- a/PostgreSQLEnhanced/postgresqlenhanced.py
+++ b/PostgreSQLEnhanced/postgresqlenhanced.py
@@ -40,6 +40,7 @@ import os
 import re
 import pickle
 import sys
+import time
 from urllib.parse import urlparse, parse_qs
 
 # -------------------------------------------------------------------------
@@ -1958,7 +1959,6 @@ class PostgreSQLEnhanced(DBAPI):
                         pass
 
                 if attempt < max_retries - 1:
-                    import time
                     time.sleep(0.01 * (2 ** attempt))  # Exponential backoff
                     continue
                 else:


### PR DESCRIPTION
## Summary

`PostgreSQLEnhanced/postgresqlenhanced.py:2102` calls `time.time()` when stamping new tree metadata:

```python
db.set_metadata("created", str(time.time()))
```

…but the file never imports `time`. Ruff (F821) flags it:

```
F821 Undefined name `time`
   --> PostgreSQLEnhanced/postgresqlenhanced.py:2102:44
```

Without the import, the tree-creation path raises `NameError` instead of recording the timestamp.

## Fix

```diff
 import logging
 import os
 import re
 import pickle
 import sys
+import time
 from urllib.parse import urlparse, parse_qs
```

## Verification

- `ruff check --select=E9,F63,F7,F82 --no-fix --exclude="*.gpr.py" PostgreSQLEnhanced/` → All checks passed.
- `python3 -m py_compile PostgreSQLEnhanced/postgresqlenhanced.py` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)