### PR TITLE
Query: import sys in QueryGramplet

### DIFF
--- a/Query/QueryGramplet.py
+++ b/Query/QueryGramplet.py
@@ -21,7 +21,7 @@
 
 # $Id$
 
-#import os
+import sys
 
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 try:


### PR DESCRIPTION
## Summary

`Query/QueryGramplet.py:63,69` reference `sys.version` and `sys.exc_info()` but never import `sys`. Ruff (F821) flags both:

```
F821 Undefined name `sys`
   --> Query/QueryGramplet.py:63:43
   --> Query/QueryGramplet.py:69:61
```

## Fix

Replace the commented-out `#import os` placeholder near the top of the file with `import sys`. Without the import, the gramplet banner line (`Python %s\n%s`) and the exception formatter (`sys.exc_info()`) both raise `NameError`.

```diff
-#import os
+import sys
```

## Verification

- `ruff check --select=E9,F63,F7,F82 --no-fix --exclude="*.gpr.py" Query/QueryGramplet.py` → All checks passed.
- `python3 -m py_compile Query/QueryGramplet.py` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)