### PR TITLE
RelID: import ErrorDialog

### DIFF
--- a/RelID/relation_tab.py
+++ b/RelID/relation_tab.py
@@ -41,7 +41,7 @@ from gramps.gui.utils import ProgressMeter
 from gramps.gui.plug import tool
 from gramps.gen.plug.menu import StringOption, FilterOption, PersonOption, EnumeratedListOption
 import gramps.gen.plug.report.utils as ReportUtils
-from gramps.gui.dialog import WarningDialog, OkDialog
+from gramps.gui.dialog import WarningDialog, OkDialog, ErrorDialog
 from gramps.gen.display.name import displayer as name_displayer
 from gramps.gen.relationship import get_relationship_calculator
 from gramps.gen.filters import GenericFilterFactory, rules


### PR DESCRIPTION
## Summary

`RelID/relation_tab.py:728` calls `ErrorDialog(_("Permission problem"), …)` when the working directory is not writable, but `ErrorDialog` is never imported. Ruff (F821) flags it:

```
F821 Undefined name `ErrorDialog`
   --> RelID/relation_tab.py:728:17
```

The file already imports `WarningDialog, OkDialog` from `gramps.gui.dialog` — extend that import to include `ErrorDialog`. Without it, the permission-error path raises `NameError` instead of displaying the dialog.

## Fix

```diff
-from gramps.gui.dialog import WarningDialog, OkDialog
+from gramps.gui.dialog import WarningDialog, OkDialog, ErrorDialog
```

## Verification

- `ruff check --select=E9,F63,F7,F82 --no-fix --exclude="*.gpr.py" RelID/` → All checks passed.
- `python3 -m py_compile RelID/relation_tab.py` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)