### PR TITLE
AttachSourceTool: remove unreachable code after return

### DIFF
--- a/AttachSourceTool/AttachSourceTool.py
+++ b/AttachSourceTool/AttachSourceTool.py
@@ -209,6 +209,3 @@ class AttachSourceWindow(PluginWindows.ToolManagedWindowBatch):
         self.db.add_source(source, self.trans)
         return source
 
-        self.db.add_event(event, self.trans)
-        return event
-


### PR DESCRIPTION
## Summary

`AttachSourceTool/AttachSourceTool.py:212-213` are unreachable — they sit immediately after a `return source` on line 210, in the same indent block, so Python never executes them. The two lines also reference an undefined name `event`, which ruff (F821) flags:

```
F821 Undefined name `event`
   --> AttachSourceTool/AttachSourceTool.py:212:27
   --> AttachSourceTool/AttachSourceTool.py:213:16
```

## Fix

```diff
             self.skeys[source_text] = source.handle
         self.db.add_source(source, self.trans)
         return source
-
-        self.db.add_event(event, self.trans)
-        return event
-
```

## Behavioural impact

Zero — the lines were unreachable and never executed.

## Verification

- `ruff check --select=E9,F63,F7,F82 --no-fix --exclude="*.gpr.py" AttachSourceTool/` → All checks passed.
- `python3 -m py_compile AttachSourceTool/AttachSourceTool.py` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)