### PR TITLE
DescendantBooks: import ErrorDialog

### DIFF
--- a/DescendantBooks/RunReport.py
+++ b/DescendantBooks/RunReport.py
@@ -36,6 +36,7 @@ LOG = logging.getLogger(".")
 
 from gramps.gen.plug import BasePluginManager
 from gramps.gen.plug.report import CATEGORY_TEXT
+from gramps.gui.dialog import ErrorDialog
 from gramps.gui.utils import open_file_with_default_application
 from gramps.gui.user import User
 from gramps.gui.plug.report._textreportdialog import TextReportDialog


### PR DESCRIPTION
## Summary

`DescendantBooks/RunReport.py` calls `ErrorDialog(...)` four times (lines 82, 84, 87, 89) inside the report-generation error handlers, but never imports it. Ruff (F821) flags all four sites.

`ErrorDialog` lives in `gramps.gui.dialog`. Without the import each of the four error paths (`FilterError`, `IOError`, `ReportError`, `DatabaseError`) raises `NameError` instead of surfacing the intended dialog.

## Fix

```diff
+from gramps.gui.dialog import ErrorDialog
 from gramps.gui.utils import open_file_with_default_application
 from gramps.gui.user import User
```

## Verification

- `ruff check --select=E9,F63,F7,F82 --no-fix --exclude="*.gpr.py" DescendantBooks/` → All checks passed.
- `python3 -m py_compile DescendantBooks/RunReport.py` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)