### PR TITLE
TimelinePedigreeView: use Python 3 except syntax

### DIFF
--- a/TimelinePedigreeView/TimelinePedigreeView.py
+++ b/TimelinePedigreeView/TimelinePedigreeView.py
@@ -578,7 +578,7 @@ class TimelinePedigreeView(NavigationView):
         """
         try:
             self.Tree_Rebuild()
-        except AttributeError(msg):
+        except AttributeError as msg:
             RunDatabaseRepair(str(msg))
 
     def change_db(self, db):


### PR DESCRIPTION
## Summary

`TimelinePedigreeView/TimelinePedigreeView.py:581` uses the Python 2 exception-binding syntax:

```python
except AttributeError(msg):
    RunDatabaseRepair(str(msg))
```

On Python 3 this means "call `AttributeError(msg)` and catch the result", not "bind the caught instance to `msg`" — and so `msg` is undefined when line 582 references it. Ruff (F821) flags both sites:

```
F821 Undefined name `msg`
   --> TimelinePedigreeView/TimelinePedigreeView.py:581:31
   --> TimelinePedigreeView/TimelinePedigreeView.py:582:35
```

## Fix

Switch to the Python 3 form `except AttributeError as msg:`.

```diff
         try:
             self.Tree_Rebuild()
-        except AttributeError(msg):
+        except AttributeError as msg:
             RunDatabaseRepair(str(msg))
```

## Verification

- `ruff check --select=E9,F63,F7,F82 --no-fix --exclude="*.gpr.py" TimelinePedigreeView/` → All checks passed.
- `python3 -m py_compile TimelinePedigreeView/TimelinePedigreeView.py` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)