### PR TITLE
QuiltView: import Surname for child-add path

### DIFF
--- a/QuiltView/QuiltView.py
+++ b/QuiltView/QuiltView.py
@@ -56,7 +56,7 @@ from gi.repository import Pango, PangoCairo
 # Gramps Modules
 #
 #-------------------------------------------------------------------------
-from gramps.gen.lib import Person, Family, ChildRef, Name
+from gramps.gen.lib import Person, Family, ChildRef, Name, Surname
 from gramps.gui.views.navigationview import NavigationView
 from gramps.gen.display.name import displayer as name_displayer
 from gramps.gen.errors import WindowActiveError


### PR DESCRIPTION
## Summary

`QuiltView/QuiltView.py:1266` constructs a fresh `Surname()` to attach to a new `Name` when adding a child via the editor, but `Surname` is never imported. Ruff (F821) flags it:

```
F821 Undefined name `Surname`
   --> QuiltView/QuiltView.py:1266:26
```

The file already imports `Person, Family, ChildRef, Name` from `gramps.gen.lib` — extend that import to include `Surname`. Without it, the add-child path raises `NameError` instead of opening the editor.

## Fix

```diff
-from gramps.gen.lib import Person, Family, ChildRef, Name
+from gramps.gen.lib import Person, Family, ChildRef, Name, Surname
```

## Scope

This PR addresses only the `Surname` F821. Two other F821 sites in the same file (`displayer` on lines 1239 and 1241, where the call should likely be `name_displayer.display(...)` rather than a top-level `displayer` reference) are real-bug fixes and are deliberately left out of this surgical lint PR — they need a small behavioural review of their own.

## Verification

- `ruff check --select=E9,F63,F7,F82 --no-fix --exclude="*.gpr.py" QuiltView/` → `Surname` F821 removed; the two unrelated `displayer` F821s remain (out of scope).
- `python3 -m py_compile QuiltView/QuiltView.py` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)