### PR TITLE
SourceIndex: remove dead references to undefined names

### DIFF
--- a/SourceIndex/birth.py
+++ b/SourceIndex/birth.py
@@ -98,9 +98,9 @@ class GtkHandlers:
         Gtk.main_save()
 
     def on_witness_clicked( widget, data=None):
-        print(event)
         #from witness import Witness
         #Witness.window.show()
+        pass
 
     def on_date_clicked(widget, data=None):
         pass

--- a/SourceIndex/index.py
+++ b/SourceIndex/index.py
@@ -420,9 +420,7 @@ class Index(tool.Tool, ManagedWindow):
 
         'Load indexes' means to load ordered tables, search environment
         """
-
-        files = f.endswith('.xml')
-        parent_path = os.path.join(USER_PLUGINS, 'SourceIndex')
+        pass
 
 
     def save_indexes(self):


### PR DESCRIPTION
## Summary

Two unused-and-broken statements in SourceIndex reference undefined names. Ruff (F821) flags both:

```
F821 Undefined name `event`  --> SourceIndex/birth.py:101:15
F821 Undefined name `f`      --> SourceIndex/index.py:424:17
```

Each site is dead code:

- **`birth.py`** — `on_witness_clicked` is a Gtk callback whose signature is `(widget, data=None)`. The body’s `print(event)` references a non-existent local — clearly a debug leftover; the rest of the body is a commented-out `Witness` import. Replace with `pass`, matching the placeholder style of the sibling `on_date_clicked` and `on_note_clicked` handlers.
- **`index.py`** — the `indexes` method body is two dead assignments: `files = f.endswith(".xml")` (where `f` is never bound) and `parent_path = os.path.join(USER_PLUGINS, "SourceIndex")` (whose value is never read). The sibling `save_indexes`/`load_indexes` methods are placeholder `pass` stubs already; collapse this one to match.

## Behavioural impact

Zero — the lines previously raised `NameError` when the function was called, which only ever happened in code paths that do not currently exist.

## Verification

- `ruff check --select=E9,F63,F7,F82 --no-fix --exclude="*.gpr.py" SourceIndex/` → All checks passed.
- `python3 -m py_compile SourceIndex/birth.py SourceIndex/index.py` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)