### PR TITLE
libaccess: initialise gettext _ and drop Py2-only __cmp__

### DIFF
--- a/libaccess/libaccess.py
+++ b/libaccess/libaccess.py
@@ -50,7 +50,14 @@ Additionals goals:
 
 """
 
+from gramps.gen.const import GRAMPS_LOCALE as glocale
 from gramps.gen.db import DbTxn
+
+try:
+    _trans = glocale.get_addon_translator(__file__)
+except ValueError:
+    _trans = glocale.translation
+_ = _trans.gettext
 
 import itertools
 
@@ -85,9 +92,6 @@ class Null(object):
 
     def __call__(self, *args, **kwargs):
         return NONE
-
-    def __cmp__(self, other):
-        return cmp(None, other)
 
     def __hash__(self):
         return hash(None)


### PR DESCRIPTION
## Summary

Three F821 sites in `libaccess/libaccess.py` are addressed here:

- **L90** `return cmp(None, other)` — `cmp` is a Python 2 builtin that does not exist on Python 3. The enclosing `__cmp__` method is also Py2-only — Python 3 ignores `__cmp__` in favour of the rich-comparison protocol (`__eq__`/`__lt__`/etc.). The class already implements `__eq__` and `__hash__`, so the dead Py2 `__cmp__` method is dropped entirely.
- **L218** `with DbTxn(_("libaccess edit name"), …)`
- **L260** `with DbTxn(_("libaccess edit person"), …)`
  - The file uses `_(...)` to mark translatable strings but never binds the gettext shortcut. Add the standard Gramps addon-translator pattern alongside the existing `from gramps.gen.db import DbTxn` import; the addon already ships a `po/` subtree (da/de/es/fi/fr local files), so the addon-translator path is the right fit.

## Out of scope

A fourth F821 in this file (`libaccess.py:252` `Undefined name `value`` — a missing parameter on a lambda) is a real-behaviour bug flagged in PR #820’s body. It is intentionally left out of this narrow lint cleanup; it deserves its own scoped fix.

## Fix

```diff
+from gramps.gen.const import GRAMPS_LOCALE as glocale
 from gramps.gen.db import DbTxn

+try:
+    _trans = glocale.get_addon_translator(__file__)
+except ValueError:
+    _trans = glocale.translation
+_ = _trans.gettext
+
 import itertools
```

```diff
     def __call__(self, *args, **kwargs):
         return NONE

-    def __cmp__(self, other):
-        return cmp(None, other)
-
     def __hash__(self):
         return hash(None)
```

## Verification

- `ruff check --select=E9,F63,F7,F82 --no-fix --exclude="*.gpr.py" libaccess/` → the three F821s above are gone; `value` (out of scope) remains.
- `python3 -m py_compile libaccess/libaccess.py` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)