### PR TITLE
GrampsWebSync: add DbTxn and typing.Any imports

### DIFF
--- a/GrampsWebSync/diffhandler.py
+++ b/GrampsWebSync/diffhandler.py
@@ -25,6 +25,7 @@ import logging
 from copy import deepcopy
 from datetime import datetime
 
+from gramps.gen.db import DbTxn
 from gramps.gen.db.base import DbReadBase
 from gramps.gen.merge.diff import diff_dbs
 from gramps.gen.user import User

--- a/GrampsWebSync/grampswebsync.py
+++ b/GrampsWebSync/grampswebsync.py
@@ -26,6 +26,7 @@ import os
 import threading
 from collections.abc import Callable
 from datetime import datetime
+from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse
 


### PR DESCRIPTION
## Summary

Two missing imports across two files cause six F821 sites:

| File | Missing | Sites |
|---|---|---|
| `diffhandler.py` | `DbTxn` (from `gramps.gen.db`) | L268 ×2, L308 ×2 |
| `grampswebsync.py` | `Any` (from `typing`) | L658, L664 |

Without these, the diff-application and websocket-callback paths raise `NameError` instead of doing the intended work.

## Fix

```diff
+from gramps.gen.db import DbTxn
 from gramps.gen.db.base import DbReadBase
 from gramps.gen.merge.diff import diff_dbs
 from gramps.gen.user import User
```

```diff
 from datetime import datetime
+from typing import Any
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse
```

## Verification

- `ruff check --select=E9,F63,F7,F82 --no-fix --exclude="*.gpr.py" GrampsWebSync/` → All checks passed.
- `python3 -m py_compile` on both files exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)