### PR TITLE
SourceReferences: import gramps.gen.errors as Errors

### DIFF
--- a/SourceReferences/SourceReferences.py
+++ b/SourceReferences/SourceReferences.py
@@ -25,6 +25,7 @@ from Utils import navigation_label
 from gen.plug import Gramplet
 import gtk
 
+import gramps.gen.errors as Errors
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 try:
     _trans = glocale.get_addon_translator(__file__)


### PR DESCRIPTION
## Summary

`SourceReferences/SourceReferences.py` references `Errors.WindowActiveError` in eight places (lines 119, 125, 131, 137, 160, 166, 172, 178) to catch the same active-editor exception across eight reference-edit paths, but never imports `Errors`. Ruff (F821) flags all eight:

```
F821 Undefined name `Errors`
   --> SourceReferences/SourceReferences.py:119:16  (and 7 others)
```

Without the import, every `except Errors.WindowActiveError` clause raises `NameError` on already-open editors instead of silently ignoring as intended.

## Fix

```diff
+import gramps.gen.errors as Errors
 from gramps.gen.const import GRAMPS_LOCALE as glocale
```

## Note on broader file state

This addon also uses the legacy pre-namespace import style (`from ListModel import ...`, `import gtk` for PyGTK) which suggests it has not been ported to PyGObject/Gramps 5+. That broader port is out of this PR’s scope — only the missing `Errors` import is addressed here.

## Verification

- `ruff check --select=E9,F63,F7,F82 --no-fix --exclude="*.gpr.py" SourceReferences/` → All checks passed.
- `python3 -m py_compile SourceReferences/SourceReferences.py` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)