### PR TITLE
QuiltView: remove dead duplicate add_children_submenu method

### DIFF
--- a/QuiltView/QuiltView.py
+++ b/QuiltView/QuiltView.py
@@ -1200,61 +1200,6 @@ class QuiltView(NavigationView):
         self.menu.popup(None, None, None, None,
                         event.get_button()[1], event.time)
 
-    def add_children_submenu(self, menu, person, family=None):
-        """
-        Go over children and build their menu.
-        """
-        item = Gtk.MenuItem(label=_("Children"))
-        item.set_submenu(Gtk.Menu())
-        child_menu = item.get_submenu()
-        child_menu.set_reserve_toggle_size(False)
-
-        no_child = 1
-
-        if family:
-            childlist = []
-            for child_ref in family.get_child_ref_list():
-                childlist.append(child_ref.ref)
-            # allow to add a child to this family
-            add_child_item = Gtk.MenuItem()
-            add_child_item.set_label(_("Add child to family"))
-            add_child_item.connect("activate", self.add_child_to_family,
-                                   family.get_handle())
-            add_child_item.show()
-            child_menu.append(add_child_item)
-            no_child = 0
-        else:
-            childlist = find_children(self.dbstate.db, person)
-
-        for child_handle in childlist:
-            child = self.dbstate.db.get_person_from_handle(child_handle)
-            if not child:
-                continue
-
-            if no_child:
-                no_child = 0
-
-            if find_children(self.dbstate.db, child):
-                label = Gtk.Label(label='<b><i>%s</i></b>'
-                                  % escape(displayer.display(child)))
-            else:
-                label = Gtk.Label(label=escape(displayer.display(child)))
-
-            child_item = Gtk.MenuItem()
-            label.set_use_markup(True)
-            label.show()
-            label.set_halign(Gtk.Align.START)
-            child_item.add(label)
-            child_item.connect("activate", self.move_to_person,
-                               child_handle, True)
-            child_item.show()
-            child_menu.append(child_item)
-
-        if no_child:
-            item.set_sensitive(0)
-        item.show()
-        menu.append(item)
-
     def add_child_to_family(self, obj, family_handle):
         """
         Open person editor to create and add child to family.


### PR DESCRIPTION
## Diagnosis

`QuiltView/QuiltView.py` defines `add_children_submenu` twice inside class `QuiltView`:

- L1203 (in upstream `maintenance/gramps60` numbering)
- L1528 (in upstream `maintenance/gramps60` numbering)

Both definitions came in together in Serge Noiraud's commit `1459195025` (March 2018). Python's class body executes top-to-bottom and rebinds the name on each `def`, so only the **second** copy is reachable; the first has been silent dead code for ~8 years.

The bare `displayer.display(child)` references at L1239/L1241 — which Ruff F821 flagged as `Undefined name 'displayer'` — live in the unreachable first copy. The live second copy already uses `name_displayer.display(child)` correctly.

## Correction to the original PR body

This PR originally claimed "NameError fires when QuiltView's right-click children-submenu is opened; the submenu never renders." That claim was wrong — the lines are unreachable. Thanks to @GaryGriffin for testing the unpatched code, observing the submenu renders correctly, and pushing back. The root cause is the dead-duplicate-method, not the typo.

## Fix

Delete the dead first definition of `add_children_submenu` (the L1203 copy) in full. The live L1528 copy is preserved unchanged.

This removes the F821 warnings at their source rather than papering over them, and prevents a future reordering or merge from accidentally reviving the broken version.

## Verification

- `python3 -c "import ast; ast.parse(open('QuiltView/QuiltView.py').read())"` — parses OK.
- Grep for any remaining bare `displayer` references (excluding the `import displayer as name_displayer` line and `name_displayer` uses) — zero results.
- Behavioural impact: none. Live `add_children_submenu` (formerly L1528, now L1473) is untouched; the children submenu continues to render via the same code path Gary tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)