### PR TITLE
JSON: log repr(obj) on unrecognized object instead of undefined data

### DIFF
--- a/JSON/JSONImport.py
+++ b/JSON/JSONImport.py
@@ -92,7 +92,7 @@ def importData(db, filename, user):
                     elif isinstance(obj, Place):
                         db.add_place(obj, trans)
                     else:
-                        LOG.warn("ignored: " + data)
+                        LOG.warn("ignored: " + repr(obj))
                     line = fp.readline()
     except EnvironmentError as err:
         user.notify_error(_("%s could not be opened\n") % filename, str(err))

--- a/JSON/tests/test_jsonimport_ignored_log.py
+++ b/JSON/tests/test_jsonimport_ignored_log.py
@@ -1,0 +1,101 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Gramps Development Team
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Regression test for the unrecognized-object branch in
+``JSONImport.importData``.
+
+Historically the ``else`` of that function's isinstance dispatch read::
+
+    LOG.warn("ignored: " + data)
+
+— but ``data`` was never bound, so any unparseable / unrecognized
+input line raised ``NameError`` instead of being logged. This test
+forces the ``else`` branch and asserts the log call happens cleanly
+with the post-fix variable (``repr(obj)``).
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from unittest import mock
+
+# Make sure addon modules are importable from the parent directory
+# (matches the convention used by TMGimporter/Form/WebSearch tests).
+# Required when this test is loaded via its dotted path
+# (`JSON.tests.test_jsonimport_ignored_log`) rather than discovered
+# from inside `tests/`.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import JSONImport
+
+
+class TestImportDataUnrecognizedObjectIsLogged(unittest.TestCase):
+    """Cover the else branch of importData's parsed-object dispatch."""
+
+    def test_unrecognized_object_logged_without_nameerror(self):
+        """When ``string_to_object`` returns a non-Gramps type the else
+        branch must log the ignored value and not raise NameError."""
+        with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".json", delete=False) as f:
+            f.write('{"_class": "UnknownType"}\n')
+            filename = f.name
+        try:
+            db = mock.MagicMock()
+            user = mock.MagicMock()
+
+            # Stub DbTxn to a no-op context manager so the function's
+            # `with DbTxn(...) as trans:` block is callable without a
+            # real Gramps database.
+            ctx = mock.MagicMock()
+            ctx.__enter__ = mock.MagicMock(return_value=ctx)
+            ctx.__exit__ = mock.MagicMock(return_value=None)
+
+            # Force the else branch: string_to_object returns a value
+            # that is none of the eleven handled Gramps classes
+            # (Person, Family, Event, Media, Repository, Tag, Source,
+            #  Citation, Note, Place — plus the also-handled Note).
+            sentinel = "not-a-gramps-object"
+            with mock.patch.object(JSONImport, "string_to_object",
+                                   return_value=sentinel), \
+                    mock.patch.object(JSONImport, "DbTxn", return_value=ctx), \
+                    mock.patch.object(JSONImport, "LOG") as mock_log:
+                JSONImport.importData(db, filename, user)
+
+            self.assertTrue(
+                mock_log.warn.called,
+                "LOG.warn must be called when an object is unrecognized",
+            )
+            (msg,), _kw = mock_log.warn.call_args
+            self.assertTrue(
+                msg.startswith("ignored: "),
+                "log message should start with 'ignored: ', got %r" % (msg,),
+            )
+            # The post-fix code uses repr(obj); confirm the sentinel
+            # appears in the message so a future refactor that reverts
+            # to an unrelated variable trips this assertion.
+            self.assertIn(repr(sentinel), msg)
+        finally:
+            os.unlink(filename)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`JSON/JSONImport.py:95` reads:

```python
else:
    LOG.warn("ignored: " + data)
```

— but `data` was never bound. Any line whose JSON parses into a value that is **not** one of the eleven handled Gramps classes (Person, Family, Event, Media, Repository, Tag, Source, Citation, Note, Place) hits this branch and raises `NameError: name "data" is not defined` instead of being logged as ignored. Ruff (F821) flags it:

```
F821 Undefined name `data`
   --> JSON/JSONImport.py:95:48
```

PR #820’s body flagged this as one of the "Real bugs": *"wrong var in JSONImport LOG.warn branch"*.

## Fix

Replace `data` with `repr(obj)` — the parsed-but-not-recognized object that the message refers to. `repr` handles `None` and unusual types cleanly, and shows the class name so a maintainer reading the log can tell what slipped through the dispatch.

```diff
                     else:
-                        LOG.warn("ignored: " + data)
+                        LOG.warn("ignored: " + repr(obj))
```

## Regression test

Added `JSON/tests/test_jsonimport_ignored_log.py` (~50 LOC). It forces the else branch by stubbing `string_to_object` to return a non-Gramps value, and asserts `LOG.warn` is called with a message starting `"ignored: "` and containing the value’s repr — and that no `NameError` is raised.

The test is module-loaded via its dotted path (`JSON.tests.test_jsonimport_ignored_log`) per the addons-source `ci.yml` convention.

Verified to:
- **fail** on the unfixed tree with the exact traceback `NameError: name "data" is not defined` at `JSONImport.py:95`
- **pass** after this patch

## Out of scope

`LOG.warn` is the deprecated alias for `LOG.warning` in Python’s `logging` module. That cosmetic cleanup belongs to a separate cross-addon PR; this change keeps the call shape identical to minimise the diff and stay focused on the F821.

## Verification

- `ruff check --select=E9,F63,F7,F82 --no-fix --exclude="*.gpr.py" JSON/` → All checks passed.
- `python3 -m py_compile JSON/JSONImport.py` exits 0.
- `python3 -m unittest JSON.tests.test_jsonimport_ignored_log -v` → 1 test, OK (fails on unfixed tree, passes after fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)