### PR TITLE
lxml: drop self.uistate.window from module-level ErrorDialog calls

### DIFF
--- a/lxml/lxmlGramplet.py
+++ b/lxml/lxmlGramplet.py
@@ -69,7 +69,7 @@ try:
     GZIP_OK = True
 except ImportError:
     GZIP_OK = False
-    ErrorDialog(_('Where is gzip?'), _('"gzip" is missing'), parent=self.uistate.window)
+    ErrorDialog(_('Where is gzip?'), _('"gzip" is missing'))
     LOG.error('No gzip')
 
 #-------------------------------------------------------------------------
@@ -91,7 +91,7 @@ try:
     LIBXSLT_VERSION = etree.LIBXSLT_VERSION
 except ImportError:
     LXML_OK = False
-    ErrorDialog(_('Missing python3 lxml'), _('Please, try to install "python3 lxml" package.'), parent=self.uistate.window)
+    ErrorDialog(_('Missing python3 lxml'), _('Please, try to install "python3 lxml" package.'))
     LOG.debug('No lxml')
 
 #-------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`lxml/lxmlGramplet.py:72,94` reference `self.uistate.window` at module top level — both inside `except ImportError:` branches that guard `import gzip` and `from lxml import etree, objectify`. `self` is undefined at module-load time (the gramplet instance does not exist yet), so when either import actually failed the addon module crashed with:

```
NameError: name "self" is not defined
```

…instead of showing the intended ErrorDialog. Ruff (F821) flags both:

```
F821 Undefined name `self`
   --> lxml/lxmlGramplet.py:72:69
   --> lxml/lxmlGramplet.py:94:104
```

PR #820’s body listed this as one of the "Real bugs": *"stray `parent=self.uistate.window` at module level in lxmlGramplet"*.

## Behavioural impact

- **gzip branch (L72)**: `gzip` is in the Python stdlib and never raises `ImportError`, so this path is dead code; the bug never showed.
- **lxml branch (L94)**: when a user installs the addon without the `lxml` package present, they now get the intended "Missing python3 lxml" dialog instead of an opaque `NameError` that masks the underlying cause.

## Fix

```diff
 except ImportError:
     GZIP_OK = False
-    ErrorDialog(_("Where is gzip?"), _(""gzip" is missing"), parent=self.uistate.window)
+    ErrorDialog(_("Where is gzip?"), _(""gzip" is missing"))
     LOG.error("No gzip")
...
 except ImportError:
     LXML_OK = False
-    ErrorDialog(_("Missing python3 lxml"), _("Please, try to install \"python3 lxml\" package."), parent=self.uistate.window)
+    ErrorDialog(_("Missing python3 lxml"), _("Please, try to install \"python3 lxml\" package."))
     LOG.debug("No lxml")
```

The dialogs render with no parent window — not ideal aesthetically, but at module-load there genuinely is no UI parent to anchor to. The alternative (moving these checks into the gramplet’s `__init__`) is a larger restructuring outside this PR’s scope.

## Why no regression test

The bug only fires when `from lxml import ...` raises `ImportError`, which requires either an unusual install or subprocess-isolated `sys.modules` tampering to simulate. The natural location for such a test would be `lxml/tests/`, but the addon directory name (`lxml`) collides with the third-party `lxml` package — Python treats the latter (regular package, `/usr/lib/python3/dist-packages/lxml`) as taking precedence over the namespace-package addon directory, so `python3 -m unittest lxml.tests.test_*` cannot reach the addon’s tests subtree on any system that has `lxml` installed (which the CI image always does).

Ruff F821 catches future regressions of this exact pattern — the same gate that surfaced the bug in the first place.

## Verification

- `ruff check --select=E9,F63,F7,F82 --no-fix --exclude="*.gpr.py" lxml/` → both F821 sites on `self` removed (the remaining F632 sites at lines 400/758 are in-flight via PR #837).
- `python3 -m py_compile lxml/lxmlGramplet.py` exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)