### PR TITLE
WordleGramplet: migrate Py2 / Gramps-3 era imports to Gramps 5+

### DIFF
--- a/WordleGramplet/WordleGramplet.py
+++ b/WordleGramplet/WordleGramplet.py
@@ -21,18 +21,11 @@
 
 #------------------------------------------------------------------------
 #
-# python modules
-#
-#------------------------------------------------------------------------
-from itertools import imap
-
-#------------------------------------------------------------------------
-#
 # GRAMPS modules
 #
 #------------------------------------------------------------------------
-from gen.plug import Gramplet
-from gen.plug.report import utils as ReportUtils
+from gramps.gen.plug import Gramplet
+from gramps.gen.plug.report import utils as ReportUtils
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 try:
     _trans = glocale.get_addon_translator(__file__)
@@ -94,7 +87,7 @@ class WordleGramplet(Gramplet):
         self.filter = self.filter_list.get_filter()
         people = self.filter.apply(self.dbstate.db, iter_people)
         cnt = 0
-        for person in imap(self.dbstate.db.get_person_from_handle, people):
+        for person in map(self.dbstate.db.get_person_from_handle, people):
             allnames = [person.get_primary_name()] + person.get_alternate_names()
             allnames = set([name.get_group_name().strip() for name in allnames])
             for surname in allnames:
@@ -136,7 +129,7 @@ class WordleGramplet(Gramplet):
         self.append_text((_("Total people") + ": %d") % total_people, "begin")
 
     def build_options(self):
-        from gen.plug.menu import FilterOption, PersonOption, NumberOption
+        from gramps.gen.plug.menu import FilterOption, PersonOption, NumberOption
         self.bins = NumberOption(_("Number of font sizes"), 5, 1, 10)
         self.add_option(self.bins)
 

--- a/WordleGramplet/tests/test_wordlegramplet_imports.py
+++ b/WordleGramplet/tests/test_wordlegramplet_imports.py
@@ -1,0 +1,91 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Gramps Development Team
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Regression test for WordleGramplet plugin-registration imports.
+
+Historically ``WordleGramplet/WordleGramplet.py`` had two import
+problems that broke plugin registration on Python 3:
+
+  - ``from itertools import imap`` (``imap`` is a Py2 builtin
+    removed in Py3 — ``map`` is already lazy on Py3).
+  - ``from gen.plug import Gramplet`` and two other ``gen.plug.*``
+    imports — Gramps-3 era pre-namespace paths that no longer
+    resolve in Gramps 5+ (the modules live under ``gramps.gen.*``).
+
+The addon failed plugin registration with ``cannot import name
+'imap' from 'itertools'`` (the first error Python hit); once that
+was fixed in isolation the next line down then raised
+``ModuleNotFoundError: No module named 'gen'``. This test pins
+down that the module imports cleanly end-to-end.
+"""
+
+import os
+import sys
+import unittest
+
+# Pin Gtk to 3.0 before importing — the gramps.gen.plug import
+# chain transitively touches GTK-3-only enums in gramps.gui.
+# Skip cleanly if GTK 3 is not available.
+try:
+    import gi
+
+    gi.require_version("Gtk", "3.0")
+    gi.require_version("Gdk", "3.0")
+except (ImportError, ValueError) as err:
+    raise unittest.SkipTest("GTK 3.0 / PyGObject not available: %s" % err)
+
+# Make sure addon modules are importable from the parent directory.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class TestWordleGrampletImports(unittest.TestCase):
+    """Regression: the module must import on Python 3 / Gramps 5+."""
+
+    def test_module_imports_and_exposes_class(self):
+        """WordleGramplet.py must import cleanly and expose its
+        ``WordleGramplet`` class as a Gramplet subclass.
+
+        Before the migration this fails with either
+        ``ImportError: cannot import name 'imap' from 'itertools'``
+        (on the unfixed tree) or
+        ``ModuleNotFoundError: No module named 'gen'`` (after the
+        narrow imap-only fix in this PR's earlier revision).
+        """
+        # Addon dir and impl module share the name ``WordleGramplet``;
+        # under dotted-path loading the dir becomes a namespace
+        # package, so use the explicit submodule path. (Same trap as
+        # libaccess; see gramps bug 0012691 family.)
+        from WordleGramplet import WordleGramplet as mod
+
+        self.assertTrue(
+            hasattr(mod, "WordleGramplet"),
+            "WordleGramplet class must be defined after import",
+        )
+        from gramps.gen.plug import Gramplet
+
+        self.assertTrue(
+            issubclass(mod.WordleGramplet, Gramplet),
+            "WordleGramplet must be a Gramplet subclass",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`WordleGramplet/WordleGramplet.py` had two import problems that broke plugin registration on Python 3:

| Line | Original | Issue |
|---|---|---|
| 27 | `from itertools import imap` | `imap` is a Py2 builtin removed in Py3 (Py3 `map` is already lazy) |
| 34 | `from gen.plug import Gramplet` | Gramps-3 era pre-namespace path; modules now under `gramps.gen.*` |
| 35 | `from gen.plug.report import utils as ReportUtils` | same |
| 139 | `from gen.plug.menu import FilterOption, PersonOption, NumberOption` | same (function-local) |

The addon failed plugin registration with `cannot import name 'imap' from 'itertools'` (the first error Python hit); once that was addressed in isolation, the next line down then raised `ModuleNotFoundError: No module named 'gen'` and the addon was **still unusable**. This PR migrates all four imports so the addon actually loads.

The April 19 plugin-registration smoke test in `eduralph/addons-source` CI flagged this addon as one of ten load failures.

## Fix

```diff
-from itertools import imap
-
-...
-from gen.plug import Gramplet
-from gen.plug.report import utils as ReportUtils
+from gramps.gen.plug import Gramplet
+from gramps.gen.plug.report import utils as ReportUtils
...
-        for person in imap(self.dbstate.db.get_person_from_handle, people):
+        for person in map(self.dbstate.db.get_person_from_handle, people):
...
-        from gen.plug.menu import FilterOption, PersonOption, NumberOption
+        from gramps.gen.plug.menu import FilterOption, PersonOption, NumberOption
```

Behaviour identical on Python 3 — `map(callable, iterable)` returns a lazy iterator equivalent to `imap` on Py2, and the `gramps.gen.plug.*` modules are the current homes of the same APIs the pre-namespace paths used to expose.

## Regression test

Added `WordleGramplet/tests/test_wordlegramplet_imports.py` that imports the module via the explicit submodule path (addon dir and impl module share the name `WordleGramplet`, namespace-package shadowing — same trap as libaccess / gramps bug 0012691 family). Asserts the `WordleGramplet` class is exposed and is a Gramplet subclass.

Verified via `./scripts/ubuntu/run-addon-unit.sh WordleGramplet`:
- **Before fix**: `ModuleNotFoundError: No module named 'gen'` at line 27 (FAIL)
- **After fix**: 1 test, OK

## Note on scope

An earlier revision of this PR addressed only the `imap` rename. That alone would have traded one `ImportError` for another — Python would have hit the `gen.plug` import on the next line. Force-pushed to a comprehensive migration so the PR actually delivers what its title claims: making WordleGramplet plugin-register cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)