### PR TITLE
SourceReferences: migrate Py2 / Gramps-3 era imports to Gramps 5+

### DIFF
--- a/SourceReferences/SourceReferences.py
+++ b/SourceReferences/SourceReferences.py
@@ -20,12 +20,13 @@
 # $Id: SourceReferences.py 2228 2013-10-17 16:46:53Z romjerome $
 #
 
-from ListModel import ListModel, NOSORT
-from Utils import navigation_label
-from gen.plug import Gramplet
-import gtk
+from gi.repository import Gtk
 
+import gramps.gen.errors as Errors
 from gramps.gen.const import GRAMPS_LOCALE as glocale
+from gramps.gen.plug import Gramplet
+from gramps.gen.utils.db import navigation_label
+from gramps.gui.listmodel import ListModel, NOSORT
 try:
     _trans = glocale.get_addon_translator(__file__)
 except ValueError:
@@ -46,7 +47,7 @@ class SourceReferences(Gramplet):
         """
         Build the GUI interface.
         """
-        top = gtk.TreeView()
+        top = Gtk.TreeView()
         titles = [(_('Type'), 0, 100),
                   (_('Name'), 1, 100),
                   ('', 2, 1), #hidden column for the handle
@@ -108,9 +109,9 @@ def edit_object(dbstate, uistate, reftype, ref):
     """
     Invokes the appropriate editor for an object type and given handle.
     """
-    from gui.editors import (EditEvent, EditPerson, EditFamily, EditSource,
-                             EditPlace, EditMedia, EditRepository,
-                             EditCitation)
+    from gramps.gui.editors import (EditEvent, EditPerson, EditFamily,
+                                    EditSource, EditPlace, EditMedia,
+                                    EditRepository, EditCitation)
 
     if reftype == 'Person':
         try:
@@ -150,7 +151,7 @@ def edit_object(dbstate, uistate, reftype, ref):
                              "editor and open an editor for the citation "
                              "alone")
 
-            from QuestionDialog import WarningDialog
+            from gramps.gui.dialog import WarningDialog
             WarningDialog(_("Cannot open new citation editor"),
                           blocked_text)
     elif reftype == 'Place':

--- a/SourceReferences/tests/test_sourcereferences_imports.py
+++ b/SourceReferences/tests/test_sourcereferences_imports.py
@@ -1,0 +1,99 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Gramps Development Team
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Regression test for SourceReferences plugin-registration imports.
+
+Historically ``SourceReferences/SourceReferences.py`` used Python-2 /
+Gramps-3 era pre-namespace imports::
+
+    from ListModel import ListModel, NOSORT
+    from Utils import navigation_label
+    from gen.plug import Gramplet
+    import gtk
+
+— none of which resolve on Python 3 / Gramps 5+. The addon failed
+plugin registration with ``ModuleNotFoundError: No module named
+'ListModel'`` before reaching any of its actual code, so it was
+completely unusable in modern Gramps.
+
+This test verifies the module imports cleanly on Python 3, with the
+``SourceReferences`` class exposed and ready for plugin registration.
+"""
+
+import os
+import sys
+import unittest
+
+# clipboard / editor imports inside SourceReferences.py transitively
+# touch GTK-3-only enums (Gtk.IconSize.MENU, etc.). Pin Gtk to 3.0
+# before importing so the underlying gramps.gui chain is happy.
+# Skip cleanly if GTK 3 is not available.
+try:
+    import gi
+
+    gi.require_version("Gtk", "3.0")
+    gi.require_version("Gdk", "3.0")
+except (ImportError, ValueError) as err:
+    raise unittest.SkipTest("GTK 3.0 / PyGObject not available: %s" % err)
+
+# Make sure addon modules are importable from the parent directory.
+# Required when this test is loaded via its dotted path
+# (``SourceReferences.tests.test_sourcereferences_imports``) rather
+# than via ``unittest discover`` from inside ``tests/``.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class TestSourceReferencesImports(unittest.TestCase):
+    """Regression: the module must import on Python 3 / Gramps 5+."""
+
+    def test_module_imports_and_exposes_class(self):
+        """SourceReferences.py must import cleanly and expose its
+        ``SourceReferences`` Gramplet subclass.
+
+        Before the Py2 → Py3 namespace migration this test fails
+        immediately with ``ModuleNotFoundError: No module named
+        'ListModel'`` on line 23.
+        """
+        # The addon directory and the implementation module share
+        # the name ``SourceReferences``; with a ``tests/`` subdir
+        # alongside, the directory becomes a namespace package and
+        # a bare ``import SourceReferences`` binds the package, not
+        # the .py file. Use the explicit submodule path. (Same
+        # workaround as libaccess; see gramps bug 0012691 family.)
+        from SourceReferences import SourceReferences as mod
+
+        self.assertTrue(
+            hasattr(mod, "SourceReferences"),
+            "SourceReferences class must be defined after import",
+        )
+        # Sanity check the class actually inherits from Gramplet — if
+        # the migration accidentally broke the class hierarchy this
+        # would catch it.
+        from gramps.gen.plug import Gramplet
+
+        self.assertTrue(
+            issubclass(mod.SourceReferences, Gramplet),
+            "SourceReferences must be a Gramplet subclass",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`SourceReferences/SourceReferences.py` used pre-namespace imports that broke at module load on Python 3 / Gramps 5+:

```python
from ListModel import ListModel, NOSORT
from Utils import navigation_label
from gen.plug import Gramplet
import gtk                          # PyGTK, lowercase
...
from gui.editors import (...)              # function-local
from QuestionDialog import WarningDialog   # function-local
```

These all raise `ImportError` on import; the addon failed plugin registration with `No module named ListModel` (the first of the cluster) and was completely unusable in modern Gramps. The April 19 plugin-registration smoke test in `eduralph/addons-source` CI flagged it as one of ten addon load failures.

## Fix

Migrate every import to its Gramps 5+ namespaced location:

| Old | New |
|---|---|
| `ListModel` | `gramps.gui.listmodel` |
| `Utils` | `gramps.gen.utils.db` |
| `gen.plug` | `gramps.gen.plug` |
| `gtk` | `gi.repository.Gtk` (uppercase) |
| `gui.editors` | `gramps.gui.editors` |
| `QuestionDialog` | `gramps.gui.dialog` |

Also rename the one `gtk.TreeView()` site to `Gtk.TreeView()`.

Fold in the `import gramps.gen.errors as Errors` that PR #868 addressed separately (8 `except Errors.WindowActiveError` sites) — that narrow lint PR alone would not make the addon load, since the `ListModel` import fails first; subsuming gives a single, coherent modernization commit.

## Regression test

Added `SourceReferences/tests/test_sourcereferences_imports.py` (~90 LOC) that imports the module via the explicit submodule path (the addon directory and the implementation module share the name `SourceReferences`, so under dotted-path loading the directory becomes a namespace package — same workaround as libaccess; see gramps bug 0012691 family). Asserts the `SourceReferences` class is exposed and is a Gramplet subclass.

Verified via the testbed`s `./scripts/ubuntu/run-addon-unit.sh SourceReferences`:

- **Before fix**: `ModuleNotFoundError: No module named "ListModel"` at `SourceReferences.py:23` (FAIL)
- **After fix**: 1 test, OK

## Supersedes #868

PR #868 was the narrow lint fix that just added `import gramps.gen.errors as Errors`. That alone would not have made the addon load. This PR subsumes it. #868 can be closed once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)