### PR TITLE
EditExifMetadata: declare Pillow and GExiv2 dependencies

### DIFF
--- a/EditExifMetadata/editexifmetadata.gpr.py
+++ b/EditExifMetadata/editexifmetadata.gpr.py
@@ -44,6 +44,6 @@ register(
     authors=["Rob G. Healey", "Paul Culley"],
     authors_email=["robhealey1@gmail.com", "paulr2787@gmail.com"],
     navtypes=["Media"],
-    requires_mod=["Pillow"],
+    requires_mod=["PIL"],
     requires_gi=[("GExiv2", "0.10")],
 )

--- a/EditExifMetadata/editexifmetadata.gpr.py
+++ b/EditExifMetadata/editexifmetadata.gpr.py
@@ -44,4 +44,6 @@ register(
     authors=["Rob G. Healey", "Paul Culley"],
     authors_email=["robhealey1@gmail.com", "paulr2787@gmail.com"],
     navtypes=["Media"],
+    requires_mod=["Pillow"],
+    requires_gi=[("GExiv2", "0.10")],
 )


### PR DESCRIPTION
## Summary

`EditExifMetadata/editexifmetadata.py` imports two unrelated external dependencies at module load:

```python
L31: from PIL import Image
L44: gi.require_version('GExiv2', '0.10')
L45: from gi.repository import GExiv2
```

…but `editexifmetadata.gpr.py` declared neither `requires_mod` nor `requires_gi`. Result: neither Gramps' Addon Manager (when installing on behalf of a user) nor the auto-derive CI step in addons-source's PR 820 installs Pillow, and the typelib search can't communicate the GExiv2 requirement either. Plugin registration fails with:

```
Plugin error (from 'editexifmetadata'): No module named 'PIL'
```

(The PIL error fires first because line 31 precedes the GExiv2 imports; once Pillow is installed the GExiv2 typelib error would follow next.)

The April 19 plugin-registration smoke test in `eduralph/addons-source` CI flagged this as one of ten addon load failures.

## Fix

```diff
     authors_email=["robhealey1@gmail.com", "paulr2787@gmail.com"],
     navtypes=["Media"],
+    requires_mod=["Pillow"],
+    requires_gi=[("GExiv2", "0.10")],
 )
```

`Pillow` is the PyPI package name; the importable name is `PIL`. The `requires_gi` format matches the convention used by sibling addons (`GeoAncestor`, `GeoTimeLines`, `GraphView`, `PlaceCoordinateGramplet`).

## Note on the CI image

`requires_gi` declares the **GObject Introspection** typelib requirement, but unlike `requires_mod` (pip packages) typelibs come from **system apt packages** — `gir1.2-gexiv2-0.10` on Debian/Ubuntu. The addons-source CI image (Dockerfile in PR 820) needs that apt package added in parallel; tracked separately as a follow-up commit to PR 820.

## Note on PR scope

An earlier revision of this PR only declared `Pillow`. The follow-up sweep for the GExiv2 typelib (which fires next once `Pillow` is installed) was missed. Force-pushed to declare both deps in one coherent change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)