### PR TITLE
MongoDB: declare pymongo in requires_mod

### DIFF
--- a/MongoDB/mongodb.gpr.py
+++ b/MongoDB/mongodb.gpr.py
@@ -32,4 +32,5 @@ register(
     authors=["Nick Hall"],
     authors_email=["nick-h@gramps-project.org"],
     include_in_listing=False,
+    requires_mod=["pymongo"],
 )


### PR DESCRIPTION
## Summary

`MongoDB/mongodb.py:31` does `from pymongo import MongoClient, version, ASCENDING`, but `mongodb.gpr.py` declares no `requires_mod`. Neither Gramps' Addon Manager nor the auto-derive CI step in addons-source's PR 820 installs `pymongo`, and the addon fails plugin registration with:

```
Plugin error (from "mongodb"): No module named "pymongo"
```

The April 19 plugin-registration smoke test in `eduralph/addons-source` CI flagged this as one of ten addon load failures.

## Fix

```diff
     authors_email=["nick-h@gramps-project.org"],
     include_in_listing=False,
+    requires_mod=["pymongo"],
 )
```

The PyPI package name and the importable name are both `pymongo`.

## Verification

After this lands, the auto-derive `Install addon runtime deps (derived from requires_mod)` step in PR 820's CI will pip-install `pymongo` before plugin-registration runs, and the addon will register cleanly. End-to-end verified by the plugin-registration smoke test itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)