### PR TITLE
PhotoTaggingGramplet: declare GExiv2 in requires_gi

### DIFF
--- a/PhotoTaggingGramplet/PhotoTaggingGramplet.gpr.py
+++ b/PhotoTaggingGramplet/PhotoTaggingGramplet.gpr.py
@@ -39,5 +39,5 @@ register(
     navtypes=["Media"],
     help_url="Addon:Photo_Tagging_Gramplet",
     include_in_listing=True,
-    requires_gi=[("GExiv2", "0.10,0.12,0.14")],
+    requires_gi=[("GExiv2", "0.10,0.12,0.14,0.16")],
 )

--- a/PhotoTaggingGramplet/PhotoTaggingGramplet.gpr.py
+++ b/PhotoTaggingGramplet/PhotoTaggingGramplet.gpr.py
@@ -39,4 +39,5 @@ register(
     navtypes=["Media"],
     help_url="Addon:Photo_Tagging_Gramplet",
     include_in_listing=True,
+    requires_gi=[("GExiv2", "0.10,0.12,0.14")],
 )


### PR DESCRIPTION
## Summary

`PhotoTaggingGramplet/PhotoTaggingGramplet.py:49` does `from gi.repository import GExiv2`, but `PhotoTaggingGramplet.gpr.py` declared no `requires_gi`. Gramps' Addon Manager and the addons-source CI auto-derive step therefore had no way to surface the missing typelib; on systems without GExiv2 the addon fails plugin registration with the unhelpful:

```
Plugin error (from "PhotoTaggingGramplet"): cannot import name GExiv2, introspection typelib not found
```

Unlike `EditExifMetadata` on gramps60 (which hard-pins `gi.require_version('GExiv2', '0.10')` in code), `PhotoTaggingGramplet.py` does a plain unpinned `from gi.repository import GExiv2`. Any installed GExiv2 typelib works for the addon's own import path — so the declaration only has to express "this addon needs *some* GExiv2 typelib."

`gen/utils/requirements.py:check_gi` accepts a comma-separated version list and matches the dep if any listed version satisfies `gi.require_version`. That mechanism is what makes a single declaration cover the GExiv2 versions in circulation across distros / Flatpak / Snap / Mac AIO / Windows AIO.

## Fix

```diff
     navtypes=["Media"],
     help_url="Addon:Photo_Tagging_Gramplet",
     include_in_listing=True,
+    requires_gi=[("GExiv2", "0.10,0.12,0.14,0.16")],
 )
```

Version list compiled from currently-shipping GExiv2 typelibs:
- `0.10` — gramps60 Linux distributions
- `0.12`, `0.14` — newer Linux distributions
- `0.16` — Mac AIO bundle (confirmed by @GaryGriffin on Mac 6.1 in this PR)

## History on this PR

The original revision declared `requires_gi=[("GExiv2", "0.10")]`, mirroring EditExifMetadata #878. That was too strict — PhotoTaggingGramplet doesn't pin a version in code, so a hard `0.10` declaration rejected every system carrying only a newer typelib. Force-pushed to the multi-version form. Gary's review then surfaced that GExiv2 0.16 was missing from the list — added in `2590e94a7`.

## Note on the CI image

`requires_gi` declares the **GObject Introspection** typelib requirement; typelibs come from system apt packages, not pip. The addons-source CI image (Dockerfile in PR 820) carries `gir1.2-gexiv2-0.10` already; that's sufficient for the auto-derive check to pass on this addon.

## Note on the gramps61 follow-up

This declaration covers the addon's needs across the GExiv2 versions in circulation today, but it requires another list entry whenever a new minor GExiv2 ships. The structurally correct fix is to port @prculley's PR #829 pattern (dynamic version detection via `Repository.enumerate_versions("GExiv2")` then `gi.require_version` of the latest) into `PhotoTaggingGramplet.py` itself — but that's a code change in the addon, not a declaration change, and matches the gramps61 idiom where the addon code adapts to the installed typelib and the `.gpr.py` declares no `requires_gi` at all (cf. EditExifMetadata #890). That follow-up is being raised separately on the gramps61 branch.

## Verification

- `python3 -c "import ast; ast.parse(open('PhotoTaggingGramplet/PhotoTaggingGramplet.gpr.py').read())"` — parses OK.
- `gen/utils/requirements.py:check_gi` (lines 62-80) splits the version field on `,` and accepts if any listed version satisfies `gi.require_version` — verified against the current upstream source.
- End-to-end: once Gramps loads with any of the four declared GExiv2 typelib versions installed, `from gi.repository import GExiv2` resolves and PhotoTaggingGramplet registers cleanly. The plugin-registration smoke test in addons-source CI is the natural gate; this PR doesn't change CI image apt packages, only the declared version list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)