### PR TITLE
ToDoReport: remove trailing whitespace

### DIFF
--- a/ToDoReport/TodoReport.py
+++ b/ToDoReport/TodoReport.py
@@ -460,7 +460,7 @@ class TodoReport(Report):
             self.doc.end_paragraph()
             self.doc.end_cell()
             self.doc.end_row()
-            
+
 
         for (class_name, r_handle) in self.database.find_backlink_handles(event_handle, include_classes=['Family']):
             family = self.database.get_family_from_handle(r_handle)
@@ -621,7 +621,7 @@ class TodoReport(Report):
         self.doc.write_text(citation.get_page())
         self.doc.end_paragraph()
         self.doc.end_cell()
-        
+
         self.doc.end_row()
 
 
@@ -660,7 +660,7 @@ class TodoReport(Report):
         self.doc.end_cell()
 
         self.doc.end_row()
-        
+
 
     def _output_events(self, event_base):
         """Write out all events for an object that subclasses EventBase"""
@@ -881,7 +881,7 @@ class TodoOptions(MenuReportOptions):
         for note_type in self.__db.get_note_types():
             type_option.add_item(note_type, note_type)
         menu.add_option(category_name, _NOTE_TYPE_OPTION_NAME, type_option)
-        
+
         can_group = BooleanOption(_("Group by reference type"), False)
         can_group.set_help( _("Group notes by Family, Person, Place, etc."))
         menu.add_option(category_name, "can_group", can_group)


### PR DESCRIPTION
Pure whitespace cleanup; no semantic change. Removes 4 lines of real trailing whitespace from `ToDoReport/TodoReport.py`.

Detected via PCRE (`git --no-pager grep -P '[ \t]+\$' -- '*.py'`).

### Note on PR #820's lint regex

PR #820 ships a Lint step using BRE `git grep '[ \t]\$'`, where `\t` inside `[...]` is interpreted as a literal `t` (not a tab). The check therefore matches any line ending in `t`/`[`/`]`/`\`/space — heavily over-reporting trailing whitespace. The four lines touched here are still genuine trailing whitespace, so the cleanup itself is valid; a separate follow-up will fix the regex on PR #820's branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)