### PR TITLE
EditExifMetadata: declare Pillow dependency (gramps61)

### DIFF
--- a/EditExifMetadata/editexifmetadata.gpr.py
+++ b/EditExifMetadata/editexifmetadata.gpr.py
@@ -44,5 +44,5 @@ register(
     authors=["Rob G. Healey", "Paul Culley"],
     authors_email=["robhealey1@gmail.com", "paulr2787@gmail.com"],
     navtypes=["Media"],
-    requires_mod=["Pillow"],
+    requires_mod=["PIL"],
 )

--- a/EditExifMetadata/editexifmetadata.gpr.py
+++ b/EditExifMetadata/editexifmetadata.gpr.py
@@ -44,4 +44,5 @@ register(
     authors=["Rob G. Healey", "Paul Culley"],
     authors_email=["robhealey1@gmail.com", "paulr2787@gmail.com"],
     navtypes=["Media"],
+    requires_mod=["Pillow"],
 )


### PR DESCRIPTION
## Root cause

`EditExifMetadata/editexifmetadata.py` imports `from PIL import Image` at module load (line 31), but `editexifmetadata.gpr.py` declares no `requires_mod`. So neither Gramps' Addon Manager nor the addons-source CI auto-derive step installs Pillow, and plugin registration fails with `No module named 'PIL'`.

## Fix

```diff
     navtypes=["Media"],
+    requires_mod=["Pillow"],
 )
```

## Relationship to #878 — and why this is a separate PR, not a cherry-pick

#878 declares the same dependency on `maintenance/gramps60`, where it *also* adds `requires_gi=[("GExiv2", "0.10")]`. That GExiv2 pin is correct on gramps60 (the code there hard-pins `gi.require_version('GExiv2', '0.10')`) but **wrong on gramps61**: PR #829 reworked `editexifmetadata.py` on gramps61 to load whatever GExiv2 typelib is installed —

```python
v_array = repository.enumerate_versions("GExiv2")
...
gi.require_version("GExiv2", v_array[-1])
```

`gen/utils/requirements.py` checks `requires_gi` with an exact `gi.require_version` match, so a static `("GExiv2", "0.10")` declaration would report the dependency as unmet on any system with a newer GExiv2 — the opposite of #829's intent. GExiv2 is therefore deliberately **left out** of this PR; the addon's own code already raises a clear `ValueError("GExiv2 is not installed")` when the typelib is absent.

So #878 cannot be cherry-picked here as-is — `requires_mod=["Pillow"]` is the portable part, and that is all this PR adds.

## Verified against

- gramps-project/addons-source@`maintenance/gramps61`:`EditExifMetadata/editexifmetadata.py:31` (`from PIL import Image`) and `:45-49` (PR #829 dynamic GExiv2 version handling)
- gramps-project/gramps:`gramps/gen/utils/requirements.py` — `check_gi` / `_test_gi` (exact `gi.require_version` match)

## Test

No automated test: `.gpr.py` files are plugin-registration metadata, exercised only by Gramps' loader. The change is verifiable by inspection against the import in `editexifmetadata.py` cited above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)