### PR TITLE
PhotoTaggingGramplet: detect GExiv2 version dynamically (gramps61)

### DIFF
--- a/PhotoTaggingGramplet/PhotoTaggingGramplet.py
+++ b/PhotoTaggingGramplet/PhotoTaggingGramplet.py
@@ -46,6 +46,12 @@ from gi.repository import Gtk
 from gi.repository import Gdk
 from gi.repository import GdkPixbuf
 from gi.repository import GObject
+import gi
+repository = gi.Repository.get_default()
+v_array = repository.enumerate_versions("GExiv2")
+if not v_array:
+    raise ValueError("GExiv2 is not installed")
+gi.require_version("GExiv2", v_array[-1])
 from gi.repository import GExiv2
 
 #-------------------------------------------------------------------------


### PR DESCRIPTION
## Root cause

`PhotoTaggingGramplet/PhotoTaggingGramplet.py:49` does a plain `from gi.repository import GExiv2` with no preceding `gi.require_version("GExiv2", …)` call. On systems carrying only a newer GExiv2 typelib (0.12 / 0.14 / 0.16 in current circulation) the import either falls back to an unintended default — depending on the installed GIRepository search order — or fires a `DeprecationWarning` and picks a version the addon author never validated. The `.gpr.py` declares no `requires_gi`, so the Addon Manager has no way to surface a missing-typelib failure either.

## Fix

Port the dynamic-version detection pattern introduced by @prculley in PR #829 for `EditExifMetadata.py` on gramps61. Enumerate installed GExiv2 typelib versions via `gi.Repository.get_default().enumerate_versions("GExiv2")`, pin the latest with `gi.require_version`, then import:

```python
import gi
repository = gi.Repository.get_default()
v_array = repository.enumerate_versions("GExiv2")
if not v_array:
    raise ValueError("GExiv2 is not installed")
gi.require_version("GExiv2", v_array[-1])
from gi.repository import GExiv2
```

The addon's import path now adapts to whatever GExiv2 minor version is on the system. No `requires_gi` declaration in `PhotoTaggingGramplet.gpr.py` — matches the gramps61 convention established by EditExifMetadata #890, where the runtime `ValueError` carries the missing-typelib failure mode and the Addon Manager does not pre-gate on a static version pin that the addon code no longer respects.

## Verified against

- `gramps-project/addons-source@maintenance/gramps61`:`EditExifMetadata/editexifmetadata.py:40-50` — same six-line block introduced in PR #829. The new code in this PR is byte-identical to that block, verified by `git show upstream/maintenance/gramps61:EditExifMetadata/editexifmetadata.py | sed -n '40,50p'` against the commit on this branch.
- `gramps-project/gramps`:`gramps/gen/utils/requirements.py:62-80` — `check_gi` exact-matches `gi.require_version(module, version)`, which is why a static `requires_gi=[("GExiv2", "0.10")]` declaration fails on a 0.14/0.16 system. The dynamic detection here sidesteps that.

## Test

No automated test: `.gpr.py` and module-load typelib resolution are exercised only by the Gramps loader. Manual repro:

1. On a Linux box with GExiv2 ≥ 0.12 (newer than the historical 0.10 pin), install Gramps 6.1 and this addon.
2. Confirm PhotoTaggingGramplet appears in the Gramplet picker (i.e. plugin registration succeeded — pre-fix this either failed silently or warned).
3. Right-click a Media object → Gramplets → Photo Tagging → confirm the tagging UI opens and `GExiv2.Metadata(...)` reads/writes successfully on a sample image.

## Companion PR

This is the gramps61 counterpart to addons-source #880, which keeps the static multi-version `requires_gi=[("GExiv2", "0.10,0.12,0.14,0.16")]` declaration on gramps60 (where the older convention applies and the addon's code is not being modified). Same split pattern as EditExifMetadata #878 (gramps60, static pin) / #890 (gramps61, no declaration + dynamic detection in code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)