### PR TITLE
DescendantsLines: remove trailing whitespace

### DIFF
--- a/DescendantsLines/DescendantsLines.py
+++ b/DescendantsLines/DescendantsLines.py
@@ -409,7 +409,7 @@ class DescendantsLinesReport(Report):
         # increase text pad to allow for box's line
         if STROKE_RECTANGLE:
             TEXT_PAD += RECTANGLE_TEXT_PAD
-            
+
         global FONT_NAME
         global BASE_FONT_SIZE
         FONT_NAME = self.options['FONT_NAME']
@@ -1614,12 +1614,12 @@ class DescendantsLinesOptions(MenuReportOptions):
         max_note_len.set_help(_("Maximum length of an event's note field in"
                                 " a text block, '$e(n)'\n 0=no limit "))
         menu.add_option(category_name, "max_note_len", max_note_len)
-        
+
         text_font_name = StringOption(_("Font Name"),
                                 r"sans-serif")
         text_font_name.set_help(_("Name of the Font to use. On Windows enter the file name of the .ttf at /Windows/Fonts"))
         menu.add_option(category_name, "FONT_NAME", text_font_name)
-        
+
         text_font_size = NumberOption(_("Font base size"), 12, 10, 250)
         menu.add_option(category_name, "BASE_FONT_SIZE", text_font_size)
 


### PR DESCRIPTION
## Root cause
3 line(s) in DescendantsLines/DescendantsLines.py end with trailing whitespace, which the testbed
CI Lint job flags via `git --no-pager grep '[ \t]$' -- '*.py'`.

## Fix
Strip the offending trailing whitespace. Pure formatting change.

## Verified
- `git diff -w upstream/maintenance/gramps60..HEAD` = 0 lines (proves
  the diff is whitespace-only)
- per-hunk audit: every `-` line equals the `+` line plus `[ \t]+$`
- `ast.parse()` clean on every touched file
- post-strip grep `[ \t]+$` on `DescendantsLines/*.py` = 0 matches
- string-token comparison before/after: 0 multi-line string literals
  affected (all strips occur on code-bearing or blank lines, not inside
  string content)

## Test
No regression test added — pure whitespace removal at end-of-line has no
functional behaviour to assert against, and the audits above prove the
patch is content-neutral.

Manual repro:
```
git fetch origin && git checkout DescendantsLines-cleanup
git --no-pager grep '[ \t]$' -- 'DescendantsLines/*.py'    # prints nothing
git diff -w upstream/maintenance/gramps60..HEAD       # empty
```
