### PR TITLE
GrampsChat: remove trailing whitespace

### DIFF
--- a/GrampsChat/GrampsChat.py
+++ b/GrampsChat/GrampsChat.py
@@ -26,7 +26,7 @@ export GRAMPS_AI_MODEL_NAME="<ENTER MODEL NAME HERE>"
 This is always needed. Examples: "ollama/deepseek-r1:1.5b", "openai/gpt-4o-mini"
 
 ```
-export GRAMPS_AI_MODEL_URL="<ENTER URL HERE>" 
+export GRAMPS_AI_MODEL_URL="<ENTER URL HERE>"
 ```
 
 This is needed if running your own LLM server. Example: "http://127.0.0.1:8000"

--- a/GrampsChat/chatbot.py
+++ b/GrampsChat/chatbot.py
@@ -30,7 +30,7 @@ export GRAMPS_AI_MODEL_NAME="<ENTER MODEL NAME HERE>"
 This is always needed. Examples: "ollama/deepseek-r1:1.5b", "openai/gpt-4o-mini"
 
 ```
-export GRAMPS_AI_MODEL_URL="<ENTER URL HERE>" 
+export GRAMPS_AI_MODEL_URL="<ENTER URL HERE>"
 ```
 
 This is needed if running your own LLM server. Example: "http://127.0.0.1:8000"


### PR DESCRIPTION
## Root cause
2 lines (one each in `GrampsChat/GrampsChat.py` and `GrampsChat/chatbot.py`)
end with trailing whitespace, which the testbed CI Lint job flags via
`git --no-pager grep '[ \t]$' -- '*.py'`.

## Fix
Strip the offending trailing whitespace from both files. Pure formatting
change.

## Verified
- `git diff -w upstream/maintenance/gramps60..HEAD` = 0 lines (proves
  the diff is whitespace-only)
- per-hunk audit: every `-` line equals the `+` line plus `[ \t]+$`
- `ast.parse()` clean on both touched files
- post-strip grep `[ \t]+$` on `GrampsChat/*.py` = 0 matches

### Multi-line string content audit
Tokenized both files before and after, compared every `STRING` token.
Both strips fall inside the `HELP_TEXT` module constant
(`GrampsChat.py:19-60` and `chatbot.py:23-64`), specifically the single
trailing space on this line, which sits inside a triple-backtick markdown
code block:

```
export GRAMPS_AI_MODEL_URL="<ENTER URL HERE>"
```

`HELP_TEXT` is consumed only by `self.append_message(HELP_TEXT, is_user=False)`
for display in the chat panel; trailing whitespace at end-of-line in
rendered markdown is invisible. Grep for `HELP_TEXT` consumers in
`GrampsChat/` finds no equality/hash/regex check.

## Test
No regression test added — whitespace removal at end-of-line has no
functional behaviour to assert against, and the audits above prove the
patch is content-neutral.

Manual repro:
```
git fetch origin && git checkout GrampsChat-cleanup
git --no-pager grep '[ \t]$' -- 'GrampsChat/*.py'  # prints nothing
git diff -w upstream/maintenance/gramps60..HEAD     # empty
```
