### PR TITLE
Form: remove trailing whitespace

### DIFF
--- a/Form/CensusCheckQuickview.gpr.py
+++ b/Form/CensusCheckQuickview.gpr.py
@@ -4,7 +4,7 @@
 #
 #------------------------------------------------------------------------
 
-register(QUICKREPORT, 
+register(QUICKREPORT,
          id    = 'censuscheckquickview',
          name  = _("CensusCheck"),
          description= _("Check whether any Census events are missing for a person and some of their descendents"),
@@ -18,7 +18,7 @@ register(QUICKREPORT,
          runfunc = 'run',
          help_url = "Addon:Census_Check"
   )
-register(QUICKREPORT, 
+register(QUICKREPORT,
          id    = 'censuscheckupquickview',
          name  = _("CensusCheckUp"),
          description= _("Check whether any Census events are missing for a person and some of their ancestors"),


### PR DESCRIPTION
## Root cause
2 line(s) in Form/CensusCheckQuickview.gpr.py (a `.gpr.py` plugin spec) end with trailing whitespace, which the testbed
CI Lint job flags via `git --no-pager grep '[ \t]$' -- '*.py'`.

## Fix
Strip the offending trailing whitespace. Pure formatting change.

## Verified
- `git diff -w upstream/maintenance/gramps60..HEAD` = 0 lines (proves
  the diff is whitespace-only)
- per-hunk audit: every `-` line equals the `+` line plus `[ \t]+$`
- `ast.parse()` clean on every touched file
- post-strip grep `[ \t]+$` on `Form/*.py` = 0 matches
- string-token comparison before/after: 0 multi-line string literals
  affected (all strips occur on code-bearing or blank lines, not inside
  string content)
- additionally, Form's existing unit suite (`Form/tests/test_form_validator.py`
  and `Form/tests/test_integration_form.py`, 48 tests total) passes against
  the cleaned tree via the testbed runner `./scripts/ubuntu/run-addon-unit.sh Form`

## Test
No regression test added — pure whitespace removal at end-of-line has no
functional behaviour to assert against, and the audits above prove the
patch is content-neutral.

Manual repro:
```
git fetch origin && git checkout Form-cleanup
git --no-pager grep '[ \t]$' -- 'Form/*.py'    # prints nothing
git diff -w upstream/maintenance/gramps60..HEAD       # empty
```
