### PR TITLE
lxml: remove trailing whitespace

### DIFF
--- a/lxml/lxmlGramplet.py
+++ b/lxml/lxmlGramplet.py
@@ -676,7 +676,7 @@ class lxmlGramplet(Gramplet):
                     '\t{number} sources\n',
                     nb_sources).format(number=nb_sources)
 
-        counters = surnames_string + places_string + notes_string + sources_string 
+        counters = surnames_string + places_string + notes_string + sources_string
 
         libs = '\nLIBXML' + str(LIBXML_VERSION) + '\tLIBXSLT' + str(LIBXSLT_VERSION)
 


### PR DESCRIPTION
## Root cause
1 line(s) in lxml/lxmlGramplet.py end with trailing whitespace, which the testbed
CI Lint job flags via `git --no-pager grep '[ \t]$' -- '*.py'`.

## Fix
Strip the offending trailing whitespace. Pure formatting change.

## Verified
- `git diff -w upstream/maintenance/gramps60..HEAD` = 0 lines (proves
  the diff is whitespace-only)
- per-hunk audit: every `-` line equals the `+` line plus `[ \t]+$`
- `ast.parse()` clean on every touched file
- post-strip grep `[ \t]+$` on `lxml/*.py` = 0 matches
- string-token comparison before/after: 0 multi-line string literals
  affected (all strips occur on code-bearing or blank lines, not inside
  string content)

This PR is scoped to trailing-whitespace only. The four remaining ruff
errors in `lxmlGramplet.py` (F821 `self`×2, F632 `is`/`==`×2) are covered
by #874 and #837 per the one-logical-fix-per-PR convention.

## Test
No regression test added — pure whitespace removal at end-of-line has no
functional behaviour to assert against, and the audits above prove the
patch is content-neutral.

Manual repro:
```
git fetch origin && git checkout lxml-cleanup
git --no-pager grep '[ \t]$' -- 'lxml/*.py'    # prints nothing
git diff -w upstream/maintenance/gramps60..HEAD       # empty
```
