### PR TITLE
TimelinePedigreeView: remove trailing whitespace

### DIFF
--- a/TimelinePedigreeView/TimelinePedigreeView.py
+++ b/TimelinePedigreeView/TimelinePedigreeView.py
@@ -602,7 +602,7 @@ class TimelinePedigreeView(NavigationView):
         if self.active:
             self.bookmarks.redraw()
         # clear the caches on loading a different tree
-        self._birth_cache = {}              
+        self._birth_cache = {}
         self.format_helper.clear_cache()
         self.build_tree()
 


### PR DESCRIPTION
## Root cause
1 line(s) in TimelinePedigreeView/TimelinePedigreeView.py end with trailing whitespace, which the testbed
CI Lint job flags via `git --no-pager grep '[ \t]$' -- '*.py'`.

## Fix
Strip the offending trailing whitespace. Pure formatting change.

## Verified
- `git diff -w upstream/maintenance/gramps60..HEAD` = 0 lines (proves
  the diff is whitespace-only)
- per-hunk audit: every `-` line equals the `+` line plus `[ \t]+$`
- `ast.parse()` clean on every touched file
- post-strip grep `[ \t]+$` on `TimelinePedigreeView/*.py` = 0 matches
- string-token comparison before/after: 0 multi-line string literals
  affected (all strips occur on code-bearing or blank lines, not inside
  string content)

## Test
No regression test added — pure whitespace removal at end-of-line has no
functional behaviour to assert against, and the audits above prove the
patch is content-neutral.

Manual repro:
```
git fetch origin && git checkout TimelinePedigreeView-cleanup
git --no-pager grep '[ \t]$' -- 'TimelinePedigreeView/*.py'    # prints nothing
git diff -w upstream/maintenance/gramps60..HEAD       # empty
```
