### PR TITLE
RelID: remove trailing whitespace

### DIFF
--- a/RelID/relation_tab.py
+++ b/RelID/relation_tab.py
@@ -736,7 +736,7 @@ class TableReport:
                     % self.path,
                     parent=None,
                 )
-            else: 
+            else:
                 return
 
     def write_table_data(self, data):


### PR DESCRIPTION
## Root cause
1 line(s) in RelID/relation_tab.py end with trailing whitespace, which the testbed
CI Lint job flags via `git --no-pager grep '[ \t]$' -- '*.py'`.

## Fix
Strip the offending trailing whitespace. Pure formatting change.

## Verified
- `git diff -w upstream/maintenance/gramps60..HEAD` = 0 lines (proves
  the diff is whitespace-only)
- per-hunk audit: every `-` line equals the `+` line plus `[ \t]+$`
- `ast.parse()` clean on every touched file
- post-strip grep `[ \t]+$` on `RelID/*.py` = 0 matches
- string-token comparison before/after: 0 multi-line string literals
  affected (all strips occur on code-bearing or blank lines, not inside
  string content)

This PR is scoped to trailing-whitespace only. The separate F821 in
`relation_tab.py` (Undefined name `ErrorDialog`) is the subject of #858.

## Test
No regression test added — pure whitespace removal at end-of-line has no
functional behaviour to assert against, and the audits above prove the
patch is content-neutral.

Manual repro:
```
git fetch origin && git checkout RelID-cleanup
git --no-pager grep '[ \t]$' -- 'RelID/*.py'    # prints nothing
git diff -w upstream/maintenance/gramps60..HEAD       # empty
```
