### PR TITLE
PhotoTaggingGramplet: remove trailing whitespace

### DIFF
--- a/PhotoTaggingGramplet/PhotoTaggingGramplet.py
+++ b/PhotoTaggingGramplet/PhotoTaggingGramplet.py
@@ -616,7 +616,7 @@ class PhotoTaggingGramplet(Gramplet):
 
             rtype = metadata.get(region_type % i)
             unit = metadata.get(region_unit % i)
-            
+
             # ensure region does not exceed bounds of image
             rect_p1 = x - (w / 2)
             if rect_p1 < 0:


### PR DESCRIPTION
## Root cause
1 line(s) in PhotoTaggingGramplet/PhotoTaggingGramplet.py end with trailing whitespace, which the testbed
CI Lint job flags via `git --no-pager grep '[ \t]$' -- '*.py'`.

## Fix
Strip the offending trailing whitespace. Pure formatting change.

## Verified
- `git diff -w upstream/maintenance/gramps60..HEAD` = 0 lines (proves
  the diff is whitespace-only)
- per-hunk audit: every `-` line equals the `+` line plus `[ \t]+$`
- `ast.parse()` clean on every touched file
- post-strip grep `[ \t]+$` on `PhotoTaggingGramplet/*.py` = 0 matches
- string-token comparison before/after: 0 multi-line string literals
  affected (all strips occur on code-bearing or blank lines, not inside
  string content)

## Test
No regression test added — pure whitespace removal at end-of-line has no
functional behaviour to assert against, and the audits above prove the
patch is content-neutral.

Manual repro:
```
git fetch origin && git checkout PhotoTaggingGramplet-cleanup
git --no-pager grep '[ \t]$' -- 'PhotoTaggingGramplet/*.py'    # prints nothing
git diff -w upstream/maintenance/gramps60..HEAD       # empty
```
