### PR TITLE
Emit depends_on as "do" field in addon catalog listings

### DIFF
--- a/make.py
+++ b/make.py
@@ -721,6 +721,8 @@ elif command == "as-needed":
                             plugin["h"] = p["help_url"]
                         if "audience" in p:
                             plugin["a"] = p["audience"]
+                        if "depends_on" in p:
+                            plugin["do"] = p["depends_on"]
                         listings[lang].append(plugin)
                         if lang == "en":
                             print("Listed:          %s" % p["name"])
@@ -968,6 +970,8 @@ elif command == "listing":
                             plugin["h"] = p["help_url"]
                         if "audience" in p:
                             plugin["a"] = p["audience"]
+                        if "depends_on" in p:
+                            plugin["do"] = p["depends_on"]
                         listings.append(plugin)
                     else:
                         print("   ignoring '%s'" % (p["name"]))


### PR DESCRIPTION
When a gpr.py declares `depends_on`, the build system now emits a `"do"` key in the catalog JSON entry for that plugin. The Gramps Addon Manager (in `gramps/gui/plug/_windows.py`) reads this field when the user clicks Install and automatically installs any unregistered dependencies first.

Both the `as-needed` and `listing` make.py commands are updated.

## Example

```python
# PDFForms/PDFForms.gpr.py
register(TOOL, id="generate_pdf_forms", depends_on=["Form Gramplet"], ...)
```

Produces a catalog entry:
```json
{"i": "generate_pdf_forms", "do": ["Form Gramplet"], ...}
```

Installing `generate_pdf_forms` will then automatically install the Form Gramplet if it is not already present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)