### PR TITLE
LinesOfDescendency: guard write_path against missing spouse_handle (bug 12913)

### DIFF
--- a/LinesOfDescendency/lines-of-descendency.py
+++ b/LinesOfDescendency/lines-of-descendency.py
@@ -126,7 +126,14 @@ class LinesOfDescendency(Report):
                 mother if mother != handle \
                     else family.get_father_handle()
             handle = next_handle
-            spouse = self.database.get_person_from_handle(spouse_handle)
+            # Bug 12913: a family may have only one parent defined,
+            # in which case spouse_handle is None and
+            # get_person_from_handle raises HandleError. Guard the
+            # lookup so the existing "N.N." fallback still applies.
+            if spouse_handle:
+                spouse = self.database.get_person_from_handle(spouse_handle)
+            else:
+                spouse = None
             if spouse:
                 spouse_name = _nd.display(spouse)
             else:

--- a/LinesOfDescendency/tests/test_linesofdescendency_guards.py
+++ b/LinesOfDescendency/tests/test_linesofdescendency_guards.py
@@ -127,5 +127,100 @@ class TestLinesOfDescendencyGuards(unittest.TestCase):
         self.assertIsNotNone(report.ancestor)
 
 
+class TestWritePathMissingSpouse(unittest.TestCase):
+    """Bug 12913: ``write_path`` raised ``HandleError: Handle is None``
+    when a family in the descent chain had only one parent defined
+    (so ``spouse_handle`` came back as ``None``) and the addon called
+    ``get_person_from_handle(None)`` directly. The guard added in
+    this PR catches the ``None`` before the lookup and falls through
+    to the existing ``'N.N.'`` spouse-name fallback that was already
+    in place for the "spouse object missing" case."""
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            cls.impl = _load_impl()
+        except ImportError as err:
+            raise unittest.SkipTest("Gramps not importable: %s" % err)
+        cls.LinesOfDescendency = cls.impl.LinesOfDescendency
+
+    @staticmethod
+    def _report_instance(database, doc):
+        """Build a ``LinesOfDescendency`` instance via ``__new__`` so
+        ``Report.__init__`` (which we don't need) doesn't run, and
+        wire up the minimum attributes ``write_path`` touches."""
+        report = TestWritePathMissingSpouse.LinesOfDescendency.__new__(
+            TestWritePathMissingSpouse.LinesOfDescendency
+        )
+        report.database = database
+        report.doc = doc
+        report.line = 1
+        return report
+
+    @staticmethod
+    def _person(handle, gramps_id, parents_family_handle):
+        """Mock person with the minimal API ``write_path`` touches."""
+        person = mock.MagicMock()
+        person.get_handle.return_value = handle
+        person.get_gramps_id.return_value = gramps_id
+        person.get_main_parents_family_handle.return_value = (
+            parents_family_handle
+        )
+        return person
+
+    @staticmethod
+    def _family(mother_handle, father_handle, relationship):
+        family = mock.MagicMock()
+        family.get_mother_handle.return_value = mother_handle
+        family.get_father_handle.return_value = father_handle
+        family.get_relationship.return_value = relationship
+        return family
+
+    def test_single_parent_family_does_not_raise(self):
+        """The reporter's case: a family in the chain has only one
+        parent defined. Pre-fix, ``get_person_from_handle(None)``
+        raised ``HandleError: Handle is None`` and torpedoed the
+        whole report."""
+        # Chain: ancestor (handle "A") -> child (handle "C")
+        # Family F0037 has father "A" and mother = None ("Reeves, Maria"
+        # removed per reporter's repro). When traversing from ancestor
+        # to child, spouse_handle resolves to None.
+        ancestor = self._person("A", "I0001", parents_family_handle=None)
+        child = self._person("C", "I0055", parents_family_handle="F0037")
+        # Family with only the father, no mother:
+        family = self._family(
+            mother_handle=None,
+            father_handle="A",
+            relationship=self.impl.FamilyRelType.MARRIED,
+        )
+
+        database = mock.MagicMock()
+        database.get_person_from_handle.side_effect = lambda h: {
+            "A": ancestor,
+            "C": child,
+        }[h]
+        database.get_family_from_handle.return_value = family
+
+        doc = mock.MagicMock()
+        report = self._report_instance(database, doc)
+
+        # Pre-fix this would raise HandleError; post-fix it must
+        # complete and never call get_person_from_handle with None.
+        report.write_path(["A", "C"])
+
+        # Verify get_person_from_handle was NEVER called with None
+        # -- the whole point of the guard.
+        for call in database.get_person_from_handle.call_args_list:
+            self.assertIsNotNone(call.args[0])
+
+        # Verify the user-visible output still uses the existing
+        # 'N.N.' fallback for the missing-spouse case.
+        written_calls = [str(c) for c in doc.write_text.call_args_list]
+        self.assertTrue(
+            any("N.N." in text for text in written_calls),
+            "Expected 'N.N.' fallback in rendered text; got %r" % written_calls,
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes [bug 0012913](https://gramps-project.org/bugs/view.php?id=12913) — *Lines of Descendency* report aborts with `HandleError: Handle is None` when a family in the descent chain has only one parent defined.

## Root cause

In [`LinesOfDescendency/lines-of-descendency.py`](LinesOfDescendency/lines-of-descendency.py) at `write_path`, the spouse handle is derived from the family record:

```python
mother = family.get_mother_handle()
spouse_handle = mother if mother != handle else family.get_father_handle()
handle = next_handle
spouse = self.database.get_person_from_handle(spouse_handle)  # ← HandleError if spouse_handle is None
if spouse:
    spouse_name = _nd.display(spouse)
else:
    spouse_name = 'N.N.'
```

When a family has only the father defined, `family.get_mother_handle()` returns `None`. If the current `handle` is the father (the common case when traversing from ancestor down to descendant), the conditional resolves `spouse_handle = mother = None`. The existing `if spouse: ... else: 'N.N.'` block was already anticipating the missing-spouse case, but the lookup right above it bypasses that branch by raising before `spouse` is even bound.

## Reporter's reproduction (against `example.gramps`)

1. Set Active Person → Boucher, David (I0801)
2. Reports → Text Reports → Lines of Descendancy → leave Ancestor=Boucher, David (I0801), set Descendant=Boucher, Mary Cecilia (I0055). Report generates successfully.
3. In Family F0037, remove Reeves, Maria (I0052) as mother (so the family now has only the father defined).
4. Re-run the report → `HandleError: Handle is None`, entire report aborts.

After the fix, step 4 generates the report with the existing `'N.N.'` placeholder in place of the missing spouse — same fallback the addon already uses for the "spouse object missing but handle present" case.

## Fix

Guard the `get_person_from_handle` call with `if spouse_handle:` and fall back to `spouse = None` on the no-handle path. Minimal-delta change; the existing `'N.N.'` fallback handles the rest of the path identically to the pre-fix behavior for the analogous missing-object case.

## Test

Extends the existing [`LinesOfDescendency/tests/test_linesofdescendency_guards.py`](LinesOfDescendency/tests/test_linesofdescendency_guards.py) with a new `TestWritePathMissingSpouse` class. The test drives `write_path` directly via `__new__`-bypass (mirrors the existing gramps-core test pattern for guard regressions — Eduard used the same idiom for the fan-chart guard tests in gramps-project/gramps#2315) and asserts:

1. The call completes without `HandleError` (pre-fix: raised; post-fix: passes).
2. `get_person_from_handle` is never called with `None` (the whole point of the guard).
3. The rendered output still contains the existing `'N.N.'` fallback for the missing-spouse case.

Run via the testbed:

```
./scripts/ubuntu/run-addon-unit.sh LinesOfDescendency
```

All 4 tests pass (1 new + 3 existing `__init__`-guard tests Eduard added previously). The testbed loads addon tests via dotted path (`LinesOfDescendency.tests.<module>`) — same form upstream's `ci.yml` uses, which is what surfaces Python namespace-package traps.
