### PR TITLE
Gramps Web Sync: clean up references on close

### DIFF
--- a/GrampsWebSync/grampswebsync.py
+++ b/GrampsWebSync/grampswebsync.py
@@ -179,6 +179,7 @@ class GrampsWebSyncTool(BatchTool, ManagedWindow):
 
         self.db1 = dbstate.db
         self.db2 = None
+        self._closing = False
         self._download_timestamp = 0
         self._changes: Actions | None = None
         self._sync: WebApiSyncDiffHandler | None = None
@@ -212,6 +213,7 @@ class GrampsWebSyncTool(BatchTool, ManagedWindow):
     def do_close(self, assistant):
         """Close the assistant."""
         LOG.debug("Closing Gramps Web Sync addon.")
+        self._closing = True
         if self.db2 is not None:
             LOG.debug("Closing in-memory remote database.")
             self.db2.close()
@@ -506,6 +508,8 @@ class GrampsWebSyncTool(BatchTool, ManagedWindow):
 
     def get_diff_actions(self) -> None:
         """Download the remote data, import it and compare it to local."""
+        if self._closing:
+            return
         LOG.info("Downloading Gramps XML file.")
         path = self.handle_server_errors(self.api.download_xml)
         if path is None:
@@ -551,6 +555,8 @@ class GrampsWebSyncTool(BatchTool, ManagedWindow):
 
     def _async_transfer_media(self):
         """Upload/download media files."""
+        if self._closing:
+            return
         self.handle_server_errors(self.download_files)
         if self.conclusion.error:
             return
@@ -670,6 +676,8 @@ class GrampsWebSyncTool(BatchTool, ManagedWindow):
         self, payload: dict[str, "Any"], force: bool
     ) -> None:
         """Upload/download media files."""
+        if self._closing:
+            return
         LOG.debug("Committing changes to remote database.")
         self.handle_server_errors(
             self.api.commit,

--- a/GrampsWebSync/grampswebsync.py
+++ b/GrampsWebSync/grampswebsync.py
@@ -212,6 +212,13 @@ class GrampsWebSyncTool(BatchTool, ManagedWindow):
     def do_close(self, assistant):
         """Close the assistant."""
         LOG.debug("Closing Gramps Web Sync addon.")
+        if self.db2 is not None:
+            LOG.debug("Closing in-memory remote database.")
+            self.db2.close()
+            self.db2 = None
+        # Clear the diff handler which holds references to both db1 and db2
+        self._sync = None
+        self._changes = None
         position = self.window.get_position()  # crock
         self.assistant.hide()
         self.window.move(position[0], position[1])


### PR DESCRIPTION
[A user reported](https://gramps.discourse.group/t/memory-consumption/9424) possible memory accumulation when running the Gramps Web Sync addon multiple times. It's not entirely clear to me why the entire object shouldn't be garbage collected, but it doesn't hurt to explicitly unbind the references to the in-memory database and diff objects. 