### PR TITLE
lxml: keep the trailing newline out of ngettext counter strings (bug 14234)

### DIFF
--- a/lxml/lxmlGramplet.py
+++ b/lxml/lxmlGramplet.py
@@ -661,20 +661,20 @@ class lxmlGramplet(Gramplet):
         _('\t{number} note'), _('\t{number} note')
         surnames_string = ngettext(
                     '\t{number} surname',
-                    '\t{number} surnames; no frequency yet\n',
-                    nb_surnames).format(number=nb_surnames)
+                    '\t{number} surnames; no frequency yet',
+                    nb_surnames).format(number=nb_surnames) + '\n'
         places_string = ngettext(
                     '\t{number} place',
-                    '\t{number} places\n',
-                    nb_pnames).format(number=nb_pnames)
+                    '\t{number} places',
+                    nb_pnames).format(number=nb_pnames) + '\n'
         notes_string = ngettext(
                     '\t{number} note',
-                    '\t{number} notes\n',
-                    nb_notes).format(number=nb_notes)
+                    '\t{number} notes',
+                    nb_notes).format(number=nb_notes) + '\n'
         sources_string = ngettext(
                     '\t{number} source',
-                    '\t{number} sources\n',
-                    nb_sources).format(number=nb_sources)
+                    '\t{number} sources',
+                    nb_sources).format(number=nb_sources) + '\n'
 
         counters = surnames_string + places_string + notes_string + sources_string
 


### PR DESCRIPTION
## Root cause
Commit 39fbcdd ([6.0] Refactor, fix for lxml and etree gramplets) added
four `ngettext()` counter calls in `lxml/lxmlGramplet.py` whose plural
form ends with `\n` but whose singular form does not. gettext requires a
`msgid` and its `msgid_plural` to agree on the trailing newline, so
`msgfmt` rejects every translated lxml catalog and `make.py build lxml`
aborts with fatal errors.

## Fix
Append the layout newline in code (`+ '\n'` after `.format()`) rather
than embedding it in the plural string — restoring the pre-39fbcdd
design, where the newline was a code-level concatenation, not part of the
translatable text. Drop the now-stale `\n` from `msgid_plural` / `msgstr`
in the five catalogs that translate these strings (de, hr, nl, pt_PT,
sk). All plural entries are then consistent, `msgfmt` accepts them, and
the singular case (count == 1) also gets its line break.

## Verified against
- `lxml/lxmlGramplet.py:662-677` — the four `ngettext()` counter calls
- `lxml/po/{de,hr,nl,pt_PT,sk}-local.po` — the only catalogs translating
  these strings; `msgfmt -c` is clean on all 20 lxml catalogs post-fix
- commit that introduced the bug: 39fbcdd ([6.0] Refactor) — added the
  `ngettext()` calls with the mismatched newline; pre-39fbcdd the newline
  was appended in code, which this PR restores

## Test
No automated test ships in this PR. A regression test would belong in
`lxml/tests/`, but the addon directory is named `lxml` and the installed
`lxml` library (a regular package) shadows it under Python's import
precedence: `python3 -m unittest lxml.tests.<module>` — the standard way
to run an addon test — resolves `lxml` to the library and fails with
`ModuleNotFoundError: No module named 'lxml.tests'`. Manual repro:

    msgfmt -c lxml/po/de-local.po        # 8 fatal errors pre-fix, clean post
    python3 make.py gramps60 build lxml  # fails pre-fix, exit 0 post

Fixes [#14234](https://gramps-project.org/bugs/view.php?id=14234).