### PR TITLE
Add HasTagSubstr filter addon for all object namespaces

### DIFF
--- a/HasTagSubstr/hastagsubstr.gpr.py
+++ b/HasTagSubstr/hastagsubstr.gpr.py
@@ -1,0 +1,171 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2025  Doug Blank <doug.blank@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+"""Filter rules to match objects with a tag whose name contains a substring."""
+
+register(
+    RULE,
+    id="PersonHasTagSubstr",
+    name=_("People with a tag containing <substring>"),
+    description=_("Matches people with a tag whose name contains the given substring"),
+    version="1.0.0",
+    authors=["Doug Blank"],
+    authors_email=["doug.blank@gmail.com"],
+    gramps_target_version="6.1",
+    status=STABLE,
+    fname="hastagsubstr.py",
+    ruleclass="PersonHasTagSubstr",
+    namespace="Person",
+)
+
+register(
+    RULE,
+    id="FamilyHasTagSubstr",
+    name=_("Families with a tag containing <substring>"),
+    description=_(
+        "Matches families with a tag whose name contains the given substring"
+    ),
+    version="1.0.0",
+    authors=["Doug Blank"],
+    authors_email=["doug.blank@gmail.com"],
+    gramps_target_version="6.1",
+    status=STABLE,
+    fname="hastagsubstr.py",
+    ruleclass="FamilyHasTagSubstr",
+    namespace="Family",
+)
+
+register(
+    RULE,
+    id="EventHasTagSubstr",
+    name=_("Events with a tag containing <substring>"),
+    description=_(
+        "Matches events with a tag whose name contains the given substring"
+    ),
+    version="1.0.0",
+    authors=["Doug Blank"],
+    authors_email=["doug.blank@gmail.com"],
+    gramps_target_version="6.1",
+    status=STABLE,
+    fname="hastagsubstr.py",
+    ruleclass="EventHasTagSubstr",
+    namespace="Event",
+)
+
+register(
+    RULE,
+    id="PlaceHasTagSubstr",
+    name=_("Places with a tag containing <substring>"),
+    description=_(
+        "Matches places with a tag whose name contains the given substring"
+    ),
+    version="1.0.0",
+    authors=["Doug Blank"],
+    authors_email=["doug.blank@gmail.com"],
+    gramps_target_version="6.1",
+    status=STABLE,
+    fname="hastagsubstr.py",
+    ruleclass="PlaceHasTagSubstr",
+    namespace="Place",
+)
+
+register(
+    RULE,
+    id="SourceHasTagSubstr",
+    name=_("Sources with a tag containing <substring>"),
+    description=_(
+        "Matches sources with a tag whose name contains the given substring"
+    ),
+    version="1.0.0",
+    authors=["Doug Blank"],
+    authors_email=["doug.blank@gmail.com"],
+    gramps_target_version="6.1",
+    status=STABLE,
+    fname="hastagsubstr.py",
+    ruleclass="SourceHasTagSubstr",
+    namespace="Source",
+)
+
+register(
+    RULE,
+    id="CitationHasTagSubstr",
+    name=_("Citations with a tag containing <substring>"),
+    description=_(
+        "Matches citations with a tag whose name contains the given substring"
+    ),
+    version="1.0.0",
+    authors=["Doug Blank"],
+    authors_email=["doug.blank@gmail.com"],
+    gramps_target_version="6.1",
+    status=STABLE,
+    fname="hastagsubstr.py",
+    ruleclass="CitationHasTagSubstr",
+    namespace="Citation",
+)
+
+register(
+    RULE,
+    id="RepositoryHasTagSubstr",
+    name=_("Repositories with a tag containing <substring>"),
+    description=_(
+        "Matches repositories with a tag whose name contains the given substring"
+    ),
+    version="1.0.0",
+    authors=["Doug Blank"],
+    authors_email=["doug.blank@gmail.com"],
+    gramps_target_version="6.1",
+    status=STABLE,
+    fname="hastagsubstr.py",
+    ruleclass="RepositoryHasTagSubstr",
+    namespace="Repository",
+)
+
+register(
+    RULE,
+    id="MediaHasTagSubstr",
+    name=_("Media objects with a tag containing <substring>"),
+    description=_(
+        "Matches media objects with a tag whose name contains the given substring"
+    ),
+    version="1.0.0",
+    authors=["Doug Blank"],
+    authors_email=["doug.blank@gmail.com"],
+    gramps_target_version="6.1",
+    status=STABLE,
+    fname="hastagsubstr.py",
+    ruleclass="MediaHasTagSubstr",
+    namespace="Media",
+)
+
+register(
+    RULE,
+    id="NoteHasTagSubstr",
+    name=_("Notes with a tag containing <substring>"),
+    description=_(
+        "Matches notes with a tag whose name contains the given substring"
+    ),
+    version="1.0.0",
+    authors=["Doug Blank"],
+    authors_email=["doug.blank@gmail.com"],
+    gramps_target_version="6.1",
+    status=STABLE,
+    fname="hastagsubstr.py",
+    ruleclass="NoteHasTagSubstr",
+    namespace="Note",
+)

--- a/HasTagSubstr/hastagsubstr.py
+++ b/HasTagSubstr/hastagsubstr.py
@@ -1,0 +1,183 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2025  Doug Blank <doug.blank@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+"""Filter rules to match objects with a tag whose name contains a substring."""
+
+# -------------------------------------------------------------------------
+#
+# Gramps modules
+#
+# -------------------------------------------------------------------------
+from gramps.gen.filters.rules import Rule
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+
+try:
+    _trans = glocale.get_addon_translator(__file__)
+except ValueError:
+    _trans = glocale.translation
+_ = _trans.gettext
+
+# -------------------------------------------------------------------------
+#
+# Typing modules
+#
+# -------------------------------------------------------------------------
+from typing import Set
+from gramps.gen.lib.primaryobj import PrimaryObject
+from gramps.gen.db import Database
+from gramps.gen.types import PrimaryObjectHandle
+
+
+# -------------------------------------------------------------------------
+#
+# HasTagSubstrBase
+#
+# -------------------------------------------------------------------------
+class HasTagSubstrBase(Rule):
+    """Rule that matches objects with a tag whose name contains a substring."""
+
+    labels = [_("Substring:")]
+    name = "Objects with a tag containing <substring>"
+    description = "Matches objects with a tag whose name contains the given substring"
+    category = _("General filters")
+    namespace = ""
+
+    def prepare(self, db: Database, user) -> None:
+        """Build the set of matching object handles once, before filtering begins.
+
+        Scans all tags for names containing the substring, then uses backlinks
+        to collect the handles of every object in this namespace that carries
+        at least one of those tags.  The optimizer sees self.selected_handles
+        and skips apply_to_one entirely for handles not in the set.
+        """
+        substring = self.list[0].upper()
+        self.selected_handles: Set[PrimaryObjectHandle] = set()
+        for tag_handle in db.get_tag_handles():
+            tag = db.get_tag_from_handle(tag_handle)
+            if tag is not None and substring in tag.get_name().upper():
+                for _classname, obj_handle in db.find_backlink_handles(
+                    tag_handle, include_classes=[self.namespace]
+                ):
+                    self.selected_handles.add(obj_handle)
+
+    def apply_to_one(self, db: Database, obj: PrimaryObject) -> bool:
+        """Return True if this object's handle is in the pre-built match set."""
+        return obj.handle in self.selected_handles
+
+
+# -------------------------------------------------------------------------
+#
+# Per-namespace subclasses
+#
+# -------------------------------------------------------------------------
+class PersonHasTagSubstr(HasTagSubstrBase):
+    """Matches people with a tag whose name contains a substring."""
+
+    labels = [_("Substring:")]
+    name = _("People with a tag containing <substring>")
+    description = _("Matches people with a tag whose name contains the given substring")
+    namespace = "Person"
+
+
+class FamilyHasTagSubstr(HasTagSubstrBase):
+    """Matches families with a tag whose name contains a substring."""
+
+    labels = [_("Substring:")]
+    name = _("Families with a tag containing <substring>")
+    description = _(
+        "Matches families with a tag whose name contains the given substring"
+    )
+    namespace = "Family"
+
+
+class EventHasTagSubstr(HasTagSubstrBase):
+    """Matches events with a tag whose name contains a substring."""
+
+    labels = [_("Substring:")]
+    name = _("Events with a tag containing <substring>")
+    description = _(
+        "Matches events with a tag whose name contains the given substring"
+    )
+    namespace = "Event"
+
+
+class PlaceHasTagSubstr(HasTagSubstrBase):
+    """Matches places with a tag whose name contains a substring."""
+
+    labels = [_("Substring:")]
+    name = _("Places with a tag containing <substring>")
+    description = _(
+        "Matches places with a tag whose name contains the given substring"
+    )
+    namespace = "Place"
+
+
+class SourceHasTagSubstr(HasTagSubstrBase):
+    """Matches sources with a tag whose name contains a substring."""
+
+    labels = [_("Substring:")]
+    name = _("Sources with a tag containing <substring>")
+    description = _(
+        "Matches sources with a tag whose name contains the given substring"
+    )
+    namespace = "Source"
+
+
+class CitationHasTagSubstr(HasTagSubstrBase):
+    """Matches citations with a tag whose name contains a substring."""
+
+    labels = [_("Substring:")]
+    name = _("Citations with a tag containing <substring>")
+    description = _(
+        "Matches citations with a tag whose name contains the given substring"
+    )
+    namespace = "Citation"
+
+
+class RepositoryHasTagSubstr(HasTagSubstrBase):
+    """Matches repositories with a tag whose name contains a substring."""
+
+    labels = [_("Substring:")]
+    name = _("Repositories with a tag containing <substring>")
+    description = _(
+        "Matches repositories with a tag whose name contains the given substring"
+    )
+    namespace = "Repository"
+
+
+class MediaHasTagSubstr(HasTagSubstrBase):
+    """Matches media objects with a tag whose name contains a substring."""
+
+    labels = [_("Substring:")]
+    name = _("Media objects with a tag containing <substring>")
+    description = _(
+        "Matches media objects with a tag whose name contains the given substring"
+    )
+    namespace = "Media"
+
+
+class NoteHasTagSubstr(HasTagSubstrBase):
+    """Matches notes with a tag whose name contains a substring."""
+
+    labels = [_("Substring:")]
+    name = _("Notes with a tag containing <substring>")
+    description = _(
+        "Matches notes with a tag whose name contains the given substring"
+    )
+    namespace = "Note"


### PR DESCRIPTION
## Summary

Adds a new third-party filter addon `HasTagSubstr` with nine filter rules — one per Gramps object namespace — that match objects whose tag names contain a given substring (case-insensitive).

**Motivation**: Users with many tags often use a naming convention (e.g. all indirect-relative tags end in 'x'). This addon lets them filter by partial tag name rather than requiring an exact match.

## Implementation

- `hastagsubstr.py` — `HasTagSubstrBase` base class + 9 per-namespace subclasses (Person, Family, Event, Place, Source, Citation, Repository, Media, Note)
- `hastagsubstr.gpr.py` — plugin registration for all 9 rules

The base class uses the `selected_handles` optimizer pattern: `prepare()` scans all tags for names containing the substring, then collects matching object handles via `find_backlink_handles(tag_handle, include_classes=[self.namespace])`. The filter engine detects `selected_handles` and skips `apply_to_one` for non-matching objects, making the filter O(matching tags × matching objects) rather than O(all objects × all tags).

## Test plan

- [ ] Install addon and apply "People with a tag containing \<substring\>" filter in the People view
- [ ] Verify case-insensitive matching (e.g. "x" matches tags "indirect-x", "X-marker")
- [ ] Verify empty substring matches all tagged objects
- [ ] Verify no results when substring matches no tag names

🤖 Generated with [Claude Code](https://claude.com/claude-code)