### PR TITLE
CombinedView: clear the view when the database is closed (bug 12572)

### DIFF
--- a/CombinedView/combinedview.py
+++ b/CombinedView/combinedview.py
@@ -474,7 +474,8 @@ class CombinedView(NavigationView):
             return
 
     def edit_active(self, *obj):
-        self.active_page.edit_active()
+        if self.active_page is not None:
+            self.active_page.edit_active()
 
     def change_db(self, db):
         #reset the connects
@@ -498,8 +499,17 @@ class CombinedView(NavigationView):
     def change_object(self, obj_tuple):
 
         if obj_tuple is None:
+            # No active object, e.g. the family tree was closed.  Clear the
+            # display instead of leaving people from the closed tree on
+            # screen: their handles no longer resolve, so editing one would
+            # raise HandleError (bug #12572, bug #14226).
+            for page in self.pages.values():
+                page.disable_actions(self.uimanager)
+            self.uimanager.update_menu()
+            list(map(self.header.remove, self.header.get_children()))
+            list(map(self.stack.remove, self.stack.get_children()))
+            self.active_page = None
             return
-
 
         if self.redrawing:
             return False


### PR DESCRIPTION
Fixes Mantis bug 12572 — https://gramps-project.org/bugs/view.php?id=12572
Also fixes the underlying stale-view defect, Mantis bug 14226 — https://gramps-project.org/bugs/view.php?id=14226

## Root cause
Closing a family tree emits `database-changed`; `change_db()` clears the navigation history and calls `redraw()`, which finds no active person and calls `change_object(None)`. `change_object()` returned immediately on `None` — before the code that rebuilds `header`/`stack` — so the Combined view kept showing the closed tree's people, whose edit buttons still held handles that no longer resolve.

## Fix
On the no-active-object path, `change_object()` now clears `header`/`stack`, disables the per-page actions, and nulls `active_page` instead of returning early. `edit_active()` is guarded against the now-possible `active_page is None`. The addon `version` is bumped 2.0.17 → 2.0.18.

## Verified against
- `CombinedView/combinedview.py:480-493` — `change_db` clears the history and `redraw` routes a closed/empty database to `change_object(None)`; that is the only path reached on tree close, so clearing there is sufficient.
- gramps-project/gramps, `maintenance/gramps61`: `gramps/plugins/view/relview.py:594-603` and `:655-667` — the built-in Relationships view clears its container/header in `change_db`, and in `_change_person` before its no-person early return. This fix mirrors that behaviour — which is why every other view already clears on tree close while the Combined view did not.

## Test
Manual repro (the report's steps): open any tree → Relationships > Combined → close the tree → click an edit button on a still-visible person. Without this fix Gramps raises `HandleError`; with it the view is cleared on close, so there is nothing stale to click.

Automated coverage: an AT-SPI/dogtail regression test in the gramps-testbed CI harness (`tests/interface/test_combinedview_stale_close.py`) reproduces the crash on the unpatched addon — it asserts on the `HandleError` traceback that Gramps surfaces in its Error Report window — and passes with this fix. A plain unit test is impractical: the defect is in GTK signal/redraw wiring that needs a running view and a live `dbstate`.
