### PR TITLE
GenealogyTree: compact-template option for the Sandclock report (bug 10512)

### DIFF
--- a/GenealogyTree/gt_sandclock.py
+++ b/GenealogyTree/gt_sandclock.py
@@ -90,6 +90,7 @@ class SandclockTree(Report):
         self.max_down = menu.get_option_by_name('gendown').get_value()
         self.include_siblings = menu.get_option_by_name('siblings').get_value()
         self.include_images = menu.get_option_by_name('images').get_value()
+        self.compact = menu.get_option_by_name('compact').get_value()
         self.set_locale(menu.get_option_by_name('trans').get_value())
 
     def write_report(self):
@@ -108,26 +109,7 @@ class SandclockTree(Report):
                     raise ReportError(_("Family %s is not in the Database") %
                                       self._pid)
 
-            options = ['pref code={\\underline{#1}}',
-                       'list separators hang',
-                       'place text={\\newline}{}']
-
-            if self.include_images:
-                images = ('if image defined={'
-                          'add to width=25mm,right=25mm,\n'
-                          'underlay={\\begin{tcbclipinterior}'
-                          '\\path[fill overzoom image=\\gtrDBimage]\n'
-                          '([xshift=-24mm]interior.south east) '
-                          'rectangle (interior.north east);\n'
-                          '\\end{tcbclipinterior}},\n'
-                          '}{},')
-                box = 'box={halign=left,\\gtrDBsex,%s\n}' % images
-            else:
-                box = 'box={halign=left,\\gtrDBsex}'
-
-            options.append(box)
-
-            self.doc.start_tree(options)
+            self.doc.start_tree(self._build_tree_options())
             if self._person_report:
                 family_handle = person.get_main_parents_family_handle()
                 if family_handle:
@@ -144,6 +126,43 @@ class SandclockTree(Report):
                         self.doc.write_node(self._db, 1, 'c', child, False)
                 self.doc.end_subgraph(0)
             self.doc.end_tree()
+
+    def _build_tree_options(self):
+        """Assemble the option list for ``\\genealogytree[...]``.
+
+        Kept separate from ``write_report`` so the option-construction
+        logic can be unit-tested without driving a full report run.
+        """
+        options = ['pref code={\\underline{#1}}',
+                   'list separators hang',
+                   'place text={\\newline}{}']
+
+        if self.include_images:
+            images = ('if image defined={'
+                      'add to width=25mm,right=25mm,\n'
+                      'underlay={\\begin{tcbclipinterior}'
+                      '\\path[fill overzoom image=\\gtrDBimage]\n'
+                      '([xshift=-24mm]interior.south east) '
+                      'rectangle (interior.north east);\n'
+                      '\\end{tcbclipinterior}},\n'
+                      '}{},')
+            box = 'box={halign=left,\\gtrDBsex,%s\n}' % images
+        else:
+            box = 'box={halign=left,\\gtrDBsex}'
+
+        options.append(box)
+
+        if self.compact:
+            # Mantis 10512 / SNoiraud's 2018-12-20 note: the default
+            # `database` template lays out sandclock trees so widely
+            # that large trees clip off the page.  `database pole
+            # reduced` gives ~4x more space per page at the cost of
+            # denser per-node formatting.  Appended last so it
+            # overrides any node-spacing defaults set by treedoc.py's
+            # built-in keys earlier in the parameter list.
+            options.append('template=database pole reduced')
+
+        return options
 
     def subgraph_up_parents(self, level, family):
         for handle in (family.get_father_handle(), family.get_mother_handle()):
@@ -250,5 +269,13 @@ class SandclockTreeOptions(MenuReportOptions):
         images = BooleanOption(_("Include images"), False)
         images.set_help(_("Include images of people in the nodes."))
         menu.add_option(category_name, "images", images)
+
+        compact = BooleanOption(_("Compact tree layout"), False)
+        compact.set_help(_(
+            "Use the genealogytree 'database pole reduced' template, "
+            "which packs more generations per page. Useful for large "
+            "sandclock trees that otherwise clip off the rendered page."
+        ))
+        menu.add_option(category_name, "compact", compact)
 
         locale_opt = stdoptions.add_localization_option(menu, category_name)

--- a/GenealogyTree/tests/test_sandclock_compact_template.py
+++ b/GenealogyTree/tests/test_sandclock_compact_template.py
@@ -1,0 +1,143 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+# 02110-1301 USA.
+#
+
+"""Regression test for Mantis bug 10512 — the Sandclock Genealogy Tree
+report rendered only one page of an arbitrarily-large tree because
+genealogytree's default ``database`` template lays the tree out so
+widely that big sandclocks clip off the page.
+
+SNoiraud's 2018-12-20 workaround on the Mantis ticket was to add
+``template=database pole reduced`` to the ``\\genealogytree[…]``
+parameter list, which gives ~4x more space per page at the cost of
+denser per-node formatting.  This PR exposes that as a user-facing
+"Compact tree layout" option on the Sandclock report.
+
+These tests cover the option-list assembly without driving a full
+report run (no LaTeX, no Gramps GUI).  They instantiate
+``SandclockTree`` via ``__new__`` so we never enter ``Report.__init__``,
+set just the attributes ``_build_tree_options`` reads, and assert the
+template directive is present exactly when ``compact=True``.
+"""
+
+import importlib.util
+import os
+import unittest
+
+
+_IMPL_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "gt_sandclock.py",
+)
+
+
+def _load_impl():
+    """Load and return the gt_sandclock module by file path.
+
+    The addon directory is not necessarily on ``sys.path`` from a
+    bare unit-test invocation, so we load by file location.
+    """
+    spec = importlib.util.spec_from_file_location(
+        "gt_sandclock_impl", _IMPL_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class SandclockCompactTemplateTest(unittest.TestCase):
+    """``_build_tree_options`` emits ``template=database pole reduced``
+    if and only if the report's ``compact`` option is True."""
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            cls.impl = _load_impl()
+        except ImportError as err:
+            raise unittest.SkipTest("Gramps not importable: %s" % err)
+        cls.SandclockTree = cls.impl.SandclockTree
+
+    def _build_report(self, compact, include_images=False):
+        """Return a SandclockTree skeleton with just the attributes
+        ``_build_tree_options`` reads."""
+        report = self.SandclockTree.__new__(self.SandclockTree)
+        report.compact = compact
+        report.include_images = include_images
+        return report
+
+    def test_default_layout_has_no_template_directive(self):
+        """With ``compact=False`` (the default), the option list does
+        not carry a ``template=`` entry — genealogytree uses its
+        default ``database`` template."""
+        opts = self._build_report(compact=False)._build_tree_options()
+        for entry in opts:
+            self.assertFalse(
+                entry.startswith("template="),
+                f"unexpected template directive: {entry!r}",
+            )
+
+    def test_compact_layout_appends_database_pole_reduced(self):
+        """With ``compact=True``, the option list contains exactly the
+        SNoiraud-suggested directive."""
+        opts = self._build_report(compact=True)._build_tree_options()
+        self.assertIn("template=database pole reduced", opts)
+
+    def test_compact_template_is_last_option(self):
+        """The template directive must come *after* the other genealogy-
+        tree options so it overrides node-spacing defaults that
+        treedoc.py's built-in keys may have set earlier in the parameter
+        list.  pgfkeys is order-sensitive: a later ``template=`` resets
+        the keys the template controls."""
+        opts = self._build_report(compact=True)._build_tree_options()
+        self.assertEqual(
+            opts[-1],
+            "template=database pole reduced",
+            f"template directive must be the LAST option; got {opts!r}",
+        )
+
+    def test_compact_layout_preserves_existing_options(self):
+        """Turning ``compact`` on must not drop the pref-code, list-
+        separator, place-text, or box options that the default option
+        list already carries."""
+        opts = self._build_report(compact=True)._build_tree_options()
+        self.assertIn("pref code={\\underline{#1}}", opts)
+        self.assertIn("list separators hang", opts)
+        self.assertIn("place text={\\newline}{}", opts)
+        # Box option is the one before the template directive.
+        self.assertTrue(
+            any(entry.startswith("box={") for entry in opts),
+            f"box directive missing from option list: {opts!r}",
+        )
+
+    def test_images_and_compact_coexist(self):
+        """``include_images=True`` and ``compact=True`` both contribute
+        their own entries — neither suppresses the other."""
+        opts = self._build_report(
+            compact=True, include_images=True
+        )._build_tree_options()
+        self.assertIn("template=database pole reduced", opts)
+        # The images path produces a longer box option that contains
+        # the genealogytree image-overlay directive ``\gtrDBimage``.
+        self.assertTrue(
+            any("\\gtrDBimage" in entry for entry in opts),
+            f"image directive missing when include_images=True: {opts!r}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Root cause

The Sandclock Genealogy Tree report rendered only one page of an
arbitrarily-large tree. The LaTeX `genealogytree` package's default
`database` template lays the tree out so widely that big sandclocks
clip off the page; the package itself does not support multi-page
output for that layout. SNoiraud confirmed this on the Mantis ticket
in note ~0046612 and offered a workaround template
(`template=database pole reduced`) that gives ~4x more space per
page at the cost of denser per-node formatting.

## Fix

Expose SNoiraud's workaround as a user-facing report option. A new
"Compact tree layout" boolean on the Sandclock report appends
`template=database pole reduced` to the `\genealogytree[…]`
parameter list when enabled.

The directive is appended **last** so it overrides any node-spacing
defaults that `gramps/gen/plug/docgen/treedoc.py`'s built-in keys
(`level distance`, `node size`, `level size`) set earlier in the
parameter list — `pgfkeys` is order-sensitive, so a later
`template=` re-sets the keys the template controls.

Option-list assembly was extracted into a `_build_tree_options()`
method so the construction logic can be unit-tested without driving
a full report run (no LaTeX toolchain dependency).

## Verified against

- `GenealogyTree/gt_sandclock.py:148` — `_build_tree_options` body
- `GenealogyTree/gt_sandclock.py:96-128` — `write_report` calls into it
- `GenealogyTree/treeplugins.gpr.py` — **unchanged**; per the
  addons-source convention the maintainer manages the `.gpr.py`
  version, not the contributor

## Test

`GenealogyTree/tests/test_sandclock_compact_template.py` — five focused
unit tests exercising the new option-list builder via
`SandclockTree.__new__(...)` skeleton (no Gramps GUI, no LaTeX, no
database):

- Default layout omits any `template=` directive
- `compact=True` appends exactly `template=database pole reduced`
- Directive lands **last** in the option list (pgfkeys order)
- Other default options (`pref code=`, `list separators hang`,
  `place text=`, `box=`) remain intact when compact is on
- `include_images` and `compact` coexist without either suppressing
  the other

All 5 pass via `gramps-testbed/scripts/ubuntu/run-addon-unit.sh GenealogyTree`.

Fixes #10512