### PR TITLE
PrerequisitesCheckerGramplet: guard active_page on tree close (bug 13966)

### DIFF
--- a/PrerequisitesCheckerGramplet/PrerequisitesCheckerGramplet.py
+++ b/PrerequisitesCheckerGramplet/PrerequisitesCheckerGramplet.py
@@ -168,7 +168,12 @@ class PrerequisitesCheckerGramplet(Gramplet):
         the web, we just yield again if not ready.
         """
         self.count += 1
-        if self.uistate.viewmanager.active_page.bottombar:
+        active_page = self.uistate.viewmanager.active_page
+        if active_page is None:
+            # Closing the family tree clears active_page before the
+            # gramplet framework stops pumping this generator (bug 13966).
+            return
+        if active_page.bottombar:
             # The dashboard has no sidebar and bottombar.
             # For all other views, the database must be opened
             if not self.dbstate.db.is_open():

--- a/PrerequisitesCheckerGramplet/tests/test_main_active_page_none.py
+++ b/PrerequisitesCheckerGramplet/tests/test_main_active_page_none.py
@@ -1,0 +1,131 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Gramps Development Team
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Regression test for Mantis bug 13966.
+
+When the family tree is closed while the
+``PrerequisitesCheckerGramplet`` gramplet is still being stepped by
+the gramplet framework's ``_updater`` / ``next(self._generator)``
+loop, ``self.uistate.viewmanager.active_page`` becomes ``None``. The
+gramplet's ``main()`` reads ``…active_page.bottombar`` unguarded and
+raises ``AttributeError: 'NoneType' object has no attribute
+'bottombar'``.
+
+This test drives ``main()`` once with a stub ``uistate`` whose
+``active_page`` is ``None`` and asserts the generator exits cleanly
+(via ``StopIteration``) without ``AttributeError``.
+"""
+
+import importlib.util
+import os
+import unittest
+from unittest import mock
+
+# The addon's module file (PrerequisitesCheckerGramplet.py) shares its
+# basename with the package directory; the dotted-path loader registers
+# the directory as a namespace package first, so a plain
+# `import PrerequisitesCheckerGramplet` then binds the package rather
+# than the submodule (the bug 0012691 trap). Load the module file
+# directly to sidestep that.
+_addon_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_module_path = os.path.join(_addon_dir, "PrerequisitesCheckerGramplet.py")
+_spec = importlib.util.spec_from_file_location(
+    "PrerequisitesCheckerGramplet_module", _module_path
+)
+pcg = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(pcg)
+
+
+class TestMainHandlesActivePageNone(unittest.TestCase):
+    """main() must not raise when viewmanager.active_page is None.
+
+    Bug 13966: on tree close, the framework still pumps the generator
+    via _gramplet.py:331 _updater → next(self._generator). The gramplet
+    assumes an active page exists; on close it doesn't.
+    """
+
+    def _make_gramplet(self, active_page):
+        # Build a gramplet instance without running Gramplet.__init__
+        # (which constructs Gtk widgets). We only need to exercise
+        # main() with the minimum attributes it reads.
+        gramplet = pcg.PrerequisitesCheckerGramplet.__new__(
+            pcg.PrerequisitesCheckerGramplet
+        )
+        gramplet.count = 0
+        gramplet.latest_gramps_version = False
+        gramplet.has_run = False
+
+        # The crash path: main() reads
+        # self.uistate.viewmanager.active_page.bottombar
+        uistate = mock.MagicMock()
+        uistate.viewmanager.active_page = active_page
+        gramplet.uistate = uistate
+
+        # dbstate.db.is_open() — only reached when active_page is
+        # truthy with a bottombar. Stubbed for completeness.
+        gramplet.dbstate = mock.MagicMock()
+        gramplet.dbstate.db.is_open.return_value = False
+        return gramplet
+
+    def test_main_does_not_crash_when_active_page_is_none(self):
+        """The exact bug 13966 traceback: active_page is None on tree
+        close, the unguarded ``.bottombar`` raises AttributeError."""
+        gramplet = self._make_gramplet(active_page=None)
+        generator = gramplet.main()
+        # The framework calls next() on the generator. The bug
+        # surfaces on the very first next() — before any yield.
+        # Post-fix: main() must return cleanly (StopIteration), not
+        # raise AttributeError.
+        with self.assertRaises(StopIteration):
+            next(generator)
+
+    def test_main_still_works_on_non_dashboard_view(self):
+        """Regression guard: when a real page IS active, the existing
+        bottombar / db-open / count<3 short-circuit chain still runs.
+        With db closed and the bottombar truthy, main() returns early
+        (no yield) just as before — same StopIteration on first
+        next()."""
+        active_page = mock.MagicMock()
+        active_page.bottombar = mock.MagicMock()  # truthy
+        gramplet = self._make_gramplet(active_page=active_page)
+        gramplet.dbstate.db.is_open.return_value = False
+        generator = gramplet.main()
+        with self.assertRaises(StopIteration):
+            next(generator)
+
+    def test_main_on_dashboard_with_pending_version_yields(self):
+        """Regression guard: on the dashboard (bottombar falsy) with
+        the upstream-version fetch still in flight (latest_gramps_version
+        is False), main() yields rather than returning. Bug 13966's
+        guard must not change this path."""
+        active_page = mock.MagicMock()
+        active_page.bottombar = False  # dashboard
+        gramplet = self._make_gramplet(active_page=active_page)
+        # latest_gramps_version is False (default) → enters the
+        # `while … is False: yield True` loop and yields.
+        generator = gramplet.main()
+        self.assertTrue(next(generator),
+                        "Dashboard path should yield True while the "
+                        "latest-version fetch is pending")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Root cause
`PrerequisitesCheckerGramplet.main()` is a generator the framework
steps via `_updater` → `next(self._generator)`. It reads
`self.uistate.viewmanager.active_page.bottombar` unguarded; when the
family tree is closed while the generator is still mid-flight,
`active_page` is `None` and the read raises
`AttributeError: 'NoneType' object has no attribute 'bottombar'`.

## Fix
Pull `active_page` into a local, return early if it's `None`, then
fall through to the existing bottombar / db-open / count<3 short-
circuit chain. No behaviour change while a tree is open.

## Verified against
- `PrerequisitesCheckerGramplet/PrerequisitesCheckerGramplet.py:170-177`
  — the unguarded read at the head of `main()`. The traceback line
  numbers in the report match this site.
- The reporter notes the trace also reproduces on Gramps 5.2.4, so
  this is long-standing rather than a 6.0 regression; the same
  guard is appropriate on `maintenance/gramps61`.

## Test
`PrerequisitesCheckerGramplet/tests/test_main_active_page_none.py`
drives `main()` once with a stub `uistate` whose `active_page` is
`None` and asserts the generator exits cleanly. Two regression-guard
cases lock the existing dashboard / non-dashboard short-circuit
behaviour. Pre-fix the first case fails with the exact bug 13966
traceback; all three pass post-fix.

Fixes #13966