### PR TITLE
Fix IndexError when an addon declares an empty requires_exe (bug 13979)

### DIFF
--- a/PluginManager/PluginManager.py
+++ b/PluginManager/PluginManager.py
@@ -650,8 +650,16 @@ class PluginStatus(tool.Tool, ManagedWindow):
                     reqs = []
                     info = Requirements().info(addon)
                     for i in range(0, len(info), 2):
-                        label = "    " + info[i]
                         req_lst = info[i + 1]
+                        if not req_lst:
+                            # Bug 13979: Requirements.info emits a label +
+                            # empty table when the addon listing has e.g.
+                            # "re": [] (PostgreSQL Enhanced declares
+                            # requires_exe=[]). Skip cleanly - indexing
+                            # req_lst[0] below would raise IndexError, and
+                            # there is nothing meaningful to show.
+                            continue
+                        label = "    " + info[i]
                         txt = " ".join(req_lst[0])
                         for j in range(1, len(req_lst)):
                             txt += ", " + " ".join(req_lst[j])

--- a/PluginManager/tests/test_info_empty_requires.py
+++ b/PluginManager/tests/test_info_empty_requires.py
@@ -1,0 +1,173 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Eduard Ralph
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Regression test for bug 13979: PluginManager Enhanced raised IndexError
+on the PostgreSQL Enhanced row.
+
+The addon's gpr.py declares ``requires_exe=[]`` which lands in the
+addons-<lang>.json listing as ``"re": []``. gramps core's
+:class:`Requirements.info` still emits an Executables label paired with
+an empty table for that key, and :meth:`PluginStatus.__info` then tries
+``" ".join(req_lst[0])`` on the empty list, raising
+``IndexError: list index out of range``.
+"""
+
+# ------------------------
+# Python modules
+# ------------------------
+import os
+import unittest
+from unittest.mock import Mock
+
+
+def _has_gtk_display():
+    """
+    Return True only if a real Gtk display is available.
+
+    PluginManager.py imports Gtk at module load. Constructing a real
+    PluginStatus is impossible without a display, and we sidestep that
+    via ``__new__``-bypass below - but the import alone can still trip
+    on hosts where Gtk has no backend (CI with GDK_BACKEND=-).
+    """
+    if not os.environ.get("DISPLAY"):
+        return False
+    if os.environ.get("GDK_BACKEND") == "-":
+        return False
+    try:
+        import gi
+
+        gi.require_version("Gtk", "3.0")
+        from gi.repository import Gtk
+
+        return bool(Gtk.init_check([])[0])
+    except Exception:  # pylint: disable=broad-except
+        return False
+
+
+_HAS_GTK_DISPLAY = _has_gtk_display()
+
+
+# ------------------------------------------------------------
+#
+# TestPluginManagerInfoEmptyRequires
+#
+# ------------------------------------------------------------
+@unittest.skipUnless(
+    _HAS_GTK_DISPLAY,
+    "needs a real Gtk display (run under xvfb-run)",
+)
+class TestPluginManagerInfoEmptyRequires(unittest.TestCase):
+    """
+    Regression for bug 13979.
+    """
+
+    def _make_addon(self):
+        """
+        Listing-shaped dict matching the real PostgreSQL Enhanced entry
+        in ``addons/gramps61/listings/addons-en.json`` - the unique
+        trigger of the original crash (the only addon currently shipping
+        with a present-but-empty ``re`` key).
+        """
+        return {
+            "n": "PostgreSQL Enhanced",
+            "i": "postgresqlenhanced",
+            "t": 12,
+            "d": "Advanced PostgreSQL backend.",
+            "v": "1.5.4",
+            "g": "6.1",
+            "s": 3,
+            "z": "PostgreSQLEnhanced.addon.tgz",
+            "rm": ["psycopg"],
+            "re": [],
+            "h": "https://example.invalid/wiki/PostgreSQLEnhanced",
+            "a": 1,
+            "_u": "https://example.invalid/download/",
+        }
+
+    def _make_status(self, addon):
+        """
+        Build a PluginStatus via ``__new__``-bypass, stubbing only the
+        attributes that ``__info`` touches.
+        """
+        # Import inside the method so the module-level Gtk imports run
+        # only after the display skip has been evaluated.
+        from PluginManager.PluginManager import PluginStatus
+
+        status = PluginStatus.__new__(PluginStatus)
+        status.addons = [addon]
+        # get_plugin returns None so __info takes the "installed plugins"
+        # branch where the bug lives.
+        status._preg = Mock()
+        status._preg.get_plugin.return_value = None
+        # _bufin is a Gtk text-buffer mutator; we only care that __info
+        # gets through it without raising, not what it writes.
+        status._bufin = Mock()
+        # __info also consults _pmgr for loaded/failed lists and self.hidden
+        # after the requirements block. Stub them to return empty.
+        status._pmgr = Mock()
+        status._pmgr.get_success_list.return_value = []
+        status._pmgr.get_fail_list.return_value = []
+        status.hidden = []
+        status.help = ""
+        status.helpname = ""
+        return status
+
+    def test_info_with_empty_requires_exe_does_not_raise(self):
+        """
+        Pre-fix this raised ``IndexError`` at
+        ``PluginManager.py:655  txt = " ".join(req_lst[0])`` when
+        iterating to the Executables entry of the Requirements list
+        (whose table is empty for PostgreSQL Enhanced). Post-fix the
+        empty entry is skipped.
+        """
+        status = self._make_status(self._make_addon())
+
+        try:
+            # __info is name-mangled on PluginStatus.
+            status._PluginStatus__info("postgresqlenhanced")
+        except IndexError as exc:
+            self.fail(
+                "Bug 13979: PluginStatus.__info() must not crash on an "
+                "addon whose listing has a present-but-empty requires "
+                "key (e.g. PostgreSQL Enhanced's `\"re\": []`). Got: %s"
+                % exc
+            )
+
+        # Sanity: the Python modules requirement still gets rendered.
+        bufin_labels = [
+            call.args[0] for call in status._bufin.call_args_list if call.args
+        ]
+        self.assertTrue(
+            any("Python modules" in label for label in bufin_labels),
+            "Expected the non-empty Python modules requirement to still "
+            "be rendered; the fix must only skip empty tables. Got "
+            "labels: %r" % bufin_labels,
+        )
+        # And the empty Executables entry must NOT be rendered.
+        self.assertFalse(
+            any("Executables" in label for label in bufin_labels),
+            "Empty Executables entry should be skipped, not rendered. "
+            "Got labels: %r" % bufin_labels,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Root cause
`PluginStatus.__info` iterates `Requirements().info(addon)` output as
`[label, table]` pairs and joins the first row with
`txt = " ".join(req_lst[0])`. gramps core's `Requirements.info` still
emits a label + empty table when the addon listing carries a
present-but-empty requires key — e.g. PostgreSQL Enhanced declares
`requires_exe=[]` in its `.gpr.py`, which lands in `addons-en.json`
as `"re": []`. Indexing `req_lst[0]` on the empty table raises
`IndexError: list index out of range`, crashing the row click.

A scan of the live `addons/gramps61/listings/addons-en.json` confirms
PostgreSQL Enhanced is the only addon currently shipping with a
present-but-empty requires key — which exactly matches the reported
"only the PostgreSQL Enhanced row crashes" symptom.

## Fix
Skip the iteration when `req_lst` is empty. Indexing it would fail,
and there is nothing meaningful to render for an empty requires
list.

## Verified against
- `PluginManager/PluginManager.py:650-660` — the
  installed-plugins branch where the bug lives. The traceback line
  numbers in the report (580 → 655) match this site.
- `gramps/gen/utils/requirements.py:146-172` (`maintenance/gramps61`)
  — the upstream `Requirements.info` that emits the label + empty
  table for any `"rm"`/`"rg"`/`"re"` key present in the addon dict,
  even when the value is `[]`. A cleaner contract would be "only
  emit pairs with at least one entry"; that is a separate gramps-core
  cleanup, not bundled here per the one-PR-per-bug rule.
- `addons-source/PostgreSQLEnhanced/postgresqlenhanced.gpr.py:47`
  — `requires_exe=[],  # No external executables required`. Source
  of the `"re": []` field in the listing.
- `addons/gramps61/listings/addons-en.json` — confirmed PostgreSQL
  Enhanced is the only addon with a present-but-empty requires key,
  matching the reported "only this row" symptom.

## Test
`PluginManager/tests/test_info_empty_requires.py` builds a
`PluginStatus` via `__new__`-bypass (no Gtk-heavy `__init__`), stubs
the Gtk-text-buffer / plugin-manager / plugin-registry attributes,
then calls the name-mangled `_PluginStatus__info("postgresqlenhanced")`
against an addon dict matching the live listing entry
(`"rm": ["psycopg"]`, `"re": []`). Two assertions:

1. No `IndexError` is raised.
2. The non-empty Python modules entry is still rendered while the
   empty Executables entry is skipped — verifies the `continue` only
   skips empty tables, not all requirements.

Pre-fix the test fails with the reported traceback (`txt = " ".join(
req_lst[0]) / IndexError: list index out of range`); post-fix it
passes.

The test class is gated on `_has_gtk_display()` — `PluginManager.py`
imports Gtk at module load, so the test skips cleanly in
display-less CI environments. Under `xvfb-run` (e.g. the testbed's
addon-unit runner with a display, or a developer's desktop) both
assertions run.

```
xvfb-run -a python3 -m unittest PluginManager.tests.test_info_empty_requires -v
```

Resolves #13979