### PR TITLE
TMGimporter: import unittest before raising SkipTest in tests

### DIFF
--- a/TMGimporter/tests/test_integration.py
+++ b/TMGimporter/tests/test_integration.py
@@ -11,6 +11,13 @@ it defaults to the RELPH backup used during development.  Tests are skipped
 automatically when the file is not present.
 """
 
+import os
+import sys
+import shutil
+import tempfile
+import unittest
+import zipfile
+
 # The TMGimporter module imports Gtk at module load — skip the whole file if
 # gi/Gtk aren't available (headless-without-GTK environments). On systems
 # where both GTK3 and GTK4 are present, pin Gtk to 3.0 before any gramps
@@ -25,13 +32,6 @@ try:
 except (ImportError, ValueError, AttributeError) as err:
     raise unittest.SkipTest("GTK 3.0 / PyGObject not available: %s" % err)
 
-
-import os
-import sys
-import shutil
-import tempfile
-import unittest
-import zipfile
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 

--- a/TMGimporter/tests/test_libtmg.py
+++ b/TMGimporter/tests/test_libtmg.py
@@ -9,6 +9,11 @@ Gramps must be installed.  The DBF-dependent import functions are tested by
 patching the module-level table globals so no real .dbf files are needed.
 """
 
+import sys
+import os
+import tempfile
+import unittest
+
 # The TMGimporter module imports Gtk at module load — skip the whole file if
 # gi/Gtk aren't available (headless-without-GTK environments). On systems
 # where both GTK3 and GTK4 are present, pin Gtk to 3.0 before any gramps
@@ -23,12 +28,6 @@ try:
 except (ImportError, ValueError, AttributeError) as err:
     raise unittest.SkipTest("GTK 3.0 / PyGObject not available: %s" % err)
 
-
-
-import sys
-import os
-import tempfile
-import unittest
 
 # Make sure libtmg is importable from the parent directory
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))


### PR DESCRIPTION
## Root cause

The Gtk 3.0 hardening commit on `maintenance/gramps61` (`c312cd7e` "Update unittests for 6.1", introduced the bug) wrapped `gi.require_version` calls in a `try`/`except` at the top of two TMGimporter test files. The `except` arm raises `unittest.SkipTest(...)` but `import unittest` only happens further down — when `gi`/`Gtk 3.0` are unavailable, module load fails with `NameError: name 'unittest' is not defined` instead of skipping cleanly, and ruff F821 reports the undefined name at lint time.

## Fix

Hoist `import unittest` (and the other stdlib imports, for symmetry) above the `try`/`except` block in both files. No behavioural change when `gi`/`Gtk` are available — same imports, just reordered.

## Verified against

- `TMGimporter/tests/test_integration.py:26` — pre-fix `raise unittest.SkipTest(...)` referenced `unittest` before it was bound (`import unittest` at line 33)
- `TMGimporter/tests/test_libtmg.py:24` — same shape, same bug (`import unittest` at line 31)
- `WebSearch/tests/test_filetable.py:40-55` — canonical fix shape (stdlib imports → comment → try/except), already merged upstream in PR #833
- Originating commit (introduced the bug): `c312cd7e` "Update unittests for 6.1"

## Test

No new regression test: ruff F821 already catches this exact use-before-bind class of bug at lint time, which is how the failure was surfaced in the first place. Manual repro:

\`\`\`
ruff check --select=F821 TMGimporter/tests/
\`\`\`

- Pre-fix: 2 F821 errors (\`unittest\` undefined at the SkipTest sites)
- Post-fix: All checks passed!

Full lint gate also verified clean: \`ruff check --select=E9,F63,F7,F82 --exclude='*.gpr.py' TMGimporter/\` → All checks passed.