### PR TITLE
FRWebConnectPack: update Geneanet search URL to current individus form (bug 14145)

### DIFF
--- a/FRWebConnectPack/FRWebPack.py
+++ b/FRWebConnectPack/FRWebPack.py
@@ -42,7 +42,7 @@ WEBSITES = [
     ["Person", "Geneabank", _("Genealogical bank"), "https://gbkcouples.geneabank.org/nom/?name=%(surname)s&place=&start=&end=&source=gbk*"],
     #["Person", "Centre Départemental d'Histoire des Familles (CDHF)", _("Historical Families Center Departement (CDHF)"), "http://www.cdhf.net/fr/index.php?t=bases&d=bases%2Fmoteurpat&c=moteurpat&f=selection&p=&order=&order2=&motcle=&patronyme=%(surname)s"],
     ["Person", "Fichier Origine", _("OrigineFile (Quebec)"), "https://www.fichierorigine.com/recherche?nom=%(surname)s"],
-    ["Person", "Geneanet", "Geneanet", "https://search.geneanet.org/result.php?lang=fr&name=%(surname)s"],
+    ["Person", "Geneanet", "Geneanet", "https://www.geneanet.org/fonds/individus/?go=1&nom=%(surname)s&prenom=%(given)s"],
     ["Person", "Filae", "Filae", "https://www.filae.com/v4/genealogie/Search.mvc/SearchForm?ln=%(surname)s&fn=%(given)s"],
     #["Person", "Geneanet-Favrejhas", "Geneanet, Favrejhas", "http://gw1.geneanet.org/index.php3?b=favrejhas&m=NG&n=%(surname)s&t=N&x=0&y=0"],
     ["Person", "Roglo", "Roglo", "http://roglo.eu/roglo?m=NG&n=%(given)s+%(surname)s&t=PN"],

--- a/FRWebConnectPack/tests/test_geneanet_url.py
+++ b/FRWebConnectPack/tests/test_geneanet_url.py
@@ -1,0 +1,127 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Gramps Development Team
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Regression test for bug 14145: FRWebConnectPack Geneanet link is stale.
+
+Pre-fix WEBSITES entry pointed at
+``https://search.geneanet.org/result.php?lang=fr&name=<surname>`` --
+Geneanet deprecated that URL, returning an unusable page, and the
+template only carried the surname (Geneanet's current individus search
+takes both ``nom`` and ``prenom``). Reporter on Mantis 14145 supplied
+the corrected URL; callmedave confirmed the bug (note 5) despite
+recommending the WebSearch Gramplet as a longer-term replacement, so
+the live FrWebConnectPack addon still needs fixing.
+
+The test imports ``WEBSITES`` from ``FRWebConnectPack.FRWebPack`` and
+applies the same ``pattern % dict`` formatting libwebconnect itself
+uses (see ``libwebconnect.Search.callback``). No network, no display,
+no Gtk -- pure string assertion.
+"""
+
+import os
+import sys
+import unittest
+
+# Make sure addon modules are importable from the parent directory.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class TestGeneanetUrl(unittest.TestCase):
+    """Regression: the Geneanet WEBSITES entry must build a working URL."""
+
+    @staticmethod
+    def _geneanet_pattern():
+        # Addon dir and impl module share the name ``FRWebConnectPack``
+        # under the addon's package namespace; load the implementation
+        # via the explicit submodule path to dodge the namespace-package
+        # shadowing trap (gramps bug 0012691 family).
+        from FRWebConnectPack import FRWebPack  # pylint: disable=import-outside-toplevel
+
+        for entry in FRWebPack.WEBSITES:
+            # entry: [nav_type, key, name, url_pattern]
+            if entry[1] == "Geneanet":
+                return entry[3]
+        raise AssertionError("Geneanet entry missing from FRWebPack.WEBSITES")
+
+    def test_built_url_contains_both_name_parts(self):
+        """Geneanet URL template must take given AND surname.
+
+        Pre-fix the template only carried ``%(surname)s``; reporter
+        on 14145 noted searches returned the wrong people because the
+        given name was discarded.
+        """
+        pattern = self._geneanet_pattern()
+        url = pattern % {
+            "surname": "Dupont",
+            "given": "Marie",
+            "middle": "",
+            "birth": "",
+            "death": "",
+        }
+        self.assertIn("Dupont", url, "surname must appear in built URL")
+        self.assertIn("Marie", url, "given name must appear in built URL")
+
+    def test_built_url_uses_current_geneanet_host_and_path(self):
+        """Geneanet URL must target the current individus search.
+
+        Pre-fix the template hit ``search.geneanet.org/result.php`` --
+        deprecated. Reporter on 14145 supplied the replacement
+        ``www.geneanet.org/fonds/individus/?go=1&nom=...&prenom=...``.
+        """
+        pattern = self._geneanet_pattern()
+        url = pattern % {
+            "surname": "Dupont",
+            "given": "Marie",
+            "middle": "",
+            "birth": "",
+            "death": "",
+        }
+        # Stale form -- must NOT appear after the fix.
+        self.assertNotIn(
+            "result.php",
+            url,
+            "deprecated Geneanet search URL must not be used",
+        )
+        self.assertNotIn(
+            "search.geneanet.org",
+            url,
+            "deprecated Geneanet search host must not be used",
+        )
+        # Corrected form -- must appear.
+        self.assertIn(
+            "www.geneanet.org/fonds/individus/",
+            url,
+            "current Geneanet individus search path must be used",
+        )
+        self.assertIn(
+            "nom=Dupont",
+            url,
+            "surname must be passed as the 'nom' query parameter",
+        )
+        self.assertIn(
+            "prenom=Marie",
+            url,
+            "given name must be passed as the 'prenom' query parameter",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Root cause
`FRWebConnectPack/FRWebPack.py:45` stored the Geneanet search URL as
`https://search.geneanet.org/result.php?lang=fr&name=%(surname)s`. Geneanet
deprecated that URL — searches no longer return useful results — and the
template only carried the surname, so Geneanet's current `fonds/individus`
search couldn't filter by given name.

## Fix
Replace the stale URL template with the corrected one the reporter supplied
on tracker note 3:
`https://www.geneanet.org/fonds/individus/?go=1&nom=%(surname)s&prenom=%(given)s`.
Both `%(...)s` placeholders match the file's existing convention and are
populated by libwebconnect's `make_person_dict`.

## Verified against
- `libwebconnect/libwebconnect.py:88-128` — `make_person_dict` populates both `surname` and `given` keys.
- `libwebconnect/libwebconnect.py:182` — `display_url(self.pattern % results, …)` is the call site that consumes the template.
- `FRWebConnectPack/FRWebPack.py:41,46,48` — adjacent entries use the same `%(surname)s` / `%(given)s` convention.

callmedave (Mantis note 4) recommends the WebSearch Gramplet as a longer-term
replacement for the Web Connect Pack family, but note 5 on the same thread
confirms the bug for FrWebConnectPack — so the live addon is still in scope.

## Test
`FRWebConnectPack/tests/test_geneanet_url.py` (new; stdlib `unittest`, plus
`tests/__init__.py` — the addon had no `tests/` package yet). Two cases, both
pure string assertion (no network, no display, no Gtk): asserts that the
built URL contains both name parts AND that it targets the corrected host /
path / `nom=` / `prenom=` query keys, while the deprecated `result.php` /
`search.geneanet.org` form is absent.

  Before fix: FAILED (failures=2) — `'Marie' not found in 'https://search.geneanet.org/result.php?lang=fr&name=Dupont'`
  After fix:  2 tests, OK

Fixes #14145