### PR TITLE
RepositoriesReport: write repository URLs when "include URLs" is on (bug 13955)

### DIFF
--- a/RepositoriesReport/RepositoriesReportAlt.py
+++ b/RepositoriesReport/RepositoriesReportAlt.py
@@ -188,20 +188,23 @@ class RepositoryReportAlt(Report):
         # additional repository informations
 
         child_list = repository.get_text_data_child_list()
+
+        if self.inc_intern:
+            urls = [url.get_path() for url in repository.get_url_list()]
+            if urls or self.incl_empty:
+                self.doc.start_paragraph('REPO-Section2')
+                self.doc.write_text(self._('Internet:') + space)
+                self.doc.write_text("\n".join(urls))
+                self.doc.end_paragraph()
+
         addresses = repository.get_handle_referents()
         for address_handle in addresses:
             address = ReportUtils.get_address_str(address_handle)
 
-            if self.inc_intern or self.inc_addres:
+            if self.inc_addres or self.incl_empty:
                 self.doc.start_paragraph('REPO-Section2')
-
-                #if self.inc_intern:
-                    #self.doc.write_text(self._('Internet:'))
-                    #self.doc.write_text(internet)
-                if self.inc_addres or self.incl_empty:
-                    self.doc.write_text(self._('Address:') + space)
-                    self.doc.write_text(address)
-
+                self.doc.write_text(self._('Address:') + space)
+                self.doc.write_text(address)
                 self.doc.end_paragraph()
 
     def __write_referenced_sources(self, handle):

--- a/RepositoriesReport/tests/test_repositoriesreport_internet.py
+++ b/RepositoriesReport/tests/test_repositoriesreport_internet.py
@@ -1,0 +1,170 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Gramps Development Team
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Regression test for bug 13955: RepositoriesReport omits URLs when the
+"include repositories urls" option is selected.
+
+Historically `RepositoriesReportAlt.__write_repository` had the URL-
+writing block commented out (codefarmer, tracker note 7: commented
+since 2010, throws `NameError: name 'internet' is not defined` if you
+uncomment it naively at line 200). With include-URLs ON, the report
+silently produced an empty Internet paragraph -- the URLs the user
+asked for never reached the doc.
+
+Construct the class via `__new__` (bypass `__init__` so we don't need
+options/database/user wiring or a real doc backend) and call the
+name-mangled `__write_repository` method with a stubbed repository,
+database, and doc. Assert the URL text reaches `doc.write_text` when
+`inc_intern` is on, and is suppressed when it's off.
+
+Pure unit test: no display, no Gtk, no real Gramps DB.
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+# Pin Gtk to 3.0 before importing -- RepositoriesReportAlt pulls in
+# gramps.gen.plug.docgen which transitively touches GTK-3-only enums.
+# Skip cleanly if GTK 3 is not available.
+try:
+    import gi
+
+    gi.require_version("Gtk", "3.0")
+    gi.require_version("Gdk", "3.0")
+except (ImportError, ValueError) as err:
+    raise unittest.SkipTest("GTK 3.0 / PyGObject not available: %s" % err)
+
+# Make sure addon modules are importable from the parent directory.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def _make_repository(urls):
+    """Return a mock Repository with the given list of URL strings."""
+    repo = MagicMock(name="Repository")
+    repo.get_name.return_value = "Test Library"
+    repo.get_type.return_value = "Library"
+    repo.get_referenced_handles.return_value = []
+    repo.get_text_data_child_list.return_value = []
+    repo.get_handle_referents.return_value = []
+    repo.handle = "REPO_HANDLE"
+
+    url_objects = []
+    for path in urls:
+        u = MagicMock(name="Url")
+        u.get_path.return_value = path
+        url_objects.append(u)
+    repo.get_url_list.return_value = url_objects
+    return repo
+
+
+def _make_report(repo, inc_intern, incl_empty=False):
+    """Construct a RepositoryReportAlt without running __init__.
+
+    The class' real __init__ wants an Options object, a database, and
+    a User -- none of which we need to exercise the per-repository
+    write path. Build a bare instance and pin only the attributes
+    `__write_repository` reads.
+    """
+    from RepositoriesReport import RepositoriesReportAlt as mod  # pylint: disable=import-outside-toplevel
+
+    report = mod.RepositoryReportAlt.__new__(mod.RepositoryReportAlt)
+    report.doc = MagicMock(name="doc")
+    report._ = lambda s: s  # identity i18n for assertion clarity
+    report.database = MagicMock(name="database")
+    report.database.get_repository_from_handle.return_value = repo
+    report.inc_intern = inc_intern
+    report.inc_addres = False
+    report.inclu_note = False
+    report.incl_empty = incl_empty
+    return report
+
+
+class TestRepositoryUrlOutput(unittest.TestCase):
+    """Regression for bug 13955."""
+
+    def _written_text(self, report):
+        return [call.args[0] for call in report.doc.write_text.call_args_list]
+
+    def test_urls_written_when_inc_intern_on(self):
+        """When include-URLs is selected the repository URLs reach
+        the doc.
+
+        Pre-fix this fails: the URL block was commented out so the
+        Internet paragraph never carried any URL text.
+        """
+        repo = _make_repository(["https://example.org/", "https://example.net/"])
+        report = _make_report(repo, inc_intern=True)
+        report._RepositoryReportAlt__write_repository("REPO_HANDLE")
+
+        written = self._written_text(report)
+        self.assertIn(
+            "Internet: ",
+            written,
+            "Internet label must appear when inc_intern is on",
+        )
+        self.assertIn(
+            "https://example.org/\nhttps://example.net/",
+            written,
+            "Both repository URLs must reach the doc",
+        )
+
+    def test_no_url_paragraph_when_inc_intern_off(self):
+        """With include-URLs off the Internet paragraph is suppressed
+        entirely (no empty paragraph, no Internet label).
+
+        Pre-fix behaviour also suppressed the URLs in this case --
+        same outcome -- but the regression guard locks the gate so a
+        later "always write the section" refactor wouldn't slip
+        through.
+        """
+        repo = _make_repository(["https://example.org/"])
+        report = _make_report(repo, inc_intern=False)
+        report._RepositoryReportAlt__write_repository("REPO_HANDLE")
+
+        written = self._written_text(report)
+        self.assertNotIn("Internet: ", written)
+        for text in written:
+            self.assertNotIn(
+                "https://example.org/",
+                text,
+                "URL must not appear when inc_intern is off",
+            )
+
+    def test_no_url_paragraph_when_no_urls_and_incl_empty_off(self):
+        """A repository with no URLs and incl_empty off must not get
+        an empty Internet paragraph.
+
+        This pins the contract: the URL section follows the same
+        "empty fields suppressed unless incl_empty" rule the rest of
+        the report uses (see inc_addres / incl_empty pattern).
+        """
+        repo = _make_repository([])
+        report = _make_report(repo, inc_intern=True, incl_empty=False)
+        report._RepositoryReportAlt__write_repository("REPO_HANDLE")
+
+        written = self._written_text(report)
+        self.assertNotIn("Internet: ", written)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Root cause
`RepositoryReportAlt.__write_repository` (RepositoriesReportAlt.py:198-200
pre-fix) carried the URL-writing block commented out, and the variable
the commented code referenced (`internet`) was never defined anywhere — a
naive uncomment would raise `NameError: name 'internet' is not defined`.
With the include-URLs option selected, the report opened an Internet
paragraph but emitted nothing into it. codefarmer captured this on
Mantis 13955 note 7 (commented since 2010).

## Fix
Replace the stub with the URL section it should always have been. Compute
URLs from `repository.get_url_list()` (the same attribute
`gramps/plugins/textreport/tagreport.py:712` uses) and write them in a
dedicated paragraph guarded by `inc_intern`. Hoist out of the per-address
loop so a repository with zero addresses still gets its URLs and one with
multiple addresses doesn't duplicate the URL list per iteration. Drop the
now-stale outer `inc_intern or inc_addres` combined guard; each block has
its own gate. Honour the report's empty-field convention (no paragraph
unless URLs OR `incl_empty`), mirroring the `inc_addres` / `incl_empty`
pattern.

## Verified against
- `gramps/gen/lib/urlbase.py:67` — `UrlBase.get_url_list()` returns the addressable URL list on Repository (via the `UrlBase` mixin at `gramps/gen/lib/repo.py:49`).
- `gramps/gen/lib/url.py:141` — `Url.get_path()` returns the URL string.
- `gramps/plugins/textreport/tagreport.py:712` — same `for url in repo.get_url_list()` pattern used elsewhere in core for repository URLs.

## Test
`RepositoriesReport/tests/test_repositoriesreport_internet.py` (new; stdlib
`unittest`, plus `tests/__init__.py` — the addon had no `tests/` package
yet). Three cases built via `__new__`-bypass with `self.doc` mocked: URLs
written when `inc_intern` is on; no Internet paragraph when off; no
Internet paragraph when there are no URLs and `incl_empty` is off. Pure
unit test — no doc backend, no Gramps DB. Gated on
`gi.require_version("Gtk", "3.0")` because the addon's import chain pulls
`gramps.gen.plug.docgen`.

  Before fix: FAILED (failures=1) — `test_urls_written_when_inc_intern_on`
              fails with `AssertionError: 'Internet: ' not found in
              ['Test Library (Library)']`
  After fix:  3 tests, OK

Fixes #13955