### PR TITLE
ImportGramplet: pin death-fallback contract for clean-XML import (bug 13420 — cannot-reproduce evidence)

### DIFF
--- a/ImportGramplet/tests/test_xml_death_fallback.py
+++ b/ImportGramplet/tests/test_xml_death_fallback.py
@@ -1,0 +1,187 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Gramps Development Team
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Repro-or-close test for bug 13420: Text Import gramplet death event
+is not shown as the person's death fallback until re-validated in the
+editor.
+
+The reporter's input was XML produced by a no-code Android tool with
+UUID handles and longer-than-normal change-times; no developer
+reproduced the symptom on conformant Gramps XML. Per the triage
+verdict in `triage/batches/batch-03-confirmed-velocity/issue_13420.md`
+the decisive test is:
+
+  - Build CONFORMANT minimal Gramps XML (one person, Birth + Death
+    events both role Primary, standard Gramps handles)
+  - Import via the addon's `AtomicGrampsParser` (the wrapper the
+    ImportGramplet uses for its XML branch)
+  - Assert person.get_death_ref() returns the Death event ref
+    WITHOUT manual editor re-save
+
+If clean XML imports correctly → reporter's XML was malformed; close
+13420 as cannot-reproduce. If clean XML still fails → real addon bug,
+fix needed.
+
+The fallback-setting logic lives in gramps CORE at
+`gramps/plugins/importer/importxml.py:1434-1473` (`start_eventref`)
+and is shared between the standard XML import and AtomicGrampsParser
+(AtomicGrampsParser only overrides `parse()` for an atomic DbTxn
+wrapper, not the per-element handlers). The note above
+`start_eventref` itself spells out the precondition: "We count here
+on events being already parsed prior to parsing people or families.
+This code will fail if this is not true." So the test fixture lists
+events BEFORE people.
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+# AtomicGrampsParser pulls `from gi.repository import Gtk` at module
+# load (via ImportGramplet.py). Pin Gtk to 3.0 before importing; skip
+# cleanly if PyGObject / GTK 3 aren't available.
+try:
+    import gi
+
+    gi.require_version("Gtk", "3.0")
+    gi.require_version("Gdk", "3.0")
+except (ImportError, ValueError) as err:
+    raise unittest.SkipTest("GTK 3.0 / PyGObject not available: %s" % err)
+
+# Make sure addon modules are importable from the parent directory.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+# Minimal CONFORMANT Gramps XML. Events listed before people, both
+# events role Primary, standard Gramps handles (no UUIDs). Mirrors
+# the structure in `example/gramps/example.gramps`.
+CLEAN_XML = """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE database PUBLIC "-//Gramps//DTD Gramps XML 1.7.2//EN"
+"http://gramps-project.org/xml/1.7.2/grampsxml.dtd">
+<database xmlns="http://gramps-project.org/xml/1.7.2/">
+  <header>
+    <created date="2026-05-25" version="6.0.0"/>
+    <researcher>
+      <resname>Bug 13420 Test</resname>
+    </researcher>
+  </header>
+  <events>
+    <event handle="_a5af0eb667015e355db" change="1284030602" id="E00001">
+      <type>Birth</type>
+      <dateval val="1900-01-01"/>
+      <description>Birth of Test, Person</description>
+    </event>
+    <event handle="_a5af0eb696917232725" change="1284030602" id="E00002">
+      <type>Death</type>
+      <dateval val="1970-12-31"/>
+      <description>Death of Test, Person</description>
+    </event>
+  </events>
+  <people>
+    <person handle="_aaa0bbb111ccc222ddd" change="1284030602" id="I00001">
+      <gender>M</gender>
+      <name type="Birth Name">
+        <first>Person</first>
+        <surname>Test</surname>
+      </name>
+      <eventref hlink="_a5af0eb667015e355db" role="Primary"/>
+      <eventref hlink="_a5af0eb696917232725" role="Primary"/>
+    </person>
+  </people>
+</database>
+"""
+
+
+class TestImportGrampletDeathFallback(unittest.TestCase):
+    """Repro-or-close for bug 13420."""
+
+    def setUp(self):
+        # Per Sqlite/tests/test_sqlite.py: create a sqlite in-memory-
+        # equivalent db in a tempdir, import the XML, exercise.
+        from gramps.gen.db.utils import make_database  # pylint: disable=import-outside-toplevel
+
+        self.db_dir = tempfile.mkdtemp(prefix="bug13420_")
+        self.database = make_database("sqlite")
+        self.database.load(self.db_dir)
+
+    def tearDown(self):
+        try:
+            self.database.close()
+        except Exception:  # pylint: disable=broad-except
+            pass
+        shutil.rmtree(self.db_dir, ignore_errors=True)
+
+    def test_clean_xml_imports_set_death_ref_via_atomic_parser(self):
+        """Clean XML through AtomicGrampsParser must set the
+        person's death_ref to the Death event.
+
+        This is the repro-or-close decision point for bug 13420.
+        If it passes, the reporter's malformed XML (UUID handles)
+        was the cause; if it fails, the addon's atomic parser is
+        skipping the fallback wiring.
+        """
+        from io import BytesIO  # pylint: disable=import-outside-toplevel
+        import time  # pylint: disable=import-outside-toplevel
+        from gramps.cli.user import User  # pylint: disable=import-outside-toplevel
+
+        # Importing the addon transitively imports Gtk -- this is why
+        # the test is gated above on gi.require_version("Gtk", "3.0").
+        from ImportGramplet.ImportGramplet import AtomicGrampsParser  # pylint: disable=import-outside-toplevel
+
+        user = User()
+        change = int(time.time())
+        parser = AtomicGrampsParser(self.database, user, change)
+        ifile = BytesIO(CLEAN_XML.encode("utf-8"))
+        parser.parse(ifile)
+
+        person = self.database.get_person_from_gramps_id("I00001")
+        self.assertIsNotNone(
+            person,
+            "Person I00001 must exist after XML import",
+        )
+
+        death_ref = person.get_death_ref()
+        self.assertIsNotNone(
+            death_ref,
+            "Person.get_death_ref() must return the Death event ref "
+            "after clean-XML import via AtomicGrampsParser. If this "
+            "assertion fails, bug 13420 reproduces on conformant XML "
+            "and is a real addon defect.",
+        )
+
+        death_event = self.database.get_event_from_handle(death_ref.ref)
+        self.assertIsNotNone(death_event)
+        self.assertEqual(str(death_event.get_type()), "Death")
+
+        # Birth ref must also be wired up -- same logic in core
+        # start_eventref. If birth is fine but death is not, the bug
+        # is type-specific; if both fail, it's the whole fallback
+        # path.
+        birth_ref = person.get_birth_ref()
+        self.assertIsNotNone(birth_ref)
+        birth_event = self.database.get_event_from_handle(birth_ref.ref)
+        self.assertEqual(str(birth_event.get_type()), "Birth")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/ImportGramplet/tests/test_xml_death_fallback.py
+++ b/ImportGramplet/tests/test_xml_death_fallback.py
@@ -154,11 +154,16 @@ class TestImportGrampletDeathFallback(unittest.TestCase):
         ifile = BytesIO(CLEAN_XML.encode("utf-8"))
         parser.parse(ifile)
 
-        person = self.database.get_person_from_gramps_id("I00001")
-        self.assertIsNotNone(
-            person,
-            "Person I00001 must exist after XML import",
+        # Look the person up by handle, not by gramps_id: core's importer
+        # normalises gramps_ids to the database's configured width (the XML
+        # "I00001" becomes "I0001" under the default "I%04d"), so a literal
+        # gramps_id lookup is brittle and fails on any default-config tree.
+        # Exactly one person was imported, so fetch it directly.
+        handles = list(self.database.get_person_handles())
+        self.assertEqual(
+            len(handles), 1, "exactly one person must be imported"
         )
+        person = self.database.get_person_from_handle(handles[0])
 
         death_ref = person.get_death_ref()
         self.assertIsNotNone(


### PR DESCRIPTION
## Root cause
Mantis 13420 reports that a person imported via the Text Import gramplet
does NOT show their Death event as the death fallback in list views until
the event ref is re-validated with OK in the editor. snoiraud established
on the tracker (note 8) that the reporter's XML was generated by a no-code
Android tool with UUID handles and longer-than-normal change-times; no
developer ever reproduced the symptom on conformant Gramps XML.

The fallback-setting logic lives in gramps **CORE** at
`gramps/plugins/importer/importxml.py:1434-1473` (`start_eventref`) and
is inherited unchanged by the addon's `AtomicGrampsParser`. The core
parser itself spells out its precondition at line 1451-1452: *"We count
here on events being already parsed prior to parsing people or families.
This code will fail if this is not true."* If `inaugurate` fails to
resolve the event handle (e.g. UUID handles that don't match between
the events block and the eventref `hlink` attributes, or events listed
after people), `start_eventref` silently early-returns and never wires
the fallback.

## Fix
None. This PR ships only a regression test that pins the contract on
clean input.

## Verified against
- `gramps/plugins/importer/importxml.py:1434-1473` — `start_eventref`
  is the only place death_ref is set during XML import; the early
  return at line 1454-1455 fires when the event handle doesn't resolve.
- `ImportGramplet/ImportGramplet.py:102-154` — `AtomicGrampsParser`
  subclasses `GrampsParser` and overrides only `parse()` for the atomic
  DbTxn wrapper; per-element handlers including `start_eventref` are
  inherited verbatim.

## Test
`ImportGramplet/tests/test_xml_death_fallback.py` (new; stdlib
`unittest`, plus `tests/__init__.py`). One case:

- Build CONFORMANT minimal Gramps XML — events listed before people,
  standard Gramps handles (no UUIDs), both events `role="Primary"`.
- Parse via `AtomicGrampsParser` against an in-memory sqlite Gramps
  database (same pattern as `Sqlite/tests/test_sqlite.py`).
- Fetch the single imported person **by handle** — core normalises
  gramps_ids to the database's configured width on import (the XML
  `I00001` becomes `I0001` under the default `I%04d`), so a literal
  gramps_id lookup is unreliable.
- Assert `person.get_death_ref()` is set; control-assert
  `person.get_birth_ref()` too; both refs resolve to events of the
  correct type.

Gated on `gi.require_version("Gtk", "3.0")` **and**
`gi.require_version("Gdk", "3.0")` because the addon's import chain pulls
both at module load (`editform`-style, Gdk before Gtk); pinning both —
mirroring `gramps/gen/constfunc.py` — keeps the imports on the GTK 3 stack
regardless of the host's default GI resolution. Headless; no display
required.

**Result: 1 test, OK** — verified two ways on the PR's base branch:
- direct `python3 -m unittest ImportGramplet.tests.test_xml_death_fallback`
  against `maintenance/gramps60`;
- gramps-testbed addon-unit runner (`run-addon-unit.sh ImportGramplet`).

The test passing IS the empirical evidence that Mantis 13420 does NOT
reproduce on conformant XML — the reporter's malformed UUID-handle XML
was the cause. The test stays as a regression guard so a later refactor
of the atomic parser cannot silently break the fallback wiring.

> **Correction (revised commit).** The first revision looked the person up
> by `get_person_from_gramps_id("I00001")` and reported a green result that
> did not hold — gramps_id normalisation makes that lookup return `None`, so
> the test actually failed on `maintenance/gramps60` (and on macOS, as
> GaryGriffin reported). The handle-based lookup above is the corrected,
> genuinely-green form.

Companion to a `cannot-reproduce / invalid input` close on bug 13420.

Bug #13420
