### PR TITLE
Quote handles in GraphView Graphviz output

### DIFF
--- a/GraphView/graphview.py
+++ b/GraphView/graphview.py
@@ -3321,9 +3321,12 @@ class DotSvgGenerator(object):
         Add a link between two nodes.
         Gramps handles are used as nodes but need to be prefixed
         with an underscore because Graphviz does not like IDs
-        that begin with a number.
+        that begin with a number. The id is quoted because handles are
+        arbitrary schema-valid strings: Gramps-Web creates UUIDv4 handles
+        containing hyphens, which an unquoted Graphviz ID would split on
+        (bug 13832).
         """
-        self.write('  _%s -> _%s' % (id1, id2))
+        self.write('  "_%s" -> "_%s"' % (id1, id2))
 
         boldok = False
         if id1 in self.current_list:
@@ -3390,7 +3393,10 @@ class DotSvgGenerator(object):
             text += ' URL="%s"' % url
 
         text += " ]"
-        self.write(' _%s %s;\n' % (node_id, text))
+        # Quote the id: handles are arbitrary schema-valid strings, and
+        # Gramps-Web creates UUIDv4 handles with hyphens that an unquoted
+        # Graphviz ID would split on, blanking the graph (bug 13832).
+        self.write(' "_%s" %s;\n' % (node_id, text))
 
     def add_tags_tooltip(self, handle, tag_list):
         """
@@ -3407,7 +3413,11 @@ class DotSvgGenerator(object):
         Opens a subgraph which is used to keep together related nodes
         on the graph.
         """
-        self.write('\n subgraph cluster_%s\n' % graph_id)
+        # Quote the name: graph_id is a handle (see bug 13832); a UUIDv4
+        # handle with hyphens would break an unquoted subgraph name.
+        # Graphviz still treats a quoted name beginning with "cluster" as
+        # a cluster subgraph.
+        self.write('\n subgraph "cluster_%s"\n' % graph_id)
         self.write(' {\n')
         # no border around subgraph (#0002176)
         self.write('  style="invis";\n')

--- a/GraphView/tests/test_graphview_dot_handles.py
+++ b/GraphView/tests/test_graphview_dot_handles.py
@@ -24,9 +24,12 @@ Unit tests for Graphviz node-id quoting in the GraphView addon (bug 13832).
 import unittest
 from io import StringIO
 
-# GraphView imports Gtk/GooCanvas at module load; on a host without those
-# typelibs (or a display) the import raises. Skip cleanly there rather than
-# erroring, so the suite stays runnable without the addon's requires_gi deps.
+# GraphView imports gi/GooCanvas at module load. Skip ONLY when those Python
+# modules are genuinely absent (ImportError, e.g. PyGObject not installed). A
+# wrong/unavailable GI version (ValueError from require_version) or a missing
+# system dep (GraphView raises if GooCanvas/dot are absent) must NOT be laundered
+# into a skip that reads as success — let it surface as a hard error. The testbed
+# image / CI provide these deps and the system-deps drift-guard enforces them.
 try:
     import gi
 
@@ -34,7 +37,7 @@ try:
     from GraphView.graphview import DotSvgGenerator
 
     _IMPORT_ERROR = None
-except Exception as err:  # pragma: no cover - depends on host gi stack
+except ImportError as err:  # genuine absence of gi / the addon's Python modules
     DotSvgGenerator = None
     _IMPORT_ERROR = err
 

--- a/GraphView/tests/test_graphview_dot_handles.py
+++ b/GraphView/tests/test_graphview_dot_handles.py
@@ -1,0 +1,101 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Eduard Ralph
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Unit tests for Graphviz node-id quoting in the GraphView addon (bug 13832).
+"""
+
+import unittest
+from io import StringIO
+
+# GraphView imports Gtk/GooCanvas at module load; on a host without those
+# typelibs (or a display) the import raises. Skip cleanly there rather than
+# erroring, so the suite stays runnable without the addon's requires_gi deps.
+try:
+    import gi
+
+    gi.require_version("Gtk", "3.0")
+    from GraphView.graphview import DotSvgGenerator
+
+    _IMPORT_ERROR = None
+except Exception as err:  # pragma: no cover - depends on host gi stack
+    DotSvgGenerator = None
+    _IMPORT_ERROR = err
+
+
+# A Gramps-Web UUIDv4 handle (hyphens) vs. a desktop handle (no hyphens).
+HYPHEN_HANDLE = "22e6b2a0-269e-4c58-8e27-0c38b2ef5a10"
+PLAIN_HANDLE = "fe4861b093015ddcbb08044be02"
+
+
+# ------------------------------------------------------------
+#
+# DotHandleQuotingTest
+#
+# ------------------------------------------------------------
+@unittest.skipIf(
+    DotSvgGenerator is None,
+    "GraphView import unavailable (gi/GooCanvas/display): %s" % (_IMPORT_ERROR,),
+)
+class DotHandleQuotingTest(unittest.TestCase):
+    """
+    The DOT generator emits Gramps handles as node ids. Handles are
+    arbitrary schema-valid strings (<=50 chars); Gramps-Web creates
+    UUIDv4 handles containing hyphens. An unquoted Graphviz id is split at
+    the first hyphen, so the node/edge/cluster name is mangled and the
+    Graph View blanks (bug 13832). Every handle written into the DOT must
+    therefore be quoted.
+    """
+
+    def _generator(self):
+        # Bypass __init__ (which needs a live dbstate/view); the DOT-writing
+        # methods only touch the attributes set up here.
+        gen = DotSvgGenerator.__new__(DotSvgGenerator)
+        gen.dot = StringIO()
+        gen.current_list = set()
+        gen.colors = {"link_color": "#000000"}
+        return gen
+
+    def test_add_node_quotes_hyphenated_handle(self):
+        gen = self._generator()
+        gen.add_node(HYPHEN_HANDLE, "Some Label")
+        out = gen.dot.getvalue()
+        self.assertIn('"_%s"' % HYPHEN_HANDLE, out)
+
+    def test_add_node_quotes_plain_handle(self):
+        gen = self._generator()
+        gen.add_node(PLAIN_HANDLE, "Some Label")
+        out = gen.dot.getvalue()
+        self.assertIn('"_%s"' % PLAIN_HANDLE, out)
+
+    def test_add_link_quotes_both_endpoints(self):
+        gen = self._generator()
+        gen.add_link(HYPHEN_HANDLE, PLAIN_HANDLE)
+        out = gen.dot.getvalue()
+        self.assertIn('"_%s" -> "_%s"' % (HYPHEN_HANDLE, PLAIN_HANDLE), out)
+
+    def test_start_subgraph_quotes_cluster_name(self):
+        gen = self._generator()
+        gen.start_subgraph(HYPHEN_HANDLE)
+        out = gen.dot.getvalue()
+        self.assertIn('"cluster_%s"' % HYPHEN_HANDLE, out)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Root cause
The GraphView DOT generator wrote Gramps handles as **unquoted** Graphviz node
ids: `add_node` emitted ` _<handle> [...]`, `add_link` emitted
` _<id1> -> _<id2>`, and `start_subgraph` emitted ` subgraph cluster_<handle>`.
Handles are arbitrary schema-valid strings (≤50 chars), and Gramps-Web creates
UUIDv4 handles containing hyphens (e.g. `22e6b2a0-269e-4c58-8e27-0c38b2ef5a10`).
Graphviz splits an unquoted id at the hyphen, so the node/edge/cluster name is
mangled, the DOT is malformed, and the Graph View renders blank (bug 13832).

## Fix
Quote the handle at the three DOT-id write sites (the leading `_`, needed
because Graphviz dislikes ids starting with a digit, stays inside the quotes):

```python
self.write('  "_%s" -> "_%s"' % (id1, id2))        # add_link
self.write(' "_%s" %s;\n' % (node_id, text))        # add_node
self.write('\n subgraph "cluster_%s"\n' % graph_id) # start_subgraph
```

A quoted subgraph name still beginning with `cluster` is recognised by Graphviz
as a cluster, so clustering is unaffected. This matches what core's own
`graphdoc.py` already does (it quotes and escapes node ids).

## Verified against
- `GraphView/graphview.py` — the three id-write sites (`add_link`, `add_node`,
  `start_subgraph`), and `start_subgraph(person_handle)` confirming the cluster
  name is handle-derived.
- `gramps/gen/plug/docgen/graphdoc.py:642,650` — core's quoted node-id writes,
  the pattern this aligns the addon with.

## Test
`GraphView/tests/test_graphview_dot_handles.py` asserts that a hyphenated
UUIDv4 handle, a plain handle, an edge's endpoints, and a cluster name are all
emitted quoted. Run in the Ubuntu CI image with graphviz/GooCanvas present, the
tests fail before this change (unquoted ids) and pass after. The import is
guarded so the suite skips cleanly where Gtk/GooCanvas/dot are unavailable.
