### PR TITLE
TMGimporter: skip real-DB import tests on Windows

### DIFF
--- a/TMGimporter/tests/test_libtmg.py
+++ b/TMGimporter/tests/test_libtmg.py
@@ -66,7 +66,23 @@ def _table(records):
 
 
 def _make_db():
-    """Return a fresh in-memory Gramps database."""
+    """Return a fresh in-memory Gramps database.
+
+    Skips on Windows: these import tests drive a real in-memory Gramps
+    database, and on the Windows CI lane the only available Gramps comes
+    from conda-forge, which has no 6.1 yet (and Gramps 6.1 does not build
+    in the conda env -- its Windows build targets MSYS2 UCRT64, not conda).
+    Run against that mismatched Gramps the real-DB import path hangs, so
+    these tests are exercised on the Linux lane (which runs the Gramps
+    matching this branch) instead. The pure-function tests in this module
+    do not call this helper and still run on Windows.
+    """
+    if sys.platform == "win32":
+        raise unittest.SkipTest(
+            "real-DB TMG import tests run on Linux; the Windows CI lane has no "
+            "Gramps matching this branch (6.1 is not on conda-forge), and the "
+            "import path hangs against a mismatched Gramps"
+        )
     db = make_database("sqlite")
     db.load(":memory:", None)
     return db


### PR DESCRIPTION
## Root cause

The import tests in `TMGimporter/tests/test_libtmg.py` drive a real in-memory
Gramps database (`make_database` + `db.load`) through the shared `_make_db()`
helper. On Windows the only Gramps available to CI comes from conda-forge, which
has no 6.1 yet and where Gramps 6.1 does not build (its Windows build targets
MSYS2 UCRT64, not conda); run against that mismatched Gramps the real-DB import
path hangs. The Windows CI lane that surfaces this is the one introduced by
#820.

## Fix

Raise `unittest.SkipTest` from `_make_db()` when `sys.platform == "win32"`. Every
real-DB test obtains its database through this single helper (all 43 db
creations route through it), so the 13 DB-backed classes skip in one place. The
pure-function tests (code stripping, date conversion, name parsing) do not call
`_make_db()` and continue to run on Windows.

## Verified against

- `TMGimporter/tests/test_libtmg.py` — `_make_db()` is the sole `make_database`
  call site; confirmed every DB-backed class reaches the database only through
  it, so one guard covers them all.
- Linux: the full suite runs unchanged — 157 tests pass.
- Windows path (with `sys.platform` forced to `win32`): 95 tests skip, 62 run
  and pass, and the module is not all-skipped (the pure-function classes keep
  running), so a skip-detecting runner does not mistake it for an empty module.

## Test

This change is itself in the test suite. Pre-change, the Windows lane added by
#820 hangs in `import_*` against the mismatched Gramps; post-change it skips the
real-DB tests cleanly. Validated on that lane (gramps61): the module reports
`157 tests, 95 skipped, 0 broke` in ~5 min (previously an indefinite hang), with
the Linux run unaffected. The skip self-heals once Gramps 6.1 reaches conda-forge
and the Windows lane runs the matching Gramps.