### PR TITLE
GrampsAssistant

### DIFF
--- a/GrampsAssistant/__init__.py
+++ b/GrampsAssistant/__init__.py
@@ -1,0 +1,18 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2024  Gramps Development Team
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#

--- a/GrampsAssistant/backend.py
+++ b/GrampsAssistant/backend.py
@@ -42,7 +42,7 @@ import threading
 import urllib.parse
 from abc import ABC, abstractmethod
 
-_LOG = logging.getLogger(__name__)
+_LOG = logging.getLogger("gramps-assistant.backend")
 
 try:
     import opik as _opik_module
@@ -139,7 +139,142 @@ def _make_connection(parsed_url):
     return http.client.HTTPConnection(host, port or 80, timeout=120)
 
 
-def _execute_tool_calls(tool_call_accum, messages, on_tool_call, _trace=None):
+def _infer_tool_name(arguments_str, tools):
+    """
+    Infer a tool name from argument content when the model omits it.
+
+    Tries json.loads first for reliable key extraction, then falls back to
+    regex for partially malformed JSON.  Handles both OpenAI format
+    (function.parameters.properties) and Anthropic format (input_schema.properties).
+    Returns the tool name only when exactly one tool matches.
+    """
+    import re
+    if not arguments_str or not tools:
+        return None
+
+    # Extract argument keys — try valid JSON first, then regex fallback
+    try:
+        parsed = json.loads(arguments_str)
+        arg_keys = set(parsed.keys()) if isinstance(parsed, dict) else set()
+    except json.JSONDecodeError:
+        arg_keys = set()
+
+    if not arg_keys:
+        m = re.search(r'\{\s*"(\w+)', arguments_str)
+        arg_keys = {m.group(1)} if m else set()
+
+    if not arg_keys:
+        return None
+
+    _LOG.debug("_infer_tool_name: arg_keys=%r, num_tools=%d", arg_keys, len(tools))
+    candidates = []
+    for tool in tools:
+        # OpenAI format: tool["function"]["parameters"]["properties"]
+        # Anthropic format: tool["input_schema"]["properties"]
+        func_def = tool.get("function", tool)
+        params = (
+            func_def.get("parameters")
+            or func_def.get("input_schema")
+            or {}
+        )
+        props = params.get("properties", {})
+        tool_name = func_def.get("name") or tool.get("name")
+        _LOG.debug("  checking tool %r, props keys=%r", tool_name, list(props.keys()))
+        # Match exactly, or by prefix — the model may fuse key+value into one
+        # word (e.g. "code" + "columns(...)" → "codecolumns").
+        matched = any(
+            k == fk or fk.startswith(k)
+            for fk in arg_keys
+            for k in props
+        )
+        if arg_keys and matched:
+            candidates.append(tool_name)
+
+    _LOG.debug("_infer_tool_name: candidates=%r", candidates)
+    return candidates[0] if len(candidates) == 1 else None
+
+
+def _decode_json_string(s):
+    """
+    Decode JSON string escape sequences in *s*.
+
+    When arguments are extracted via regex rather than ``json.loads``, escape
+    sequences like ``\\n`` remain as the two raw characters backslash + n.
+    This restores them to their intended values.
+    """
+    # Process double-backslash first so it doesn't interfere with other escapes
+    result = []
+    i = 0
+    while i < len(s):
+        if s[i] == '\\' and i + 1 < len(s):
+            nxt = s[i + 1]
+            if nxt == 'n':
+                result.append('\n'); i += 2
+            elif nxt == 't':
+                result.append('\t'); i += 2
+            elif nxt == 'r':
+                result.append('\r'); i += 2
+            elif nxt == '"':
+                result.append('"'); i += 2
+            elif nxt == "'":
+                result.append("'"); i += 2
+            elif nxt == '\\':
+                result.append('\\'); i += 2
+            else:
+                # Unknown escape (e.g. \c, \p) — drop the backslash, keep the char
+                result.append(nxt); i += 2
+        else:
+            result.append(s[i]); i += 1
+    return ''.join(result)
+
+
+def _recover_args(arguments_str, tool_name, tools):
+    """
+    Try to recover a usable args dict from malformed JSON.
+
+    Falls back to extracting the rest of the string as the value for the
+    tool's first required parameter (handles the common case where a local
+    model emits ``{"code<broken>`` for execute_script).
+    """
+    import re
+    try:
+        return json.loads(arguments_str)
+    except json.JSONDecodeError:
+        pass
+    # Find the first required parameter name for this tool
+    param_name = None
+    for tool in (tools or []):
+        func_def = tool.get("function", tool)
+        if func_def.get("name") != tool_name:
+            continue
+        required = func_def.get("parameters", {}).get("required", [])
+        if required:
+            param_name = required[0]
+        break
+    if param_name is None:
+        return {}
+    # Anchor on the known parameter name so greedy \w+ doesn't swallow the
+    # start of the value (e.g. "code" + "columns(...)" → "codecolumns(...)").
+    # The optional closing quote and separator handle both valid JSON
+    # ({"code": "value"}) and broken output ({"codecolumns(...)}).
+    pname = re.escape(param_name)
+    m = re.search(
+        r'\{\s*"' + pname + r'"?\s*(?::\s*"?)?(.*)',
+        arguments_str,
+        re.DOTALL,
+    )
+    if m:
+        raw = m.group(1).rstrip('}"').strip()
+        # The value was inside a JSON string but extracted via regex, so JSON
+        # escape sequences are still raw bytes — decode them now.
+        raw = _decode_json_string(raw)
+        _LOG.debug("_recover_args: recovered %r from malformed JSON (first 80 chars): %r",
+                   param_name, raw[:80])
+        return {param_name: raw}
+    return {}
+
+
+def _execute_tool_calls(tool_call_accum, messages, on_tool_call, _trace=None, tools=None):
     """
     Synchronously execute all accumulated tool calls.
 
@@ -148,16 +283,25 @@ def _execute_tool_calls(tool_call_accum, messages, on_tool_call, _trace=None):
 
     Returns the updated *messages* list with tool results appended.
     """
-    # Build the canonical tool_calls list from accumulator, skipping
-    # any entries with an empty name (malformed model output).
+    # Build the canonical tool_calls list from accumulator.
+    # When the model omits the name, try to infer it from argument keys.
     tool_calls_list = []
     for idx in sorted(tool_call_accum.keys()):
         acc = tool_call_accum[idx]
         if not acc.get("name"):
-            continue
+            inferred = _infer_tool_name(acc.get("arguments", ""), tools)
+            if inferred:
+                _LOG.debug("Inferred tool name %r from arguments", inferred)
+                acc["name"] = inferred
+            else:
+                _LOG.warning(
+                    "tool_call_accum entry %d has empty name and could not be "
+                    "inferred — skipping. accum=%r", idx, acc,
+                )
+                continue
         tool_calls_list.append(
             {
-                "id": acc["id"],
+                "id": acc["id"] or f"local-{idx}",
                 "type": "function",
                 "function": {
                     "name": acc["name"],
@@ -187,10 +331,13 @@ def _execute_tool_calls(tool_call_accum, messages, on_tool_call, _trace=None):
     # Execute each tool call, blocking until result arrives from main thread
     for tc in tool_calls_list:
         tc_name = tc["function"]["name"]
+        raw_args = tc["function"]["arguments"]
         try:
-            tc_args = json.loads(tc["function"]["arguments"])
+            tc_args = json.loads(raw_args)
         except json.JSONDecodeError:
-            tc_args = {}
+            _LOG.debug("tool %r: JSON decode failed on %r, attempting recovery", tc_name, raw_args[:120])
+            tc_args = _recover_args(raw_args, tc_name, tools)
+        _LOG.debug("tool call: name=%r  args=%r", tc_name, tc_args)
 
         tool_span = None
         if _trace:
@@ -214,6 +361,7 @@ def _execute_tool_calls(tool_call_accum, messages, on_tool_call, _trace=None):
         if not event.wait(timeout=60):  # block until GTK thread executes tool
             _LOG.warning("Tool call %r timed out after 60 s", tc_name)
         result_str = str(result_holder[0]) if result_holder[0] is not None else ""
+        _LOG.debug("tool result: name=%r  result=%r", tc_name, result_str[:200])
 
         if tool_span:
             try:
@@ -405,6 +553,7 @@ class OpenAICompatibleBackend(ChatBackend):
 
                 # Tool call delta accumulation
                 for tc_delta in delta.get("tool_calls") or []:
+                    _LOG.debug("tool_call delta: %r", tc_delta)
                     idx = tc_delta.get("index", 0)
                     if idx not in tool_call_accum:
                         tool_call_accum[idx] = {"id": "", "name": "", "arguments": ""}
@@ -412,12 +561,17 @@ class OpenAICompatibleBackend(ChatBackend):
                     if tc_delta.get("id"):
                         acc["id"] = tc_delta["id"]
                     func = tc_delta.get("function", {})
-                    if func.get("name"):
-                        acc["name"] = func["name"]
-                    if func.get("arguments"):
-                        acc["arguments"] += func["arguments"]
+                    # name may be under function.name (OpenAI) or at top level (some local models)
+                    name = func.get("name") or tc_delta.get("name", "")
+                    if name:
+                        acc["name"] = name
+                    # arguments may be under function.arguments or at top level
+                    args = func.get("arguments") or tc_delta.get("arguments", "")
+                    if args:
+                        acc["arguments"] += args
 
                 if finish_reason in ("stop", "end_turn", "tool_calls"):
+                    _LOG.debug("finish_reason=%r, tool_call_accum=%r", finish_reason, tool_call_accum)
                     break
         finally:
             conn.close()
@@ -447,7 +601,7 @@ class OpenAICompatibleBackend(ChatBackend):
                 except Exception:
                     pass
             updated_messages = _execute_tool_calls(
-                tool_call_accum, messages, on_tool_call, _trace
+                tool_call_accum, messages, on_tool_call, _trace, tools=tools
             )
             if updated_messages is messages:
                 # All tool calls had empty names; nothing was executed.
@@ -759,7 +913,7 @@ class AnthropicBackend(ChatBackend):
                     "arguments": tu["partial_json"],
                 }
             updated_messages = _execute_tool_calls(
-                openai_style_accum, messages, on_tool_call, _trace
+                openai_style_accum, messages, on_tool_call, _trace, tools=tools
             )
             if updated_messages is messages:
                 on_done()

--- a/GrampsAssistant/backend.py
+++ b/GrampsAssistant/backend.py
@@ -45,11 +45,26 @@ from abc import ABC, abstractmethod
 _LOG = logging.getLogger(__name__)
 
 try:
-    import opik
-    _OPIK_CLIENT = opik.Opik(project_name="gramps-assistant")
-    _LOG.debug("Opik tracing enabled (project: gramps-assistant)")
+    import opik as _opik_module
+    _OPIK_AVAILABLE = True
 except Exception:
-    _OPIK_CLIENT = None
+    _opik_module = None
+    _OPIK_AVAILABLE = False
+
+_OPIK_CLIENT = None
+
+
+def _get_opik_client():
+    global _OPIK_CLIENT
+    if not _OPIK_AVAILABLE:
+        return None
+    if _OPIK_CLIENT is None:
+        try:
+            _OPIK_CLIENT = _opik_module.Opik(project_name="gramps-assistant")
+            _LOG.debug("Opik tracing enabled (project: gramps-assistant)")
+        except Exception:
+            pass
+    return _OPIK_CLIENT
 
 
 # ---------------------------------------------------------------------------
@@ -152,6 +167,12 @@ def _execute_tool_calls(tool_call_accum, messages, on_tool_call, _trace=None):
         )
 
     if not tool_calls_list:
+        _LOG.warning(
+            "tool_call_accum had %d entries but all had empty names — "
+            "model may be using a non-standard tool-call format. accum=%r",
+            len(tool_call_accum),
+            tool_call_accum,
+        )
         return messages  # no valid tool calls; caller will invoke on_done()
 
     # Append the assistant message that triggered the tool calls
@@ -261,9 +282,10 @@ class OpenAICompatibleBackend(ChatBackend):
 
     def _worker(self, messages, tools, on_chunk, on_tool_call, on_done, on_error, thread_id=None):
         trace = None
-        if _OPIK_CLIENT:
+        opik_client = _get_opik_client()
+        if opik_client:
             try:
-                trace = _OPIK_CLIENT.trace(
+                trace = opik_client.trace(
                     name="gramps-chat",
                     input={"messages": messages},
                     project_name="gramps-assistant",
@@ -418,6 +440,7 @@ class OpenAICompatibleBackend(ChatBackend):
                 pass
 
         if tool_call_accum:
+            _LOG.debug("tool_call_accum after SSE loop: %r", tool_call_accum)
             if span:
                 try:
                     span.end(output={"text": "".join(_response_parts), "finish_reason": finish_reason})
@@ -571,9 +594,10 @@ class AnthropicBackend(ChatBackend):
 
     def _worker(self, messages, tools, on_chunk, on_tool_call, on_done, on_error, thread_id=None):
         trace = None
-        if _OPIK_CLIENT:
+        opik_client = _get_opik_client()
+        if opik_client:
             try:
-                trace = _OPIK_CLIENT.trace(
+                trace = opik_client.trace(
                     name="gramps-chat",
                     input={"messages": messages},
                     project_name="gramps-assistant",

--- a/GrampsAssistant/backend.py
+++ b/GrampsAssistant/backend.py
@@ -1,0 +1,752 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2024  Gramps Development Team
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Streaming chat backends for the Gramps Chatbot.
+
+All HTTP is done with the Python standard library (http.client / urllib.parse).
+No third-party packages are required.
+
+Supported backends
+------------------
+OpenAICompatibleBackend
+    Works with Ollama, llama.cpp server, LM Studio, and OpenAI.
+    Uses the ``/v1/chat/completions`` endpoint with ``stream=True``.
+
+AnthropicBackend
+    Uses the Anthropic ``/v1/messages`` endpoint.
+    Handles the different message format and SSE event schema.
+"""
+
+import http.client
+import json
+import logging
+import ssl
+import threading
+import urllib.parse
+from abc import ABC, abstractmethod
+
+_LOG = logging.getLogger(__name__)
+
+try:
+    import opik
+    _OPIK_CLIENT = opik.Opik(project_name="gramps-assistant")
+    _LOG.debug("Opik tracing enabled (project: gramps-assistant)")
+except Exception:
+    _OPIK_CLIENT = None
+
+
+# ---------------------------------------------------------------------------
+# Abstract base
+# ---------------------------------------------------------------------------
+
+
+class ChatBackend(ABC):
+    """
+    Abstract base class for streaming chat backends.
+
+    ``stream_chat`` spawns a daemon thread and returns immediately.
+    All callbacks are called from that background thread **except**
+    ``on_tool_call``, which the panel marshals to the GTK main thread
+    via ``GLib.idle_add``.
+    """
+
+    @abstractmethod
+    def stream_chat(
+        self,
+        messages: list,
+        tools: list,
+        on_chunk,
+        on_tool_call,
+        on_done,
+        on_error,
+        thread_id: str = None,
+    ):
+        """
+        Start a streaming completion in a background thread.
+
+        Parameters
+        ----------
+        messages:
+            Conversation history in OpenAI message format::
+
+                [{"role": "user", "content": "Hello"}]
+
+        tools:
+            List of tool dicts in the backend's native format.
+            Pass an empty list to disable tool use.
+
+        on_chunk(text: str):
+            Called for each incremental text token from the model.
+
+        on_tool_call(name: str, args: dict, result_callback: callable):
+            Called when the model requests a tool invocation.
+            The panel must eventually call ``result_callback(result_str)``
+            (from any thread) to resume the stream.
+
+        on_done():
+            Called once when the full response is complete.
+
+        on_error(exc: Exception):
+            Called if an unrecoverable error occurs.
+        """
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_connection(parsed_url):
+    """Return an ``http.client`` connection for *parsed_url*."""
+    scheme = parsed_url.scheme
+    host = parsed_url.hostname
+    port = parsed_url.port
+    if scheme == "https":
+        ctx = ssl.create_default_context()
+        return http.client.HTTPSConnection(host, port or 443, context=ctx, timeout=120)
+    return http.client.HTTPConnection(host, port or 80, timeout=120)
+
+
+def _execute_tool_calls(tool_call_accum, messages, on_tool_call, _trace=None):
+    """
+    Synchronously execute all accumulated tool calls.
+
+    Blocks the calling (background) thread on a ``threading.Event`` while
+    the GTK main thread runs each tool via ``GLib.idle_add``.
+
+    Returns the updated *messages* list with tool results appended.
+    """
+    # Build the canonical tool_calls list from accumulator, skipping
+    # any entries with an empty name (malformed model output).
+    tool_calls_list = []
+    for idx in sorted(tool_call_accum.keys()):
+        acc = tool_call_accum[idx]
+        if not acc.get("name"):
+            continue
+        tool_calls_list.append(
+            {
+                "id": acc["id"],
+                "type": "function",
+                "function": {
+                    "name": acc["name"],
+                    "arguments": acc["arguments"],
+                },
+            }
+        )
+
+    if not tool_calls_list:
+        return messages  # no valid tool calls; caller will invoke on_done()
+
+    # Append the assistant message that triggered the tool calls
+    messages = messages + [
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": tool_calls_list,
+        }
+    ]
+
+    # Execute each tool call, blocking until result arrives from main thread
+    for tc in tool_calls_list:
+        tc_name = tc["function"]["name"]
+        try:
+            tc_args = json.loads(tc["function"]["arguments"])
+        except json.JSONDecodeError:
+            tc_args = {}
+
+        tool_span = None
+        if _trace:
+            try:
+                tool_span = _trace.span(
+                    name=f"tool:{tc_name}",
+                    type="tool",
+                    input={"name": tc_name, "args": tc_args},
+                )
+            except Exception:
+                pass
+
+        result_holder = [None]
+        event = threading.Event()
+
+        def _result_callback(result, _ev=event, _rh=result_holder):
+            _rh[0] = result
+            _ev.set()
+
+        on_tool_call(tc_name, tc_args, _result_callback)
+        if not event.wait(timeout=60):  # block until GTK thread executes tool
+            _LOG.warning("Tool call %r timed out after 60 s", tc_name)
+        result_str = str(result_holder[0]) if result_holder[0] is not None else ""
+
+        if tool_span:
+            try:
+                tool_span.end(output={"result": result_str})
+            except Exception:
+                pass
+
+        messages = messages + [
+            {
+                "role": "tool",
+                "tool_call_id": tc["id"],
+                "content": result_str,
+            }
+        ]
+
+    return messages
+
+
+def _read_sse_lines(response):
+    """
+    Yield decoded lines from an SSE response.
+
+    Uses ``response.fp.readline()`` for true line-by-line streaming.
+    Falls back to splitting the full body if ``fp`` is unavailable.
+    """
+    fp = getattr(response, "fp", None)
+    if fp is not None:
+        while True:
+            raw = fp.readline()
+            if not raw:
+                break
+            yield raw.decode("utf-8", errors="replace").rstrip("\r\n")
+    else:
+        # Fallback: buffer entire response (no live streaming)
+        body = response.read().decode("utf-8", errors="replace")
+        for line in body.splitlines():
+            yield line
+
+
+# ---------------------------------------------------------------------------
+# OpenAI-compatible backend
+# ---------------------------------------------------------------------------
+
+
+class OpenAICompatibleBackend(ChatBackend):
+    """
+    Streaming backend for any OpenAI-compatible API.
+
+    Works with Ollama (``http://localhost:11434``), llama.cpp server,
+    LM Studio, and the OpenAI API (``https://api.openai.com``).
+    """
+
+    def __init__(self, base_url: str, model: str, api_key: str = ""):
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+        self.api_key = api_key
+        self._parsed = urllib.parse.urlparse(self.base_url)
+
+    def stream_chat(self, messages, tools, on_chunk, on_tool_call, on_done, on_error, thread_id=None):
+        t = threading.Thread(
+            target=self._worker,
+            args=(messages, tools, on_chunk, on_tool_call, on_done, on_error, thread_id),
+            daemon=True,
+        )
+        t.start()
+
+    def _worker(self, messages, tools, on_chunk, on_tool_call, on_done, on_error, thread_id=None):
+        trace = None
+        if _OPIK_CLIENT:
+            try:
+                trace = _OPIK_CLIENT.trace(
+                    name="gramps-chat",
+                    input={"messages": messages},
+                    project_name="gramps-assistant",
+                    metadata={"backend": "openai", "model": self.model},
+                    thread_id=thread_id,
+                )
+                _orig_done = on_done
+                _orig_error = on_error
+                _orig_on_chunk = on_chunk
+                _all_parts = []
+
+                def on_chunk(text):
+                    _all_parts.append(text)
+                    _orig_on_chunk(text)
+
+                def on_done():
+                    try:
+                        trace.end(output={"text": "".join(_all_parts)})
+                    except Exception:
+                        pass
+                    _orig_done()
+
+                def on_error(exc):
+                    try:
+                        trace.end(output={"text": "".join(_all_parts)},
+                                  metadata={"error": str(exc)})
+                    except Exception:
+                        pass
+                    _orig_error(exc)
+            except Exception:
+                _LOG.debug("Opik trace creation failed", exc_info=True)
+        try:
+            self._do_stream(messages, tools, on_chunk, on_tool_call, on_done, on_error, trace)
+        except Exception as exc:
+            _LOG.debug("OpenAI backend stream error", exc_info=True)
+            on_error(exc)
+
+    def _do_stream(self, messages, tools, on_chunk, on_tool_call, on_done, on_error, _trace=None):
+        """Core streaming loop — may recurse after tool calls."""
+        span = None
+        _response_parts = []
+        _orig_on_chunk = on_chunk
+        if _trace:
+            try:
+                span = _trace.span(
+                    name="llm",
+                    type="llm",
+                    input={"messages": messages},
+                    model=self.model,
+                )
+
+                def on_chunk(text):
+                    _response_parts.append(text)
+                    _orig_on_chunk(text)
+            except Exception:
+                _LOG.debug("Opik span creation failed", exc_info=True)
+
+        base_path = self._parsed.path.rstrip("/")
+        path = base_path + "/v1/chat/completions"
+
+        payload = {
+            "model": self.model,
+            "messages": messages,
+            "stream": True,
+        }
+        if tools:
+            payload["tools"] = tools
+            payload["tool_choice"] = "auto"
+
+        body = json.dumps(payload).encode("utf-8")
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "text/event-stream",
+        }
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        conn = _make_connection(self._parsed)
+        try:
+            conn.request("POST", path, body=body, headers=headers)
+            response = conn.getresponse()
+
+            if response.status != 200:
+                raw = response.read().decode("utf-8", errors="replace")
+                try:
+                    msg = json.loads(raw).get("error", {}).get("message") or raw[:500]
+                except Exception:
+                    msg = raw[:500]
+                raise RuntimeError(f"HTTP {response.status}: {msg}")
+
+            tool_call_accum = {}  # index → {"id","name","arguments"}
+            finish_reason = None
+
+            for line in _read_sse_lines(response):
+                if not line.startswith("data: "):
+                    continue
+                data_str = line[len("data: "):]
+                if data_str.strip() == "[DONE]":
+                    break
+                try:
+                    chunk = json.loads(data_str)
+                except json.JSONDecodeError:
+                    continue
+
+                choices = chunk.get("choices", [])
+                if not choices:
+                    continue
+
+                choice = choices[0]
+                delta = choice.get("delta", {})
+                finish_reason = choice.get("finish_reason") or finish_reason
+
+                # Text delta
+                content = delta.get("content")
+                if content:
+                    on_chunk(content)
+
+                # Tool call delta accumulation
+                for tc_delta in delta.get("tool_calls") or []:
+                    idx = tc_delta.get("index", 0)
+                    if idx not in tool_call_accum:
+                        tool_call_accum[idx] = {"id": "", "name": "", "arguments": ""}
+                    acc = tool_call_accum[idx]
+                    if tc_delta.get("id"):
+                        acc["id"] = tc_delta["id"]
+                    func = tc_delta.get("function", {})
+                    if func.get("name"):
+                        acc["name"] = func["name"]
+                    if func.get("arguments"):
+                        acc["arguments"] += func["arguments"]
+
+                if finish_reason in ("stop", "end_turn", "tool_calls"):
+                    break
+        finally:
+            conn.close()
+
+        # Fallback: some smaller models emit the tool call as plain-text JSON
+        # e.g. {"function":"get_main_person"} instead of using tool_calls.
+        if not tool_call_accum and _response_parts and tools:
+            plain = "".join(_response_parts).strip()
+            try:
+                obj = json.loads(plain)
+                if isinstance(obj, dict) and "function" in obj:
+                    tool_call_accum[0] = {
+                        "id": "plain-0",
+                        "name": obj["function"],
+                        "arguments": json.dumps(obj.get("arguments") or obj.get("parameters") or {}),
+                    }
+                    finish_reason = "tool_calls"
+                    _response_parts.clear()
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+        if tool_call_accum:
+            if span:
+                try:
+                    span.end(output={"text": "".join(_response_parts), "finish_reason": finish_reason})
+                except Exception:
+                    pass
+            updated_messages = _execute_tool_calls(
+                tool_call_accum, messages, on_tool_call, _trace
+            )
+            if updated_messages is messages:
+                # All tool calls had empty names; nothing was executed.
+                on_done()
+                return
+            self._do_stream(
+                updated_messages, tools, _orig_on_chunk, on_tool_call, on_done, on_error, _trace
+            )
+        else:
+            if span:
+                try:
+                    span.end(output={"text": "".join(_response_parts)})
+                except Exception:
+                    pass
+            on_done()
+
+
+# ---------------------------------------------------------------------------
+# Anthropic backend
+# ---------------------------------------------------------------------------
+
+
+class AnthropicBackend(ChatBackend):
+    """
+    Streaming backend for the Anthropic Messages API.
+
+    Default base URL is ``https://api.anthropic.com``.
+    """
+
+    ANTHROPIC_VERSION = "2023-06-01"
+
+    def __init__(
+        self,
+        base_url: str = "https://api.anthropic.com",
+        model: str = "claude-opus-4-5",
+        api_key: str = "",
+    ):
+        self.base_url = base_url.rstrip("/")
+        self.model = model
+        self.api_key = api_key
+        self._parsed = urllib.parse.urlparse(self.base_url)
+
+    # ------------------------------------------------------------------
+    # Message format conversion
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _convert_messages(messages: list):
+        """
+        Translate from internal OpenAI-format messages to Anthropic format.
+
+        Returns ``(system_str_or_None, anthropic_messages_list)``.
+
+        Rules
+        -----
+        * ``role=="system"`` → extracted into the top-level ``system`` field.
+        * ``role=="assistant"`` with ``tool_calls`` → content list with
+          ``{"type":"tool_use", ...}`` blocks.
+        * Consecutive ``role=="tool"`` messages → merged into one
+          ``role=="user"`` message with a list of ``tool_result`` blocks.
+        """
+        system_parts = []
+        result = []
+        i = 0
+
+        while i < len(messages):
+            msg = messages[i]
+            role = msg["role"]
+
+            if role == "system":
+                if msg.get("content"):
+                    system_parts.append(msg["content"])
+                i += 1
+                continue
+
+            if role == "user":
+                content = msg.get("content")
+                if isinstance(content, list):
+                    result.append({"role": "user", "content": content})
+                else:
+                    result.append({"role": "user", "content": content or ""})
+                i += 1
+                continue
+
+            if role == "assistant":
+                tool_calls = msg.get("tool_calls")
+                if tool_calls:
+                    content_blocks = []
+                    if msg.get("content"):
+                        content_blocks.append({"type": "text", "text": msg["content"]})
+                    for tc in tool_calls:
+                        try:
+                            inp = json.loads(tc["function"]["arguments"])
+                        except (json.JSONDecodeError, KeyError):
+                            inp = {}
+                        content_blocks.append(
+                            {
+                                "type": "tool_use",
+                                "id": tc["id"],
+                                "name": tc["function"]["name"],
+                                "input": inp,
+                            }
+                        )
+                    result.append({"role": "assistant", "content": content_blocks})
+                else:
+                    result.append(
+                        {"role": "assistant", "content": msg.get("content") or ""}
+                    )
+                i += 1
+                continue
+
+            if role == "tool":
+                # Gather consecutive tool-result messages into one user turn
+                tool_results = []
+                while i < len(messages) and messages[i]["role"] == "tool":
+                    tm = messages[i]
+                    tool_results.append(
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": tm.get("tool_call_id", ""),
+                            "content": tm.get("content", ""),
+                        }
+                    )
+                    i += 1
+                result.append({"role": "user", "content": tool_results})
+                continue
+
+            i += 1
+
+        system_str = "\n\n".join(system_parts) if system_parts else None
+        return system_str, result
+
+    # ------------------------------------------------------------------
+    # Streaming
+    # ------------------------------------------------------------------
+
+    def stream_chat(self, messages, tools, on_chunk, on_tool_call, on_done, on_error, thread_id=None):
+        t = threading.Thread(
+            target=self._worker,
+            args=(messages, tools, on_chunk, on_tool_call, on_done, on_error, thread_id),
+            daemon=True,
+        )
+        t.start()
+
+    def _worker(self, messages, tools, on_chunk, on_tool_call, on_done, on_error, thread_id=None):
+        trace = None
+        if _OPIK_CLIENT:
+            try:
+                trace = _OPIK_CLIENT.trace(
+                    name="gramps-chat",
+                    input={"messages": messages},
+                    project_name="gramps-assistant",
+                    metadata={"backend": "anthropic", "model": self.model},
+                    thread_id=thread_id,
+                )
+                _orig_done = on_done
+                _orig_error = on_error
+                _orig_on_chunk = on_chunk
+                _all_parts = []
+
+                def on_chunk(text):
+                    _all_parts.append(text)
+                    _orig_on_chunk(text)
+
+                def on_done():
+                    try:
+                        trace.end(output={"text": "".join(_all_parts)})
+                    except Exception:
+                        pass
+                    _orig_done()
+
+                def on_error(exc):
+                    try:
+                        trace.end(output={"text": "".join(_all_parts)},
+                                  metadata={"error": str(exc)})
+                    except Exception:
+                        pass
+                    _orig_error(exc)
+            except Exception:
+                _LOG.debug("Opik trace creation failed", exc_info=True)
+        try:
+            self._do_stream(messages, tools, on_chunk, on_tool_call, on_done, on_error, trace)
+        except Exception as exc:
+            _LOG.debug("Anthropic backend stream error", exc_info=True)
+            on_error(exc)
+
+    def _do_stream(self, messages, tools, on_chunk, on_tool_call, on_done, on_error, _trace=None):
+        """Core streaming loop for the Anthropic API."""
+        span = None
+        _response_parts = []
+        _orig_on_chunk = on_chunk
+        if _trace:
+            try:
+                span = _trace.span(
+                    name="llm",
+                    type="llm",
+                    input={"messages": messages},
+                    model=self.model,
+                )
+
+                def on_chunk(text):
+                    _response_parts.append(text)
+                    _orig_on_chunk(text)
+            except Exception:
+                _LOG.debug("Opik span creation failed", exc_info=True)
+
+        system_str, anthropic_messages = self._convert_messages(messages)
+
+        base_path = self._parsed.path.rstrip("/")
+        path = base_path + "/v1/messages"
+
+        payload = {
+            "model": self.model,
+            "max_tokens": 4096,
+            "messages": anthropic_messages,
+            "stream": True,
+        }
+        if system_str:
+            payload["system"] = system_str
+        if tools:
+            payload["tools"] = tools
+
+        body = json.dumps(payload).encode("utf-8")
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "text/event-stream",
+            "anthropic-version": self.ANTHROPIC_VERSION,
+        }
+        if self.api_key:
+            headers["x-api-key"] = self.api_key
+
+        conn = _make_connection(self._parsed)
+        try:
+            conn.request("POST", path, body=body, headers=headers)
+            response = conn.getresponse()
+
+            if response.status != 200:
+                raw = response.read().decode("utf-8", errors="replace")
+                try:
+                    msg = json.loads(raw).get("error", {}).get("message") or raw[:500]
+                except Exception:
+                    msg = raw[:500]
+                raise RuntimeError(f"HTTP {response.status}: {msg}")
+
+            # Accumulate tool-use blocks indexed by content-block index
+            # Each entry: {"id","name","partial_json"}
+            tool_use_accum = {}
+            stop_reason = None
+
+            for line in _read_sse_lines(response):
+                if not line.startswith("data: "):
+                    continue
+                data_str = line[len("data: "):]
+                try:
+                    event = json.loads(data_str)
+                except json.JSONDecodeError:
+                    continue
+
+                etype = event.get("type", "")
+
+                if etype == "content_block_start":
+                    block = event.get("content_block", {})
+                    idx = event.get("index", 0)
+                    if block.get("type") == "tool_use":
+                        tool_use_accum[idx] = {
+                            "id": block.get("id", ""),
+                            "name": block.get("name", ""),
+                            "partial_json": "",
+                        }
+
+                elif etype == "content_block_delta":
+                    idx = event.get("index", 0)
+                    delta = event.get("delta", {})
+                    dtype = delta.get("type", "")
+
+                    if dtype == "text_delta":
+                        text = delta.get("text", "")
+                        if text:
+                            on_chunk(text)
+
+                    elif dtype == "input_json_delta":
+                        if idx in tool_use_accum:
+                            tool_use_accum[idx]["partial_json"] += delta.get(
+                                "partial_json", ""
+                            )
+
+                elif etype == "message_delta":
+                    stop_reason = event.get("delta", {}).get("stop_reason")
+
+                elif etype == "message_stop":
+                    break
+
+        finally:
+            conn.close()
+
+        if stop_reason == "tool_use" and tool_use_accum:
+            if span:
+                try:
+                    span.end(output={"text": "".join(_response_parts), "finish_reason": "tool_use"})
+                except Exception:
+                    pass
+            # Convert Anthropic accumulator format → OpenAI tool_call_accum format
+            openai_style_accum = {}
+            for idx, tu in tool_use_accum.items():
+                openai_style_accum[idx] = {
+                    "id": tu["id"],
+                    "name": tu["name"],
+                    "arguments": tu["partial_json"],
+                }
+            updated_messages = _execute_tool_calls(
+                openai_style_accum, messages, on_tool_call, _trace
+            )
+            if updated_messages is messages:
+                on_done()
+                return
+            self._do_stream(
+                updated_messages, tools, _orig_on_chunk, on_tool_call, on_done, on_error, _trace
+            )
+        else:
+            if span:
+                try:
+                    span.end(output={"text": "".join(_response_parts)})
+                except Exception:
+                    pass
+            on_done()

--- a/GrampsAssistant/backend.py
+++ b/GrampsAssistant/backend.py
@@ -358,8 +358,8 @@ def _execute_tool_calls(tool_call_accum, messages, on_tool_call, _trace=None, to
             _ev.set()
 
         on_tool_call(tc_name, tc_args, _result_callback)
-        if not event.wait(timeout=60):  # block until GTK thread executes tool
-            _LOG.warning("Tool call %r timed out after 60 s", tc_name)
+        if not event.wait(timeout=300):  # block until GTK thread executes tool
+            _LOG.warning("Tool call %r timed out after 300 s", tc_name)
         result_str = str(result_holder[0]) if result_holder[0] is not None else ""
         _LOG.debug("tool result: name=%r  result=%r", tc_name, result_str[:200])
 
@@ -472,151 +472,157 @@ class OpenAICompatibleBackend(ChatBackend):
             on_error(exc)
 
     def _do_stream(self, messages, tools, on_chunk, on_tool_call, on_done, on_error, _trace=None):
-        """Core streaming loop — may recurse after tool calls."""
-        span = None
-        _response_parts = []
+        """Core streaming loop — iterates through tool-call rounds without recursion."""
         _orig_on_chunk = on_chunk
-        if _trace:
-            try:
-                span = _trace.span(
-                    name="llm",
-                    type="llm",
-                    input={"messages": messages},
-                    model=self.model,
-                )
+        max_rounds = 20
 
-                def on_chunk(text):
-                    _response_parts.append(text)
-                    _orig_on_chunk(text)
-            except Exception:
-                _LOG.debug("Opik span creation failed", exc_info=True)
+        for _round in range(max_rounds):
+            span = None
+            _response_parts = []
 
-        base_path = self._parsed.path.rstrip("/")
-        path = base_path + "/v1/chat/completions"
+            def on_chunk(text):
+                _response_parts.append(text)
+                _orig_on_chunk(text)
 
-        payload = {
-            "model": self.model,
-            "messages": messages,
-            "stream": True,
-        }
-        if tools:
-            payload["tools"] = tools
-            payload["tool_choice"] = "auto"
-
-        body = json.dumps(payload).encode("utf-8")
-        headers = {
-            "Content-Type": "application/json",
-            "Accept": "text/event-stream",
-        }
-        if self.api_key:
-            headers["Authorization"] = f"Bearer {self.api_key}"
-
-        conn = _make_connection(self._parsed)
-        try:
-            conn.request("POST", path, body=body, headers=headers)
-            response = conn.getresponse()
-
-            if response.status != 200:
-                raw = response.read().decode("utf-8", errors="replace")
+            if _trace:
                 try:
-                    msg = json.loads(raw).get("error", {}).get("message") or raw[:500]
+                    span = _trace.span(
+                        name="llm",
+                        type="llm",
+                        input={"messages": messages},
+                        model=self.model,
+                    )
                 except Exception:
-                    msg = raw[:500]
-                raise RuntimeError(f"HTTP {response.status}: {msg}")
+                    _LOG.debug("Opik span creation failed", exc_info=True)
 
-            tool_call_accum = {}  # index → {"id","name","arguments"}
-            finish_reason = None
+            base_path = self._parsed.path.rstrip("/")
+            path = base_path + "/v1/chat/completions"
 
-            for line in _read_sse_lines(response):
-                if not line.startswith("data: "):
-                    continue
-                data_str = line[len("data: "):]
-                if data_str.strip() == "[DONE]":
-                    break
-                try:
-                    chunk = json.loads(data_str)
-                except json.JSONDecodeError:
-                    continue
+            payload = {
+                "model": self.model,
+                "messages": messages,
+                "stream": True,
+            }
+            if tools:
+                payload["tools"] = tools
+                payload["tool_choice"] = "auto"
 
-                choices = chunk.get("choices", [])
-                if not choices:
-                    continue
+            body = json.dumps(payload).encode("utf-8")
+            headers = {
+                "Content-Type": "application/json",
+                "Accept": "text/event-stream",
+            }
+            if self.api_key:
+                headers["Authorization"] = f"Bearer {self.api_key}"
 
-                choice = choices[0]
-                delta = choice.get("delta", {})
-                finish_reason = choice.get("finish_reason") or finish_reason
-
-                # Text delta
-                content = delta.get("content")
-                if content:
-                    on_chunk(content)
-
-                # Tool call delta accumulation
-                for tc_delta in delta.get("tool_calls") or []:
-                    _LOG.debug("tool_call delta: %r", tc_delta)
-                    idx = tc_delta.get("index", 0)
-                    if idx not in tool_call_accum:
-                        tool_call_accum[idx] = {"id": "", "name": "", "arguments": ""}
-                    acc = tool_call_accum[idx]
-                    if tc_delta.get("id"):
-                        acc["id"] = tc_delta["id"]
-                    func = tc_delta.get("function", {})
-                    # name may be under function.name (OpenAI) or at top level (some local models)
-                    name = func.get("name") or tc_delta.get("name", "")
-                    if name:
-                        acc["name"] = name
-                    # arguments may be under function.arguments or at top level
-                    args = func.get("arguments") or tc_delta.get("arguments", "")
-                    if args:
-                        acc["arguments"] += args
-
-                if finish_reason in ("stop", "end_turn", "tool_calls"):
-                    _LOG.debug("finish_reason=%r, tool_call_accum=%r", finish_reason, tool_call_accum)
-                    break
-        finally:
-            conn.close()
-
-        # Fallback: some smaller models emit the tool call as plain-text JSON
-        # e.g. {"function":"get_main_person"} instead of using tool_calls.
-        if not tool_call_accum and _response_parts and tools:
-            plain = "".join(_response_parts).strip()
+            conn = _make_connection(self._parsed)
             try:
-                obj = json.loads(plain)
-                if isinstance(obj, dict) and "function" in obj:
-                    tool_call_accum[0] = {
-                        "id": "plain-0",
-                        "name": obj["function"],
-                        "arguments": json.dumps(obj.get("arguments") or obj.get("parameters") or {}),
-                    }
-                    finish_reason = "tool_calls"
-                    _response_parts.clear()
-            except (json.JSONDecodeError, TypeError):
-                pass
+                conn.request("POST", path, body=body, headers=headers)
+                response = conn.getresponse()
 
-        if tool_call_accum:
-            _LOG.debug("tool_call_accum after SSE loop: %r", tool_call_accum)
-            if span:
+                if response.status != 200:
+                    raw = response.read().decode("utf-8", errors="replace")
+                    try:
+                        msg = json.loads(raw).get("error", {}).get("message") or raw[:500]
+                    except Exception:
+                        msg = raw[:500]
+                    raise RuntimeError(f"HTTP {response.status}: {msg}")
+
+                tool_call_accum = {}  # index → {"id","name","arguments"}
+                finish_reason = None
+
+                for line in _read_sse_lines(response):
+                    if not line.startswith("data: "):
+                        continue
+                    data_str = line[len("data: "):]
+                    if data_str.strip() == "[DONE]":
+                        break
+                    try:
+                        chunk = json.loads(data_str)
+                    except json.JSONDecodeError:
+                        continue
+
+                    choices = chunk.get("choices", [])
+                    if not choices:
+                        continue
+
+                    choice = choices[0]
+                    delta = choice.get("delta", {})
+                    finish_reason = choice.get("finish_reason") or finish_reason
+
+                    # Text delta
+                    content = delta.get("content")
+                    if content:
+                        on_chunk(content)
+
+                    # Tool call delta accumulation
+                    for tc_delta in delta.get("tool_calls") or []:
+                        _LOG.debug("tool_call delta: %r", tc_delta)
+                        idx = tc_delta.get("index", 0)
+                        if idx not in tool_call_accum:
+                            tool_call_accum[idx] = {"id": "", "name": "", "arguments": ""}
+                        acc = tool_call_accum[idx]
+                        if tc_delta.get("id"):
+                            acc["id"] = tc_delta["id"]
+                        func = tc_delta.get("function", {})
+                        # name may be under function.name (OpenAI) or at top level (some local models)
+                        name = func.get("name") or tc_delta.get("name", "")
+                        if name:
+                            acc["name"] = name
+                        # arguments may be under function.arguments or at top level
+                        args = func.get("arguments") or tc_delta.get("arguments", "")
+                        if args:
+                            acc["arguments"] += args
+
+                    if finish_reason in ("stop", "end_turn", "tool_calls"):
+                        _LOG.debug("finish_reason=%r, tool_call_accum=%r", finish_reason, tool_call_accum)
+                        break
+            finally:
+                conn.close()
+
+            # Fallback: some smaller models emit the tool call as plain-text JSON
+            # e.g. {"function":"get_main_person"} instead of using tool_calls.
+            if not tool_call_accum and _response_parts and tools:
+                plain = "".join(_response_parts).strip()
                 try:
-                    span.end(output={"text": "".join(_response_parts), "finish_reason": finish_reason})
-                except Exception:
+                    obj = json.loads(plain)
+                    if isinstance(obj, dict) and "function" in obj:
+                        tool_call_accum[0] = {
+                            "id": "plain-0",
+                            "name": obj["function"],
+                            "arguments": json.dumps(obj.get("arguments") or obj.get("parameters") or {}),
+                        }
+                        finish_reason = "tool_calls"
+                        _response_parts.clear()
+                except (json.JSONDecodeError, TypeError):
                     pass
-            updated_messages = _execute_tool_calls(
-                tool_call_accum, messages, on_tool_call, _trace, tools=tools
-            )
-            if updated_messages is messages:
-                # All tool calls had empty names; nothing was executed.
+
+            if tool_call_accum:
+                _LOG.debug("tool_call_accum after SSE loop: %r", tool_call_accum)
+                if span:
+                    try:
+                        span.end(output={"text": "".join(_response_parts), "finish_reason": finish_reason})
+                    except Exception:
+                        pass
+                updated_messages = _execute_tool_calls(
+                    tool_call_accum, messages, on_tool_call, _trace, tools=tools
+                )
+                if updated_messages is messages:
+                    # All tool calls had empty names; nothing was executed.
+                    on_done()
+                    return
+                messages = updated_messages  # advance to next round
+            else:
+                if span:
+                    try:
+                        span.end(output={"text": "".join(_response_parts)})
+                    except Exception:
+                        pass
                 on_done()
                 return
-            self._do_stream(
-                updated_messages, tools, _orig_on_chunk, on_tool_call, on_done, on_error, _trace
-            )
-        else:
-            if span:
-                try:
-                    span.end(output={"text": "".join(_response_parts)})
-                except Exception:
-                    pass
-            on_done()
+
+        _LOG.warning("Maximum tool-call rounds (%d) reached; stopping.", max_rounds)
+        on_done()
 
 
 # ---------------------------------------------------------------------------
@@ -790,141 +796,147 @@ class AnthropicBackend(ChatBackend):
             on_error(exc)
 
     def _do_stream(self, messages, tools, on_chunk, on_tool_call, on_done, on_error, _trace=None):
-        """Core streaming loop for the Anthropic API."""
-        span = None
-        _response_parts = []
+        """Core streaming loop for the Anthropic API — iterates through tool-call rounds without recursion."""
         _orig_on_chunk = on_chunk
-        if _trace:
+        max_rounds = 20
+
+        for _round in range(max_rounds):
+            span = None
+            _response_parts = []
+
+            def on_chunk(text):
+                _response_parts.append(text)
+                _orig_on_chunk(text)
+
+            if _trace:
+                try:
+                    span = _trace.span(
+                        name="llm",
+                        type="llm",
+                        input={"messages": messages},
+                        model=self.model,
+                    )
+                except Exception:
+                    _LOG.debug("Opik span creation failed", exc_info=True)
+
+            system_str, anthropic_messages = self._convert_messages(messages)
+
+            base_path = self._parsed.path.rstrip("/")
+            path = base_path + "/v1/messages"
+
+            payload = {
+                "model": self.model,
+                "max_tokens": 4096,
+                "messages": anthropic_messages,
+                "stream": True,
+            }
+            if system_str:
+                payload["system"] = system_str
+            if tools:
+                payload["tools"] = tools
+
+            body = json.dumps(payload).encode("utf-8")
+            headers = {
+                "Content-Type": "application/json",
+                "Accept": "text/event-stream",
+                "anthropic-version": self.ANTHROPIC_VERSION,
+            }
+            if self.api_key:
+                headers["x-api-key"] = self.api_key
+
+            conn = _make_connection(self._parsed)
             try:
-                span = _trace.span(
-                    name="llm",
-                    type="llm",
-                    input={"messages": messages},
-                    model=self.model,
+                conn.request("POST", path, body=body, headers=headers)
+                response = conn.getresponse()
+
+                if response.status != 200:
+                    raw = response.read().decode("utf-8", errors="replace")
+                    try:
+                        msg = json.loads(raw).get("error", {}).get("message") or raw[:500]
+                    except Exception:
+                        msg = raw[:500]
+                    raise RuntimeError(f"HTTP {response.status}: {msg}")
+
+                # Accumulate tool-use blocks indexed by content-block index
+                # Each entry: {"id","name","partial_json"}
+                tool_use_accum = {}
+                stop_reason = None
+
+                for line in _read_sse_lines(response):
+                    if not line.startswith("data: "):
+                        continue
+                    data_str = line[len("data: "):]
+                    try:
+                        event = json.loads(data_str)
+                    except json.JSONDecodeError:
+                        continue
+
+                    etype = event.get("type", "")
+
+                    if etype == "content_block_start":
+                        block = event.get("content_block", {})
+                        idx = event.get("index", 0)
+                        if block.get("type") == "tool_use":
+                            tool_use_accum[idx] = {
+                                "id": block.get("id", ""),
+                                "name": block.get("name", ""),
+                                "partial_json": "",
+                            }
+
+                    elif etype == "content_block_delta":
+                        idx = event.get("index", 0)
+                        delta = event.get("delta", {})
+                        dtype = delta.get("type", "")
+
+                        if dtype == "text_delta":
+                            text = delta.get("text", "")
+                            if text:
+                                on_chunk(text)
+
+                        elif dtype == "input_json_delta":
+                            if idx in tool_use_accum:
+                                tool_use_accum[idx]["partial_json"] += delta.get(
+                                    "partial_json", ""
+                                )
+
+                    elif etype == "message_delta":
+                        stop_reason = event.get("delta", {}).get("stop_reason")
+
+                    elif etype == "message_stop":
+                        break
+
+            finally:
+                conn.close()
+
+            if stop_reason == "tool_use" and tool_use_accum:
+                if span:
+                    try:
+                        span.end(output={"text": "".join(_response_parts), "finish_reason": "tool_use"})
+                    except Exception:
+                        pass
+                # Convert Anthropic accumulator format → OpenAI tool_call_accum format
+                openai_style_accum = {}
+                for idx, tu in tool_use_accum.items():
+                    openai_style_accum[idx] = {
+                        "id": tu["id"],
+                        "name": tu["name"],
+                        "arguments": tu["partial_json"],
+                    }
+                updated_messages = _execute_tool_calls(
+                    openai_style_accum, messages, on_tool_call, _trace, tools=tools
                 )
-
-                def on_chunk(text):
-                    _response_parts.append(text)
-                    _orig_on_chunk(text)
-            except Exception:
-                _LOG.debug("Opik span creation failed", exc_info=True)
-
-        system_str, anthropic_messages = self._convert_messages(messages)
-
-        base_path = self._parsed.path.rstrip("/")
-        path = base_path + "/v1/messages"
-
-        payload = {
-            "model": self.model,
-            "max_tokens": 4096,
-            "messages": anthropic_messages,
-            "stream": True,
-        }
-        if system_str:
-            payload["system"] = system_str
-        if tools:
-            payload["tools"] = tools
-
-        body = json.dumps(payload).encode("utf-8")
-        headers = {
-            "Content-Type": "application/json",
-            "Accept": "text/event-stream",
-            "anthropic-version": self.ANTHROPIC_VERSION,
-        }
-        if self.api_key:
-            headers["x-api-key"] = self.api_key
-
-        conn = _make_connection(self._parsed)
-        try:
-            conn.request("POST", path, body=body, headers=headers)
-            response = conn.getresponse()
-
-            if response.status != 200:
-                raw = response.read().decode("utf-8", errors="replace")
-                try:
-                    msg = json.loads(raw).get("error", {}).get("message") or raw[:500]
-                except Exception:
-                    msg = raw[:500]
-                raise RuntimeError(f"HTTP {response.status}: {msg}")
-
-            # Accumulate tool-use blocks indexed by content-block index
-            # Each entry: {"id","name","partial_json"}
-            tool_use_accum = {}
-            stop_reason = None
-
-            for line in _read_sse_lines(response):
-                if not line.startswith("data: "):
-                    continue
-                data_str = line[len("data: "):]
-                try:
-                    event = json.loads(data_str)
-                except json.JSONDecodeError:
-                    continue
-
-                etype = event.get("type", "")
-
-                if etype == "content_block_start":
-                    block = event.get("content_block", {})
-                    idx = event.get("index", 0)
-                    if block.get("type") == "tool_use":
-                        tool_use_accum[idx] = {
-                            "id": block.get("id", ""),
-                            "name": block.get("name", ""),
-                            "partial_json": "",
-                        }
-
-                elif etype == "content_block_delta":
-                    idx = event.get("index", 0)
-                    delta = event.get("delta", {})
-                    dtype = delta.get("type", "")
-
-                    if dtype == "text_delta":
-                        text = delta.get("text", "")
-                        if text:
-                            on_chunk(text)
-
-                    elif dtype == "input_json_delta":
-                        if idx in tool_use_accum:
-                            tool_use_accum[idx]["partial_json"] += delta.get(
-                                "partial_json", ""
-                            )
-
-                elif etype == "message_delta":
-                    stop_reason = event.get("delta", {}).get("stop_reason")
-
-                elif etype == "message_stop":
-                    break
-
-        finally:
-            conn.close()
-
-        if stop_reason == "tool_use" and tool_use_accum:
-            if span:
-                try:
-                    span.end(output={"text": "".join(_response_parts), "finish_reason": "tool_use"})
-                except Exception:
-                    pass
-            # Convert Anthropic accumulator format → OpenAI tool_call_accum format
-            openai_style_accum = {}
-            for idx, tu in tool_use_accum.items():
-                openai_style_accum[idx] = {
-                    "id": tu["id"],
-                    "name": tu["name"],
-                    "arguments": tu["partial_json"],
-                }
-            updated_messages = _execute_tool_calls(
-                openai_style_accum, messages, on_tool_call, _trace, tools=tools
-            )
-            if updated_messages is messages:
+                if updated_messages is messages:
+                    on_done()
+                    return
+                messages = updated_messages  # advance to next round
+            else:
+                if span:
+                    try:
+                        span.end(output={"text": "".join(_response_parts)})
+                    except Exception:
+                        pass
                 on_done()
                 return
-            self._do_stream(
-                updated_messages, tools, _orig_on_chunk, on_tool_call, on_done, on_error, _trace
-            )
-        else:
-            if span:
-                try:
-                    span.end(output={"text": "".join(_response_parts)})
-                except Exception:
-                    pass
-            on_done()
+
+        _LOG.warning("Maximum tool-call rounds (%d) reached; stopping.", max_rounds)
+        on_done()

--- a/GrampsAssistant/grampsassistant.gpr.py
+++ b/GrampsAssistant/grampsassistant.gpr.py
@@ -1,0 +1,64 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Doug Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+
+_ = glocale.translation.gettext
+
+MODULE_VERSION = "6.0"
+
+# SIDEPANEL is added by gramps-project/gramps PR #2220; use it when available,
+# otherwise fall back to a TOOL that opens a persistent floating window.
+try:
+    _has_sidepanel = SIDEPANEL is not None
+except NameError:
+    _has_sidepanel = False
+
+if _has_sidepanel:
+    register(
+        SIDEPANEL,
+        id="grampsassistant",
+        name=_("Gramps Assistant"),
+        description=_("AI assistant panel for querying your Gramps family tree"),
+        version="1.0.0",
+        gramps_target_version=MODULE_VERSION,
+        status=STABLE,
+        fname="grampsassistant.py",
+        authors=["Douglas S. Blank"],
+        authors_email=["dsblank@gmail.com"],
+        sidepanelclass="GrampsAssistant",
+        panel_label=_("Gramps Assistant"),
+        order=END,
+    )
+else:
+    register(
+        TOOL,
+        id="grampsassistant",
+        name=_("Gramps Assistant"),
+        description=_("AI assistant for querying your Gramps family tree"),
+        version="1.0.0",
+        gramps_target_version=MODULE_VERSION,
+        status=STABLE,
+        fname="grampsassistant.py",
+        authors=["Douglas S. Blank"],
+        authors_email=["dsblank@gmail.com"],
+        category=TOOL_UTILS,
+        toolclass="GrampsAssistantTool",
+        optionclass="GrampsAssistantOptions",
+        tool_modes=[TOOL_MODE_GUI],
+    )

--- a/GrampsAssistant/grampsassistant.gpr.py
+++ b/GrampsAssistant/grampsassistant.gpr.py
@@ -20,45 +20,20 @@ from gramps.gen.const import GRAMPS_LOCALE as glocale
 
 _ = glocale.translation.gettext
 
-MODULE_VERSION = "6.0"
-
-# SIDEPANEL is added by gramps-project/gramps PR #2220; use it when available,
-# otherwise fall back to a TOOL that opens a persistent floating window.
-try:
-    _has_sidepanel = SIDEPANEL is not None
-except NameError:
-    _has_sidepanel = False
-
-if _has_sidepanel:
-    register(
-        SIDEPANEL,
-        id="grampsassistant",
-        name=_("Gramps Assistant"),
-        description=_("AI assistant panel for querying your Gramps family tree"),
-        version="1.0.0",
-        gramps_target_version=MODULE_VERSION,
-        status=STABLE,
-        fname="grampsassistant.py",
-        authors=["Douglas S. Blank"],
-        authors_email=["dsblank@gmail.com"],
-        sidepanelclass="GrampsAssistant",
-        panel_label=_("Gramps Assistant"),
-        order=END,
-    )
-else:
-    register(
-        TOOL,
-        id="grampsassistant",
-        name=_("Gramps Assistant"),
-        description=_("AI assistant for querying your Gramps family tree"),
-        version="1.0.0",
-        gramps_target_version=MODULE_VERSION,
-        status=STABLE,
-        fname="grampsassistant.py",
-        authors=["Douglas S. Blank"],
-        authors_email=["dsblank@gmail.com"],
-        category=TOOL_UTILS,
-        toolclass="GrampsAssistantTool",
-        optionclass="GrampsAssistantOptions",
-        tool_modes=[TOOL_MODE_GUI],
-    )
+register(
+    TOOL,
+    id="grampsassistant",
+    name=_("Gramps Assistant"),
+    description=_("AI assistant for querying your Gramps family tree"),
+    version="1.0.0",
+    gramps_target_version="6.0",
+    status=STABLE,
+    fname="grampsassistant.py",
+    authors=["Douglas S. Blank"],
+    authors_email=["dsblank@gmail.com"],
+    category=TOOL_UTILS,
+    toolclass="GrampsAssistantTool",
+    optionclass="GrampsAssistantOptions",
+    tool_modes=[TOOL_MODE_GUI],
+    depends_on=["Grampy Script"],
+)

--- a/GrampsAssistant/grampsassistant.py
+++ b/GrampsAssistant/grampsassistant.py
@@ -1,0 +1,1329 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Gramps Development Team
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+GrampsAssistant — a persistent AI chatbot SIDEPANEL plugin for Gramps.
+"""
+
+import logging
+import os
+import re
+import uuid
+
+from gi.repository import GLib, Gdk, Gtk, Pango
+
+from gramps.gen.config import config as global_config
+
+try:
+    from gramps.gui.sidepanel import BaseSidePanel
+    _HAVE_SIDEPANEL = True
+except ImportError:
+    _HAVE_SIDEPANEL = False
+    BaseSidePanel = object  # neutral base when SIDEPANEL unavailable
+
+from backend import AnthropicBackend, OpenAICompatibleBackend
+from tools import call_tool, get_tools_schema, register_gramps_tools, tool_registry
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+
+_ = glocale.translation.gettext
+_LOG = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Plugin-local configuration
+# ---------------------------------------------------------------------------
+
+_cfg = global_config.register_manager("GrampsAssistant", use_config_path=True)
+_cfg.register("backend.type", "openai")
+_cfg.register("backend.url", "https://api.openai.com")
+_cfg.register("backend.model", "")
+_cfg.register("backend.api_key_env", "")
+_cfg.register(
+    "chat.system_prompt",
+    _("You are a helpful genealogy assistant with access to the user's Gramps database. "
+      "Answer questions about people, families, events, and relationships. "
+      "Use the available tools to look up information when needed."),
+)
+_cfg.register("chat.include_context", True)
+_cfg.register("chat.simplify_tools", False)
+_cfg.register("backend.use_local_url", False)
+_cfg.register("backend.local_url", "http://localhost:11434")
+_cfg.register("backend.local_model", "")
+try:
+    _cfg.load()
+except Exception:
+    pass  # file may not exist yet on first run
+
+
+# ---------------------------------------------------------------------------
+# GrampsAssistant
+# ---------------------------------------------------------------------------
+
+
+class GrampsAssistant(BaseSidePanel):
+    """
+    Persistent sidepanel chatbot that supports OpenAI-compatible and
+    Anthropic backends, streaming output, and Python function tools.
+    """
+
+    def __init__(self, dbstate, uistate):
+        self.dbstate = dbstate
+        self.uistate = uistate
+
+        self._messages = []             # conversation history (OpenAI format)
+        self._thread_id = str(uuid.uuid4())  # Opik thread; rotated on Clear
+        self._streaming = False         # True while a request is in flight
+        self._cancelled = False         # set True when panel is hidden/destroyed
+        self._current_context = ""
+        self._full_response = ""        # full text of current turn (for history)
+        self._tools_called_this_turn = 0
+        # Line-by-line streaming markdown state
+        self._line_buffer = ""          # partial (uncommitted) current line
+        self._line_start_mark = None    # TextMark at start of _line_buffer in buffer
+        self._in_code_block = False     # inside a ``` fence?
+        self._table_buffer = []         # raw table lines buffered until table ends
+        # Maps unique tag name → URL for clickable links
+        self._link_tags = {}
+
+        # Register the built-in Gramps tools
+        register_gramps_tools(dbstate, uistate)
+
+        # Build backend from current config
+        self._backend = self._make_backend()
+
+        # Build the GTK widget tree
+        self._build_ui()
+
+        # Connect to navigation history for context updates
+        self._connect_history_signals()
+        self._update_context_label()
+
+    # ------------------------------------------------------------------
+    # BaseSidePanel interface
+    # ------------------------------------------------------------------
+
+    def get_top(self):
+        return self.top
+
+    def view_changed(self, cat_num, view_num):
+        self._update_context()
+
+    def db_changed(self, db):
+        self._messages.clear()
+        self._thread_id = str(uuid.uuid4())
+        self._current_context = ""
+
+    def active(self, cat_num, view_num):
+        self._cancelled = False
+
+    def inactive(self):
+        self._cancelled = True
+        if self._line_start_mark is not None:
+            try:
+                self._chat_buffer.delete_mark(self._line_start_mark)
+            except Exception:
+                pass
+            self._line_start_mark = None
+
+    # ------------------------------------------------------------------
+    # GTK widget construction
+    # ------------------------------------------------------------------
+
+    def _build_ui(self):
+        self.top = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=0)
+        self.top.set_border_width(4)
+
+        # --- Chat display ---
+        chat_scroll = Gtk.ScrolledWindow()
+        chat_scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        chat_scroll.set_vexpand(True)
+        chat_scroll.set_size_request(-1, 200)
+
+        self._chat_view = Gtk.TextView()
+        self._chat_view.set_editable(False)
+        self._chat_view.set_cursor_visible(False)
+        self._chat_view.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
+        self._chat_view.set_left_margin(6)
+        self._chat_view.set_right_margin(6)
+        self._chat_view.set_top_margin(4)
+        self._chat_view.set_bottom_margin(4)
+
+        self._chat_buffer = self._chat_view.get_buffer()
+        self._create_text_tags()
+        self._chat_view.connect("button-press-event", self._on_chat_button_press)
+
+        # Welcome message
+        self._show_welcome()
+
+        chat_scroll.add(self._chat_view)
+
+        # --- Separator ---
+        sep = Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL)
+
+        # --- Input area (vertical): [text input full-width] / [⚙  Clear  →  Send] ---
+        input_area = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=2)
+        input_area.set_border_width(4)
+
+        # Multi-line input spanning full width
+        input_scroll = Gtk.ScrolledWindow()
+        input_scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        input_scroll.set_shadow_type(Gtk.ShadowType.IN)
+        input_scroll.set_size_request(-1, 80)
+        input_scroll.set_hexpand(True)
+
+        self._input_view = Gtk.TextView()
+        self._input_view.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
+        self._input_view.set_left_margin(4)
+        self._input_view.set_right_margin(4)
+        self._input_view.set_top_margin(4)
+        self._input_view.set_bottom_margin(4)
+        self._input_buffer = self._input_view.get_buffer()
+        self._input_view.connect("key-press-event", self._on_key_press)
+
+        input_scroll.add(self._input_view)
+
+        # Button row below the text input
+        btn_row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=4)
+
+        settings_btn = Gtk.Button(label="⚙")
+        settings_btn.set_tooltip_text(_("Gramps Assistant settings"))
+        settings_btn.connect("clicked", self._on_settings_clicked)
+
+        clear_btn = Gtk.Button(label=_("Clear"))
+        clear_btn.set_tooltip_text(_("Clear conversation and context"))
+        clear_btn.connect("clicked", self._on_clear_clicked)
+
+        self._send_btn = Gtk.Button(label=_("Send"))
+        self._send_btn.connect("clicked", self._on_send_clicked)
+
+        self._context_label = Gtk.Label(label="")
+        self._context_label.set_xalign(0.5)
+
+        btn_row.pack_start(settings_btn, False, False, 0)
+        btn_row.pack_start(clear_btn, False, False, 0)
+        btn_row.pack_start(self._context_label, True, True, 4)
+        btn_row.pack_end(self._send_btn, False, False, 0)
+
+        input_area.pack_start(input_scroll, False, False, 0)
+        input_area.pack_start(btn_row, False, False, 0)
+
+        # --- Assemble ---
+        self.top.pack_start(chat_scroll, True, True, 0)
+        self.top.pack_start(sep, False, False, 2)
+        self.top.pack_start(input_area, False, False, 0)
+
+        self.top.show_all()
+
+    def _create_text_tags(self):
+        buf = self._chat_buffer
+
+        buf.create_tag(
+            "user_label",
+            weight=Pango.Weight.BOLD,
+            foreground="#1a6496",
+        )
+        buf.create_tag(
+            "user_body",
+            foreground="#1a6496",
+            left_margin=12,
+        )
+        buf.create_tag(
+            "assistant_label",
+            weight=Pango.Weight.BOLD,
+            foreground="#2d6a2d",
+        )
+        buf.create_tag(
+            "assistant_body",
+            foreground="#1a1a1a",
+            left_margin=12,
+        )
+        buf.create_tag(
+            "tool_call",
+            family="Monospace",
+            foreground="#888888",
+            style=Pango.Style.ITALIC,
+            left_margin=12,
+            size_points=9.0,
+        )
+        buf.create_tag(
+            "tool_result",
+            family="Monospace",
+            foreground="#555555",
+            left_margin=12,
+            size_points=9.0,
+        )
+        buf.create_tag(
+            "error",
+            foreground="#cc0000",
+            weight=Pango.Weight.BOLD,
+        )
+
+        # Markdown rendering tags
+        buf.create_tag(
+            "md_h1",
+            weight=Pango.Weight.BOLD,
+            scale=1.4,
+            left_margin=12,
+        )
+        buf.create_tag(
+            "md_h2",
+            weight=Pango.Weight.BOLD,
+            scale=1.2,
+            left_margin=12,
+        )
+        buf.create_tag(
+            "md_h3",
+            weight=Pango.Weight.BOLD,
+            scale=1.05,
+            left_margin=12,
+        )
+        buf.create_tag(
+            "md_bold",
+            weight=Pango.Weight.BOLD,
+            left_margin=12,
+        )
+        buf.create_tag(
+            "md_italic",
+            style=Pango.Style.ITALIC,
+            left_margin=12,
+        )
+        buf.create_tag(
+            "md_bold_italic",
+            weight=Pango.Weight.BOLD,
+            style=Pango.Style.ITALIC,
+            left_margin=12,
+        )
+        buf.create_tag(
+            "md_code_inline",
+            family="Monospace",
+            foreground="#c7254e",
+            background="#f9f2f4",
+            size_points=9.0,
+        )
+        buf.create_tag(
+            "md_code_block",
+            family="Monospace",
+            foreground="#333333",
+            background="#f5f5f5",
+            left_margin=16,
+            size_points=9.0,
+        )
+        buf.create_tag(
+            "md_bullet",
+            left_margin=20,
+        )
+        buf.create_tag(
+            "md_table_row",
+            family="Monospace",
+            foreground="#222222",
+            background="#f7f7f7",
+            left_margin=12,
+            size_points=9.0,
+        )
+
+    # ------------------------------------------------------------------
+    # Buffer helpers (always called on GTK main thread)
+    # ------------------------------------------------------------------
+
+    def _append_text(self, text: str, tag_name: str = None):
+        """Insert *text* at end of chat buffer with optional tag."""
+        end_iter = self._chat_buffer.get_end_iter()
+        if tag_name:
+            self._chat_buffer.insert_with_tags_by_name(end_iter, text, tag_name)
+        else:
+            self._chat_buffer.insert(end_iter, text)
+        self._scroll_to_end()
+
+    def _scroll_to_end(self):
+        self._chat_buffer.place_cursor(self._chat_buffer.get_end_iter())
+        self._chat_view.scroll_mark_onscreen(self._chat_buffer.get_insert())
+
+    def _update_context_label(self):
+        """Recompute and display the approximate token count of the current context."""
+        if not self._messages:
+            self._context_label.set_text("")
+            return
+        total_chars = sum(
+            len(m.get("content") or "")
+            for m in self._messages
+        )
+        # Include system prompt + active-person context in the estimate
+        total_chars += len(_cfg.get("chat.system_prompt"))
+        if self._current_context:
+            total_chars += len(self._current_context)
+        approx_tokens = total_chars // 4
+        if approx_tokens == 0:
+            self._context_label.set_text("")
+        elif approx_tokens < 1000:
+            self._context_label.set_text(f"~{approx_tokens} tokens")
+        else:
+            self._context_label.set_text(f"~{approx_tokens / 1000:.1f}k tokens")
+
+    def _show_welcome(self):
+        self._append_text(_("Gramps Assistant:") + "\n", "assistant_label")
+        self._append_text(
+            _("Ask me anything about the Gramps program or your specific Gramps family tree. "
+              "Use the ⚙ button to configure the AI.\n"),
+            "assistant_body",
+        )
+
+    # ------------------------------------------------------------------
+    # Markdown rendering
+    # ------------------------------------------------------------------
+
+    # Matches [text](url), `code`, ***bold-italic***, **bold**, *italic*, _variants_
+    _INLINE_RE = re.compile(
+        r"\[([^\]]+)\]\(([^)]+)\)"    # [link text](url)   → groups 1, 2
+        r"|(`+)(.+?)\3"               # `code`             → groups 3, 4
+        r"|\*\*\*(.+?)\*\*\*"         # ***bold italic***  → group 5
+        r"|___(.+?)___"               # ___bold italic___  → group 6
+        r"|\*\*(.+?)\*\*"             # **bold**           → group 7
+        r"|__(.+?)__"                 # __bold__           → group 8
+        r"|\*(.+?)\*"                 # *italic*           → group 9
+        r"|_(.+?)_",                  # _italic_           → group 10
+        re.DOTALL,
+    )
+
+    # Separator rows: | --- | :---: | ---: |
+    _TABLE_SEP_RE = re.compile(r"^\|[\s\-:|]+\|[\s\-:|]*$")
+
+    def _insert_inline(self, text: str, base_tag: str):
+        """Insert *text* into the buffer, applying inline markdown tags."""
+        buf = self._chat_buffer
+        pos = 0
+        for m in self._INLINE_RE.finditer(text):
+            if m.start() > pos:
+                end = buf.get_end_iter()
+                buf.insert_with_tags_by_name(end, text[pos:m.start()], base_tag)
+            end = buf.get_end_iter()
+            if m.group(1):      # [text](url)
+                self._insert_link(m.group(1), m.group(2))
+            elif m.group(3):    # `code`
+                buf.insert_with_tags_by_name(end, m.group(4), "md_code_inline")
+            elif m.group(5):    # ***bold italic***
+                buf.insert_with_tags_by_name(end, m.group(5), "md_bold_italic")
+            elif m.group(6):    # ___bold italic___
+                buf.insert_with_tags_by_name(end, m.group(6), "md_bold_italic")
+            elif m.group(7):    # **bold**
+                buf.insert_with_tags_by_name(end, m.group(7), "md_bold")
+            elif m.group(8):    # __bold__
+                buf.insert_with_tags_by_name(end, m.group(8), "md_bold")
+            elif m.group(9):    # *italic*
+                buf.insert_with_tags_by_name(end, m.group(9), "md_italic")
+            elif m.group(10):   # _italic_
+                buf.insert_with_tags_by_name(end, m.group(10), "md_italic")
+            pos = m.end()
+        if pos < len(text):
+            end = buf.get_end_iter()
+            buf.insert_with_tags_by_name(end, text[pos:], base_tag)
+
+    def _insert_link(self, text: str, url: str):
+        """Insert a styled, clickable hyperlink into the buffer."""
+        buf = self._chat_buffer
+        tag_name = f"_link_{len(self._link_tags)}"
+        buf.create_tag(
+            tag_name,
+            foreground="#0645ad",
+            underline=Pango.Underline.SINGLE,
+        )
+        self._link_tags[tag_name] = url.strip()
+        end = buf.get_end_iter()
+        buf.insert_with_tags_by_name(end, text, tag_name)
+
+    # CSS applied once per instance for embedded tables
+    _TABLE_CSS = b"""
+        .ga-table {
+            border: 1px solid #bbbbbb;
+            background-color: #bbbbbb;
+        }
+        .ga-table-header {
+            background-color: #dde8f0;
+            padding: 3px 10px;
+        }
+        .ga-table-cell {
+            background-color: #ffffff;
+            padding: 3px 10px;
+        }
+    """
+
+    @staticmethod
+    def _md_to_pango(text: str) -> str:
+        """Convert simple inline markdown to Pango markup."""
+        import html as _html
+        out = _html.escape(text)
+        out = re.sub(r"\*\*\*(.+?)\*\*\*", r"<b><i>\1</i></b>", out)
+        out = re.sub(r"\*\*(.+?)\*\*",     r"<b>\1</b>",         out)
+        out = re.sub(r"\*(.+?)\*",          r"<i>\1</i>",         out)
+        out = re.sub(r"`(.+?)`",            r"<tt>\1</tt>",       out)
+        return out
+
+    def _flush_table(self):
+        """Embed a Gtk.Grid widget for all buffered table rows, then clear the buffer."""
+        if not self._table_buffer:
+            return
+        buf = self._chat_buffer
+
+        # Parse rows: None = separator row, list[str] = data/header cells
+        parsed = []
+        for line in self._table_buffer:
+            stripped = line.strip()
+            if self._TABLE_SEP_RE.match(stripped):
+                parsed.append(None)
+            else:
+                parsed.append([c.strip() for c in stripped.strip("|").split("|")])
+        self._table_buffer = []
+
+        # Split header (rows before first separator) from body rows
+        header_rows, body_rows, sep_seen = [], [], False
+        for row in parsed:
+            if row is None:
+                sep_seen = True
+            elif sep_seen:
+                body_rows.append(row)
+            else:
+                header_rows.append(row)
+        if not sep_seen:
+            body_rows = header_rows
+            header_rows = []
+
+        # Apply CSS (idempotent — GTK deduplicates by provider object)
+        css_provider = Gtk.CssProvider()
+        css_provider.load_from_data(self._TABLE_CSS)
+        Gtk.StyleContext.add_provider_for_screen(
+            Gdk.Screen.get_default(),
+            css_provider,
+            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION,
+        )
+
+        grid = Gtk.Grid()
+        grid.set_row_spacing(1)
+        grid.set_column_spacing(1)
+        grid.get_style_context().add_class("ga-table")
+
+        gtk_row = 0
+        for row in header_rows:
+            for col, cell in enumerate(row):
+                lbl = Gtk.Label()
+                lbl.set_markup(self._md_to_pango(cell))
+                lbl.set_halign(Gtk.Align.START)
+                lbl.set_hexpand(True)
+                lbl.get_style_context().add_class("ga-table-header")
+                grid.attach(lbl, col, gtk_row, 1, 1)
+            gtk_row += 1
+
+        for row in body_rows:
+            for col, cell in enumerate(row):
+                lbl = Gtk.Label()
+                lbl.set_markup(self._md_to_pango(cell))
+                lbl.set_halign(Gtk.Align.START)
+                lbl.set_hexpand(True)
+                lbl.get_style_context().add_class("ga-table-cell")
+                grid.attach(lbl, col, gtk_row, 1, 1)
+            gtk_row += 1
+
+        grid.show_all()
+
+        end = buf.get_end_iter()
+        buf.insert(end, "\n")
+        end = buf.get_end_iter()
+        anchor = buf.create_child_anchor(end)
+        self._chat_view.add_child_at_anchor(grid, anchor)
+        end = buf.get_end_iter()
+        buf.insert(end, "\n")
+
+    def _insert_markdown_line(self, line: str):
+        """
+        Insert one completed line (no trailing newline) into the buffer
+        with appropriate markdown formatting.  Updates self._in_code_block.
+        Always appends a trailing newline.
+        """
+        buf = self._chat_buffer
+
+        # Code fence toggle
+        if line.startswith("```"):
+            self._in_code_block = not self._in_code_block
+            if not self._in_code_block:
+                # closing fence — insert a blank line for spacing
+                end = buf.get_end_iter()
+                buf.insert(end, "\n")
+            return
+
+        if self._in_code_block:
+            end = buf.get_end_iter()
+            buf.insert_with_tags_by_name(end, line + "\n", "md_code_block")
+            return
+
+        # Table row — buffer until table ends so we can compute column widths
+        if line.startswith("|"):
+            self._table_buffer.append(line)
+            return
+
+        # Non-table line: flush any buffered table first
+        self._flush_table()
+
+        # Headers
+        if line.startswith("### "):
+            self._insert_inline(line[4:] + "\n", "md_h3")
+        elif line.startswith("## "):
+            self._insert_inline(line[3:] + "\n", "md_h2")
+        elif line.startswith("# "):
+            self._insert_inline(line[2:] + "\n", "md_h1")
+        # Horizontal rule (only outside bullets/headers)
+        elif line.strip() in ("---", "***", "___"):
+            end = buf.get_end_iter()
+            buf.insert_with_tags_by_name(end, "─" * 28 + "\n", "assistant_body")
+        # Bullet list
+        elif re.match(r"^[-*] ", line):
+            end = buf.get_end_iter()
+            buf.insert_with_tags_by_name(end, "  • ", "md_bullet")
+            self._insert_inline(line[2:] + "\n", "md_bullet")
+        # Numbered list
+        elif re.match(r"^\d+\. ", line):
+            m = re.match(r"^(\d+\.) (.+)$", line)
+            if m:
+                end = buf.get_end_iter()
+                buf.insert_with_tags_by_name(end, "  " + m.group(1) + " ", "md_bullet")
+                self._insert_inline(m.group(2) + "\n", "md_bullet")
+            else:
+                self._insert_inline(line + "\n", "assistant_body")
+        # Normal paragraph line
+        else:
+            self._insert_inline(line + "\n", "assistant_body")
+
+    # ------------------------------------------------------------------
+    # Line-by-line streaming helpers (GTK main thread)
+    # ------------------------------------------------------------------
+
+    def _process_chunk(self, text: str):
+        """
+        Called on the GTK main thread via GLib.idle_add.
+
+        Splits incoming text at newlines.  Each complete line is committed
+        (formatted and written permanently); new characters for the partial
+        line are appended directly to avoid mark-gravity issues.
+        """
+        if self._line_start_mark is None:
+            return False  # panel was deactivated; discard
+        combined = self._line_buffer + text
+        parts = combined.split("\n")
+
+        # Every part except the last is a complete line
+        for part in parts[:-1]:
+            self._line_buffer = part
+            self._commit_line()
+
+        # Append only the new characters for the partial line, inserting
+        # at the exact end of the partial region (before any tool annotations).
+        new_partial = parts[-1]
+        increment = new_partial[len(self._line_buffer):]
+        if increment:
+            buf = self._chat_buffer
+            start_off = buf.get_iter_at_mark(self._line_start_mark).get_offset()
+            end_iter = buf.get_iter_at_offset(start_off + len(self._line_buffer))
+            buf.insert_with_tags_by_name(end_iter, increment, "assistant_body")
+        self._line_buffer = new_partial
+        self._scroll_to_end()
+        return False
+
+    def _commit_line(self):
+        """
+        Delete only the accumulated partial-line text (between the two marks),
+        insert the formatted line (with trailing newline), and advance both
+        marks to the new end so tool annotations inserted after are preserved.
+        """
+        buf = self._chat_buffer
+        start_iter = buf.get_iter_at_mark(self._line_start_mark)
+        start_off = start_iter.get_offset()
+        end_iter = buf.get_iter_at_offset(start_off + len(self._line_buffer))
+        if start_iter.compare(end_iter) < 0:
+            buf.delete(start_iter, end_iter)
+        self._insert_markdown_line(self._line_buffer)  # appends at buffer end
+        buf.move_mark(self._line_start_mark, buf.get_end_iter())
+        self._line_buffer = ""
+
+    # ------------------------------------------------------------------
+    # Input handling
+    # ------------------------------------------------------------------
+
+    def _on_key_press(self, widget, event):
+        from gi.repository import Gdk
+        if event.keyval in (Gdk.KEY_Return, Gdk.KEY_KP_Enter):
+            if event.state & Gdk.ModifierType.SHIFT_MASK:
+                return False  # Shift+Enter → newline
+            self._submit_message()
+            return True
+        return False
+
+    def _on_send_clicked(self, button):
+        self._submit_message()
+
+    def _on_clear_clicked(self, button):
+        self._messages.clear()
+        self._thread_id = str(uuid.uuid4())
+        self._current_context = ""
+        self._link_tags.clear()
+        self._chat_buffer.set_text("")
+        self._show_welcome()
+        self._update_context_label()
+
+    # ------------------------------------------------------------------
+    # Message submission
+    # ------------------------------------------------------------------
+
+    def _submit_message(self):
+        if self._streaming:
+            return
+
+        if not _cfg.get("backend.model"):
+            self._append_text(
+                _("\nNo model configured. Please click the Settings button "
+                  "to choose a backend and model before chatting.\n"),
+                "assistant_body",
+            )
+            return
+
+        text = self._input_buffer.get_text(
+            self._input_buffer.get_start_iter(),
+            self._input_buffer.get_end_iter(),
+            False,
+        ).strip()
+        if not text:
+            return
+
+        # Clear input
+        self._input_buffer.set_text("")
+
+        # Display user turn
+        self._append_text("\nYou: ", "user_label")
+        self._append_text(text + "\n", "user_body")
+
+        # Build message list for this turn
+        user_msg = {"role": "user", "content": text}
+        send_messages = self._build_context_messages() + self._messages + [user_msg]
+
+        # Persist user message in history
+        self._messages.append(user_msg)
+
+        # Show assistant label; streaming tokens land on the next line
+        self._append_text("\n" + _("Gramps Assistant:") + "\n", "assistant_label")
+
+        # Initialise per-turn streaming state
+        self._full_response = ""
+        self._line_buffer = ""
+        self._in_code_block = False
+        self._tools_called_this_turn = 0
+        end_iter = self._chat_buffer.get_end_iter()
+        self._line_start_mark = self._chat_buffer.create_mark(
+            None, end_iter, left_gravity=True
+        )
+
+        # Disable input while streaming
+        self._streaming = True
+        self._cancelled = False
+        self._send_btn.set_sensitive(False)
+        self._input_view.set_sensitive(False)
+
+        # Start streaming in background
+        tools_schema = self._select_tools(text)
+        self._backend.stream_chat(
+            messages=send_messages,
+            tools=tools_schema,
+            on_chunk=self._on_stream_chunk,
+            on_tool_call=self._on_tool_call,
+            on_done=self._on_stream_done,
+            on_error=self._on_stream_error,
+            thread_id=self._thread_id,
+        )
+
+    def _build_context_messages(self):
+        """Return system message list with optional active-person context."""
+        system_prompt = _cfg.get("chat.system_prompt")
+        if _cfg.get("chat.include_context") and self._current_context:
+            system_prompt += f"\n\nCurrent context: {self._current_context}"
+        if system_prompt:
+            return [{"role": "system", "content": system_prompt}]
+        return []
+
+    # ------------------------------------------------------------------
+    # Streaming callbacks (called from background thread)
+    # ------------------------------------------------------------------
+
+    def _on_stream_chunk(self, text: str):
+        if self._cancelled:
+            _LOG.warning("_on_stream_chunk: chunk dropped because _cancelled=True")
+            return
+        self._full_response += text
+        GLib.idle_add(self._process_chunk, text)
+
+    def _on_tool_call(self, name: str, args: dict, result_callback):
+        """
+        Marshal tool execution to the GTK main thread.
+
+        The background thread is already blocking on a threading.Event;
+        this method simply schedules the execution and returns immediately.
+        """
+        GLib.idle_add(self._execute_tool_on_main, name, args, result_callback)
+
+    def _on_stream_done(self):
+        GLib.idle_add(self._finish_stream)
+
+    def _on_stream_error(self, exc: Exception):
+        msg = str(exc)
+        env_var = _cfg.get("backend.api_key_env")
+        if msg.startswith("HTTP 401:") or msg.startswith("HTTP 403:"):
+            if env_var:
+                msg = _(
+                    "API key error: the environment variable {var} is not set "
+                    "or is invalid. Set it before launching Gramps:\n"
+                    "  export {var}=your-key-here"
+                ).format(var=env_var)
+            else:
+                msg = _(
+                    "API key error: this provider requires an API key. "
+                    "Open Settings and enter the environment variable name "
+                    "for your API key (e.g. OPENAI_API_KEY)."
+                )
+        GLib.idle_add(self._show_error, msg)
+
+    # ------------------------------------------------------------------
+    # GTK-thread streaming helpers
+    # ------------------------------------------------------------------
+
+    def _on_chat_button_press(self, widget, event):
+        """Open URLs when the user clicks on a link in the chat view."""
+        if event.button != 1:
+            return False
+        x, y = self._chat_view.window_to_buffer_coords(
+            Gtk.TextWindowType.WIDGET, int(event.x), int(event.y)
+        )
+        result = self._chat_view.get_iter_at_location(x, y)
+        it = result[1] if isinstance(result, tuple) else result
+        if it is None:
+            return False
+        for tag in it.get_tags():
+            url = self._link_tags.get(tag.get_property("name"))
+            if url:
+                from gi.repository import Gio
+                try:
+                    Gio.AppInfo.launch_default_for_uri(url, None)
+                except Exception:
+                    pass
+                return True
+        return False
+
+    def _execute_tool_on_main(self, name: str, args: dict, result_callback):
+        """Run on GTK main thread (scheduled via GLib.idle_add)."""
+        self._tools_called_this_turn += 1
+        args_display = ", ".join(f"{k}={v!r}" for k, v in args.items())
+        self._append_text(f"\n🔧 Tool call: {name}({args_display})\n", "tool_call")
+
+        try:
+            result = call_tool(name, args)
+            result_str = str(result)
+        except Exception as exc:
+            result_str = f"Error calling {name}: {exc}"
+
+        # Resume background thread with the full result.
+        # Use PRIORITY_LOW so any UI updates queued by the tool (e.g. set_active
+        # scheduling its own idle callbacks) have a chance to run first.
+        GLib.idle_add(result_callback, result_str, priority=GLib.PRIORITY_LOW)
+        return False  # remove idle source
+
+    def _finish_stream(self):
+        # Commit any remaining partial line
+        if self._line_buffer:
+            self._commit_line()
+        # Flush any table that ended at the very end of the response
+        self._flush_table()
+        # Clean up the streaming mark
+        if self._line_start_mark:
+            self._chat_buffer.delete_mark(self._line_start_mark)
+            self._line_start_mark = None
+        self._append_text("\n", None)
+        # If tools ran but the model produced no text, show a brief acknowledgment.
+        if not self._full_response and self._tools_called_this_turn:
+            self._append_text(_("Done.\n"), "assistant_body")
+        # Persist the assistant turn in history
+        if self._full_response:
+            _LOG.debug("full response: %r", self._full_response)
+            self._messages.append(
+                {"role": "assistant", "content": self._full_response}
+            )
+        self._full_response = ""
+        self._streaming = False
+        self._send_btn.set_sensitive(True)
+        self._input_view.set_sensitive(True)
+        self._input_view.grab_focus()
+        self._update_context_label()
+        return False
+
+    def _show_error(self, msg: str):
+        if self._line_start_mark:
+            self._chat_buffer.delete_mark(self._line_start_mark)
+            self._line_start_mark = None
+        self._line_buffer = ""
+        self._append_text(f"\n[Error: {msg}]\n", "error")
+        self._full_response = ""
+        self._streaming = False
+        self._send_btn.set_sensitive(True)
+        self._input_view.set_sensitive(True)
+        self._input_view.grab_focus()
+        return False
+
+    # ------------------------------------------------------------------
+    # Context tracking
+    # ------------------------------------------------------------------
+
+    def _connect_history_signals(self):
+        """Connect to the Person history so context updates on navigation."""
+        try:
+            history = self.uistate.get_history("Person")
+            if history:
+                history.connect("active-changed", self._on_active_person_changed)
+        except Exception:
+            pass
+
+    def _on_active_person_changed(self, handle):
+        self._update_context()
+        self._update_context_label()
+
+    def _update_context(self):
+        if not _cfg.get("chat.include_context"):
+            self._current_context = ""
+            return
+        if not self.dbstate.is_open():
+            self._current_context = ""
+            return
+        try:
+            handle = self.uistate.get_active("Person")
+            if handle:
+                person = self.dbstate.db.get_person_from_handle(handle)
+                from gramps.gen.display.name import displayer as name_displayer
+
+                name = name_displayer.display(person)
+                gid = person.get_gramps_id()
+                self._current_context = f"Active person: {name} (ID: {gid})"
+            else:
+                self._current_context = ""
+        except Exception:
+            self._current_context = ""
+
+    # ------------------------------------------------------------------
+    # Tool selection
+    # ------------------------------------------------------------------
+
+    _TOOL_KEYWORDS = {
+        "people":       ["person", "people", "who", "name", "birth", "death",
+                         "individual", "ancestor", "descendant", "relative"],
+        "families":     ["family", "families", "father", "mother", "child",
+                         "children", "spouse", "married", "marriage", "husband",
+                         "wife", "parent", "sibling", "brother", "sister"],
+        "events":       ["event", "events", "when", "date", "census", "baptism",
+                         "burial", "immigration", "graduation", "occupation"],
+        "places":       ["place", "places", "where", "location", "city", "town",
+                         "county", "country", "state", "village", "address"],
+        "sources":      ["source", "sources", "citation", "citations", "record",
+                         "document", "reference", "archive", "book", "page"],
+        "media":        ["photo", "photograph", "image", "picture", "media",
+                         "file", "scan", "document", "attachment"],
+        "repositories": ["repository", "repositories", "archive", "library",
+                         "collection", "institution", "museum"],
+        "notes":        ["note", "notes", "text", "comment", "annotation",
+                         "memo", "description"],
+    }
+
+    _CATEGORY_TO_TAG = {
+        "People":       "people",
+        "Families":     "families",
+        "Events":       "events",
+        "Places":       "places",
+        "Sources":      "sources",
+        "Citations":    "sources",
+        "Media":        "media",
+        "Repositories": "repositories",
+        "Notes":        "notes",
+    }
+
+    def _current_view_tag(self) -> str | None:
+        """Return the tool tag for the currently active Gramps view, or None."""
+        try:
+            active = self.uistate.viewmanager.active_page
+            if active and hasattr(active, "category"):
+                return self._CATEGORY_TO_TAG.get(active.category[1])
+        except Exception:
+            pass
+        return None
+
+    def _select_tools(self, current_message: str) -> list:
+        """
+        Return a filtered tools schema based on keywords in the current
+        message and recent conversation history.
+
+        When 'Simplify tools' is off, all tools are returned unchanged.
+        When on, scans the last 4 messages plus the current message for
+        keywords and returns only matching tools (plus always-on tools).
+        Falls back to the current Gramps view's tool set if no keywords match.
+        """
+        if not _cfg.get("chat.simplify_tools"):
+            return get_tools_schema(_cfg.get("backend.type")) if tool_registry else []
+
+        # Build search text from current message + recent history
+        search_text = current_message.lower()
+        for msg in self._messages[-4:]:
+            content = msg.get("content")
+            if isinstance(content, str):
+                search_text += " " + content.lower()
+
+        active_tags = set()
+        for tag, keywords in self._TOOL_KEYWORDS.items():
+            if any(kw in search_text for kw in keywords):
+                active_tags.add(tag)
+
+        # If nothing matched, fall back to the current view's tag
+        if not active_tags:
+            view_tag = self._current_view_tag()
+            if view_tag:
+                active_tags.add(view_tag)
+
+        return get_tools_schema(_cfg.get("backend.type"), tags=active_tags) if tool_registry else []
+
+    # ------------------------------------------------------------------
+    # Backend factory
+    # ------------------------------------------------------------------
+
+    def _make_backend(self):
+        if _cfg.get("backend.use_local_url"):
+            local_url = _cfg.get("backend.local_url")
+            if local_url:
+                model = _cfg.get("backend.local_model") or _cfg.get("backend.model")
+                return OpenAICompatibleBackend(base_url=local_url, model=model, api_key="")
+        btype = _cfg.get("backend.type")
+        url = _cfg.get("backend.url")
+        model = _cfg.get("backend.model")
+        env_var = _cfg.get("backend.api_key_env")
+        api_key = os.environ.get(env_var, "") if env_var else ""
+        if btype == "anthropic":
+            return AnthropicBackend(base_url=url, model=model, api_key=api_key)
+        return OpenAICompatibleBackend(base_url=url, model=model, api_key=api_key)
+
+    # ------------------------------------------------------------------
+    # Settings dialog
+    # ------------------------------------------------------------------
+
+    # Preset list: (label, backend_type, base_url, model)
+    # backend_type=None flags the Custom entry.
+    # Preset list: (label, backend_type, base_url, model, api_key_env)
+    # backend_type=None flags the Custom entry.
+    # api_key_env="" means no key needed (local models).
+    _PRESETS = [
+        # ── OpenAI ────────────────────────────────────────────────────
+        ("OpenAI – gpt-5",           "openai", "https://api.openai.com", "gpt-5",             "OPENAI_API_KEY"),
+        ("OpenAI – gpt-4.1",         "openai", "https://api.openai.com", "gpt-4.1",           "OPENAI_API_KEY"),
+        ("OpenAI – gpt-4.1-mini",    "openai", "https://api.openai.com", "gpt-4.1-mini",      "OPENAI_API_KEY"),
+        ("OpenAI – gpt-4.1-nano",    "openai", "https://api.openai.com", "gpt-4.1-nano",      "OPENAI_API_KEY"),
+        ("OpenAI – gpt-4o",          "openai", "https://api.openai.com", "gpt-4o",            "OPENAI_API_KEY"),
+        ("OpenAI – gpt-4o-mini",     "openai", "https://api.openai.com", "gpt-4o-mini",       "OPENAI_API_KEY"),
+        ("OpenAI – o3",              "openai", "https://api.openai.com", "o3",                "OPENAI_API_KEY"),
+        ("OpenAI – o3-mini",         "openai", "https://api.openai.com", "o3-mini",           "OPENAI_API_KEY"),
+        ("OpenAI – o1",              "openai", "https://api.openai.com", "o1",                "OPENAI_API_KEY"),
+        ("OpenAI – o1-mini",         "openai", "https://api.openai.com", "o1-mini",           "OPENAI_API_KEY"),
+        # ── Anthropic ─────────────────────────────────────────────────
+        ("Anthropic – claude-opus-4-5",    "anthropic", "https://api.anthropic.com", "claude-opus-4-5",          "ANTHROPIC_API_KEY"),
+        ("Anthropic – claude-sonnet-4-5",  "anthropic", "https://api.anthropic.com", "claude-sonnet-4-5",        "ANTHROPIC_API_KEY"),
+        ("Anthropic – claude-haiku-4-5",   "anthropic", "https://api.anthropic.com", "claude-haiku-4-5",         "ANTHROPIC_API_KEY"),
+        ("Anthropic – claude-3-5-sonnet",  "anthropic", "https://api.anthropic.com", "claude-3-5-sonnet-20241022", "ANTHROPIC_API_KEY"),
+        ("Anthropic – claude-3-5-haiku",   "anthropic", "https://api.anthropic.com", "claude-3-5-haiku-20241022",  "ANTHROPIC_API_KEY"),
+        ("Anthropic – claude-3-opus",      "anthropic", "https://api.anthropic.com", "claude-3-opus-20240229",    "ANTHROPIC_API_KEY"),
+        # ── Google Gemini (OpenAI-compatible endpoint) ─────────────────
+        ("Gemini – gemini-2.0-flash",  "openai", "https://generativelanguage.googleapis.com/v1beta/openai", "gemini-2.0-flash", "GEMINI_API_KEY"),
+        ("Gemini – gemini-1.5-pro",    "openai", "https://generativelanguage.googleapis.com/v1beta/openai", "gemini-1.5-pro",   "GEMINI_API_KEY"),
+        ("Gemini – gemini-1.5-flash",  "openai", "https://generativelanguage.googleapis.com/v1beta/openai", "gemini-1.5-flash", "GEMINI_API_KEY"),
+        # ── Custom ────────────────────────────────────────────────────
+        ("Custom",                     None,     None,                    None,                ""),
+    ]
+
+    def _find_preset_index(self, btype, url, model):
+        """Return the index of the matching preset, or the Custom index."""
+        for i, (_, t, u, m, _env) in enumerate(self._PRESETS):
+            if t is not None and t == btype and u == url and m == model:
+                return i
+        return len(self._PRESETS) - 1  # Custom
+
+    def _on_settings_clicked(self, button):
+        parent = self.top.get_toplevel()
+        if not isinstance(parent, Gtk.Window):
+            parent = None
+
+        dialog = Gtk.Dialog(
+            title="Gramps Assistant Settings",
+            transient_for=parent,
+            modal=True,
+            destroy_with_parent=True,
+        )
+        dialog.add_button("_Cancel", Gtk.ResponseType.CANCEL)
+        dialog.add_button("_Save", Gtk.ResponseType.OK)
+        dialog.set_default_response(Gtk.ResponseType.OK)
+        dialog.set_default_size(460, -1)
+
+        content = dialog.get_content_area()
+        content.set_spacing(8)
+        content.set_border_width(12)
+
+        # ── System prompt ───────────────────────────────────────────────
+        sys_grid = Gtk.Grid()
+        sys_grid.set_row_spacing(6)
+        sys_grid.set_column_spacing(8)
+        content.add(sys_grid)
+
+        sys_label = Gtk.Label(label=_("System Prompt:"), xalign=1.0, yalign=0.0)
+        sys_scroll = Gtk.ScrolledWindow()
+        sys_scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        sys_scroll.set_min_content_height(180)
+        sys_scroll.set_hexpand(True)
+        sys_text = Gtk.TextView()
+        sys_text.set_wrap_mode(Gtk.WrapMode.WORD)
+        sys_text.get_buffer().set_text(_cfg.get("chat.system_prompt"))
+        sys_scroll.add(sys_text)
+        sys_grid.attach(sys_label, 0, 0, 1, 1)
+        sys_grid.attach(sys_scroll, 1, 0, 1, 1)
+
+        # ── Simplify tools ──────────────────────────────────────────────
+        simplify_check = Gtk.CheckButton(
+            label=_("Simplify tools (recommended for smaller/local models)")
+        )
+        simplify_check.set_active(_cfg.get("chat.simplify_tools"))
+        simplify_check.set_tooltip_text(
+            _("When enabled, only the tools relevant to your question are sent "
+              "to the model. This improves performance with smaller local models.")
+        )
+        content.add(simplify_check)
+
+        content.add(Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL))
+
+        # ── Local model frame ───────────────────────────────────────────
+        local_radio = Gtk.RadioButton(label=_("Use Local Model"))
+        local_radio.set_active(_cfg.get("backend.use_local_url"))
+        is_local = local_radio.get_active()
+
+        local_frame = Gtk.Frame()
+        local_frame.set_label_widget(local_radio)
+        local_frame.set_label_align(0.02, 0.5)
+        content.add(local_frame)
+
+        local_grid = Gtk.Grid()
+        local_grid.set_row_spacing(8)
+        local_grid.set_column_spacing(8)
+        local_grid.set_border_width(8)
+        local_grid.set_sensitive(is_local)
+        local_frame.add(local_grid)
+
+        local_url_entry = Gtk.Entry()
+        local_url_entry.set_text(_cfg.get("backend.local_url"))
+        local_url_entry.set_placeholder_text("http://localhost:11434")
+        local_url_entry.set_hexpand(True)
+        local_url_entry.set_tooltip_text(
+            _("URL of a local OpenAI-compatible server. "
+              "Ollama: http://localhost:11434  "
+              "LM Studio: http://localhost:1234  "
+              "llama.cpp: http://localhost:8080")
+        )
+
+        local_model_entry = Gtk.Entry()
+        local_model_entry.set_text(_cfg.get("backend.local_model"))
+        local_model_entry.set_placeholder_text(_("model name (leave blank for LM Studio / llama.cpp)"))
+        local_model_entry.set_hexpand(True)
+        local_model_entry.set_tooltip_text(
+            _("Model to request from the local server. "
+              "Required for Ollama (e.g. llama3.1). "
+              "Leave blank for LM Studio or llama.cpp, which use whatever model is loaded.")
+        )
+
+        local_grid.attach(Gtk.Label(label=_("URL:"), xalign=1.0),   0, 0, 1, 1)
+        local_grid.attach(local_url_entry,                           1, 0, 1, 1)
+        local_grid.attach(Gtk.Label(label=_("Model:"), xalign=1.0), 0, 1, 1, 1)
+        local_grid.attach(local_model_entry,                         1, 1, 1, 1)
+
+        content.add(Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL))
+
+        # ── Foundational model frame ────────────────────────────────────
+        cloud_radio = Gtk.RadioButton(group=local_radio, label=_("Use Foundational Model"))
+        cloud_radio.set_active(not is_local)
+
+        cloud_frame = Gtk.Frame()
+        cloud_frame.set_label_widget(cloud_radio)
+        cloud_frame.set_label_align(0.02, 0.5)
+        cloud_grid_sensitive = not is_local
+        content.add(cloud_frame)
+
+        cloud_grid = Gtk.Grid()
+        cloud_grid.set_row_spacing(8)
+        cloud_grid.set_column_spacing(8)
+        cloud_grid.set_border_width(8)
+        cloud_grid.set_sensitive(cloud_grid_sensitive)
+        cloud_frame.add(cloud_grid)
+
+        cloud_row = [0]
+
+        def add_cloud_row(label_text, widget):
+            lbl = Gtk.Label(label=label_text, xalign=1.0)
+            cloud_grid.attach(lbl, 0, cloud_row[0], 1, 1)
+            cloud_grid.attach(widget, 1, cloud_row[0], 1, 1)
+            widget.set_hexpand(True)
+            cloud_row[0] += 1
+            return lbl
+
+        preset_combo = Gtk.ComboBoxText()
+        for label, *_rest in self._PRESETS:
+            preset_combo.append_text(label)
+        cur_idx = self._find_preset_index(
+            _cfg.get("backend.type"),
+            _cfg.get("backend.url"),
+            _cfg.get("backend.model"),
+        )
+        preset_combo.set_active(cur_idx)
+        add_cloud_row(_("Model:"), preset_combo)
+
+        apikey_env_entry = Gtk.Entry()
+        apikey_env_entry.set_text(_cfg.get("backend.api_key_env"))
+        apikey_env_entry.set_placeholder_text(_("e.g. OPENAI_API_KEY"))
+        apikey_env_entry.set_tooltip_text(
+            _("Name of the environment variable holding your API key.")
+        )
+        add_cloud_row(_("API key env var:"), apikey_env_entry)
+
+        # Custom fields (shown only when Custom is selected)
+        custom_lbl_type = Gtk.Label(label=_("Backend:"), xalign=1.0)
+        type_combo = Gtk.ComboBoxText()
+        type_combo.append("openai", "OpenAI-compatible")
+        type_combo.append("anthropic", "Anthropic")
+        type_combo.set_active_id(_cfg.get("backend.type"))
+        type_combo.set_hexpand(True)
+        cloud_grid.attach(custom_lbl_type, 0, cloud_row[0], 1, 1)
+        cloud_grid.attach(type_combo,      1, cloud_row[0], 1, 1)
+        cloud_row[0] += 1
+
+        url_entry = Gtk.Entry()
+        url_entry.set_text(_cfg.get("backend.url"))
+        custom_lbl_url = add_cloud_row(_("Base URL:"), url_entry)
+
+        model_entry = Gtk.Entry()
+        model_entry.set_text(_cfg.get("backend.model"))
+        custom_lbl_model = add_cloud_row(_("Model name:"), model_entry)
+
+        custom_widgets = [
+            custom_lbl_type, type_combo,
+            custom_lbl_url, url_entry,
+            custom_lbl_model, model_entry,
+        ]
+
+        def _update_custom_visibility():
+            is_custom = self._PRESETS[preset_combo.get_active()][1] is None
+            for w in custom_widgets:
+                w.set_visible(is_custom)
+
+        def _on_preset_changed(combo):
+            idx = combo.get_active()
+            if idx < 0:
+                return
+            _, btype, url, model, env_var = self._PRESETS[idx]
+            if btype is not None:
+                type_combo.set_active_id(btype)
+                url_entry.set_text(url)
+                model_entry.set_text(model)
+            apikey_env_entry.set_text(env_var)
+            _update_custom_visibility()
+
+        preset_combo.connect("changed", _on_preset_changed)
+
+        def _on_local_toggled(btn):
+            active = local_radio.get_active()
+            local_grid.set_sensitive(active)
+            cloud_grid.set_sensitive(not active)
+
+        local_radio.connect("toggled", _on_local_toggled)
+
+        dialog.show_all()
+        _update_custom_visibility()
+
+        response = dialog.run()
+
+        if response == Gtk.ResponseType.OK:
+            sys_buf = sys_text.get_buffer()
+            _cfg.set("chat.system_prompt", sys_buf.get_text(
+                sys_buf.get_start_iter(), sys_buf.get_end_iter(), False
+            ))
+            _cfg.set("chat.simplify_tools", simplify_check.get_active())
+            _cfg.set("backend.use_local_url", local_radio.get_active())
+            _cfg.set("backend.local_url", local_url_entry.get_text().strip())
+            _cfg.set("backend.local_model", local_model_entry.get_text().strip())
+            _cfg.set("backend.type", type_combo.get_active_id() or "openai")
+            _cfg.set("backend.url", url_entry.get_text().strip())
+            _cfg.set("backend.model", model_entry.get_text().strip())
+            _cfg.set("backend.api_key_env", apikey_env_entry.get_text().strip())
+            _cfg.save()
+            self._update_context_label()
+            self._backend = self._make_backend()
+
+        dialog.destroy()
+
+
+# ---------------------------------------------------------------------------
+# TOOL fallback — used when SIDEPANEL is not available
+# ---------------------------------------------------------------------------
+
+if not _HAVE_SIDEPANEL:
+    _assistant_window = None  # module-level singleton; persists across menu invocations
+
+    class GrampsAssistantOptions:
+        """Minimal options stub required by the TOOL plugin framework."""
+
+        def __init__(self, name):
+            self.name = name
+
+        def load_previous_values(self):
+            pass
+
+    class _AssistantFloatingWindow:
+        """Wraps GrampsAssistant in a persistent top-level window."""
+
+        def __init__(self, dbstate, uistate):
+            self._win = Gtk.Window(title=_("Gramps Assistant"))
+            self._win.set_default_size(420, 640)
+            self._win.set_transient_for(uistate.window)
+            self._assistant = GrampsAssistant(dbstate, uistate)
+            self._win.add(self._assistant.get_top())
+            # Hide rather than destroy so conversation state is preserved
+            self._win.connect("delete-event", lambda w, e: w.hide() or True)
+            self._win.show_all()
+
+        def present(self):
+            self._win.present()
+
+    class GrampsAssistantTool:
+        """
+        TOOL entry-point: opens (or raises) a persistent floating window
+        containing a GrampsAssistant widget.
+        """
+
+        def __init__(self, dbstate, user, options_class, name, callback=None):
+            global _assistant_window
+            uistate = user.uistate
+            if _assistant_window is None:
+                _assistant_window = _AssistantFloatingWindow(dbstate, uistate)
+            else:
+                _assistant_window.present()

--- a/GrampsAssistant/grampsassistant.py
+++ b/GrampsAssistant/grampsassistant.py
@@ -42,7 +42,7 @@ from tools import call_tool, get_tools_schema, register_gramps_tools, tool_regis
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 
 _ = glocale.translation.gettext
-_LOG = logging.getLogger(__name__)
+_LOG = logging.getLogger("gramps-assistant")
 
 # ---------------------------------------------------------------------------
 # Plugin-local configuration
@@ -562,11 +562,17 @@ class GrampsAssistant(BaseSidePanel):
         """
         buf = self._chat_buffer
 
-        # Code fence toggle
-        if line.startswith("```"):
+        # Code fence toggle — handle both "```" at start of line (standard)
+        # and embedded at end of a sentence (e.g. "...genders```python")
+        # which local models sometimes emit without a preceding newline.
+        fence_pos = line.find("```")
+        if fence_pos != -1:
+            before = line[:fence_pos].rstrip()
+            if before:
+                # Render any text that came before the fence on the same line
+                self._insert_inline(before + "\n", "assistant_body")
             self._in_code_block = not self._in_code_block
             if not self._in_code_block:
-                # closing fence — insert a blank line for spacing
                 end = buf.get_end_iter()
                 buf.insert(end, "\n")
             return
@@ -755,6 +761,8 @@ class GrampsAssistant(BaseSidePanel):
 
         # Start streaming in background
         tools_schema = self._select_tools(text)
+        _LOG.debug("sending %d tools: %r", len(tools_schema),
+                   [t.get("function", t).get("name") for t in tools_schema])
         self._backend.stream_chat(
             messages=send_messages,
             tools=tools_schema,

--- a/GrampsAssistant/grampsassistant.py
+++ b/GrampsAssistant/grampsassistant.py
@@ -57,7 +57,9 @@ _cfg.register(
     "chat.system_prompt",
     _("You are a helpful genealogy assistant with access to the user's Gramps database. "
       "Answer questions about people, families, events, and relationships. "
-      "Use the available tools to look up information when needed."),
+      "When you need information from the database, call the provided tools — "
+      "never write code, simulate results, or make up data. "
+      "If no tool exists for the requested information, say so plainly."),
 )
 _cfg.register("chat.include_context", True)
 _cfg.register("chat.simplify_tools", False)
@@ -92,6 +94,7 @@ class GrampsAssistant(BaseSidePanel):
         self._current_context = ""
         self._full_response = ""        # full text of current turn (for history)
         self._tools_called_this_turn = 0
+        self._thinking_mark = None      # TextMark before "Thinking..." placeholder
         # Line-by-line streaming markdown state
         self._line_buffer = ""          # partial (uncommitted) current line
         self._line_start_mark = None    # TextMark at start of _line_buffer in buffer
@@ -251,6 +254,11 @@ class GrampsAssistant(BaseSidePanel):
             "assistant_body",
             foreground="#1a1a1a",
             left_margin=12,
+        )
+        buf.create_tag(
+            "thinking",
+            foreground="#999999",
+            style=Pango.Style.ITALIC,
         )
         buf.create_tag(
             "tool_call",
@@ -617,6 +625,7 @@ class GrampsAssistant(BaseSidePanel):
         (formatted and written permanently); new characters for the partial
         line are appended directly to avoid mark-gravity issues.
         """
+        self._clear_thinking()
         if self._line_start_mark is None:
             return False  # panel was deactivated; discard
         combined = self._line_buffer + text
@@ -689,7 +698,7 @@ class GrampsAssistant(BaseSidePanel):
         if self._streaming:
             return
 
-        if not _cfg.get("backend.model"):
+        if not _cfg.get("backend.use_local_url") and not _cfg.get("backend.model"):
             self._append_text(
                 _("\nNo model configured. Please click the Settings button "
                   "to choose a backend and model before chatting.\n"),
@@ -721,6 +730,12 @@ class GrampsAssistant(BaseSidePanel):
 
         # Show assistant label; streaming tokens land on the next line
         self._append_text("\n" + _("Gramps Assistant:") + "\n", "assistant_label")
+
+        # Insert a "Thinking..." placeholder that is removed on first chunk
+        buf = self._chat_buffer
+        end_iter = buf.get_end_iter()
+        self._thinking_mark = buf.create_mark(None, end_iter, left_gravity=True)
+        buf.insert_with_tags_by_name(end_iter, _("Thinking..."), "thinking")
 
         # Initialise per-turn streaming state
         self._full_response = ""
@@ -804,6 +819,18 @@ class GrampsAssistant(BaseSidePanel):
     # GTK-thread streaming helpers
     # ------------------------------------------------------------------
 
+    def _clear_thinking(self):
+        """Remove the 'Thinking...' placeholder if it is still present."""
+        if self._thinking_mark is None:
+            return
+        buf = self._chat_buffer
+        start = buf.get_iter_at_mark(self._thinking_mark)
+        end = buf.get_end_iter()
+        if start.compare(end) < 0:
+            buf.delete(start, end)
+        buf.delete_mark(self._thinking_mark)
+        self._thinking_mark = None
+
     def _on_chat_button_press(self, widget, event):
         """Open URLs when the user clicks on a link in the chat view."""
         if event.button != 1:
@@ -845,6 +872,7 @@ class GrampsAssistant(BaseSidePanel):
         return False  # remove idle source
 
     def _finish_stream(self):
+        self._clear_thinking()
         # Commit any remaining partial line
         if self._line_buffer:
             self._commit_line()
@@ -873,6 +901,7 @@ class GrampsAssistant(BaseSidePanel):
         return False
 
     def _show_error(self, msg: str):
+        self._clear_thinking()
         if self._line_start_mark:
             self._chat_buffer.delete_mark(self._line_start_mark)
             self._line_start_mark = None

--- a/GrampsAssistant/grampsassistant.py
+++ b/GrampsAssistant/grampsassistant.py
@@ -38,7 +38,7 @@ except ImportError:
     BaseSidePanel = object  # neutral base when SIDEPANEL unavailable
 
 from backend import AnthropicBackend, OpenAICompatibleBackend
-from tools import call_tool, get_tools_schema, register_gramps_tools, tool_registry
+from tools import _AwaitUserExecution, call_tool, get_tools_schema, register_gramps_tools, tool_registry
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 
 _ = glocale.translation.gettext
@@ -91,6 +91,7 @@ class GrampsAssistant(BaseSidePanel):
         self._thread_id = str(uuid.uuid4())  # Opik thread; rotated on Clear
         self._streaming = False         # True while a request is in flight
         self._cancelled = False         # set True when panel is hidden/destroyed
+        self._pending_execute_handler = None  # (instance, handler_id, result_callback) for staged execute_script
         self._current_context = ""
         self._full_response = ""        # full text of current turn (for history)
         self._tools_called_this_turn = 0
@@ -136,6 +137,7 @@ class GrampsAssistant(BaseSidePanel):
 
     def inactive(self):
         self._cancelled = True
+        self._cancel_pending_execute()
         if self._line_start_mark is not None:
             try:
                 self._chat_buffer.delete_mark(self._line_start_mark)
@@ -631,6 +633,7 @@ class GrampsAssistant(BaseSidePanel):
         (formatted and written permanently); new characters for the partial
         line are appended directly to avoid mark-gravity issues.
         """
+        self._full_response += text
         self._clear_thinking()
         if self._line_start_mark is None:
             return False  # panel was deactivated; discard
@@ -685,7 +688,15 @@ class GrampsAssistant(BaseSidePanel):
         return False
 
     def _on_send_clicked(self, button):
-        self._submit_message()
+        if self._streaming:
+            self._on_cancel_clicked()
+        else:
+            self._submit_message()
+
+    def _on_cancel_clicked(self):
+        self._cancelled = True
+        self._cancel_pending_execute(cancelled=True)
+        self._reset_streaming_ui()
 
     def _on_clear_clicked(self, button):
         self._messages.clear()
@@ -753,10 +764,10 @@ class GrampsAssistant(BaseSidePanel):
             None, end_iter, left_gravity=True
         )
 
-        # Disable input while streaming
+        # Switch Send → Cancel while streaming; keep input locked
         self._streaming = True
         self._cancelled = False
-        self._send_btn.set_sensitive(False)
+        self._send_btn.set_label(_("Cancel"))
         self._input_view.set_sensitive(False)
 
         # Start streaming in background
@@ -790,7 +801,6 @@ class GrampsAssistant(BaseSidePanel):
         if self._cancelled:
             _LOG.warning("_on_stream_chunk: chunk dropped because _cancelled=True")
             return
-        self._full_response += text
         GLib.idle_add(self._process_chunk, text)
 
     def _on_tool_call(self, name: str, args: dict, result_callback):
@@ -869,15 +879,81 @@ class GrampsAssistant(BaseSidePanel):
 
         try:
             result = call_tool(name, args)
-            result_str = str(result)
         except Exception as exc:
             result_str = f"Error calling {name}: {exc}"
+            GLib.idle_add(result_callback, result_str, priority=GLib.PRIORITY_LOW)
+            return False
+
+        if isinstance(result, _AwaitUserExecution):
+            self._stage_execute_script(result.instance, result_callback)
+            return False
 
         # Resume background thread with the full result.
         # Use PRIORITY_LOW so any UI updates queued by the tool (e.g. set_active
         # scheduling its own idle callbacks) have a chance to run first.
-        GLib.idle_add(result_callback, result_str, priority=GLib.PRIORITY_LOW)
+        GLib.idle_add(result_callback, str(result), priority=GLib.PRIORITY_LOW)
         return False  # remove idle source
+
+    def _cancel_pending_execute(self, cancelled=False):
+        """Disconnect the staged execute_script button handler, if any.
+
+        When *cancelled* is True, also calls result_callback with a cancellation
+        message so the backend thread unblocks immediately instead of timing out.
+        """
+        if self._pending_execute_handler is not None:
+            instance, handler_id, result_callback = self._pending_execute_handler
+            try:
+                instance.apply_button.disconnect(handler_id)
+            except Exception:
+                pass
+            self._pending_execute_handler = None
+            if cancelled:
+                GLib.idle_add(
+                    result_callback,
+                    "Script execution cancelled by user.",
+                    priority=GLib.PRIORITY_LOW,
+                )
+
+    def _reset_streaming_ui(self):
+        """Restore the UI to its idle state after streaming ends or is cancelled."""
+        self._streaming = False
+        self._send_btn.set_label(_("Send"))
+        self._send_btn.set_sensitive(True)
+        self._input_view.set_sensitive(True)
+        self._input_view.grab_focus()
+
+    def _stage_execute_script(self, instance, result_callback):
+        """
+        Code is already in the GrampyScript buffer. Connect a one-shot handler
+        to the Execute button; when the user clicks it, apply_clicked runs first
+        (executing the code and populating output_buffer), then our handler reads
+        the output and resumes the backend thread.
+        """
+        self._cancel_pending_execute()  # drop any previous handler that was never clicked
+        self._append_text(
+            "\n⏳ Review the script in the GrampyScript panel and press Execute to continue.\n",
+            "tool_call",
+        )
+
+        # handler_id is set on self so _cancel_pending_execute can disconnect it.
+        # The closure reads self._pending_execute_handler to get the id, which is
+        # guaranteed to be set before GTK can dispatch a click (same thread).
+        def on_execute_clicked(button):
+            if self._pending_execute_handler is None:
+                return  # already cancelled
+            _, hid, cb = self._pending_execute_handler
+            self._pending_execute_handler = None
+            button.disconnect(hid)
+            buf = instance.output_buffer
+            output = buf.get_text(buf.get_start_iter(), buf.get_end_iter(), False)
+            GLib.idle_add(
+                cb,
+                output or "Script executed with no output.",
+                priority=GLib.PRIORITY_LOW,
+            )
+
+        handler_id = instance.apply_button.connect("clicked", on_execute_clicked)
+        self._pending_execute_handler = (instance, handler_id, result_callback)
 
     def _finish_stream(self):
         self._clear_thinking()
@@ -891,20 +967,19 @@ class GrampsAssistant(BaseSidePanel):
             self._chat_buffer.delete_mark(self._line_start_mark)
             self._line_start_mark = None
         self._append_text("\n", None)
-        # If tools ran but the model produced no text, show a brief acknowledgment.
-        if not self._full_response and self._tools_called_this_turn:
-            self._append_text(_("Done.\n"), "assistant_body")
-        # Persist the assistant turn in history
-        if self._full_response:
-            _LOG.debug("full response: %r", self._full_response)
-            self._messages.append(
-                {"role": "assistant", "content": self._full_response}
-            )
+        if not self._cancelled:
+            # If tools ran but the model produced no text, show a brief acknowledgment.
+            if not self._full_response and self._tools_called_this_turn:
+                self._append_text(_("Done.\n"), "assistant_body")
+            # Persist the assistant turn in history
+            if self._full_response:
+                _LOG.debug("full response: %r", self._full_response)
+                self._messages.append(
+                    {"role": "assistant", "content": self._full_response}
+                )
         self._full_response = ""
-        self._streaming = False
-        self._send_btn.set_sensitive(True)
-        self._input_view.set_sensitive(True)
-        self._input_view.grab_focus()
+        if self._streaming:  # not already reset by _on_cancel_clicked
+            self._reset_streaming_ui()
         self._update_context_label()
         return False
 
@@ -916,10 +991,8 @@ class GrampsAssistant(BaseSidePanel):
         self._line_buffer = ""
         self._append_text(f"\n[Error: {msg}]\n", "error")
         self._full_response = ""
-        self._streaming = False
-        self._send_btn.set_sensitive(True)
-        self._input_view.set_sensitive(True)
-        self._input_view.grab_focus()
+        if self._streaming:  # not already reset by _on_cancel_clicked
+            self._reset_streaming_ui()
         return False
 
     # ------------------------------------------------------------------

--- a/GrampsAssistant/grampsassistant.py
+++ b/GrampsAssistant/grampsassistant.py
@@ -1145,9 +1145,8 @@ class GrampsAssistant(BaseSidePanel):
         content.add(Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL))
 
         # ── Local model frame ───────────────────────────────────────────
+        is_local = bool(_cfg.get("backend.use_local_url"))
         local_radio = Gtk.RadioButton(label=_("Use Local Model"))
-        local_radio.set_active(_cfg.get("backend.use_local_url"))
-        is_local = local_radio.get_active()
 
         local_frame = Gtk.Frame()
         local_frame.set_label_widget(local_radio)
@@ -1191,6 +1190,9 @@ class GrampsAssistant(BaseSidePanel):
 
         # ── Foundational model frame ────────────────────────────────────
         cloud_radio = Gtk.RadioButton(group=local_radio, label=_("Use Foundational Model"))
+        # Set active states after both buttons are in the same group so the
+        # mutual-exclusion logic works correctly.
+        local_radio.set_active(is_local)
         cloud_radio.set_active(not is_local)
 
         cloud_frame = Gtk.Frame()

--- a/GrampsAssistant/tests/conftest.py
+++ b/GrampsAssistant/tests/conftest.py
@@ -1,0 +1,7 @@
+"""Shared pytest configuration for GrampsAssist tests."""
+
+import sys
+import os
+
+# Make GrampsAssist importable without installing it.
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))

--- a/GrampsAssistant/tests/test_backend.py
+++ b/GrampsAssistant/tests/test_backend.py
@@ -32,8 +32,11 @@ import pytest
 from backend import (
     AnthropicBackend,
     OpenAICompatibleBackend,
+    _decode_json_string,
     _execute_tool_calls,
+    _infer_tool_name,
     _read_sse_lines,
+    _recover_args,
 )
 
 
@@ -335,6 +338,244 @@ class TestExecuteToolCalls:
         updated = _execute_tool_calls(accum, messages, on_tool_call)
         assert updated is not messages
         assert invocations == ["real_tool"]
+
+    def test_empty_name_inferred_from_arguments(self):
+        """Local models that omit the name: infer it from argument keys."""
+        invocations = []
+
+        def on_tool_call(name, args, result_cb):
+            invocations.append(name)
+            result_cb("{}")
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "execute_script",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"code": {"type": "string"}},
+                        "required": ["code"],
+                    },
+                },
+            }
+        ]
+        accum = {0: {"id": "", "name": "", "arguments": '{"code": "print(1)"}'}}
+        messages = [{"role": "user", "content": "run"}]
+        updated = _execute_tool_calls(accum, messages, on_tool_call, tools=tools)
+        assert updated is not messages
+        assert invocations == ["execute_script"]
+
+    def test_empty_name_inferred_from_malformed_arguments(self):
+        """Inference works even when the model emits broken JSON like {"code# ..."""
+        invocations = []
+
+        def on_tool_call(name, args, result_cb):
+            invocations.append(name)
+            result_cb("{}")
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "execute_script",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"code": {"type": "string"}},
+                        "required": ["code"],
+                    },
+                },
+            }
+        ]
+        # Malformed JSON as produced by low-quality local models
+        accum = {0: {"id": "", "name": "", "arguments": '{"code# list all people'}}
+        messages = [{"role": "user", "content": "run"}]
+        updated = _execute_tool_calls(accum, messages, on_tool_call, tools=tools)
+        assert updated is not messages
+        assert invocations == ["execute_script"]
+
+    def test_missing_id_gets_fallback(self):
+        """Empty id should be replaced so the tool result can be correlated."""
+        ids_seen = []
+
+        def on_tool_call(name, args, result_cb):
+            result_cb("{}")
+
+        accum = {0: {"id": "", "name": "my_tool", "arguments": "{}"}}
+        messages = [{"role": "user", "content": "hi"}]
+        updated = _execute_tool_calls(accum, messages, on_tool_call)
+        assistant_msg = next(m for m in updated if m["role"] == "assistant")
+        tc_id = assistant_msg["tool_calls"][0]["id"]
+        assert tc_id  # must not be empty
+
+
+# ---------------------------------------------------------------------------
+# _infer_tool_name
+# ---------------------------------------------------------------------------
+
+
+_EXECUTE_SCRIPT_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "execute_script",
+        "parameters": {
+            "type": "object",
+            "properties": {"code": {"type": "string"}},
+            "required": ["code"],
+        },
+    },
+}
+
+_GET_PERSON_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_person_details",
+        "parameters": {
+            "type": "object",
+            "properties": {"gramps_id": {"type": "string"}},
+            "required": ["gramps_id"],
+        },
+    },
+}
+
+
+_EXECUTE_SCRIPT_TOOL_ANTHROPIC = {
+    "name": "execute_script",
+    "description": "Run a GrampyScript.",
+    "input_schema": {
+        "type": "object",
+        "properties": {"code": {"type": "string"}},
+        "required": ["code"],
+    },
+}
+
+
+class TestInferToolName:
+    def test_infers_from_valid_json(self):
+        tools = [_EXECUTE_SCRIPT_TOOL]
+        assert _infer_tool_name('{"code": "print(1)"}', tools) == "execute_script"
+
+    def test_infers_from_malformed_json_missing_closing_quote(self):
+        # Matches the real broken output observed: {"code# list all people...
+        tools = [_EXECUTE_SCRIPT_TOOL]
+        assert _infer_tool_name('{"code# list all people', tools) == "execute_script"
+
+    def test_infers_when_key_and_value_fused(self):
+        # Model emits {"code" + "columns(...)" with no separator → "{"codecolumns(..."
+        tools = [_EXECUTE_SCRIPT_TOOL]
+        assert _infer_tool_name('{"codecolumns(\'ID\', \'Name\')', tools) == "execute_script"
+
+    def test_infers_correct_tool_from_two_tools(self):
+        tools = [_EXECUTE_SCRIPT_TOOL, _GET_PERSON_TOOL]
+        assert _infer_tool_name('{"gramps_id": "I001"}', tools) == "get_person_details"
+        assert _infer_tool_name('{"code": "for p in people(): row(p)"}', tools) == "execute_script"
+
+    def test_infers_from_anthropic_format_tools(self):
+        # Anthropic tools use input_schema instead of parameters
+        tools = [_EXECUTE_SCRIPT_TOOL_ANTHROPIC]
+        assert _infer_tool_name('{"code": "print(1)"}', tools) == "execute_script"
+
+    def test_infers_from_anthropic_format_malformed(self):
+        tools = [_EXECUTE_SCRIPT_TOOL_ANTHROPIC]
+        assert _infer_tool_name('{"code# broken', tools) == "execute_script"
+
+    def test_returns_none_when_no_match(self):
+        tools = [_EXECUTE_SCRIPT_TOOL]
+        assert _infer_tool_name('{"unknown_param": "x"}', tools) is None
+
+    def test_returns_none_when_tools_empty(self):
+        assert _infer_tool_name('{"code": "x"}', []) is None
+
+    def test_returns_none_when_arguments_empty(self):
+        assert _infer_tool_name("", [_EXECUTE_SCRIPT_TOOL]) is None
+
+    def test_returns_none_when_ambiguous(self):
+        # Two tools both have a "name" parameter → ambiguous
+        tool_a = {"type": "function", "function": {
+            "name": "tool_a",
+            "parameters": {"type": "object", "properties": {"name": {"type": "string"}}},
+        }}
+        tool_b = {"type": "function", "function": {
+            "name": "tool_b",
+            "parameters": {"type": "object", "properties": {"name": {"type": "string"}}},
+        }}
+        assert _infer_tool_name('{"name": "foo"}', [tool_a, tool_b]) is None
+
+
+# ---------------------------------------------------------------------------
+# _recover_args
+# ---------------------------------------------------------------------------
+
+
+class TestDecodeJsonString:
+    def test_newline_escape(self):
+        assert _decode_json_string("line1\\nline2") == "line1\nline2"
+
+    def test_tab_escape(self):
+        assert _decode_json_string("col1\\tcol2") == "col1\tcol2"
+
+    def test_quote_escape(self):
+        assert _decode_json_string('\\"hello\\"') == '"hello"'
+
+    def test_backslash_escape(self):
+        assert _decode_json_string("a\\\\b") == "a\\b"
+
+    def test_backslash_not_swallowed_by_n_replacement(self):
+        # \\n should become \n (literal backslash + n), not a newline
+        assert _decode_json_string("\\\\n") == "\\n"
+
+    def test_no_escapes_unchanged(self):
+        assert _decode_json_string("plain text") == "plain text"
+
+    def test_unknown_escape_drops_backslash(self):
+        # \c is not a JSON escape — drop the backslash so \columns → columns
+        assert _decode_json_string("\\columns(x)") == "columns(x)"
+
+    def test_unknown_escape_mid_string(self):
+        assert _decode_json_string("abc\\def") == "abcdef"
+
+    def test_real_grampy_script(self):
+        raw = "for p in people():\\n    row(p.gramps_id, p.name)"
+        decoded = _decode_json_string(raw)
+        assert "\n" in decoded
+        assert "\\n" not in decoded
+
+
+class TestRecoverArgs:
+    def test_valid_json_returned_unchanged(self):
+        tools = [_EXECUTE_SCRIPT_TOOL]
+        result = _recover_args('{"code": "print(1)"}', "execute_script", tools)
+        assert result == {"code": "print(1)"}
+
+    def test_recovers_code_from_malformed_json(self):
+        tools = [_EXECUTE_SCRIPT_TOOL]
+        raw = '{"code# for p in people(): print(p.name)'
+        result = _recover_args(raw, "execute_script", tools)
+        assert "code" in result
+        assert "people" in result["code"]
+
+    def test_recovers_code_when_key_and_value_fused(self):
+        # {"code" + "columns(...)" merged → "{"codecolumns(..."
+        tools = [_EXECUTE_SCRIPT_TOOL]
+        raw = '{"codecolumns(\'Gramps ID\', \'Name\')\\nfor p in people():\\n    row(p.gramps_id)'
+        result = _recover_args(raw, "execute_script", tools)
+        assert "code" in result
+        assert "columns" in result["code"]
+        assert "\n" in result["code"]  # JSON escape sequences decoded
+
+    def test_returns_empty_dict_when_no_tool_matches(self):
+        result = _recover_args('{"code# broken', "nonexistent_tool", [_EXECUTE_SCRIPT_TOOL])
+        assert result == {}
+
+    def test_returns_empty_dict_when_tools_none(self):
+        result = _recover_args('{"code# broken', "execute_script", None)
+        assert result == {}
+
+    def test_returns_empty_dict_for_completely_garbled_input(self):
+        tools = [_EXECUTE_SCRIPT_TOOL]
+        result = _recover_args("not json at all", "execute_script", tools)
+        # May or may not recover — just must not raise
+        assert isinstance(result, dict)
 
 
 # ---------------------------------------------------------------------------

--- a/GrampsAssistant/tests/test_backend.py
+++ b/GrampsAssistant/tests/test_backend.py
@@ -1,0 +1,552 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Gramps Development Team
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Tests for backend.py: message conversion, SSE parsing, tool-call filtering,
+and live integration tests against the configured OpenAI-compatible backend.
+"""
+
+import io
+import json
+import os
+import threading
+
+import pytest
+
+from backend import (
+    AnthropicBackend,
+    OpenAICompatibleBackend,
+    _execute_tool_calls,
+    _read_sse_lines,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+HAVE_OPENAI_KEY = bool(os.environ.get("OPENAI_API_KEY"))
+
+
+def _make_fake_fp_response(lines):
+    """Return an object with a ``.fp`` whose ``readline`` yields *lines*."""
+    body = "\r\n".join(lines).encode("utf-8") + b"\r\n"
+
+    class _FP:
+        _buf = io.BytesIO(body)
+
+        @classmethod
+        def readline(cls):
+            return cls._buf.readline()
+
+    class _Resp:
+        fp = _FP
+
+    return _Resp()
+
+
+def _collect(backend, messages, tools=None, timeout=30):
+    """
+    Drive *backend.stream_chat* synchronously and return ``(full_text, tool_calls_list)``.
+
+    tool_calls_list contains dicts {name, args} for each invocation.
+    Raises the backend error if one occurs.
+    """
+    chunks = []
+    tool_calls = []
+    done_ev = threading.Event()
+    error_holder = [None]
+
+    def on_chunk(text):
+        chunks.append(text)
+
+    def on_tool_call(name, args, result_cb):
+        tool_calls.append({"name": name, "args": args})
+        result_cb(json.dumps({"result": "ok"}))
+
+    def on_done():
+        done_ev.set()
+
+    def on_error(exc):
+        error_holder[0] = exc
+        done_ev.set()
+
+    backend.stream_chat(
+        messages=messages,
+        tools=tools or [],
+        on_chunk=on_chunk,
+        on_tool_call=on_tool_call,
+        on_done=on_done,
+        on_error=on_error,
+    )
+    done_ev.wait(timeout=timeout)
+    if error_holder[0]:
+        raise error_holder[0]
+    return "".join(chunks), tool_calls
+
+
+# ---------------------------------------------------------------------------
+# AnthropicBackend._convert_messages
+# ---------------------------------------------------------------------------
+
+
+class TestConvertMessages:
+    def test_system_extracted_from_messages(self):
+        msgs = [{"role": "system", "content": "You are helpful."}]
+        system, result = AnthropicBackend._convert_messages(msgs)
+        assert system == "You are helpful."
+        assert result == []
+
+    def test_no_system_returns_none(self):
+        msgs = [{"role": "user", "content": "Hi"}]
+        system, _ = AnthropicBackend._convert_messages(msgs)
+        assert system is None
+
+    def test_multiple_systems_joined(self):
+        msgs = [
+            {"role": "system", "content": "Part 1."},
+            {"role": "system", "content": "Part 2."},
+        ]
+        system, _ = AnthropicBackend._convert_messages(msgs)
+        assert "Part 1." in system and "Part 2." in system
+
+    def test_user_message_preserved(self):
+        msgs = [{"role": "user", "content": "Hello"}]
+        _, result = AnthropicBackend._convert_messages(msgs)
+        assert result[0] == {"role": "user", "content": "Hello"}
+
+    def test_assistant_message_preserved(self):
+        msgs = [{"role": "assistant", "content": "Hi there"}]
+        _, result = AnthropicBackend._convert_messages(msgs)
+        assert result[0]["role"] == "assistant"
+        assert result[0]["content"] == "Hi there"
+
+    def test_assistant_with_tool_calls_produces_tool_use_blocks(self):
+        msgs = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_person",
+                            "arguments": '{"gramps_id": "I001"}',
+                        },
+                    }
+                ],
+            }
+        ]
+        _, result = AnthropicBackend._convert_messages(msgs)
+        assert result[0]["role"] == "assistant"
+        blocks = result[0]["content"]
+        tool_blocks = [b for b in blocks if b.get("type") == "tool_use"]
+        assert len(tool_blocks) == 1
+        assert tool_blocks[0]["name"] == "get_person"
+        assert tool_blocks[0]["input"] == {"gramps_id": "I001"}
+
+    def test_assistant_text_plus_tool_call_includes_text_block(self):
+        msgs = [
+            {
+                "role": "assistant",
+                "content": "Let me look that up.",
+                "tool_calls": [
+                    {
+                        "id": "c1",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": "{}"},
+                    }
+                ],
+            }
+        ]
+        _, result = AnthropicBackend._convert_messages(msgs)
+        blocks = result[0]["content"]
+        types = [b["type"] for b in blocks]
+        assert "text" in types
+        assert "tool_use" in types
+
+    def test_single_tool_result_becomes_user_message(self):
+        msgs = [{"role": "tool", "tool_call_id": "c1", "content": "Smith, John"}]
+        _, result = AnthropicBackend._convert_messages(msgs)
+        assert result[0]["role"] == "user"
+        blocks = result[0]["content"]
+        assert blocks[0]["type"] == "tool_result"
+        assert blocks[0]["tool_use_id"] == "c1"
+        assert blocks[0]["content"] == "Smith, John"
+
+    def test_consecutive_tool_results_merged_into_one_user_message(self):
+        msgs = [
+            {"role": "tool", "tool_call_id": "c1", "content": "result1"},
+            {"role": "tool", "tool_call_id": "c2", "content": "result2"},
+        ]
+        _, result = AnthropicBackend._convert_messages(msgs)
+        assert len(result) == 1
+        assert result[0]["role"] == "user"
+        assert len(result[0]["content"]) == 2
+
+    def test_tool_results_not_merged_across_assistant_turns(self):
+        msgs = [
+            {"role": "tool", "tool_call_id": "c1", "content": "r1"},
+            {"role": "assistant", "content": "ok"},
+            {"role": "tool", "tool_call_id": "c2", "content": "r2"},
+        ]
+        _, result = AnthropicBackend._convert_messages(msgs)
+        user_msgs = [m for m in result if m["role"] == "user"]
+        assert len(user_msgs) == 2
+
+    def test_invalid_tool_call_json_yields_empty_input(self):
+        msgs = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "c1",
+                        "type": "function",
+                        "function": {"name": "foo", "arguments": "NOT JSON"},
+                    }
+                ],
+            }
+        ]
+        _, result = AnthropicBackend._convert_messages(msgs)
+        blocks = result[0]["content"]
+        tool_block = next(b for b in blocks if b["type"] == "tool_use")
+        assert tool_block["input"] == {}
+
+
+# ---------------------------------------------------------------------------
+# _read_sse_lines
+# ---------------------------------------------------------------------------
+
+
+class TestReadSseLines:
+    def test_fp_readline_used_when_available(self):
+        resp = _make_fake_fp_response(["data: hello", "data: world"])
+        lines = [l for l in _read_sse_lines(resp) if l]
+        assert "data: hello" in lines
+        assert "data: world" in lines
+
+    def test_fallback_when_no_fp(self):
+        class _NoFPResp:
+            fp = None
+
+            def read(self):
+                return b"data: one\r\ndata: two\r\n"
+
+        lines = [l for l in _read_sse_lines(_NoFPResp()) if l]
+        assert "data: one" in lines
+        assert "data: two" in lines
+
+    def test_done_sentinel_yields_as_line(self):
+        resp = _make_fake_fp_response(["data: [DONE]"])
+        lines = list(_read_sse_lines(resp))
+        assert any("[DONE]" in l for l in lines)
+
+    def test_empty_body_yields_nothing_meaningful(self):
+        resp = _make_fake_fp_response([])
+        non_empty = [l for l in _read_sse_lines(resp) if l]
+        assert non_empty == []
+
+
+# ---------------------------------------------------------------------------
+# _execute_tool_calls (unit — no HTTP)
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteToolCalls:
+    def _make_accum(self, **overrides):
+        base = {"id": "call_1", "name": "my_tool", "arguments": '{"x": 1}'}
+        base.update(overrides)
+        return {0: base}
+
+    def _sync_on_tool_call(self, name, args, result_cb):
+        """Immediately return a canned result."""
+        result_cb(json.dumps({"done": True}))
+
+    def test_returns_updated_messages(self):
+        messages = [{"role": "user", "content": "Hi"}]
+        updated = _execute_tool_calls(
+            self._make_accum(), messages, self._sync_on_tool_call
+        )
+        assert updated is not messages
+        roles = [m["role"] for m in updated]
+        assert "assistant" in roles
+        assert "tool" in roles
+
+    def test_tool_result_appended(self):
+        messages = [{"role": "user", "content": "Hi"}]
+        updated = _execute_tool_calls(
+            self._make_accum(), messages, self._sync_on_tool_call
+        )
+        tool_msg = next(m for m in updated if m["role"] == "tool")
+        assert tool_msg["tool_call_id"] == "call_1"
+
+    def test_empty_name_skipped_returns_original(self):
+        messages = [{"role": "user", "content": "Hi"}]
+        accum = {0: {"id": "bad", "name": "", "arguments": "{}"}}
+        updated = _execute_tool_calls(accum, messages, self._sync_on_tool_call)
+        assert updated is messages  # identity check — nothing was executed
+
+    def test_multiple_tool_calls_all_executed(self):
+        invocations = []
+
+        def on_tool_call(name, args, result_cb):
+            invocations.append(name)
+            result_cb(json.dumps({"ok": True}))
+
+        accum = {
+            0: {"id": "c1", "name": "tool_a", "arguments": "{}"},
+            1: {"id": "c2", "name": "tool_b", "arguments": "{}"},
+        }
+        messages = [{"role": "user", "content": "run both"}]
+        _execute_tool_calls(accum, messages, on_tool_call)
+        assert "tool_a" in invocations
+        assert "tool_b" in invocations
+
+    def test_mixed_empty_and_valid_names(self):
+        invocations = []
+
+        def on_tool_call(name, args, result_cb):
+            invocations.append(name)
+            result_cb("{}")
+
+        accum = {
+            0: {"id": "c0", "name": "",        "arguments": "{}"},
+            1: {"id": "c1", "name": "real_tool","arguments": "{}"},
+        }
+        messages = [{"role": "user", "content": "hi"}]
+        updated = _execute_tool_calls(accum, messages, on_tool_call)
+        assert updated is not messages
+        assert invocations == ["real_tool"]
+
+
+# ---------------------------------------------------------------------------
+# _process_chunk pure-logic unit tests (no GTK required)
+# ---------------------------------------------------------------------------
+
+
+class TestProcessChunkLogic:
+    """
+    Verify the increment / line-buffer logic that mirrors _process_chunk.
+
+    This is extracted from grampsassistant.py as a pure function so it can run
+    without GTK.  A regression test for the 'May24' / 'Johnjalmar' space-loss
+    investigation: if spaces dropped here, the display would be wrong.
+    """
+
+    @staticmethod
+    def _simulate(chunks):
+        """
+        Simulate the core text-assembly of _process_chunk.
+
+        Returns ``(committed_lines, final_partial)`` where committed_lines are
+        the completed (newline-terminated) lines and final_partial is the
+        unfinished partial line still in the buffer.
+        """
+        line_buffer = ""
+        committed = []
+
+        for text in chunks:
+            combined = line_buffer + text
+            parts = combined.split("\n")
+
+            for part in parts[:-1]:
+                line_buffer = part
+                committed.append(part)
+                line_buffer = ""
+
+            new_partial = parts[-1]
+            # Only the increment (characters not yet in the buffer) gets inserted
+            increment = new_partial[len(line_buffer):]  # noqa: F841 — mirrors real code
+            line_buffer = new_partial
+
+        return committed, line_buffer
+
+    def test_single_chunk_no_newline(self):
+        _, partial = self._simulate(["Hello world"])
+        assert partial == "Hello world"
+
+    def test_space_preserved_as_own_chunk(self):
+        _, partial = self._simulate(["May", " ", "24"])
+        assert partial == "May 24"
+
+    def test_space_at_end_of_chunk(self):
+        _, partial = self._simulate(["May ", "24"])
+        assert partial == "May 24"
+
+    def test_space_at_start_of_next_chunk(self):
+        _, partial = self._simulate(["May", " 24"])
+        assert partial == "May 24"
+
+    def test_words_not_merged(self):
+        _, partial = self._simulate(["John", " ", "Hjalmar"])
+        assert partial == "John Hjalmar"
+        assert "JohnHjalmar" not in partial
+
+    def test_newline_commits_line(self):
+        committed, partial = self._simulate(["Hello\n", "world"])
+        assert committed == ["Hello"]
+        assert partial == "world"
+
+    def test_multiple_lines_in_one_chunk(self):
+        committed, partial = self._simulate(["line1\nline2\npar"])
+        assert committed == ["line1", "line2"]
+        assert partial == "par"
+
+    def test_partial_then_newline_commits(self):
+        committed, partial = self._simulate(["Hel", "lo\n", "nex"])
+        assert committed == ["Hello"]
+        assert partial == "nex"
+
+    def test_empty_chunk_ignored(self):
+        _, partial = self._simulate(["Hello", "", " world"])
+        assert partial == "Hello world"
+
+    def test_multiple_spaces_preserved(self):
+        _, partial = self._simulate(["a ", " b"])
+        assert partial == "a  b"
+
+    def test_final_empty_line_after_newline(self):
+        committed, partial = self._simulate(["done\n"])
+        assert committed == ["done"]
+        assert partial == ""
+
+
+# ---------------------------------------------------------------------------
+# Live integration — OpenAI-compatible backend
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not HAVE_OPENAI_KEY, reason="OPENAI_API_KEY not set")
+class TestOpenAIBackendLive:
+    """End-to-end tests against the real OpenAI API (gpt-4.1-mini for speed/cost)."""
+
+    def _backend(self):
+        return OpenAICompatibleBackend(
+            base_url="https://api.openai.com",
+            model="gpt-4.1-mini",
+            api_key=os.environ["OPENAI_API_KEY"],
+        )
+
+    def test_basic_response_streamed(self):
+        messages = [{"role": "user", "content": "Reply with exactly the word: PONG"}]
+        text, _ = _collect(self._backend(), messages)
+        assert "PONG" in text
+
+    def test_response_is_non_empty_text(self):
+        """Streamed chunks assemble into a non-empty string."""
+        messages = [{"role": "user", "content": "Say exactly: hello world"}]
+        text, _ = _collect(self._backend(), messages)
+        assert len(text) > 0
+        assert " " in text  # at minimum "hello world" has a space
+
+    def test_multiline_response_has_newlines(self):
+        messages = [
+            {
+                "role": "user",
+                "content": "List three colors, one per line, nothing else.",
+            }
+        ]
+        text, _ = _collect(self._backend(), messages)
+        assert text.count("\n") >= 2
+
+    def test_tool_call_is_invoked(self):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_temperature",
+                    "description": "Get the current temperature in Celsius.",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        messages = [
+            {
+                "role": "user",
+                "content": (
+                    "You must call get_temperature to answer this question. "
+                    "What is the current temperature? Call the tool now."
+                ),
+            }
+        ]
+        _, tool_calls = _collect(self._backend(), messages, tools=tools)
+        assert any(tc["name"] == "get_temperature" for tc in tool_calls)
+
+    def test_tool_result_used_in_response(self):
+        """Model should incorporate the tool result into its reply."""
+        tool_result_value = "42 degrees Celsius"
+        chunks = []
+        done_ev = threading.Event()
+        error_holder = [None]
+
+        def on_chunk(t):
+            chunks.append(t)
+
+        def on_tool_call(name, args, result_cb):
+            result_cb(json.dumps({"temperature": tool_result_value}))
+
+        def on_done():
+            done_ev.set()
+
+        def on_error(exc):
+            error_holder[0] = exc
+            done_ev.set()
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_temperature",
+                    "description": "Get the current temperature.",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ]
+        messages = [
+            {
+                "role": "user",
+                "content": "What is the temperature? Use get_temperature and tell me the exact value.",
+            }
+        ]
+        backend = self._backend()
+        backend.stream_chat(
+            messages=messages,
+            tools=tools,
+            on_chunk=on_chunk,
+            on_tool_call=on_tool_call,
+            on_done=on_done,
+            on_error=on_error,
+        )
+        done_ev.wait(timeout=30)
+        if error_holder[0]:
+            raise error_holder[0]
+
+        full = "".join(chunks)
+        assert "42" in full
+
+    def test_bad_api_key_raises_runtime_error(self):
+        backend = OpenAICompatibleBackend(
+            base_url="https://api.openai.com",
+            model="gpt-4.1-mini",
+            api_key="sk-bad-key",
+        )
+        with pytest.raises(RuntimeError, match="HTTP 401"):
+            _collect(backend, [{"role": "user", "content": "hi"}])

--- a/GrampsAssistant/tests/test_gramps_tools.py
+++ b/GrampsAssistant/tests/test_gramps_tools.py
@@ -1,0 +1,429 @@
+"""
+Tests for register_gramps_tools — each Gramps-specific tool tested in isolation.
+
+Gramps is not required: module-level stubs are installed into sys.modules before
+any Gramps imports are attempted.
+"""
+
+import json
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Gramps module stubs (installed before importing tools)
+# ---------------------------------------------------------------------------
+
+def _install_gramps_stubs():
+    for mod_name in [
+        "gramps",
+        "gramps.gen",
+        "gramps.gen.display",
+        "gramps.gen.display.name",
+        "gramps.gen.datehandler",
+        "gramps.gui",
+        "gramps.gui.editors",
+    ]:
+        sys.modules.setdefault(mod_name, ModuleType(mod_name))
+
+    name_mod = sys.modules["gramps.gen.display.name"]
+    name_mod.displayer = MagicMock()
+    name_mod.displayer.display = lambda p: getattr(p, "_display_name", "Unknown")
+
+    date_mod = sys.modules["gramps.gen.datehandler"]
+    date_mod.displayer = MagicMock()
+    date_mod.displayer.display = lambda d: "1 Jan 1900"
+
+    editors_mod = sys.modules["gramps.gui.editors"]
+    editors_mod.EditPerson = MagicMock()
+
+
+_install_gramps_stubs()
+
+import tools as _tools_module  # noqa: E402  (must come after stubs)
+from tools import call_tool, register_gramps_tools  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures and helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    """Isolate each test from global registry state."""
+    original = list(_tools_module.tool_registry)
+    _tools_module.tool_registry.clear()
+    yield
+    _tools_module.tool_registry.clear()
+    _tools_module.tool_registry.extend(original)
+
+
+def _make_person(gramps_id="I0001", handle="h001", name="Smith, John", gender=1):
+    p = MagicMock()
+    p.get_gramps_id.return_value = gramps_id
+    p.get_handle.return_value = handle
+    p.get_gender.return_value = gender
+    p.get_birth_ref.return_value = None
+    p.get_death_ref.return_value = None
+    p.get_parent_family_handle_list.return_value = []
+    p.get_family_handle_list.return_value = []
+    p._display_name = name
+    return p
+
+
+def _make_model(handles=None):
+    """Mock model with node_map._index2hndl populated."""
+    handles = handles if handles is not None else [("", "h001"), ("", "h002")]
+    model = MagicMock()
+    model.node_map = MagicMock()
+    model.node_map._index2hndl = handles
+    model.get_n_columns.return_value = 3
+    model.get_value.return_value = "Test Value"
+    model.get_iter_from_handle.return_value = MagicMock()
+    return model
+
+
+def _make_sidebar(sidebar_filter):
+    """Mock sidebar notebook with one tab exposing *sidebar_filter*."""
+    sidebar = MagicMock()
+    sidebar.is_visible.return_value = True
+    sidebar.get_n_pages.return_value = 1
+    tab = MagicMock()
+    tab.pui = MagicMock()
+    tab.pui.filter = sidebar_filter
+    sidebar.get_nth_page.return_value = tab
+    return sidebar
+
+
+def _make_page(model=None, sidebar_filter=None):
+    page = MagicMock()
+    page.model = model if model is not None else _make_model()
+    page.sidebar = _make_sidebar(sidebar_filter) if sidebar_filter is not None else None
+    return page
+
+
+def _make_uistate(active_handle="h001", page=None):
+    uistate = MagicMock()
+    uistate.get_active.return_value = active_handle
+
+    _page = page if page is not None else _make_page()
+    vm = MagicMock()
+    vm.get_category.return_value = 0
+    vm.goto_page.return_value = _page
+    vm.active_page = _page
+    uistate.viewmanager = vm
+    return uistate
+
+
+def _make_dbstate(open=True, person=None):
+    dbstate = MagicMock()
+    dbstate.is_open.return_value = open
+    dbstate.db.get_person_from_gramps_id.return_value = person
+    dbstate.db.get_person_from_handle.return_value = person
+    return dbstate
+
+
+def _jcall(tool_name, args=None):
+    """call_tool and JSON-decode the result."""
+    return json.loads(call_tool(tool_name, args or {}))
+
+
+# ---------------------------------------------------------------------------
+# get_person_details
+# ---------------------------------------------------------------------------
+
+class TestGetPersonDetails:
+    def test_success_returns_person_data(self):
+        person = _make_person(gramps_id="I0001", gender=0)  # tuple index 0 → "Male"
+        register_gramps_tools(_make_dbstate(person=person), _make_uistate())
+        result = _jcall("get_person_details", {"gramps_id": "I0001"})
+        assert result["gramps_id"] == "I0001"
+        assert result["gender"] == "Male"
+
+    def test_female_gender(self):
+        person = _make_person(gender=1)  # tuple index 1 → "Female"
+        register_gramps_tools(_make_dbstate(person=person), _make_uistate())
+        result = _jcall("get_person_details", {"gramps_id": "I0001"})
+        assert result["gender"] == "Female"
+
+    def test_unknown_gender(self):
+        person = _make_person(gender=99)  # clamped to 2 → "Unknown"
+        register_gramps_tools(_make_dbstate(person=person), _make_uistate())
+        result = _jcall("get_person_details", {"gramps_id": "I0001"})
+        assert result["gender"] == "Unknown"
+
+    def test_person_not_found_returns_error(self):
+        register_gramps_tools(_make_dbstate(person=None), _make_uistate())
+        result = _jcall("get_person_details", {"gramps_id": "I9999"})
+        assert "error" in result
+
+    def test_db_closed_returns_error(self):
+        register_gramps_tools(_make_dbstate(open=False), _make_uistate())
+        result = _jcall("get_person_details", {"gramps_id": "I0001"})
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# get_active_person
+# ---------------------------------------------------------------------------
+
+class TestGetActivePerson:
+    def test_success_returns_person_data(self):
+        person = _make_person()
+        register_gramps_tools(_make_dbstate(person=person), _make_uistate(active_handle="h001"))
+        result = _jcall("get_active_person")
+        assert "gramps_id" in result
+
+    def test_no_active_handle_returns_error(self):
+        register_gramps_tools(_make_dbstate(person=_make_person()), _make_uistate(active_handle=None))
+        result = _jcall("get_active_person")
+        assert "error" in result
+
+    def test_db_closed_returns_error(self):
+        register_gramps_tools(_make_dbstate(open=False), _make_uistate())
+        result = _jcall("get_active_person")
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# set_active_person
+# ---------------------------------------------------------------------------
+
+class TestSetActivePerson:
+    def test_success_calls_set_active(self):
+        person = _make_person()
+        uistate = _make_uistate()
+        register_gramps_tools(_make_dbstate(person=person), uistate)
+        result = _jcall("set_active_person", {"gramps_id": "I0001"})
+        assert result.get("gramps_id") == "I0001"
+        uistate.set_active.assert_called_once()
+
+    def test_person_not_found_returns_error(self):
+        register_gramps_tools(_make_dbstate(person=None), _make_uistate())
+        result = _jcall("set_active_person", {"gramps_id": "I9999"})
+        assert "error" in result
+
+    def test_db_closed_returns_error(self):
+        register_gramps_tools(_make_dbstate(open=False), _make_uistate())
+        result = _jcall("set_active_person", {"gramps_id": "I0001"})
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# edit_active_person
+# ---------------------------------------------------------------------------
+
+class TestEditActivePerson:
+    def test_success_opens_dialog(self):
+        person = _make_person()
+        register_gramps_tools(_make_dbstate(person=person), _make_uistate(active_handle="h001"))
+        result = _jcall("edit_active_person")
+        assert "status" in result
+
+    def test_no_active_person_returns_error(self):
+        register_gramps_tools(_make_dbstate(person=_make_person()), _make_uistate(active_handle=None))
+        result = _jcall("edit_active_person")
+        assert "error" in result
+
+    def test_db_closed_returns_error(self):
+        register_gramps_tools(_make_dbstate(open=False), _make_uistate())
+        result = _jcall("edit_active_person")
+        assert "error" in result
+
+    def test_edit_dialog_exception_returns_error(self):
+        person = _make_person()
+        sys.modules["gramps.gui.editors"].EditPerson.side_effect = RuntimeError("dialog failed")
+        register_gramps_tools(_make_dbstate(person=person), _make_uistate(active_handle="h001"))
+        result = _jcall("edit_active_person")
+        assert "error" in result
+        sys.modules["gramps.gui.editors"].EditPerson.side_effect = None
+
+
+# ---------------------------------------------------------------------------
+# switch_to_view
+# ---------------------------------------------------------------------------
+
+class TestSwitchToView:
+    def test_success_returns_status(self):
+        register_gramps_tools(_make_dbstate(), _make_uistate())
+        result = _jcall("switch_to_view", {"category_name": "People"})
+        assert "status" in result
+
+    def test_unknown_category_returns_error(self):
+        uistate = _make_uistate()
+        uistate.viewmanager.get_category.return_value = None
+        uistate.viewmanager.get_views.return_value = []
+        register_gramps_tools(_make_dbstate(), uistate)
+        result = _jcall("switch_to_view", {"category_name": "Bogus"})
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# get_view_results
+# ---------------------------------------------------------------------------
+
+class TestGetViewResults:
+    def test_success_returns_items(self):
+        model = _make_model([("", "h001"), ("", "h002")])
+        register_gramps_tools(_make_dbstate(), _make_uistate(page=_make_page(model=model)))
+        result = _jcall("get_view_results")
+        assert result["total"] == 2
+        assert len(result["items"]) == 2
+
+    def test_empty_model(self):
+        model = _make_model([])
+        register_gramps_tools(_make_dbstate(), _make_uistate(page=_make_page(model=model)))
+        result = _jcall("get_view_results")
+        assert result["total"] == 0
+        assert result["items"] == []
+
+    def test_no_active_page_returns_error(self):
+        uistate = _make_uistate()
+        uistate.viewmanager.active_page = None
+        register_gramps_tools(_make_dbstate(), uistate)
+        result = _jcall("get_view_results")
+        assert "error" in result
+
+    def test_model_without_node_map_returns_error(self):
+        # spec=[] gives an object with no attributes
+        model = MagicMock(spec=[])
+        register_gramps_tools(_make_dbstate(), _make_uistate(page=_make_page(model=model)))
+        result = _jcall("get_view_results")
+        assert "error" in result
+        assert "model_type" in result  # debug info included
+
+    def test_pagination_page_zero(self):
+        handles = [("", f"h{i:03}") for i in range(10)]
+        model = _make_model(handles)
+        register_gramps_tools(_make_dbstate(), _make_uistate(page=_make_page(model=model)))
+        result = _jcall("get_view_results", {"page_number": 0, "page_size": 3})
+        assert result["total"] == 10
+        assert result["total_pages"] == 4
+        assert len(result["items"]) == 3
+
+    def test_pagination_last_page(self):
+        handles = [("", f"h{i:03}") for i in range(10)]
+        model = _make_model(handles)
+        register_gramps_tools(_make_dbstate(), _make_uistate(page=_make_page(model=model)))
+        result = _jcall("get_view_results", {"page_number": 3, "page_size": 3})
+        assert len(result["items"]) == 1  # only 1 item on last page
+
+    def test_page_out_of_range_returns_error(self):
+        model = _make_model([("", "h001")])
+        register_gramps_tools(_make_dbstate(), _make_uistate(page=_make_page(model=model)))
+        result = _jcall("get_view_results", {"page_number": 99, "page_size": 10})
+        assert "error" in result
+
+    def test_page_size_clamped_to_100(self):
+        handles = [("", f"h{i:03}") for i in range(200)]
+        model = _make_model(handles)
+        register_gramps_tools(_make_dbstate(), _make_uistate(page=_make_page(model=model)))
+        result = _jcall("get_view_results", {"page_number": 0, "page_size": 999})
+        assert len(result["items"]) == 100
+
+    def test_markup_stripped_from_values(self):
+        model = _make_model([("", "h001")])
+        model.get_value.return_value = "<b>Bold Name</b>"
+        register_gramps_tools(_make_dbstate(), _make_uistate(page=_make_page(model=model)))
+        result = _jcall("get_view_results")
+        assert result["items"][0]["values"] == ["Bold Name"]
+
+
+# ---------------------------------------------------------------------------
+# filter_people
+# ---------------------------------------------------------------------------
+
+class TestFilterPeople:
+    def _setup(self, filter_mock=None):
+        sf = filter_mock or MagicMock()
+        model = _make_model([("", "h001")])
+        page = _make_page(model=model, sidebar_filter=sf)
+        uistate = _make_uistate(page=page)
+        register_gramps_tools(_make_dbstate(), uistate)
+        return sf
+
+    def test_sets_name_filter(self):
+        sf = self._setup()
+        _jcall("filter_people", {"name": "Smith"})
+        sf.filter_name.set_text.assert_called_with("Smith")
+
+    def test_calls_clicked(self):
+        sf = self._setup()
+        _jcall("filter_people", {"name": "Smith"})
+        sf.clicked.assert_called()
+
+    def test_result_has_filter_key(self):
+        self._setup()
+        result = _jcall("filter_people", {"name": "Smith"})
+        assert "filter" in result
+        assert result["filter"]["name"] == "Smith"
+
+    def test_empty_params_not_included_in_filter(self):
+        self._setup()
+        result = _jcall("filter_people", {})
+        assert result["filter"] == {}
+
+    def test_no_sidebar_returns_error_string(self):
+        model = _make_model([("", "h001")])
+        page = _make_page(model=model, sidebar_filter=None)
+        uistate = _make_uistate(page=page)
+        register_gramps_tools(_make_dbstate(), uistate)
+        result = _jcall("filter_people", {"name": "Smith"})
+        # returns a plain string (no sidebar found)
+        assert isinstance(result, str)
+
+
+# ---------------------------------------------------------------------------
+# filter_* smoke tests (views that use _open_sidebar_filter)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("tool_name,kwargs,checked_field", [
+    ("filter_families",    {"father": "John"},      "filter_father"),
+    ("filter_events",      {"description": "Birth"}, "filter_desc"),
+    ("filter_places",      {"name": "London"},       "filter_name"),
+    ("filter_sources",     {"title": "Census"},      "filter_title"),
+    ("filter_citations",   {"source_title": "Tax"},  "filter_src_title"),
+    ("filter_media",       {"title": "Photo"},       "filter_title"),
+    ("filter_repositories",{"name": "Library"},      "filter_title"),
+    ("filter_notes",       {"text": "important"},    "filter_text"),
+])
+def test_filter_smoke(tool_name, kwargs, checked_field):
+    """Each filter tool sets the correct field, clicks, and returns a result dict."""
+    sf = MagicMock()
+    model = _make_model([("", "h001")])
+    page = _make_page(model=model, sidebar_filter=sf)
+    uistate = _make_uistate(page=page)
+    _tools_module.tool_registry.clear()
+    register_gramps_tools(_make_dbstate(), uistate)
+
+    result = _jcall(tool_name, kwargs)
+
+    # The filter field should have been set
+    field = getattr(sf, checked_field)
+    field.set_text.assert_called()
+    sf.clicked.assert_called()
+
+    # Result is either a success dict (with "filter") or an error dict
+    assert isinstance(result, dict)
+    assert "filter" in result or "error" in result
+
+
+@pytest.mark.parametrize("tool_name", [
+    "filter_families", "filter_events", "filter_places",
+    "filter_sources", "filter_citations", "filter_media",
+    "filter_repositories", "filter_notes",
+])
+def test_filter_no_sidebar_returns_error(tool_name):
+    """When the sidebar is unavailable, filters return a non-crashing error."""
+    model = _make_model([("", "h001")])
+    page = _make_page(model=model, sidebar_filter=None)
+    uistate = _make_uistate(page=page)
+    _tools_module.tool_registry.clear()
+    register_gramps_tools(_make_dbstate(), uistate)
+
+    result = _jcall(tool_name, {})
+    # Should not raise; returns either a string error or dict with error key
+    assert isinstance(result, (str, dict))

--- a/GrampsAssistant/tests/test_tool_registry.py
+++ b/GrampsAssistant/tests/test_tool_registry.py
@@ -1,0 +1,304 @@
+"""
+Tests for the tool registry: Tool, register_tool, get_tools_schema, call_tool.
+
+No Gramps dependency — pure stdlib / registry logic only.
+"""
+
+import inspect
+import json
+from typing import Annotated
+
+import pytest
+
+import tools as _tools_module
+from tools import (
+    Tool,
+    _resolve_annotation,
+    call_tool,
+    get_tools_schema,
+    register_tool,
+    tool_registry,
+)
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    """Isolate each test: save, clear, restore the global registry."""
+    original = list(_tools_module.tool_registry)
+    _tools_module.tool_registry.clear()
+    yield
+    _tools_module.tool_registry.clear()
+    _tools_module.tool_registry.extend(original)
+
+
+# ---------------------------------------------------------------------------
+# _resolve_annotation
+# ---------------------------------------------------------------------------
+
+class TestResolveAnnotation:
+    def test_str(self):
+        assert _resolve_annotation(str) == ("string", None)
+
+    def test_int(self):
+        assert _resolve_annotation(int) == ("integer", None)
+
+    def test_float(self):
+        assert _resolve_annotation(float) == ("number", None)
+
+    def test_bool(self):
+        assert _resolve_annotation(bool) == ("boolean", None)
+
+    def test_list(self):
+        assert _resolve_annotation(list) == ("array", None)
+
+    def test_empty_annotation_defaults_to_string(self):
+        assert _resolve_annotation(inspect.Parameter.empty) == ("string", None)
+
+    def test_unknown_type_defaults_to_string(self):
+        assert _resolve_annotation(dict) == ("string", None)
+
+    def test_annotated_str_with_description(self):
+        ann = Annotated[str, "a query string"]
+        json_type, desc = _resolve_annotation(ann)
+        assert json_type == "string"
+        assert desc == "a query string"
+
+    def test_annotated_int_with_description(self):
+        ann = Annotated[int, "a count"]
+        json_type, desc = _resolve_annotation(ann)
+        assert json_type == "integer"
+        assert desc == "a count"
+
+    def test_annotated_without_description_returns_none(self):
+        ann = Annotated[str, 42]  # non-string metadata
+        _, desc = _resolve_annotation(ann)
+        assert desc is None
+
+
+# ---------------------------------------------------------------------------
+# Tool.from_function
+# ---------------------------------------------------------------------------
+
+class TestToolFromFunction:
+    def test_name_taken_from_function(self):
+        def my_func(): pass
+        assert Tool.from_function(my_func).name == "my_func"
+
+    def test_full_docstring_used_as_description(self):
+        def my_func():
+            """First paragraph.
+
+            Second paragraph with more detail.
+            """
+        t = Tool.from_function(my_func)
+        assert "First paragraph." in t.description
+        assert "Second paragraph with more detail." in t.description
+
+    def test_empty_docstring(self):
+        def my_func(): pass
+        assert Tool.from_function(my_func).description == ""
+
+    def test_required_params_have_no_default(self):
+        def my_func(a: str, b: int): pass
+        t = Tool.from_function(my_func)
+        assert t.parameters["required"] == ["a", "b"]
+
+    def test_optional_params_omitted_from_required(self):
+        def my_func(a: str = ""): pass
+        t = Tool.from_function(my_func)
+        assert "required" not in t.parameters
+
+    def test_mixed_required_and_optional(self):
+        def my_func(a: str, b: int = 0): pass
+        t = Tool.from_function(my_func)
+        assert t.parameters["required"] == ["a"]
+        assert "b" in t.parameters["properties"]
+
+    def test_param_json_types(self):
+        def my_func(a: str, b: int, c: float, d: bool, e: list): pass
+        props = Tool.from_function(my_func).parameters["properties"]
+        assert props["a"]["type"] == "string"
+        assert props["b"]["type"] == "integer"
+        assert props["c"]["type"] == "number"
+        assert props["d"]["type"] == "boolean"
+        assert props["e"]["type"] == "array"
+
+    def test_annotated_param_gets_description(self):
+        def my_func(q: Annotated[str, "the search query"]): pass
+        props = Tool.from_function(my_func).parameters["properties"]
+        assert props["q"]["description"] == "the search query"
+
+    def test_self_param_skipped(self):
+        class Foo:
+            def method(self, x: str): pass
+        props = Tool.from_function(Foo.method).parameters["properties"]
+        assert "self" not in props
+        assert "x" in props
+
+    def test_no_annotations_default_to_string(self):
+        def my_func(x): pass
+        props = Tool.from_function(my_func).parameters["properties"]
+        assert props["x"]["type"] == "string"
+
+
+# ---------------------------------------------------------------------------
+# Tool schema serialisation
+# ---------------------------------------------------------------------------
+
+class TestToolSchema:
+    def _simple_tool(self):
+        def greet(name: str) -> str:
+            "Say hello to someone."
+        return Tool.from_function(greet)
+
+    def test_openai_schema_top_level_keys(self):
+        schema = self._simple_tool().to_openai_schema()
+        assert schema["type"] == "function"
+        assert "function" in schema
+
+    def test_openai_schema_function_keys(self):
+        fn = self._simple_tool().to_openai_schema()["function"]
+        assert fn["name"] == "greet"
+        assert "description" in fn
+        assert "parameters" in fn
+
+    def test_openai_schema_has_no_input_schema(self):
+        schema = self._simple_tool().to_openai_schema()
+        assert "input_schema" not in schema
+        assert "input_schema" not in schema.get("function", {})
+
+    def test_anthropic_schema_top_level_keys(self):
+        schema = self._simple_tool().to_anthropic_schema()
+        assert schema["name"] == "greet"
+        assert "description" in schema
+        assert "input_schema" in schema
+
+    def test_anthropic_schema_has_no_parameters_key(self):
+        schema = self._simple_tool().to_anthropic_schema()
+        assert "parameters" not in schema
+
+    def test_description_appears_in_both_schemas(self):
+        t = self._simple_tool()
+        assert t.to_openai_schema()["function"]["description"] == t.description
+        assert t.to_anthropic_schema()["description"] == t.description
+
+
+# ---------------------------------------------------------------------------
+# register_tool
+# ---------------------------------------------------------------------------
+
+class TestRegisterTool:
+    def test_decorator_adds_to_registry(self):
+        @register_tool
+        def my_tool(x: str) -> str:
+            "A tool."
+        assert any(t.name == "my_tool" for t in _tools_module.tool_registry)
+
+    def test_original_function_still_callable(self):
+        @register_tool
+        def double(x: int) -> int:
+            "Double x."
+            return x * 2
+        assert double(4) == 8
+
+    def test_tool_instance_registered_directly(self):
+        t = Tool(
+            name="direct",
+            description="Direct.",
+            func=lambda: None,
+            parameters={"type": "object", "properties": {}},
+        )
+        register_tool(t)
+        assert any(tool.name == "direct" for tool in _tools_module.tool_registry)
+
+    def test_multiple_registrations_accumulate(self):
+        @register_tool
+        def tool_a() -> str:
+            "A."
+        @register_tool
+        def tool_b() -> str:
+            "B."
+        names = {t.name for t in _tools_module.tool_registry}
+        assert "tool_a" in names
+        assert "tool_b" in names
+
+
+# ---------------------------------------------------------------------------
+# get_tools_schema
+# ---------------------------------------------------------------------------
+
+class TestGetToolsSchema:
+    def _register_one(self, name="schema_tool"):
+        func = lambda q: q
+        func.__name__ = name
+        func.__doc__ = "A schema tool."
+        func.__annotations__ = {"q": str}
+        register_tool(func)
+
+    def test_openai_format(self):
+        self._register_one("openai_tool")
+        schemas = get_tools_schema("openai")
+        assert all(s.get("type") == "function" for s in schemas)
+
+    def test_anthropic_format(self):
+        self._register_one("anthropic_tool")
+        schemas = get_tools_schema("anthropic")
+        assert all("input_schema" in s for s in schemas)
+
+    def test_default_is_openai(self):
+        self._register_one("default_tool")
+        schemas = get_tools_schema()
+        assert all(s.get("type") == "function" for s in schemas)
+
+    def test_empty_registry_returns_empty_list(self):
+        assert get_tools_schema() == []
+
+
+# ---------------------------------------------------------------------------
+# call_tool
+# ---------------------------------------------------------------------------
+
+class TestCallTool:
+    def test_returns_json_string(self):
+        @register_tool
+        def add(a: int, b: int) -> int:
+            "Add two numbers."
+            return a + b
+        result = call_tool("add", {"a": 2, "b": 3})
+        assert isinstance(result, str)
+        assert json.loads(result) == 5
+
+    def test_dict_result_serialised(self):
+        @register_tool
+        def get_dict() -> dict:
+            "Return a dict."
+            return {"key": "value"}
+        assert json.loads(call_tool("get_dict", {})) == {"key": "value"}
+
+    def test_unknown_tool_raises_key_error(self):
+        with pytest.raises(KeyError):
+            call_tool("no_such_tool_xyz", {})
+
+    def test_tool_receives_kwargs(self):
+        received = {}
+
+        @register_tool
+        def capture(x: str, y: int) -> str:
+            "Capture args."
+            received["x"] = x
+            received["y"] = y
+            return "ok"
+
+        call_tool("capture", {"x": "hello", "y": 42})
+        assert received == {"x": "hello", "y": 42}
+
+    def test_non_serialisable_uses_str_fallback(self):
+        import datetime
+
+        @register_tool
+        def get_date() -> dict:
+            "Return a date."
+            return {"d": datetime.date(2024, 1, 1)}
+
+        result = json.loads(call_tool("get_date", {}))
+        assert isinstance(result["d"], str)

--- a/GrampsAssistant/tools.py
+++ b/GrampsAssistant/tools.py
@@ -1,0 +1,1090 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2024  Gramps Development Team
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+"""
+Tool registry for the Gramps Chatbot.
+
+Usage::
+
+    from .tools import register_tool
+
+    @register_tool
+    def my_tool(query: str) -> str:
+        "Search for something."
+        ...
+
+Tools registered here are automatically exposed to the LLM.
+"""
+
+import inspect
+import json
+import logging
+import typing
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
+
+_LOG = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Python type → JSON Schema type mapping
+# ---------------------------------------------------------------------------
+_PY_TO_JSON: Dict[Any, str] = {
+    str: "string",
+    int: "integer",
+    float: "number",
+    bool: "boolean",
+    list: "array",
+}
+
+
+def _resolve_annotation(annotation) -> tuple:
+    """
+    Return (json_type_str, description_or_None) for a parameter annotation.
+
+    Handles plain types (str, int, …) and Annotated[T, "description"].
+    """
+    if annotation is inspect.Parameter.empty:
+        return "string", None
+
+    # Annotated[T, "description"] — requires Python 3.9+
+    if hasattr(annotation, "__metadata__"):
+        args = typing.get_args(annotation)
+        base = args[0] if args else str
+        desc = args[1] if len(args) > 1 and isinstance(args[1], str) else None
+        return _PY_TO_JSON.get(base, "string"), desc
+
+    return _PY_TO_JSON.get(annotation, "string"), None
+
+
+# ---------------------------------------------------------------------------
+# Tool dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Tool:
+    """
+    Wraps a Python callable with the metadata needed to expose it as an
+    LLM tool.
+    """
+
+    name: str
+    description: str
+    func: Callable
+    parameters: Dict  # JSON Schema {"type":"object","properties":{...},"required":[...]}
+    tags: set = field(default_factory=set)  # e.g. {"always"}, {"people"}, {"families"}
+
+    # ------------------------------------------------------------------
+    # Schema serialisation
+    # ------------------------------------------------------------------
+
+    def to_openai_schema(self) -> Dict:
+        """Return OpenAI-format tool dict."""
+        return {
+            "type": "function",
+            "function": {
+                "name": self.name,
+                "description": self.description,
+                "parameters": self.parameters,
+            },
+        }
+
+    def to_anthropic_schema(self) -> Dict:
+        """Return Anthropic-format tool dict (uses input_schema key)."""
+        return {
+            "name": self.name,
+            "description": self.description,
+            "input_schema": self.parameters,
+        }
+
+    # ------------------------------------------------------------------
+    # Factory
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_function(cls, func: Callable) -> "Tool":
+        """
+        Build a Tool by introspecting *func*.
+
+        - Name is taken from ``func.__name__``.
+        - Description is the full ``func.__doc__``.
+        - Parameters are derived from type annotations (``inspect.signature``
+          + ``typing.get_type_hints``).
+        - Parameters with default values are optional; the rest are required.
+        - ``Annotated[T, "description text"]`` populates per-param descriptions.
+        """
+        name = func.__name__
+        doc = inspect.getdoc(func) or ""
+        description = doc.strip()
+
+        try:
+            hints = typing.get_type_hints(func, include_extras=True)
+        except Exception:
+            hints = {}
+
+        sig = inspect.signature(func)
+        properties: Dict[str, Dict] = {}
+        required: List[str] = []
+
+        for param_name, param in sig.parameters.items():
+            if param_name == "self":
+                continue
+
+            annotation = hints.get(param_name, inspect.Parameter.empty)
+            json_type, param_desc = _resolve_annotation(annotation)
+
+            prop: Dict[str, Any] = {"type": json_type}
+            if param_desc:
+                prop["description"] = param_desc
+
+            properties[param_name] = prop
+
+            if param.default is inspect.Parameter.empty:
+                required.append(param_name)
+
+        parameters = {
+            "type": "object",
+            "properties": properties,
+        }
+        if required:
+            parameters["required"] = required
+
+        return cls(
+            name=name,
+            description=description,
+            func=func,
+            parameters=parameters,
+        )
+
+    def call(self, **kwargs) -> Any:
+        """Invoke the wrapped function."""
+        return self.func(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Global registry
+# ---------------------------------------------------------------------------
+
+tool_registry: List[Tool] = []
+
+
+def register_tool(func_or_tool=None, *, tags=None):
+    """
+    Decorator or direct call to add a tool to the global registry.
+
+    Can be used as a plain decorator or with keyword arguments::
+
+        @register_tool
+        def search(q: str) -> str:
+            ...
+
+        @register_tool(tags={"always"})
+        def search_wikipedia(query: str) -> str:
+            ...
+
+        result = search("Smith")   # still works as a normal function
+    """
+    def _register(func, tag_set):
+        if isinstance(func, Tool):
+            tool_registry.append(func)
+            return func
+        tool = Tool.from_function(func)
+        if tag_set:
+            tool.tags = set(tag_set)
+        tool_registry.append(tool)
+        return func
+
+    if func_or_tool is None:
+        # Called as @register_tool(tags=...) — return a decorator
+        def decorator(func):
+            return _register(func, tags)
+        return decorator
+
+    # Called as @register_tool (no parentheses) or register_tool(func)
+    return _register(func_or_tool, tags)
+
+
+def get_tools_schema(backend_type: str = "openai", tags=None) -> List[Dict]:
+    """
+    Return a list of tool dicts formatted for the given backend.
+
+    *backend_type* is ``"openai"`` (default) or ``"anthropic"``.
+
+    If *tags* is provided (a set of strings), only tools whose tags
+    intersect with it are returned, plus tools tagged ``"always"`` and
+    untagged tools (for backward compatibility with user-registered tools).
+    If *tags* is None, all tools are returned.
+    """
+    if tags is None:
+        tools = tool_registry
+    else:
+        tools = [
+            t for t in tool_registry
+            if not t.tags or "always" in t.tags or bool(t.tags & tags)
+        ]
+    if backend_type == "anthropic":
+        return [t.to_anthropic_schema() for t in tools]
+    return [t.to_openai_schema() for t in tools]
+
+
+def call_tool(name: str, args: Dict) -> str:
+    """
+    Find the tool named *name*, call it with *args*, and return the result
+    as a JSON string.
+
+    Raises ``KeyError`` if no such tool is registered.
+    """
+    for tool in tool_registry:
+        if tool.name == name:
+            result = tool.func(**args)
+            return json.dumps(result, ensure_ascii=False, default=str)
+    raise KeyError(f"No tool named {name!r}")
+
+
+# ---------------------------------------------------------------------------
+# Built-in Gramps tools
+# ---------------------------------------------------------------------------
+
+
+def _format_person_details(db, person) -> dict:
+    """
+    Return a structured dict describing *person* suitable for JSON serialisation.
+    """
+    from gramps.gen.display.name import displayer as name_displayer
+    from gramps.gen.datehandler import displayer as date_displayer
+
+    result = {
+        "name": name_displayer.display(person),
+        "gramps_id": person.get_gramps_id(),
+        "gender": ("Male", "Female", "Unknown")[min(person.get_gender(), 2)],
+    }
+
+    birth_ref = person.get_birth_ref()
+    if birth_ref:
+        birth_event = db.get_event_from_handle(birth_ref.ref)
+        birth = {"date": date_displayer.display(birth_event.get_date_object())}
+        place_handle = birth_event.get_place_handle()
+        if place_handle:
+            birth["place"] = db.get_place_from_handle(place_handle).get_name().get_value()
+        result["birth"] = birth
+
+    death_ref = person.get_death_ref()
+    if death_ref:
+        death_event = db.get_event_from_handle(death_ref.ref)
+        death = {"date": date_displayer.display(death_event.get_date_object())}
+        place_handle = death_event.get_place_handle()
+        if place_handle:
+            death["place"] = db.get_place_from_handle(place_handle).get_name().get_value()
+        result["death"] = death
+
+    parents = []
+    for fhandle in person.get_parent_family_handle_list()[:2]:
+        family = db.get_family_from_handle(fhandle)
+        father_handle = family.get_father_handle()
+        mother_handle = family.get_mother_handle()
+        if father_handle:
+            father = db.get_person_from_handle(father_handle)
+            parents.append({"role": "father", "name": name_displayer.display(father),
+                            "gramps_id": father.get_gramps_id()})
+        if mother_handle:
+            mother = db.get_person_from_handle(mother_handle)
+            parents.append({"role": "mother", "name": name_displayer.display(mother),
+                            "gramps_id": mother.get_gramps_id()})
+    if parents:
+        result["parents"] = parents
+
+    families = []
+    for fhandle in person.get_family_handle_list()[:3]:
+        family = db.get_family_from_handle(fhandle)
+        father_h = family.get_father_handle()
+        mother_h = family.get_mother_handle()
+        spouse_h = mother_h if father_h == person.get_handle() else father_h
+        family_entry = {}
+        if spouse_h:
+            spouse = db.get_person_from_handle(spouse_h)
+            family_entry["spouse"] = {"name": name_displayer.display(spouse),
+                                      "gramps_id": spouse.get_gramps_id()}
+        children = []
+        for child_ref in family.get_child_ref_list()[:8]:
+            child = db.get_person_from_handle(child_ref.ref)
+            children.append({"name": name_displayer.display(child),
+                             "gramps_id": child.get_gramps_id()})
+        if children:
+            family_entry["children"] = children
+        if family_entry:
+            families.append(family_entry)
+    if families:
+        result["families"] = families
+
+    return result
+
+
+# Maps sidebar filter class name → primary text field used for keyword search
+_SIDEBAR_FILTER_FIELD = {
+    "PersonSidebarFilter": "filter_name",
+    "FamilySidebarFilter": "filter_father",
+    "EventSidebarFilter": "filter_desc",
+    "PlaceSidebarFilter": "filter_name",
+    "SourceSidebarFilter": "filter_title",
+    "CitationSidebarFilter": "filter_src_title",
+    "MediaSidebarFilter": "filter_title",
+    "RepoSidebarFilter": "filter_title",
+    "NoteSidebarFilter": "filter_text",
+}
+
+
+def register_gramps_tools(dbstate, uistate):
+    """
+    Create and register the built-in Gramps database tools.
+
+    Safe to call multiple times — guards against double-registration.
+    Call this from ``ChatbotPanel.__init__`` after *dbstate* is available.
+    """
+    existing_names = {t.name for t in tool_registry}
+
+    def get_person_details(gramps_id: str) -> dict:
+        """
+        Get detailed information about a specific person by their Gramps ID.
+
+        Returns name, birth, death, parents, spouses, and children.
+        gramps_id: The Gramps ID of the person (e.g. I0001).
+        """
+        if not dbstate.is_open():
+            return {"error": "No database is currently open."}
+        db = dbstate.db
+        person = db.get_person_from_gramps_id(gramps_id)
+        if person is None:
+            return {"error": f"No person found with ID '{gramps_id}'."}
+        return _format_person_details(db, person)
+
+    def get_active_person() -> dict:
+        """
+        Get information about the currently active (selected) person in Gramps.
+
+        Returns full details of the person currently being viewed.
+        """
+        if not dbstate.is_open():
+            return {"error": "No database is currently open."}
+        handle = uistate.get_active("Person")
+        if not handle:
+            return {"error": "No person is currently selected."}
+        person = dbstate.db.get_person_from_handle(handle)
+        return _format_person_details(dbstate.db, person)
+
+    def switch_to_view(category_name: str) -> dict:
+        """
+        Switch the main Gramps window to a named view category.
+
+        Valid category names include: People, Families, Events, Places,
+        Sources, Repositories, Media, Notes, Citations, Dashboard, Geography,
+        Relationships, Pedigree, Fan Chart.
+        category_name: The name of the view category to switch to.
+        """
+        vm = uistate.viewmanager
+        cat_num = vm.get_category(category_name)
+        if cat_num is None:
+            available = [
+                cat_views[0][0].category[1]
+                for cat_views in vm.get_views()
+                if cat_views
+            ]
+            return {"error": f"Unknown category '{category_name}'.",
+                    "available": available}
+        vm.goto_page(cat_num, None)
+        return {"status": f"Switched to {category_name} view."}
+
+    def search_in_view(category_name: str, search_text: str) -> dict:
+        """
+        Switch to a view category, apply a sidebar filter, and press Find.
+
+        Works on list views: People, Families, Events, Places, Sources,
+        Repositories, Media, Notes, Citations.
+        category_name: The view category to search in (e.g. People, Events).
+        search_text: The text to filter by (name, title, description, etc.).
+        """
+        vm = uistate.viewmanager
+        cat_num = vm.get_category(category_name)
+        if cat_num is None:
+            available = [
+                cat_views[0][0].category[1]
+                for cat_views in vm.get_views()
+                if cat_views
+            ]
+            return {"error": f"Unknown category '{category_name}'.",
+                    "available": available}
+        page = vm.goto_page(cat_num, None)
+        filter_class = getattr(page, "filter_class", None)
+        if filter_class is None:
+            return {"error": f"{category_name} does not support sidebar filtering."}
+
+        field_name = _SIDEBAR_FILTER_FIELD.get(filter_class.__name__)
+        if field_name is None:
+            return {"error": f"No known filter field for {filter_class.__name__}."}
+
+        sidebar = getattr(page, "sidebar", None)
+        if sidebar is not None and not sidebar.is_visible():
+            sidebar.show()
+            if hasattr(page, "search_bar"):
+                page.search_bar.hide()
+
+        live_filter = None
+        if sidebar is not None:
+            for i in range(sidebar.get_n_pages()):
+                tab = sidebar.get_nth_page(i)
+                if tab and tab.pui and hasattr(tab.pui, "filter"):
+                    live_filter = tab.pui.filter
+                    break
+
+        if live_filter is not None:
+            getattr(live_filter, field_name).set_text(search_text)
+            live_filter.clicked(None)
+        else:
+            def _apply():
+                page.generic_filter = _sf.get_filter()
+                page.build_tree()
+            _sf = filter_class(dbstate, uistate, _apply)
+            getattr(_sf, field_name).set_text(search_text)
+            _sf.clicked(None)
+
+        return {"filter": {"category": category_name, "text": search_text},
+                "results": get_view_results()}
+
+    def set_active_person(gramps_id: str) -> dict:
+        """
+        Set the active (selected) person in Gramps by their Gramps ID.
+
+        Navigates the UI to the person so all views update to show them.
+        gramps_id: The Gramps ID of the person to select (e.g. I0001).
+        """
+        if not dbstate.is_open():
+            return {"error": "No database is currently open."}
+        db = dbstate.db
+        person = db.get_person_from_gramps_id(gramps_id)
+        if person is None:
+            return {"error": f"No person found with ID '{gramps_id}'."}
+        uistate.set_active(person.get_handle(), "Person")
+        from gramps.gen.display.name import displayer as name_displayer
+        return {"status": "Active person set.",
+                "name": name_displayer.display(person),
+                "gramps_id": gramps_id}
+
+    def edit_active_person() -> dict:
+        """
+        Open the Gramps edit dialog for the currently active (selected) person.
+
+        Use this when the user asks to edit, update, or modify the current person.
+        Returns a confirmation message or an error.
+        """
+        if not dbstate.is_open():
+            return {"error": "No database is currently open."}
+        handle = uistate.get_active("Person")
+        if not handle:
+            return {"error": "No person is currently selected."}
+        person = dbstate.db.get_person_from_handle(handle)
+        try:
+            from gramps.gui.editors import EditPerson
+
+            EditPerson(dbstate, uistate, [], person)
+            return {"status": f"Opened edit dialog for {person.get_gramps_id()}."}
+        except Exception as exc:
+            return {"error": f"Could not open edit dialog: {exc}"}
+
+    _GENDER_INDEX = {"male": 1, "female": 2, "other": 3, "unknown": 4}
+
+    def filter_people(
+        name: str = "",
+        gender: str = "",
+        birth_year: str = "",
+        death_year: str = "",
+        birth_place: str = "",
+        death_place: str = "",
+        note: str = "",
+    ) -> str:
+        """
+        Switch to the People view and filter using the sidebar filter.
+
+        Each parameter is optional; supply only the ones you need.
+        Dates accept Gramps date expressions such as "1760", "before 1800",
+        or "between 1750 and 1800".
+
+        name: Substring of the person's name.
+        gender: One of: male, female, other, unknown.
+        birth_year: Birth date expression (e.g. "1760", "before 1800").
+        death_year: Death date expression.
+        birth_place: Substring of the birth place name.
+        death_place: Substring of the death place name.
+        note: Substring to search for in notes.
+        """
+        vm = uistate.viewmanager
+        cat_num = vm.get_category("People")
+        if cat_num is None:
+            return "Could not find the People view."
+        page = vm.goto_page(cat_num, None)
+
+        sidebar = getattr(page, "sidebar", None)
+        if sidebar is not None and not sidebar.is_visible():
+            sidebar.show()
+            if hasattr(page, "search_bar"):
+                page.search_bar.hide()
+
+        live_filter = None
+        if sidebar is not None:
+            for i in range(sidebar.get_n_pages()):
+                tab = sidebar.get_nth_page(i)
+                if tab and tab.pui and hasattr(tab.pui, "filter"):
+                    live_filter = tab.pui.filter
+                    break
+
+        if live_filter is None:
+            return "Could not find the People sidebar filter."
+
+        live_filter.clear(None)
+
+        if name:
+            live_filter.filter_name.set_text(name)
+        if gender:
+            live_filter.filter_gender.set_active(
+                _GENDER_INDEX.get(gender.lower(), 0)
+            )
+        if birth_year:
+            live_filter.filter_birth.set_text(birth_year)
+        if death_year:
+            live_filter.filter_death.set_text(death_year)
+        if birth_place:
+            live_filter.filter_birth_place.set_text(birth_place)
+        if death_place:
+            live_filter.filter_death_place.set_text(death_place)
+        if note:
+            live_filter.filter_note.set_text(note)
+
+        live_filter.clicked(None)
+
+        applied = {k: v for k, v in [("name", name), ("gender", gender),
+                                      ("birth_year", birth_year), ("death_year", death_year),
+                                      ("birth_place", birth_place), ("death_place", death_place),
+                                      ("note", note)] if v}
+        return {"filter": applied, "results": get_view_results()}
+
+    # ------------------------------------------------------------------
+    # Shared helper: navigate to a category, show sidebar, return filter
+    # ------------------------------------------------------------------
+
+    def _open_sidebar_filter(category_name):
+        """Return (live_filter, error_str). error_str is None on success."""
+        vm = uistate.viewmanager
+        cat_num = vm.get_category(category_name)
+        if cat_num is None:
+            return None, f"Could not find the {category_name} view."
+        page = vm.goto_page(cat_num, None)
+        sidebar = getattr(page, "sidebar", None)
+        if sidebar is not None and not sidebar.is_visible():
+            sidebar.show()
+            if hasattr(page, "search_bar"):
+                page.search_bar.hide()
+        if sidebar is None:
+            return None, f"{category_name} has no sidebar."
+        for i in range(sidebar.get_n_pages()):
+            tab = sidebar.get_nth_page(i)
+            if tab and tab.pui and hasattr(tab.pui, "filter"):
+                return tab.pui.filter, None
+        return None, f"Could not find sidebar filter for {category_name}."
+
+    # ------------------------------------------------------------------
+    # Per-view filter tools
+    # ------------------------------------------------------------------
+
+    def filter_families(
+        father: str = "",
+        mother: str = "",
+        child: str = "",
+        note: str = "",
+    ) -> str:
+        """
+        Switch to the Families view and filter using the sidebar filter.
+
+        Each parameter is optional; supply only the ones you need.
+        father: Substring of the father's name.
+        mother: Substring of the mother's name.
+        child: Substring of a child's name.
+        note: Substring to search for in notes.
+        """
+        f, err = _open_sidebar_filter("Families")
+        if err:
+            return err
+        f.clear(None)
+        if father: f.filter_father.set_text(father)
+        if mother: f.filter_mother.set_text(mother)
+        if child:  f.filter_child.set_text(child)
+        if note:   f.filter_note.set_text(note)
+        f.clicked(None)
+        applied = {k: v for k, v in [("father", father), ("mother", mother),
+                                      ("child", child), ("note", note)] if v}
+        return {"filter": applied, "results": get_view_results()}
+
+    def filter_events(
+        description: str = "",
+        participants: str = "",
+        date: str = "",
+        place: str = "",
+        note: str = "",
+    ) -> str:
+        """
+        Switch to the Events view and filter using the sidebar filter.
+
+        Each parameter is optional; supply only the ones you need.
+        description: Substring of the event description.
+        participants: Substring of participant names.
+        date: Date expression (e.g. "1760", "before 1800").
+        place: Substring of the place name.
+        note: Substring to search for in notes.
+        """
+        f, err = _open_sidebar_filter("Events")
+        if err:
+            return err
+        f.clear(None)
+        if description:  f.filter_desc.set_text(description)
+        if participants: f.filter_mainparts.set_text(participants)
+        if date:         f.filter_date.set_text(date)
+        if place:        f.filter_place.set_text(place)
+        if note:         f.filter_note.set_text(note)
+        f.clicked(None)
+        applied = {k: v for k, v in [("description", description), ("participants", participants),
+                                      ("date", date), ("place", place), ("note", note)] if v}
+        return {"filter": applied, "results": get_view_results()}
+
+    def filter_places(
+        name: str = "",
+        code: str = "",
+        note: str = "",
+    ) -> str:
+        """
+        Switch to the Places view and filter using the sidebar filter.
+
+        Each parameter is optional; supply only the ones you need.
+        name: Substring of the place name.
+        code: Place code substring.
+        note: Substring to search for in notes.
+        """
+        f, err = _open_sidebar_filter("Places")
+        if err:
+            return err
+        f.clear(None)
+        if name: f.filter_name.set_text(name)
+        if code: f.filter_code.set_text(code)
+        if note: f.filter_note.set_text(note)
+        f.clicked(None)
+        applied = {k: v for k, v in [("name", name), ("code", code), ("note", note)] if v}
+        return {"filter": applied, "results": get_view_results()}
+
+    def filter_sources(
+        title: str = "",
+        author: str = "",
+        abbreviation: str = "",
+        publication: str = "",
+        note: str = "",
+    ) -> str:
+        """
+        Switch to the Sources view and filter using the sidebar filter.
+
+        Each parameter is optional; supply only the ones you need.
+        title: Substring of the source title.
+        author: Substring of the author name.
+        abbreviation: Substring of the abbreviation.
+        publication: Substring of the publication info.
+        note: Substring to search for in notes.
+        """
+        f, err = _open_sidebar_filter("Sources")
+        if err:
+            return err
+        f.clear(None)
+        if title:        f.filter_title.set_text(title)
+        if author:       f.filter_author.set_text(author)
+        if abbreviation: f.filter_abbr.set_text(abbreviation)
+        if publication:  f.filter_pub.set_text(publication)
+        if note:         f.filter_note.set_text(note)
+        f.clicked(None)
+        applied = {k: v for k, v in [("title", title), ("author", author),
+                                      ("abbreviation", abbreviation), ("publication", publication),
+                                      ("note", note)] if v}
+        return {"filter": applied, "results": get_view_results()}
+
+    def filter_citations(
+        source_title: str = "",
+        source_author: str = "",
+        page: str = "",
+        date: str = "",
+        note: str = "",
+    ) -> str:
+        """
+        Switch to the Citations view and filter using the sidebar filter.
+
+        Each parameter is optional; supply only the ones you need.
+        source_title: Substring of the source title.
+        source_author: Substring of the source author.
+        page: Volume/page substring.
+        date: Date expression (e.g. "1760", "before 1800").
+        note: Substring to search for in notes.
+        """
+        f, err = _open_sidebar_filter("Citations")
+        if err:
+            return err
+        f.clear(None)
+        if source_title:  f.filter_src_title.set_text(source_title)
+        if source_author: f.filter_src_author.set_text(source_author)
+        if page:          f.filter_page.set_text(page)
+        if date:          f.filter_date.set_text(date)
+        if note:          f.filter_note.set_text(note)
+        f.clicked(None)
+        applied = {k: v for k, v in [("source_title", source_title), ("source_author", source_author),
+                                      ("page", page), ("date", date), ("note", note)] if v}
+        return {"filter": applied, "results": get_view_results()}
+
+    def filter_media(
+        title: str = "",
+        mime_type: str = "",
+        path: str = "",
+        date: str = "",
+        note: str = "",
+    ) -> str:
+        """
+        Switch to the Media view and filter using the sidebar filter.
+
+        Each parameter is optional; supply only the ones you need.
+        title: Substring of the media title.
+        mime_type: MIME type substring (e.g. "image/jpeg").
+        path: Substring of the file path.
+        date: Date expression.
+        note: Substring to search for in notes.
+        """
+        f, err = _open_sidebar_filter("Media")
+        if err:
+            return err
+        f.clear(None)
+        if title:     f.filter_title.set_text(title)
+        if mime_type: f.filter_type.set_text(mime_type)
+        if path:      f.filter_path.set_text(path)
+        if date:      f.filter_date.set_text(date)
+        if note:      f.filter_note.set_text(note)
+        f.clicked(None)
+        applied = {k: v for k, v in [("title", title), ("mime_type", mime_type),
+                                      ("path", path), ("date", date), ("note", note)] if v}
+        return {"filter": applied, "results": get_view_results()}
+
+    def filter_repositories(
+        name: str = "",
+        address: str = "",
+        url: str = "",
+        note: str = "",
+    ) -> str:
+        """
+        Switch to the Repositories view and filter using the sidebar filter.
+
+        Each parameter is optional; supply only the ones you need.
+        name: Substring of the repository name.
+        address: Substring of the address.
+        url: Substring of the URL.
+        note: Substring to search for in notes.
+        """
+        f, err = _open_sidebar_filter("Repositories")
+        if err:
+            return err
+        f.clear(None)
+        if name:    f.filter_title.set_text(name)
+        if address: f.filter_address.set_text(address)
+        if url:     f.filter_url.set_text(url)
+        if note:    f.filter_note.set_text(note)
+        f.clicked(None)
+        applied = {k: v for k, v in [("name", name), ("address", address),
+                                      ("url", url), ("note", note)] if v}
+        return {"filter": applied, "results": get_view_results()}
+
+    def filter_notes(
+        text: str = "",
+    ) -> str:
+        """
+        Switch to the Notes view and filter using the sidebar filter.
+
+        text: Substring to search for within note text.
+        """
+        f, err = _open_sidebar_filter("Notes")
+        if err:
+            return err
+        f.clear(None)
+        if text: f.filter_text.set_text(text)
+        f.clicked(None)
+        applied = {"text": text} if text else {}
+        return {"filter": applied, "results": get_view_results()}
+
+    def get_view_results(page_number: int = 0, page_size: int = 100) -> dict:
+        """
+        Get items currently shown in the active Gramps view after filtering.
+
+        All data comes from the in-memory list model — no database lookups.
+        page_number: Zero-based page number (default 0).
+        page_size: Number of items per page (1–100, default 100).
+        """
+        import re as _re
+        _strip_markup = lambda s: _re.sub(r"<[^>]+>", "", s)
+
+        page_size = max(1, min(100, page_size))
+
+        vm = uistate.viewmanager
+        active = vm.active_page
+        if active is None:
+            return {"error": "No active view."}
+
+        model = getattr(active, "model", None)
+        if model is None or not hasattr(model, "node_map"):
+            model_type = type(model).__name__ if model is not None else "None"
+            model_attrs = [a for a in dir(model) if not a.startswith("__")] if model is not None else []
+            return {"error": "Current view does not expose a filterable list model.",
+                    "model_type": model_type,
+                    "model_attrs": model_attrs}
+
+        node_map = model.node_map
+        index2hndl = node_map._index2hndl
+        total = len(index2hndl)
+
+        if total == 0:
+            return {"total": 0, "page": page_number, "total_pages": 0, "items": []}
+
+        start = page_number * page_size
+        total_pages = (total + page_size - 1) // page_size
+        if start >= total:
+            return {"error": f"Page {page_number} is out of range.",
+                    "total": total, "total_pages": total_pages}
+
+        end = min(start + page_size, total)
+        n_cols = model.get_n_columns()
+
+        items = []
+        for pos in range(start, end):
+            _, handle = index2hndl[pos]
+            try:
+                iter_ = model.get_iter_from_handle(handle)
+            except Exception:
+                items.append({"error": True})
+                continue
+            values = []
+            seen: set = set()
+            for col in range(min(n_cols, 8)):
+                try:
+                    val = model.get_value(iter_, col)
+                    if isinstance(val, str):
+                        val = _strip_markup(val).strip()
+                        if val and val not in seen:
+                            seen.add(val)
+                            values.append(val)
+                except Exception:
+                    pass
+            items.append({"values": values})
+
+        return {"total": total, "page": page_number, "total_pages": total_pages, "items": items}
+
+    _tool_tags = {
+        "get_active_person":    {"always"},
+        "get_view_results":     {"always"},
+        "switch_to_view":       {"always"},
+        "get_person_details":   {"people"},
+        "set_active_person":    {"people"},
+        "edit_active_person":   {"people"},
+        "filter_people":        {"people"},
+        "filter_families":      {"families"},
+        "filter_events":        {"events"},
+        "filter_places":        {"places"},
+        "filter_sources":       {"sources"},
+        "filter_citations":     {"sources"},
+        "filter_media":         {"media"},
+        "filter_repositories":  {"repositories"},
+        "filter_notes":         {"notes"},
+        "search_in_view":       {"people", "families", "events", "places",
+                                 "sources", "media", "repositories", "notes"},
+    }
+
+    for func in [get_person_details, get_active_person, set_active_person,
+                 get_view_results,
+                 switch_to_view, search_in_view,
+                 filter_people, filter_families, filter_events, filter_places,
+                 filter_sources, filter_citations, filter_media,
+                 filter_repositories, filter_notes,
+                 edit_active_person]:
+        if func.__name__ not in existing_names:
+            tool = Tool.from_function(func)
+            tool.tags = _tool_tags.get(func.__name__, set())
+            tool_registry.append(tool)
+            _LOG.debug("Registered Gramps tool: %s", func.__name__)
+
+
+# ---------------------------------------------------------------------------
+# Gramps wiki search tool (registered at import time, no db needed)
+# ---------------------------------------------------------------------------
+
+
+@register_tool(tags={"always"})
+def search_wikipedia(query: str) -> str:
+    """
+    Search Wikipedia for articles matching a query and return summaries.
+
+    Useful for looking up historical context, places, surnames, events,
+    and general genealogical background information.
+    query: The search terms (e.g. 'Ellis Island immigration history').
+    """
+    import html as _html
+    import urllib.parse
+    import urllib.request
+
+    # Step 1: find matching page titles
+    search_params = urllib.parse.urlencode({
+        "action": "query",
+        "list": "search",
+        "srsearch": query,
+        "srlimit": 3,
+        "utf8": 1,
+        "format": "json",
+    })
+    search_url = "https://en.wikipedia.org/w/api.php?" + search_params
+    req = urllib.request.Request(
+        search_url, headers={"User-Agent": "GrampsAssist/1.0 (genealogy research tool)"}
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            data = resp.read().decode("utf-8", errors="replace")
+    except Exception as exc:
+        return f"Wikipedia search failed: {exc}"
+
+    import json as _json
+    try:
+        search_data = _json.loads(data)
+    except Exception:
+        return "Wikipedia search returned unparseable data."
+
+    hits = search_data.get("query", {}).get("search", [])
+    if not hits:
+        return f"No Wikipedia articles found for '{query}'."
+
+    titles = [h["title"] for h in hits]
+
+    # Step 2: fetch intro extracts for those titles
+    extract_params = urllib.parse.urlencode({
+        "action": "query",
+        "prop": "extracts",
+        "exintro": True,
+        "explaintext": True,
+        "exsentences": 3,
+        "titles": "|".join(titles),
+        "utf8": 1,
+        "format": "json",
+    })
+    extract_url = "https://en.wikipedia.org/w/api.php?" + extract_params
+    req2 = urllib.request.Request(
+        extract_url, headers={"User-Agent": "GrampsAssist/1.0 (genealogy research tool)"}
+    )
+    try:
+        with urllib.request.urlopen(req2, timeout=15) as resp2:
+            ext_data = _json.loads(resp2.read().decode("utf-8", errors="replace"))
+    except Exception as exc:
+        return f"Wikipedia extract fetch failed: {exc}"
+
+    pages = ext_data.get("query", {}).get("pages", {})
+    # Build title → extract map
+    extract_map = {
+        page["title"]: page.get("extract", "").strip()
+        for page in pages.values()
+    }
+
+    lines = []
+    for title in titles:
+        url = "https://en.wikipedia.org/wiki/" + urllib.parse.quote(title.replace(" ", "_"))
+        extract = extract_map.get(title, "")
+        if len(extract) > 300:
+            extract = extract[:297] + "..."
+        entry = f"{title}\n  {url}"
+        if extract:
+            entry += f"\n  {extract}"
+        lines.append(entry)
+
+    return f"Wikipedia results for '{query}':\n\n" + "\n\n".join(lines)
+
+
+# @register_tool
+# def search_gramps_wiki(query: str, max_results: int = 5) -> str:
+#     """
+#     Search the Gramps Project wiki for pages matching a query.
+
+#     Returns the titles, URLs, and brief excerpts of the top matching pages.
+#     Useful for answering questions about how to use Gramps, its features,
+#     and genealogy workflows documented on the wiki.
+#     """
+#     import html as _html
+#     import re
+#     import urllib.parse
+#     import urllib.request
+
+#     params = urllib.parse.urlencode(
+#         {"title": "Special:Search", "search": query, "fulltext": "Search"}
+#     )
+#     url = "https://www.gramps-project.org/wiki/index.php?" + params
+#     req = urllib.request.Request(url, headers={"User-Agent": "GrampsChatbot/1.0"})
+#     try:
+#         with urllib.request.urlopen(req, timeout=15) as resp:
+#             body = resp.read().decode("utf-8", errors="replace")
+#     except Exception as exc:
+#         return f"Wiki search failed: {exc}"
+
+#     # Each search hit is wrapped in an <li class="mw-search-result ..."> block
+#     items = re.findall(
+#         r'class="mw-search-result[^"]*".*?</li>',
+#         body,
+#         re.DOTALL,
+#     )
+
+#     _tag_re = re.compile(r"<[^>]+>")
+#     _ws_re = re.compile(r"\s+")
+
+#     lines = []
+#     for item in items[: int(max_results)]:
+#         m = re.search(
+#             r'class="mw-search-result-heading".*?href="([^"]+)"[^>]*>([^<]+)',
+#             item,
+#             re.DOTALL,
+#         )
+#         if not m:
+#             continue
+#         href = m.group(1)
+#         title = _html.unescape(m.group(2)).strip()
+#         page_url = (
+#             "https://www.gramps-project.org" + href
+#             if href.startswith("/")
+#             else href
+#         )
+#         s = re.search(r'class="searchresult"[^>]*>(.*?)</div>', item, re.DOTALL)
+#         snippet = ""
+#         if s:
+#             snippet = _ws_re.sub(
+#                 " ", _tag_re.sub("", _html.unescape(s.group(1)))
+#             ).strip()
+#             if len(snippet) > 200:
+#                 snippet = snippet[:197] + "..."
+#         lines.append(
+#             f"{title}\n  {page_url}" + (f"\n  {snippet}" if snippet else "")
+#         )
+
+#     if not lines:
+#         return f"No Gramps wiki pages found for '{query}'."
+#     return f"Gramps wiki results for '{query}':\n\n" + "\n\n".join(lines)

--- a/GrampsAssistant/tools.py
+++ b/GrampsAssistant/tools.py
@@ -243,16 +243,31 @@ def get_tools_schema(backend_type: str = "openai", tags=None) -> List[Dict]:
     return [t.to_openai_schema() for t in tools]
 
 
-def call_tool(name: str, args: Dict) -> str:
+class _AwaitUserExecution:
     """
-    Find the tool named *name*, call it with *args*, and return the result
-    as a JSON string.
+    Sentinel returned by execute_script when code has been staged in the
+    GrampyScript buffer and the model is waiting for the user to press Execute.
+    Detected by _execute_tool_on_main, which connects a one-shot button handler
+    instead of immediately returning a result to the backend.
+    """
+    def __init__(self, instance):
+        self.instance = instance
+
+
+def call_tool(name: str, args: Dict):
+    """
+    Find the tool named *name*, call it with *args*, and return the result.
+
+    Normally returns a JSON string.  For execute_script, may return an
+    ``_AwaitUserExecution`` sentinel — the caller must handle that case.
 
     Raises ``KeyError`` if no such tool is registered.
     """
     for tool in tool_registry:
         if tool.name == name:
             result = tool.func(**args)
+            if isinstance(result, _AwaitUserExecution):
+                return result
             return json.dumps(result, ensure_ascii=False, default=str)
     raise KeyError(f"No tool named {name!r}")
 
@@ -1286,10 +1301,7 @@ def register_gramps_tools(dbstate, uistate):
             )
 
         instance.ebuf.set_text(code)
-        output = instance.execute_code(code) or "Script executed with no output."
-        if "Traceback (most recent call last)" in output:
-            return "Script error — fix and retry:\n" + output
-        return output
+        return _AwaitUserExecution(instance)
 
     for func in [get_person_details, get_active_person, get_home_person, set_active_person,
                  get_view_results,

--- a/GrampsAssistant/tools.py
+++ b/GrampsAssistant/tools.py
@@ -912,25 +912,295 @@ def register_gramps_tools(dbstate, uistate):
 
         return {"total": total, "page": page_number, "total_pages": total_pages, "items": items}
 
+    def is_person_alive(gramps_id: str) -> dict:
+        """
+        Check whether a person is probably alive, using Gramps' built-in heuristic.
+
+        Uses birth, death, and family dates to estimate whether the person is
+        still living. Returns a best-guess boolean and a plain-English explanation
+        of the reasoning.
+        gramps_id: The Gramps ID of the person (e.g. I0001).
+        """
+        if not dbstate.is_open():
+            return {"error": "No database is currently open."}
+        db = dbstate.db
+        person = db.get_person_from_gramps_id(gramps_id)
+        if person is None:
+            return {"error": f"No person found with ID '{gramps_id}'."}
+        from gramps.gen.utils.alive import probably_alive
+        alive, birth, death, explanation, _relative = probably_alive(
+            person, db, return_range=True
+        )
+        from gramps.gen.datehandler import displayer as date_displayer
+        result = {"gramps_id": gramps_id, "probably_alive": alive, "explanation": explanation}
+        if birth and birth.is_valid():
+            result["estimated_birth"] = date_displayer.display(birth)
+        if death and death.is_valid():
+            result["estimated_death"] = date_displayer.display(death)
+        return result
+
+    def find_relationship(gramps_id_a: str, gramps_id_b: str) -> dict:
+        """
+        Find the relationship between two people in the database.
+
+        Returns a human-readable relationship string such as
+        'second cousin twice removed' or 'great-grandmother'.
+        gramps_id_a: Gramps ID of the first person (e.g. I0001).
+        gramps_id_b: Gramps ID of the second person (e.g. I0042).
+        """
+        if not dbstate.is_open():
+            return {"error": "No database is currently open."}
+        db = dbstate.db
+        person_a = db.get_person_from_gramps_id(gramps_id_a)
+        if person_a is None:
+            return {"error": f"No person found with ID '{gramps_id_a}'."}
+        person_b = db.get_person_from_gramps_id(gramps_id_b)
+        if person_b is None:
+            return {"error": f"No person found with ID '{gramps_id_b}'."}
+        from gramps.gen.relationship import get_relationship_calculator
+        from gramps.gen.display.name import displayer as name_displayer
+        calc = get_relationship_calculator()
+        rel_str, dist_a, dist_b = calc.get_one_relationship(
+            db, person_a, person_b, extra_info=True
+        )
+        return {
+            "person_a": {"gramps_id": gramps_id_a, "name": name_displayer.display(person_a)},
+            "person_b": {"gramps_id": gramps_id_b, "name": name_displayer.display(person_b)},
+            "relationship": rel_str if rel_str else "no relationship found",
+            "distance_from_a": dist_a,
+            "distance_from_b": dist_b,
+        }
+
+    def get_database_statistics() -> dict:
+        """
+        Return a summary of how many records are in the currently open database.
+
+        Counts people, families, events, places, sources, citations, media
+        objects, notes, repositories, and tags.
+        """
+        if not dbstate.is_open():
+            return {"error": "No database is currently open."}
+        db = dbstate.db
+        return {
+            "people":       db.get_number_of_people(),
+            "families":     db.get_number_of_families(),
+            "events":       db.get_number_of_events(),
+            "places":       db.get_number_of_places(),
+            "sources":      db.get_number_of_sources(),
+            "citations":    db.get_number_of_citations(),
+            "media":        db.get_number_of_media(),
+            "notes":        db.get_number_of_notes(),
+            "repositories": db.get_number_of_repositories(),
+            "tags":         db.get_number_of_tags(),
+        }
+
+    def get_person_events(gramps_id: str) -> dict:
+        """
+        Get all recorded events for a person, not just birth and death.
+
+        Returns each event's type, date, place, and description.
+        Useful for seeing a full life timeline including baptism, marriage,
+        census, immigration, military service, occupation, and more.
+        gramps_id: The Gramps ID of the person (e.g. I0001).
+        """
+        if not dbstate.is_open():
+            return {"error": "No database is currently open."}
+        db = dbstate.db
+        person = db.get_person_from_gramps_id(gramps_id)
+        if person is None:
+            return {"error": f"No person found with ID '{gramps_id}'."}
+        from gramps.gen.display.name import displayer as name_displayer
+        from gramps.gen.datehandler import displayer as date_displayer
+        events = []
+        for event_ref in person.get_event_ref_list():
+            event = db.get_event_from_handle(event_ref.ref)
+            if event is None:
+                continue
+            entry = {
+                "type": str(event.get_type()),
+                "role": str(event_ref.get_role()),
+                "date": date_displayer.display(event.get_date_object()),
+                "description": event.get_description(),
+            }
+            place_handle = event.get_place_handle()
+            if place_handle:
+                place = db.get_place_from_handle(place_handle)
+                if place:
+                    entry["place"] = place.get_name().get_value()
+            events.append(entry)
+        from gramps.gen.display.name import displayer as name_displayer
+        return {
+            "gramps_id": gramps_id,
+            "name": name_displayer.display(person),
+            "events": events,
+        }
+
+    def get_children(gramps_id: str) -> dict:
+        """
+        Get all children of a person.
+
+        Returns a list of children with their names and Gramps IDs,
+        grouped by family (spouse).
+        gramps_id: The Gramps ID of the person (e.g. I0001).
+        """
+        if not dbstate.is_open():
+            return {"error": "No database is currently open."}
+        db = dbstate.db
+        person = db.get_person_from_gramps_id(gramps_id)
+        if person is None:
+            return {"error": f"No person found with ID '{gramps_id}'."}
+        from gramps.gen.display.name import displayer as name_displayer
+        families = []
+        for family_handle in person.get_family_handle_list():
+            family = db.get_family_from_handle(family_handle)
+            if not family:
+                continue
+            father_h = family.get_father_handle()
+            mother_h = family.get_mother_handle()
+            spouse_h = mother_h if father_h == person.get_handle() else father_h
+            family_entry = {"family_id": family.get_gramps_id(), "children": []}
+            if spouse_h:
+                spouse = db.get_person_from_handle(spouse_h)
+                if spouse:
+                    family_entry["spouse"] = {
+                        "name": name_displayer.display(spouse),
+                        "gramps_id": spouse.get_gramps_id(),
+                    }
+            for child_ref in family.get_child_ref_list():
+                child = db.get_person_from_handle(child_ref.ref)
+                if child:
+                    family_entry["children"].append({
+                        "name": name_displayer.display(child),
+                        "gramps_id": child.get_gramps_id(),
+                    })
+            families.append(family_entry)
+        return {
+            "gramps_id": gramps_id,
+            "name": name_displayer.display(person),
+            "families": families,
+        }
+
+    def get_siblings(gramps_id: str) -> dict:
+        """
+        Get all siblings of a person.
+
+        Returns a list of siblings with their names and Gramps IDs.
+        Half-siblings (from different parents) are included and labelled.
+        gramps_id: The Gramps ID of the person (e.g. I0001).
+        """
+        if not dbstate.is_open():
+            return {"error": "No database is currently open."}
+        db = dbstate.db
+        person = db.get_person_from_gramps_id(gramps_id)
+        if person is None:
+            return {"error": f"No person found with ID '{gramps_id}'."}
+        from gramps.gen.display.name import displayer as name_displayer
+        seen = set()
+        seen.add(person.get_handle())
+        siblings = []
+        for family_handle in person.get_parent_family_handle_list():
+            family = db.get_family_from_handle(family_handle)
+            if not family:
+                continue
+            for child_ref in family.get_child_ref_list():
+                handle = child_ref.ref
+                if handle in seen:
+                    continue
+                seen.add(handle)
+                sibling = db.get_person_from_handle(handle)
+                if sibling:
+                    siblings.append({
+                        "name": name_displayer.display(sibling),
+                        "gramps_id": sibling.get_gramps_id(),
+                    })
+        return {
+            "gramps_id": gramps_id,
+            "name": name_displayer.display(person),
+            "siblings": siblings,
+        }
+
+    def get_ancestors(gramps_id: str, max_generations: int = 4) -> dict:
+        """
+        Get ancestors of a person up to a given number of generations.
+
+        Returns a flat list of ancestors with their names, Gramps IDs, and
+        generation number (1 = parents, 2 = grandparents, etc.).
+        gramps_id: The Gramps ID of the person (e.g. I0001).
+        max_generations: How many generations back to search (default 4, max 10).
+        """
+        if not dbstate.is_open():
+            return {"error": "No database is currently open."}
+        db = dbstate.db
+        person = db.get_person_from_gramps_id(gramps_id)
+        if person is None:
+            return {"error": f"No person found with ID '{gramps_id}'."}
+        from gramps.gen.display.name import displayer as name_displayer
+        max_generations = max(1, min(10, max_generations))
+        ancestors = []
+        seen = set()
+        queue = [(person.get_handle(), 0)]
+        while queue:
+            handle, gen = queue.pop(0)
+            if gen == 0:
+                for family_handle in db.get_person_from_handle(handle).get_parent_family_handle_list():
+                    family = db.get_family_from_handle(family_handle)
+                    if not family:
+                        continue
+                    for parent_h in [family.get_father_handle(), family.get_mother_handle()]:
+                        if parent_h and parent_h not in seen:
+                            seen.add(parent_h)
+                            queue.append((parent_h, 1))
+                continue
+            ancestor = db.get_person_from_handle(handle)
+            if not ancestor:
+                continue
+            ancestors.append({
+                "name": name_displayer.display(ancestor),
+                "gramps_id": ancestor.get_gramps_id(),
+                "generation": gen,
+            })
+            if gen < max_generations:
+                for family_handle in ancestor.get_parent_family_handle_list():
+                    family = db.get_family_from_handle(family_handle)
+                    if not family:
+                        continue
+                    for parent_h in [family.get_father_handle(), family.get_mother_handle()]:
+                        if parent_h and parent_h not in seen:
+                            seen.add(parent_h)
+                            queue.append((parent_h, gen + 1))
+        return {
+            "gramps_id": gramps_id,
+            "name": name_displayer.display(person),
+            "max_generations": max_generations,
+            "ancestors": ancestors,
+        }
+
     _tool_tags = {
-        "get_active_person":    {"always"},
-        "get_home_person":      {"always"},
-        "get_view_results":     {"always"},
-        "switch_to_view":       {"always"},
-        "get_person_details":   {"people"},
-        "set_active_person":    {"people"},
-        "edit_active_person":   {"people"},
-        "filter_people":        {"people"},
-        "filter_families":      {"families"},
-        "filter_events":        {"events"},
-        "filter_places":        {"places"},
-        "filter_sources":       {"sources"},
-        "filter_citations":     {"sources"},
-        "filter_media":         {"media"},
-        "filter_repositories":  {"repositories"},
-        "filter_notes":         {"notes"},
-        "search_in_view":       {"people", "families", "events", "places",
-                                 "sources", "media", "repositories", "notes"},
+        "get_active_person":      {"always"},
+        "get_home_person":        {"always"},
+        "get_view_results":       {"always"},
+        "switch_to_view":         {"always"},
+        "get_database_statistics": {"always"},
+        "get_person_details":     {"people"},
+        "set_active_person":      {"people"},
+        "edit_active_person":     {"people"},
+        "filter_people":          {"people"},
+        "is_person_alive":        {"people"},
+        "find_relationship":      {"people"},
+        "get_person_events":      {"people"},
+        "get_children":           {"people", "families"},
+        "get_siblings":           {"people"},
+        "get_ancestors":          {"people"},
+        "filter_families":        {"families"},
+        "filter_events":          {"events"},
+        "filter_places":          {"places"},
+        "filter_sources":         {"sources"},
+        "filter_citations":       {"sources"},
+        "filter_media":           {"media"},
+        "filter_repositories":    {"repositories"},
+        "filter_notes":           {"notes"},
+        "search_in_view":         {"people", "families", "events", "places",
+                                   "sources", "media", "repositories", "notes"},
     }
 
     for func in [get_person_details, get_active_person, get_home_person, set_active_person,
@@ -939,7 +1209,9 @@ def register_gramps_tools(dbstate, uistate):
                  filter_people, filter_families, filter_events, filter_places,
                  filter_sources, filter_citations, filter_media,
                  filter_repositories, filter_notes,
-                 edit_active_person]:
+                 edit_active_person,
+                 is_person_alive, find_relationship, get_database_statistics,
+                 get_person_events, get_children, get_siblings, get_ancestors]:
         if func.__name__ not in existing_names:
             tool = Tool.from_function(func)
             tool.tags = _tool_tags.get(func.__name__, set())

--- a/GrampsAssistant/tools.py
+++ b/GrampsAssistant/tools.py
@@ -39,7 +39,7 @@ import typing
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional
 
-_LOG = logging.getLogger(__name__)
+_LOG = logging.getLogger("gramps-assistant.tools")
 
 # ---------------------------------------------------------------------------
 # Python type → JSON Schema type mapping
@@ -1181,6 +1181,7 @@ def register_gramps_tools(dbstate, uistate):
         "get_view_results":       {"always"},
         "switch_to_view":         {"always"},
         "get_database_statistics": {"always"},
+        "execute_script":         {"always"},
         "get_person_details":     {"people"},
         "set_active_person":      {"people"},
         "edit_active_person":     {"people"},
@@ -1203,6 +1204,93 @@ def register_gramps_tools(dbstate, uistate):
                                    "sources", "media", "repositories", "notes"},
     }
 
+    def execute_script(code: str) -> str:
+        """
+        Write and execute a GrampyScript to query or analyze the Gramps database.
+
+        The script runs in the GrampyScript panel (opened automatically if needed),
+        so the user can see the results and any errors there.
+
+        Available API:
+          people(), families(), events(), places(), sources(), citations(),
+          media(), notes(), repositories()  -- iterate all objects of that type
+          active_person, active_family, active_event, active_place,
+          active_source, active_citation, active_media, active_note  -- active object
+          row(*values)    -- emit a table row (columns auto-detected from code)
+          columns(*names) -- explicitly name the output table columns
+          print(...)      -- write text to the output area
+          today           -- a Date object for today
+          counter()       -- returns a defaultdict(int) for tallying
+
+        Example -- list people born before 1800:
+            for p in people():
+                if p.birth_year and int(p.birth_year) < 1800:
+                    row(p.gramps_id, p.name, p.birth_year)
+
+        Write clean, readable code -- it will be shown to the user so they can
+        learn the GrampyScript API and re-run it themselves.
+
+        If the output contains "Traceback" or "Error", the script failed.
+        Read the error, fix the code, and call execute_script again with the
+        corrected code.
+        code: Valid GrampyScript Python code to execute.
+        """
+        import sys
+
+        # Locate the active page's sidebar — the module may not be in
+        # sys.modules yet because gramplet plugins load on first instantiation.
+        vm = uistate.viewmanager
+        page = getattr(vm, "active_page", None)
+        if page is None:
+            for p in getattr(vm, "pages", []):
+                if getattr(p, "sidebar", None) is not None:
+                    page = p
+                    break
+
+        sidebar = getattr(page, "sidebar", None) if page is not None else None
+
+        if sidebar is None:
+            return "Could not find a view with a sidebar to open GrampyScript in."
+
+        if not sidebar.is_visible():
+            sidebar.show()
+
+        if not sidebar.has_gramplet("Grampy Script"):
+            # add_gramplet imports and instantiates the class, setting _instance
+            sidebar.add_gramplet("Grampy Script")
+        else:
+            # Already present — make sure it is the selected tab
+            for i in range(sidebar.get_n_pages()):
+                tab = sidebar.get_nth_page(i)
+                if tab and hasattr(getattr(tab, "pui", None), "execute_code"):
+                    sidebar.set_current_page(i)
+                    break
+
+        # Module is now loaded (either it was before, or add_gramplet just loaded it)
+        grampy_module = sys.modules.get("GrampyScript")
+        if grampy_module is None:
+            return "GrampyScript addon is not installed. Please install it first."
+
+        instance = grampy_module._instance
+        if instance is None:
+            return "GrampyScript was added to the sidebar but could not be initialised."
+
+        import ast
+        try:
+            ast.parse(code)
+        except SyntaxError as e:
+            return (
+                f"Syntax error in script at line {e.lineno}: {e.msg}\n"
+                f"  {e.text}"
+                f"Please fix the code and call execute_script again."
+            )
+
+        instance.ebuf.set_text(code)
+        output = instance.execute_code(code) or "Script executed with no output."
+        if "Traceback (most recent call last)" in output:
+            return "Script error — fix and retry:\n" + output
+        return output
+
     for func in [get_person_details, get_active_person, get_home_person, set_active_person,
                  get_view_results,
                  switch_to_view, search_in_view,
@@ -1211,7 +1299,8 @@ def register_gramps_tools(dbstate, uistate):
                  filter_repositories, filter_notes,
                  edit_active_person,
                  is_person_alive, find_relationship, get_database_statistics,
-                 get_person_events, get_children, get_siblings, get_ancestors]:
+                 get_person_events, get_children, get_siblings, get_ancestors,
+                 execute_script]:
         if func.__name__ not in existing_names:
             tool = Tool.from_function(func)
             tool.tags = _tool_tags.get(func.__name__, set())

--- a/GrampsAssistant/tools.py
+++ b/GrampsAssistant/tools.py
@@ -387,6 +387,21 @@ def register_gramps_tools(dbstate, uistate):
         person = dbstate.db.get_person_from_handle(handle)
         return _format_person_details(dbstate.db, person)
 
+    def get_home_person() -> dict:
+        """
+        Get information about the home person (default person) of the Gramps database.
+
+        The home person is the default person set in Gramps preferences,
+        distinct from whoever is currently selected.
+        Returns full details including name, birth, death, parents, spouses, and children.
+        """
+        if not dbstate.is_open():
+            return {"error": "No database is currently open."}
+        person = dbstate.db.get_default_person()
+        if person is None:
+            return {"error": "No home person is set in this database."}
+        return _format_person_details(dbstate.db, person)
+
     def switch_to_view(category_name: str) -> dict:
         """
         Switch the main Gramps window to a named view category.
@@ -899,6 +914,7 @@ def register_gramps_tools(dbstate, uistate):
 
     _tool_tags = {
         "get_active_person":    {"always"},
+        "get_home_person":      {"always"},
         "get_view_results":     {"always"},
         "switch_to_view":       {"always"},
         "get_person_details":   {"people"},
@@ -917,7 +933,7 @@ def register_gramps_tools(dbstate, uistate):
                                  "sources", "media", "repositories", "notes"},
     }
 
-    for func in [get_person_details, get_active_person, set_active_person,
+    for func in [get_person_details, get_active_person, get_home_person, set_active_person,
                  get_view_results,
                  switch_to_view, search_in_view,
                  filter_people, filter_families, filter_events, filter_places,

--- a/GrampyScript/GrampyScript.py
+++ b/GrampyScript/GrampyScript.py
@@ -65,6 +65,9 @@ config.register("defaults.encoding", "utf-8")
 config.register("defaults.delimiter", "comma")
 config.register("defaults.last_filename", "")
 
+_instance = None
+
+
 def contains_any_none_data(args):
     if isinstance(args, list):
         return any(contains_any_none_data(arg) for arg in args)
@@ -193,6 +196,8 @@ class CsvFileChooserDialog(Gtk.FileChooserDialog):
 
 class GrampyScript(Gramplet):
     def init(self):
+        global _instance
+        _instance = self
         self.keywords = [
             "_",
             "and",
@@ -1187,3 +1192,5 @@ for person in people():
         else:
             self.notebook.set_current_page(1)
             self.statusmsg.set_text("Completed")
+
+        return STDOUT


### PR DESCRIPTION
## What is GrampsAssistant?

GrampsAssistant adds an AI chat panel directly inside Gramps. You type a question about your family tree in plain English — \"Who are the children of John Smith?\" or \"Show me all people born in Germany before 1800\" — and the assistant answers using your actual database. It never makes up data: every answer is drawn from tools that query Gramps directly.

The assistant lives in the Gramps sidebar (or opens as a floating window on older Gramps versions). Your conversation is preserved as you switch views, and is cleared only when you click the Clear button or open a different database.

---

## Key Features

### Conversational chat with your family tree
- Ask questions in plain English; the assistant figures out which database queries to run
- Full conversation history is kept so you can ask follow-up questions
- A \"Thinking...\" indicator shows while the assistant is working
- Responses stream in word-by-word, like a modern chat app
- Formatted output: bold, italic, headers, bullet lists, tables, and clickable links all render correctly

### Works with many AI services — including ones running on your own computer
- **Cloud services**: OpenAI (GPT-4, GPT-4o, o3, …), Anthropic (Claude), Google Gemini — pick from a built-in preset list
- **Local / private models**: Ollama, LM Studio, or llama.cpp running on your own machine — no data ever leaves your computer
- No extra Python packages required; all network calls use Python's built-in standard library

### Rich set of database tools the AI can use
The assistant can call over 25 built-in tools to answer your questions:

| Tool | What it does |
|---|---|
| Get active / home person | Returns full details of the person currently selected or set as the default |
| Get person details | Looks up any person by their Gramps ID |
| Get ancestors | Walks the family tree up to N generations back |
| Get children / siblings | Lists all children or siblings of a person |
| Get person events | Returns a person's full life timeline (baptism, census, immigration, …) |
| Is person alive? | Uses Gramps' built-in heuristic to estimate whether someone is still living |
| Find relationship | Calculates the relationship between any two people (\"second cousin twice removed\", etc.) |
| Database statistics | Counts people, families, events, places, sources, and more |
| Navigate to any view | Switches the main Gramps window to People, Families, Events, Places, etc. |
| Filter any list view | Applies sidebar filters in every Gramps list view so results appear visually |
| Search Wikipedia | Looks up historical context (places, surnames, events) to enrich answers |
| Execute GrampyScript | Writes and runs a short script for complex queries; the code is shown to the user so they can learn and re-run it |

### Context-aware
- The assistant automatically knows which person is currently selected in Gramps and includes that context in every message
- An approximate token-count indicator shows how much of the AI's memory the current conversation is using

### Settings
- **System prompt** — customise the assistant's personality or add standing instructions
- **Simplify tools** — when enabled, only the tools relevant to your question are sent to the AI; recommended for smaller local models
- **Local model** — enter the URL and model name of a local Ollama / LM Studio / llama.cpp server
- **Foundational model** — choose from a built-in preset list of cloud providers, or enter a custom backend URL and model name
- **API key** — enter the name of the environment variable that holds your API key (the key itself is never stored in the config file)

---

## File overview

| File | Purpose |
|---|---|
| `grampsassistant.py` | Main UI: chat panel, markdown rendering, streaming, settings dialog |
| `backend.py` | HTTP clients for OpenAI-compatible and Anthropic APIs; optional Opik tracing |
| `tools.py` | Tool registry, JSON Schema derivation, all built-in Gramps database tools |
| `grampsassistant.gpr.py` | Plugin registration (Gramps plugin framework) |
| `tests/` | Unit tests (`python -m pytest GrampsAssistant/tests/`) |

---

## Test plan

- [ ] Install the addon and open Gramps — the Assistant panel should appear in the sidebar
- [ ] Click ⚙ → Settings; confirm System Prompt and Simplify Tools appear at the top
- [ ] Select a cloud preset (e.g. OpenAI – gpt-4o), set the API key env var, send a message → response streams in
- [ ] Ask \"Who is the active person?\" → assistant should name whoever is selected in Gramps
- [ ] Ask \"How many people are in my database?\" → correct count returned
- [ ] Ask \"Show me all people with the surname Smith\" → People view opens with sidebar filter applied
- [ ] Ask \"What is the relationship between I0001 and I0042?\"
- [ ] Select \"Use Local Model\", enter Ollama URL + model, send a message → routes to local model; no data sent to cloud
- [ ] Click Clear → conversation resets, welcome message reappears
- [ ] Run tests: `python -m pytest GrampsAssistant/tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)