### PR TITLE
New "exclude subtree" filter

### DIFF
--- a/excludesubtree.gpr.py
+++ b/excludesubtree.gpr.py
@@ -11,7 +11,7 @@ register(RULE,
   name  = _("All people, starting at <person>, except those in/behind <filter>"),
   description = _("Matches people who are reachable starting from <person> "
       "except those in <filter>."),
-  version = '0.3',
+  version = '0.4',
   authors = ["Jonathan Biegert"],
   authors_email = ["azrdev@gmail.com"],
   gramps_target_version = '5.1',

--- a/excludesubtree.gpr.py
+++ b/excludesubtree.gpr.py
@@ -1,0 +1,22 @@
+
+"""
+Person filter rule including all persons reachable from the active/selected person, except those in the given filter.
+
+This allows to cut partial trees, e.g. exclude everything learned about my spouse but have all non-relatives in my half of the tree.
+"""
+
+# https://github.com/gramps-project/gramps/blob/master/gramps/gen/plug/_pluginreg.py
+register(RULE,
+  id    = 'ExcludeSubtree',
+  name  = _("All people, starting at <person>, except those in/behind <filter>"),
+  description = _("Matches people who are reachable starting from <person> "
+      "except those in <filter>."),
+  version = '0.2',
+  authors = ["Jonathan Biegert"],
+  authors_email = ["azrdev@gmail.com"],
+  gramps_target_version = '5.1',
+  status = UNSTABLE,
+  fname = "excludesubtree.py",
+  ruleclass = 'ExcludeSubtree',  # must be rule class name
+  namespace = 'Person',  # one of the primary object classes
+  )

--- a/excludesubtree.gpr.py
+++ b/excludesubtree.gpr.py
@@ -11,7 +11,7 @@ register(RULE,
   name  = _("All people, starting at <person>, except those in/behind <filter>"),
   description = _("Matches people who are reachable starting from <person> "
       "except those in <filter>."),
-  version = '0.2',
+  version = '0.3',
   authors = ["Jonathan Biegert"],
   authors_email = ["azrdev@gmail.com"],
   gramps_target_version = '5.1',

--- a/excludesubtree.gpr.py
+++ b/excludesubtree.gpr.py
@@ -27,12 +27,12 @@ register(
         "(walking all parents and children of attached families, "
         "recursively) stopping at persons in <Filter>."
     ),
-    version="0.5",
+    version="0.6",
     authors=["Jonathan Biegert"],
     authors_email=["azrdev@gmail.com"],
     gramps_target_version="6.0",
     status=BETA,
     fname="excludesubtree.py",
-    ruleclass="ExcludeSubtree",  # must be rule class name
-    namespace="Person",  # one of the primary object classes
+    ruleclass="ExcludeSubtree",
+    namespace="Person",
 )

--- a/excludesubtree.gpr.py
+++ b/excludesubtree.gpr.py
@@ -1,16 +1,29 @@
-
-"""
-Person filter rule including all persons reachable from the active/selected person, except those in the given filter.
-
-This allows to cut partial trees, e.g. exclude everything learned about my spouse but have all non-relatives in my half of the tree.
-"""
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Jonathan Biegert
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
 
 # https://github.com/gramps-project/gramps/blob/master/gramps/gen/plug/_pluginreg.py
 register(RULE,
   id    = 'ExcludeSubtree',
-  name  = _("All people, starting at <person>, except those in/behind <filter>"),
-  description = _("Matches people who are reachable starting from <person> "
-      "except those in <filter>."),
+  name  = _("People reachable from <Person>, stopping at <Filter> matches"),
+  description = _("Matches people who are reachable starting from <Person> "
+                  "(walking all parents and children of attached families, "
+                  "recursively) stopping at persons in <Filter>."),
   version = '0.5',
   authors = ["Jonathan Biegert"],
   authors_email = ["azrdev@gmail.com"],

--- a/excludesubtree.gpr.py
+++ b/excludesubtree.gpr.py
@@ -18,18 +18,21 @@
 #
 
 # https://github.com/gramps-project/gramps/blob/master/gramps/gen/plug/_pluginreg.py
-register(RULE,
-  id    = 'ExcludeSubtree',
-  name  = _("People reachable from <Person>, stopping at <Filter> matches"),
-  description = _("Matches people who are reachable starting from <Person> "
-                  "(walking all parents and children of attached families, "
-                  "recursively) stopping at persons in <Filter>."),
-  version = '0.5',
-  authors = ["Jonathan Biegert"],
-  authors_email = ["azrdev@gmail.com"],
-  gramps_target_version = '6.0',
-  status = BETA,
-  fname = "excludesubtree.py",
-  ruleclass = 'ExcludeSubtree',  # must be rule class name
-  namespace = 'Person',  # one of the primary object classes
+register(
+    RULE,
+    id="ExcludeSubtree",
+    name=_("People reachable from <Person>, stopping at <Filter> matches"),
+    description=_(
+        "Matches people who are reachable starting from <Person> "
+        "(walking all parents and children of attached families, "
+        "recursively) stopping at persons in <Filter>."
+    ),
+    version="0.5",
+    authors=["Jonathan Biegert"],
+    authors_email=["azrdev@gmail.com"],
+    gramps_target_version="6.0",
+    status=BETA,
+    fname="excludesubtree.py",
+    ruleclass="ExcludeSubtree",  # must be rule class name
+    namespace="Person",  # one of the primary object classes
 )

--- a/excludesubtree.gpr.py
+++ b/excludesubtree.gpr.py
@@ -11,12 +11,12 @@ register(RULE,
   name  = _("All people, starting at <person>, except those in/behind <filter>"),
   description = _("Matches people who are reachable starting from <person> "
       "except those in <filter>."),
-  version = '0.4',
+  version = '0.5',
   authors = ["Jonathan Biegert"],
   authors_email = ["azrdev@gmail.com"],
-  gramps_target_version = '5.1',
-  status = UNSTABLE,
+  gramps_target_version = '6.0',
+  status = BETA,
   fname = "excludesubtree.py",
   ruleclass = 'ExcludeSubtree',  # must be rule class name
   namespace = 'Person',  # one of the primary object classes
-  )
+)

--- a/excludesubtree.py
+++ b/excludesubtree.py
@@ -1,0 +1,80 @@
+import itertools
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+_ = glocale.translation.gettext
+from gramps.gen.filters.rules.person import MatchesFilter
+from gramps.gen.filters.rules import Rule
+
+
+def get_relatives(db, person):
+    """
+    Given a person handle, iterate all existing person handles of its
+    relatives.
+
+    adapted from IsRelatedWith.add_relative()
+    """
+    if person:
+        for h in itertools.chain(
+                # person as child
+                person.get_parent_family_handle_list(),
+                # person as parent
+                person.get_family_handle_list(),
+                ):
+            family = db.get_family_from_handle(h)
+            if family:
+                # parents / spouse
+                yield from (family.get_father_handle(),
+                            family.get_mother_handle())
+                # siblings / children
+                for child_ref in family.get_child_ref_list():
+                    yield child_ref.ref
+
+
+class ExcludeSubtree(Rule):
+    labels = [
+        # strings must match gramps.gui.editors.filtereditor.EditRule.__init__
+        _('ID:'),
+        _('Person filter name:'),  # TODO: also make family possible?
+    ]
+    name = _("People reachable from <Person>, stopping at <Filter> matches")
+    category = _("Relationship filters")
+    description = _("People reachable from <Person>, stopping at <Filter> matches")
+
+    def prepare(self, db, user):
+        self.reset()
+        self.db = db
+
+        if user:
+            user.begin_progress(self.category,
+                                _('Retrieving all sub-filter matches'),
+                                db.get_number_of_people())
+        try:
+            start = db.get_person_from_gramps_id(self.list[0]).handle
+            self.filt = MatchesFilter(self.list[1:])
+            self.filt.requestprepare(db, user)
+
+            # walk the db using a queue
+            search_list = [start]
+            while search_list:
+                if user:
+                    user.step_progress()
+                current_h = search_list.pop()
+                current = db.get_person_from_handle(current_h)
+                if current_h in self.matched_relatives:
+                    continue  # already got them
+                if self.filt.apply(db, current):
+                    continue  # exclude them
+                self.matched_relatives.add(current_h)
+                # add their relatives to the search
+                search_list.extend((h
+                                    for h in get_relatives(db, current)
+                                    if h))
+
+        finally:
+            if user:
+                user.end_progress()
+
+    def reset(self):
+        self.matched_relatives = set()  # set of person handles
+
+    def apply(self, db, person):
+        return person.handle in self.matched_relatives

--- a/excludesubtree.py
+++ b/excludesubtree.py
@@ -3,7 +3,7 @@ from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.gettext
 from gramps.gen.filters.rules.person import MatchesFilter
 from gramps.gen.filters.rules import Rule
-from gramps.gui.editors.filtereditor import MyBoolean, MyID
+from gramps.gui.editors.filtereditor import MyBoolean
 
 
 def get_relatives(db, person):
@@ -34,7 +34,7 @@ class ExcludeSubtree(Rule):
     labels = [
         # see gramps.gui.editors.filtereditor.EditRule.__init__
         # must be (label, widget class) or special string as label
-        (_('Starting Person:'), MyID),
+        _('ID:'),  # starting person
         (_('Include filter matches'), MyBoolean),
         _('Person filter name:'),  # TODO: also allow family filter
     ]

--- a/excludesubtree.py
+++ b/excludesubtree.py
@@ -1,9 +1,14 @@
 import itertools
+import logging
+
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 _ = glocale.translation.gettext
 from gramps.gen.filters.rules.person import MatchesFilter
 from gramps.gen.filters.rules import Rule
 from gramps.gui.editors.filtereditor import MyBoolean
+
+
+LOG = logging.getLogger(__name__)
 
 
 def get_relatives(db, person):
@@ -74,10 +79,11 @@ class ExcludeSubtree(Rule):
                 if user:
                     user.step_progress()
                 current_h = search_list.pop()
-                current = db.get_person_from_handle(current_h)
                 if current_h in self.matched_relatives:
                     continue  # already got them
+                current = db.get_person_from_handle(current_h)
                 if self.filt.apply(db, current):
+                    LOG.debug("Stopping at filter match %s", current.gramps_id)
                     if include_matched:
                         self.matched_relatives.add(current_h)
                     continue  # stop at filter matches
@@ -86,6 +92,7 @@ class ExcludeSubtree(Rule):
                 search_list.extend((h
                                     for h in get_relatives(db, current)
                                     if h))
+            LOG.debug("Found %d relatives", len(self.matched_relatives))
 
         finally:
             if user:

--- a/excludesubtree.py
+++ b/excludesubtree.py
@@ -30,12 +30,24 @@ def get_relatives(db, person):
                     yield child_ref.ref
 
 
+class GUICheckBox(MyBoolean):
+    """
+    Input widget for a boolean filter rule parameter.
+
+    Needed because gramps.gui.editors.filtereditor defines MyBoolean widget
+    with a single `label: str` parameter, but creates custom widgets with a
+    single argument `db` in EditRule.__init__
+    """
+    def __init__(self, db, *args, **kwargs):
+        super().__init__('', *args, **kwargs)  # first argument must be string (hidden label)
+
+
 class ExcludeSubtree(Rule):
     labels = [
         # see gramps.gui.editors.filtereditor.EditRule.__init__
         # must be (label, widget class) or special string as label
         _('ID:'),  # starting person
-        (_('Include filter matches'), MyBoolean),
+        (_('Include filter matches'), GUICheckBox),
         _('Person filter name:'),  # TODO: also allow family filter
     ]
     name = _("People reachable from <Person>, stopping at <Filter> matches")

--- a/excludesubtree.py
+++ b/excludesubtree.py
@@ -48,6 +48,7 @@ class GUICheckBox(MyBoolean):
 
 
 class ExcludeSubtree(Rule):
+    selected_handles: Set[PrimaryObjectHandle] = set([])
     labels = [
         # see gramps.gui.editors.filtereditor.EditRule.__init__
         # must be (label, widget class) or special string as label
@@ -79,28 +80,28 @@ class ExcludeSubtree(Rule):
                 if user:
                     user.step_progress()
                 current_h = search_list.pop()
-                if current_h in self.matched_relatives:
+                if current_h in self.selected_handles:
                     continue  # already got them
                 current = db.get_person_from_handle(current_h)
                 LOG.debug("tree walk arrived at id %s", current.gramps_id)
                 if self.filt.apply_to_one(db, current):
                     LOG.debug("Stopping at filter match %s", current.gramps_id)
                     if include_matched:
-                        self.matched_relatives.add(current_h)
+                        self.selected_handles.add(current_h)
                     continue  # stop at filter matches
-                self.matched_relatives.add(current_h)
+                self.selected_handles.add(current_h)
                 # add their relatives to the search
                 search_list.extend((h
                                     for h in get_relatives(db, current)
                                     if h))
-            LOG.debug("Found %d relatives", len(self.matched_relatives))
+            LOG.debug("Found %d relatives", len(self.selected_handles))
 
         finally:
             if user:
                 user.end_progress()
 
     def reset(self):
-        self.matched_relatives = set()  # set of person handles
+        self.selected_handles = set()  # set of person handles
 
     def apply_to_one(self, db: Database, person: Person) -> bool:
-        return person.handle in self.matched_relatives
+        return person.handle in self.selected_handles

--- a/excludesubtree.py
+++ b/excludesubtree.py
@@ -41,7 +41,7 @@ _ = glocale.translation.gettext
 # Typing modules
 #
 # -------------------------------------------------------------------------
-from typing import Set
+from typing import List, Set
 from gramps.gen.lib import Person
 from gramps.gen.db import Database
 
@@ -57,21 +57,21 @@ def get_relatives(db, person):
     """
     if person:
         for h in itertools.chain(
-                # person as child
-                person.get_parent_family_handle_list(),
-                # person as parent
-                person.get_family_handle_list(),
-                ):
+            # person as child
+            person.get_parent_family_handle_list(),
+            # person as parent
+            person.get_family_handle_list(),
+        ):
             family = db.get_family_from_handle(h)
             if family:
                 # parents / spouse
-                for parent in (family.get_father_handle(),
-                               family.get_mother_handle()):
+                for parent in (family.get_father_handle(), family.get_mother_handle()):
                     if parent:
                         yield parent
                 # siblings / children
                 for child_ref in family.get_child_ref_list():
                     yield child_ref.ref
+
 
 # -------------------------------------------------------------------------
 #
@@ -94,24 +94,28 @@ class ExcludeSubtree(Rule):
         # rule parameters, see
         # gramps.gui.editors.filtereditor.EditRule.__init__
         # must be (label, widget class) or special string as label
-        _('ID:'),  # starting person
-        _('Handle filter matches: include (default), exclude'),
-        _('Person filter name:'),  # TODO: also allow family filter
+        _("ID:"),  # starting person
+        _("Handle filter matches: include (default), exclude"),
+        _("Person filter name:"),  # TODO: also allow family filter
     ]
     name = _("People reachable from <Person>, stopping at <Filter> matches")
     category = _("Relationship filters")
-    description = _("Matches people who are reachable starting from <Person> "
-                    "(walking all parents and children of attached families, "
-                    "recursively) stopping at persons in <Filter>.")
+    description = _(
+        "Matches people who are reachable starting from <Person> "
+        "(walking all parents and children of attached families, "
+        "recursively) stopping at persons in <Filter>."
+    )
 
     def prepare(self, db: Database, user):
         self.reset()
         self.db = db
 
         if user:
-            user.begin_progress(self.category,
-                                _('Retrieving all sub-filter matches'),
-                                db.get_number_of_people())
+            user.begin_progress(
+                self.category,
+                _("Retrieving all sub-filter matches"),
+                db.get_number_of_people(),
+            )
         try:
             # initialize search from filter parameters (passed as self.list)
             start_person = db.get_person_from_gramps_id(self.list[0])
@@ -139,9 +143,7 @@ class ExcludeSubtree(Rule):
                     continue  # stop at filter matches
                 # whitelist person and add their relatives to the queue
                 self.selected_handles.add(current_h)
-                search_list.extend((h
-                                    for h in get_relatives(db, current)
-                                    if h))
+                search_list.extend((h for h in get_relatives(db, current) if h))
             LOG.debug("Found %d relatives", len(self.selected_handles))
 
         finally:

--- a/excludesubtree.py
+++ b/excludesubtree.py
@@ -92,7 +92,7 @@ class ExcludeSubtree(Rule):
     """
 
     # filter rule operation
-    selected_handles: Set[PersonHandle] = set()
+    selected_handles: Set[PersonHandle]
     filt = None  # "stop" person filter
 
     # external interface

--- a/excludesubtree.py
+++ b/excludesubtree.py
@@ -33,7 +33,6 @@ import logging
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 from gramps.gen.filters.rules.person import MatchesFilter
 from gramps.gen.filters.rules import Rule
-from gramps.gui.editors.filtereditor import MyBoolean
 
 _ = glocale.translation.gettext
 
@@ -74,19 +73,6 @@ def get_relatives(db, person):
                 for child_ref in family.get_child_ref_list():
                     yield child_ref.ref
 
-
-class GUICheckBox(MyBoolean):
-    """
-    Input widget for a boolean filter rule parameter.
-
-    Needed because gramps.gui.editors.filtereditor defines MyBoolean widget
-    with a single `label: str` parameter, but creates custom widgets with a
-    single argument `db` in EditRule.__init__
-    """
-    def __init__(self, db, *args, **kwargs):
-        super().__init__('', *args, **kwargs)  # first argument must be string (hidden label)
-
-
 # -------------------------------------------------------------------------
 #
 # ExcludeSubtree
@@ -109,7 +95,7 @@ class ExcludeSubtree(Rule):
         # gramps.gui.editors.filtereditor.EditRule.__init__
         # must be (label, widget class) or special string as label
         _('ID:'),  # starting person
-        (_('Include filter matches'), GUICheckBox),
+        _('Handle filter matches: include (default), exclude'),
         _('Person filter name:'),  # TODO: also allow family filter
     ]
     name = _("People reachable from <Person>, stopping at <Filter> matches")
@@ -131,7 +117,7 @@ class ExcludeSubtree(Rule):
             start_person = db.get_person_from_gramps_id(self.list[0])
             if start_person is None:
                 return
-            include_matched = bool(int(self.list[1]))
+            include_stopfilter_matches = self.list[1] != "exclude"
             self.filt = MatchesFilter(self.list[2:])
             self.filt.requestprepare(db, user)
 
@@ -145,13 +131,14 @@ class ExcludeSubtree(Rule):
                     user.step_progress()
                 current = db.get_person_from_handle(current_h)
                 LOG.debug("tree walk arrived at id %s", current.gramps_id)
+                # check stop filter
                 if self.filt.apply_to_one(db, current):
                     LOG.debug("Stopping at filter match %s", current.gramps_id)
-                    if include_matched:
+                    if include_stopfilter_matches:
                         self.selected_handles.add(current_h)
                     continue  # stop at filter matches
+                # whitelist person and add their relatives to the queue
                 self.selected_handles.add(current_h)
-                # add their relatives to the search
                 search_list.extend((h
                                     for h in get_relatives(db, current)
                                     if h))

--- a/excludesubtree.py
+++ b/excludesubtree.py
@@ -34,7 +34,11 @@ from gramps.gen.const import GRAMPS_LOCALE as glocale
 from gramps.gen.filters.rules.person import MatchesFilter
 from gramps.gen.filters.rules import Rule
 
-_ = glocale.translation.gettext
+try:
+    _trans = glocale.get_addon_translator(__file__)
+except ValueError:
+    _trans = glocale.translation
+_ = _trans.gettext
 
 # -------------------------------------------------------------------------
 #

--- a/excludesubtree.py
+++ b/excludesubtree.py
@@ -59,7 +59,7 @@ class ExcludeSubtree(Rule):
     category = _("Relationship filters")
     description = _("People reachable from <Person>, stopping at <Filter> matches")
 
-    def prepare(self, db, user):
+    def prepare(self, db: Database, user):
         self.reset()
         self.db = db
 
@@ -82,7 +82,8 @@ class ExcludeSubtree(Rule):
                 if current_h in self.matched_relatives:
                     continue  # already got them
                 current = db.get_person_from_handle(current_h)
-                if self.filt.apply(db, current):
+                LOG.debug("tree walk arrived at id %s", current.gramps_id)
+                if self.filt.apply_to_one(db, current):
                     LOG.debug("Stopping at filter match %s", current.gramps_id)
                     if include_matched:
                         self.matched_relatives.add(current_h)
@@ -101,5 +102,5 @@ class ExcludeSubtree(Rule):
     def reset(self):
         self.matched_relatives = set()  # set of person handles
 
-    def apply(self, db, person):
+    def apply_to_one(self, db: Database, person: Person) -> bool:
         return person.handle in self.matched_relatives

--- a/excludesubtree.py
+++ b/excludesubtree.py
@@ -48,6 +48,7 @@ _ = _trans.gettext
 from typing import List, Set
 from gramps.gen.lib import Person
 from gramps.gen.db import Database
+from gramps.gen.types import PersonHandle
 
 LOG = logging.getLogger(__name__)
 
@@ -90,7 +91,7 @@ class ExcludeSubtree(Rule):
     """
 
     # filter rule operation
-    selected_handles: Set[PrimaryObjectHandle] = None
+    selected_handles: Set[PersonHandle] = set()
     filt = None  # "stop" person filter
 
     # external interface
@@ -130,7 +131,7 @@ class ExcludeSubtree(Rule):
             self.filt.requestprepare(db, user)
 
             # walk the db using a queue
-            search_list: List[PrimaryObjectHandle] = [start_person.handle]
+            search_list: List[PersonHandle] = [start_person.handle]
             while search_list:
                 current_h = search_list.pop()
                 if current_h in self.selected_handles:

--- a/excludesubtree.py
+++ b/excludesubtree.py
@@ -1,12 +1,50 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Jonathan Biegert
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, see <https://www.gnu.org/licenses/>.
+#
+
+# -------------------------------------------------------------------------
+#
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
 import itertools
 import logging
 
+# -------------------------------------------------------------------------
+#
+# Gramps modules
+#
+# -------------------------------------------------------------------------
 from gramps.gen.const import GRAMPS_LOCALE as glocale
-_ = glocale.translation.gettext
 from gramps.gen.filters.rules.person import MatchesFilter
 from gramps.gen.filters.rules import Rule
 from gramps.gui.editors.filtereditor import MyBoolean
 
+_ = glocale.translation.gettext
+
+# -------------------------------------------------------------------------
+#
+# Typing modules
+#
+# -------------------------------------------------------------------------
+from typing import Set
+from gramps.gen.lib import Person
+from gramps.gen.db import Database
 
 LOG = logging.getLogger(__name__)
 
@@ -28,8 +66,10 @@ def get_relatives(db, person):
             family = db.get_family_from_handle(h)
             if family:
                 # parents / spouse
-                yield from (family.get_father_handle(),
-                            family.get_mother_handle())
+                for parent in (family.get_father_handle(),
+                               family.get_mother_handle()):
+                    if parent:
+                        yield parent
                 # siblings / children
                 for child_ref in family.get_child_ref_list():
                     yield child_ref.ref
@@ -47,10 +87,26 @@ class GUICheckBox(MyBoolean):
         super().__init__('', *args, **kwargs)  # first argument must be string (hidden label)
 
 
+# -------------------------------------------------------------------------
+#
+# ExcludeSubtree
+#
+# -------------------------------------------------------------------------
 class ExcludeSubtree(Rule):
-    selected_handles: Set[PrimaryObjectHandle] = set([])
+    """
+    Person filter rule including all persons reachable (parents/children in the same families) from the active/selected person, except those in the given filter.
+
+    This allows to cut partial trees, e.g. exclude everything learned about my spouse but have all non-relatives in my half of the tree.
+    """
+
+    # filter rule operation
+    selected_handles: Set[PrimaryObjectHandle] = None
+    filt = None  # "stop" person filter
+
+    # external interface
     labels = [
-        # see gramps.gui.editors.filtereditor.EditRule.__init__
+        # rule parameters, see
+        # gramps.gui.editors.filtereditor.EditRule.__init__
         # must be (label, widget class) or special string as label
         _('ID:'),  # starting person
         (_('Include filter matches'), GUICheckBox),
@@ -58,7 +114,9 @@ class ExcludeSubtree(Rule):
     ]
     name = _("People reachable from <Person>, stopping at <Filter> matches")
     category = _("Relationship filters")
-    description = _("People reachable from <Person>, stopping at <Filter> matches")
+    description = _("Matches people who are reachable starting from <Person> "
+                    "(walking all parents and children of attached families, "
+                    "recursively) stopping at persons in <Filter>.")
 
     def prepare(self, db: Database, user):
         self.reset()
@@ -69,19 +127,22 @@ class ExcludeSubtree(Rule):
                                 _('Retrieving all sub-filter matches'),
                                 db.get_number_of_people())
         try:
-            start = db.get_person_from_gramps_id(self.list[0]).handle
+            # initialize search from filter parameters (passed as self.list)
+            start_person = db.get_person_from_gramps_id(self.list[0])
+            if start_person is None:
+                return
             include_matched = bool(int(self.list[1]))
             self.filt = MatchesFilter(self.list[2:])
             self.filt.requestprepare(db, user)
 
             # walk the db using a queue
-            search_list = [start]
+            search_list: List[PrimaryObjectHandle] = [start_person.handle]
             while search_list:
-                if user:
-                    user.step_progress()
                 current_h = search_list.pop()
                 if current_h in self.selected_handles:
                     continue  # already got them
+                if user:
+                    user.step_progress()
                 current = db.get_person_from_handle(current_h)
                 LOG.debug("tree walk arrived at id %s", current.gramps_id)
                 if self.filt.apply_to_one(db, current):
@@ -101,7 +162,9 @@ class ExcludeSubtree(Rule):
                 user.end_progress()
 
     def reset(self):
-        self.selected_handles = set()  # set of person handles
+        self.selected_handles = set()
+        if self.filt:
+            self.filt.requestreset()
 
     def apply_to_one(self, db: Database, person: Person) -> bool:
         return person.handle in self.selected_handles

--- a/excludesubtree.py
+++ b/excludesubtree.py
@@ -101,7 +101,6 @@ class ExcludeSubtree(Rule):
         # gramps.gui.editors.filtereditor.EditRule.__init__
         # must be (label, widget class) or special string as label
         _("ID:"),  # starting person
-        _("Handle filter matches: include (default), exclude"),
         _("Person filter name:"),  # TODO: also allow family filter
     ]
     name = _("People reachable from <Person>, stopping at <Filter> matches")
@@ -127,8 +126,7 @@ class ExcludeSubtree(Rule):
             start_person = db.get_person_from_gramps_id(self.list[0])
             if start_person is None:
                 return
-            include_stopfilter_matches = self.list[1] != "exclude"
-            self.filt = MatchesFilter(self.list[2:])
+            self.filt = MatchesFilter(self.list[1:])
             self.filt.requestprepare(db, user)
 
             # walk the db using a queue
@@ -146,8 +144,6 @@ class ExcludeSubtree(Rule):
                 if self.filt.apply_to_one(db, current):
                     if LOG.isEnabledFor(logging.DEBUG):
                         LOG.debug("Stopping at filter match %s", current.gramps_id)
-                    if include_stopfilter_matches:
-                        self.selected_handles.add(current_h)
                     continue  # stop at filter matches
                 # whitelist person and add their relatives to the queue
                 self.selected_handles.add(current_h)

--- a/excludesubtree.py
+++ b/excludesubtree.py
@@ -22,6 +22,7 @@
 # Standard Python modules
 #
 # -------------------------------------------------------------------------
+from __future__ import annotations
 import itertools
 import logging
 

--- a/excludesubtree.py
+++ b/excludesubtree.py
@@ -140,17 +140,19 @@ class ExcludeSubtree(Rule):
                 if user:
                     user.step_progress()
                 current = db.get_person_from_handle(current_h)
-                LOG.debug("tree walk arrived at id %s", current.gramps_id)
+                if LOG.isEnabledFor(logging.DEBUG):
+                    LOG.debug("tree walk arrived at id %s", current.gramps_id)
                 # check stop filter
                 if self.filt.apply_to_one(db, current):
-                    LOG.debug("Stopping at filter match %s", current.gramps_id)
+                    if LOG.isEnabledFor(logging.DEBUG):
+                        LOG.debug("Stopping at filter match %s", current.gramps_id)
                     if include_stopfilter_matches:
                         self.selected_handles.add(current_h)
                     continue  # stop at filter matches
                 # whitelist person and add their relatives to the queue
                 self.selected_handles.add(current_h)
                 search_list.extend((h for h in get_relatives(db, current) if h))
-            LOG.debug("Found %d relatives", len(self.selected_handles))
+            LOG.debug("Found %d filter matches", len(self.selected_handles))
 
         finally:
             if user:


### PR DESCRIPTION
This adds a new Person Filter rule, which "walks the tree" of relatives (looking for each person at all their Families and the parents and children in them for new persons), starting at a given person, but *stopping* if any person from a specified filter is encountered.
This allows for splitting one branch from a bigger tree with only two filters, e.g. when a Family Tree contains two married persons and their families, which are not otherwise connected.

I've published my code already years ago <https://gramps.discourse.group/t/how-to-extract-a-subtree-of-my-tree/5142/14> but now I'd finally see it submitted to the addons repo.