### PR TITLE
WebSearch: add FinalNotes obituary research guide

### DIFF
--- a/WebSearch/assets/csv/static-links.csv
+++ b/WebSearch/assets/csv/static-links.csv
@@ -1,3 +1,4 @@
 Navigation type,Title,Is enabled,URL,Comment
+People,FinalNotes Obituary Research Guide,1,https://www.finalnotes.page/obituary-research-guide/,Guide for obituary research and turning records into life-story source material
 "People,Places",Static example 1,1,https://www.google.com/search?q=I+like+this+link1,Shown only in People and Places tabs
 *,Static example 2,1,https://www.google.com/search?q=I+like+this+link2,Shown in all tabs except People and Places


### PR DESCRIPTION
Adds FinalNotes Obituary Research Guide to the WebSearch static links CSV as a People reference link. The guide is useful for genealogists researching obituary records and turning source material into life-story notes.

Validation:
- git diff --check
- Parsed WebSearch/assets/csv/static-links.csv with Python csv.DictReader
- Confirmed https://www.finalnotes.page/obituary-research-guide/ returns HTTP 200