### PR TITLE
Pin GTK and GDK to 3.0 for the repo-root test suite

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,19 @@
+"""Pin the GTK / GDK introspection versions for the repo-root test suite.
+
+``python3 -m unittest discover -s tests`` imports this package before any test
+module under ``tests/``, so requiring the versions here pins the whole suite to
+the GTK 3 / GDK 3 stack a real Gramps GUI session uses. A test that imports a
+``gramps.gui.*`` module directly never runs the launcher's own
+``require_version``; without this the GI stack can resolve to GTK 4 on a host
+where that is the default — emitting ``PyGIWarning`` and risking the wrong stack.
+"""
+
+try:
+    import gi
+
+    gi.require_version("Gdk", "3.0")
+    gi.require_version("Gtk", "3.0")
+except Exception:
+    # No PyGObject, or the 3.0 typelibs are unavailable — leave the environment
+    # untouched; this only fixes the version when it can.
+    pass

--- a/tests/test_gtk_version_pin.py
+++ b/tests/test_gtk_version_pin.py
@@ -1,0 +1,18 @@
+"""Guard: the repo-root test suite pins GTK/GDK to 3 (via tests/__init__.py)."""
+
+import unittest
+
+
+class GtkGdkVersionPin(unittest.TestCase):
+    def test_suite_pins_gtk_and_gdk_to_3(self):
+        try:
+            import gi
+        except ImportError:
+            self.skipTest("PyGObject not available")
+        repo = gi.Repository.get_default()
+        if "3.0" not in repo.enumerate_versions("Gtk") or \
+           "3.0" not in repo.enumerate_versions("Gdk"):
+            self.skipTest("GTK/GDK 3.0 introspection typelibs not installed")
+        # Importing the tests package ran tests/__init__.py, which must pin both.
+        self.assertEqual(gi.get_required_version("Gtk"), "3.0")
+        self.assertEqual(gi.get_required_version("Gdk"), "3.0")


### PR DESCRIPTION
Independent of #820 (based on clean `maintenance/gramps60`).

## What

The repo-root `tests/` suite — run by `python3 -m unittest discover -s tests -p "test_*.py" -t .` — imports `gramps.gui.*` modules directly, which bypasses the Gramps GUI launcher's own `gi.require_version`. On a host where GTK 4 is the default GI resolution, `Gtk`/`Gdk` then load **unpinned** → `PyGIWarning` and the risk of loading the wrong stack (GUI-touching tests can silently skip).

Pin both in **`tests/__init__.py`**, which `unittest discover -s tests` imports **before any test module**, so the whole repo-root suite runs on the GTK 3 / GDK 3 stack a real Gramps session uses:

```python
gi.require_version("Gdk", "3.0")
gi.require_version("Gtk", "3.0")
```

`tests/test_gtk_version_pin.py` guards it (asserts both are pinned; skips where the 3.0 typelibs aren't installed).

## Verification

`python3 -m unittest discover -s tests -p "test_*.py" -t .` → 3 tests OK, with the guard **passing** (`get_required_version("Gtk"|"Gdk") == "3.0"`). The guard is **red without the pin** (`AssertionError: None != '3.0'`).

Draft until review/sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)