### PR TITLE
Sqlite: update for Gramps 6.1, plus enhancements

### DIFF
--- a/Sqlite/ExportSql.py
+++ b/Sqlite/ExportSql.py
@@ -1,3 +1,4 @@
+#
 # Gramps - a GTK+/GNOME based genealogy program
 #
 # Copyright (C) 2008 Douglas S. Blank <doug.blank@gmail.com>
@@ -15,8 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-#
-# $Id: ExportSql.py 508 2010-08-16 01:48:01Z dsblank $
 #
 
 "Export to SQLite Database"
@@ -532,18 +531,15 @@ def makeDB(db: Database, callback) -> None:
 # Helper lookup
 #
 # -------------------------------------------------------------------------
-def lookup(index: int, event_ref_list) -> str | None:
+def lookup(index: int, event_ref_list: list) -> str | None:
     """
-    Return the event handle at the given index in a serialized event_ref_list.
+    Return the event handle at position index in the event_ref_list DataDicts.
     """
     if index < 0:
         return None
-    count = 0
-    for event_ref in event_ref_list:
-        (_private, _citation_list, _note_list, _attribute_list, ref, _role) = event_ref
-        if index == count:
-            return ref
-        count += 1
+    for i, event_ref in enumerate(event_ref_list):
+        if i == index:
+            return event_ref["ref"]
     return None
 
 
@@ -552,416 +548,58 @@ def lookup(index: int, event_ref_list) -> str | None:
 # Export helper functions
 #
 # -------------------------------------------------------------------------
-def export_alt_place_name_list(
-    db: Database, handle: str, alt_place_name_list
-) -> None:
-    """Export all alternate place names for a place."""
-    for place_name in alt_place_name_list:
-        export_place_name(db, handle, place_name)
-
-
-def export_place_name(db: Database, handle: str, place_name) -> None:
-    """Export a single place name record."""
-    # alt_place_name_list = [('Ohio', None, ''), ...] [(value, date, lang)...]
-    (value, date, lang) = place_name
-    ref_handle = create_id()
-    db.query(
-        "insert into place_name (handle, from_handle, value, lang)"
-        " VALUES (?, ?, ?, ?);",
-        ref_handle,
-        handle,
-        value,
-        lang,
-    )
-    export_date(db, "place_name", ref_handle, date)
-
-
-def export_place_ref_list(db: Database, handle: str, place_ref_list) -> None:
-    """Export all place reference records for a place."""
-    # place_ref_list = Enclosed by:  [('4ECKQCWCLO5YIHXEXC', None)]
-    # [(handle, date)...]
-    for place_ref in place_ref_list:
-        export_place_ref(db, handle, place_ref)
-
-
-def export_place_ref(db: Database, handle: str, place_ref) -> None:
-    """Export a single place reference."""
-    (to_place_handle, date) = place_ref
-    ref_handle = create_id()
-    db.query(
-        "insert into place_ref"
-        " (handle, from_place_handle, to_place_handle) VALUES (?, ?, ?);",
-        ref_handle,
-        handle,
-        to_place_handle,
-    )
-    export_date(db, "place_ref", ref_handle, date)
-
-
-def export_location_list(
-    db: Database, from_type: str, from_handle: str, locations
-) -> None:
-    """Export a list of location records."""
-    for location in locations:
-        export_location(db, from_type, from_handle, location)
-
-
-def export_url_list(db: Database, from_type: str, from_handle: str, urls) -> None:
-    """Export all URL records for a parent object."""
-    for url in urls:
-        # (False, 'http://www.gramps-project.org/', 'loleach', (0, 'kaabgo'))
-        (private, path, desc, type_) = url
-        handle = create_id()
-        db.query(
-            """insert INTO url (
-                 handle,
-                 path,
-                 desc,
-                 type0,
-                 type1,
-                 private) VALUES (?, ?, ?, ?, ?, ?);
-                 """,
-            handle,
-            path,
-            desc,
-            type_[0],
-            type_[1],
-            private,
-        )
-        # finally, link this to parent
-        export_link(db, from_type, from_handle, "url", handle)
-
-
-def export_person_ref_list(
-    db: Database, from_type: str, from_handle: str, person_ref_list
-) -> None:
-    """Export all person reference records for a parent object."""
-    for person_ref in person_ref_list:
-        (
-            private,
-            citation_list,
-            note_list,
-            handle,
-            desc,
-        ) = person_ref
-        ref_handle = create_id()
-        db.query(
-            """INSERT INTO person_ref (
-                    handle,
-                    ref,
-                    description,
-                    private) VALUES (?, ?, ?, ?);""",
-            ref_handle,
-            handle,
-            desc,
-            private,
-        )
-        export_list(db, "person_ref", ref_handle, "note", note_list)
-        export_citation_list(db, "person_ref", ref_handle, citation_list)
-        # And finally, make a link from parent to new object
-        export_link(db, from_type, from_handle, "person_ref", ref_handle)
-
-
-def export_lds(db: Database, from_type: str, from_handle: str, data) -> None:
-    """Export a single LDS ordinance record."""
-    (lcitation_list, lnote_list, date, type_, place, famc, temple, status, private) = (
-        data
-    )
-    lds_handle = create_id()
-    db.query(
-        "INSERT into lds"
-        " (handle, type, place, famc, temple, status, private) "
-        "VALUES (?,?,?,?,?,?,?);",
-        lds_handle,
-        type_,
-        place,
-        famc,
-        temple,
-        status,
-        private,
-    )
-    export_link(db, "lds", lds_handle, "place", place)
-    export_list(db, "lds", lds_handle, "note", lnote_list)
-    export_date(db, "lds", lds_handle, date)
-    export_citation_list(db, "lds", lds_handle, lcitation_list)
-    # And finally, make a link from parent to new object
-    export_link(db, from_type, from_handle, "lds", lds_handle)
-
-
-def export_citation_ref(
-    db: Database, from_type: str, from_handle: str, citation_handle: str
-) -> None:
-    """Export a single citation reference link."""
-    export_link(db, from_type, from_handle, "citation", citation_handle)
-
-
-def export_source(
-    db: Database,
-    handle: str,
-    gid: str,
-    title: str,
-    author: str,
-    pubinfo: str,
-    abbrev: str,
-    change: int,
-    private: bool,
-) -> None:
-    """Insert a source record into the source table."""
-    db.query(
-        """INSERT into source (
-             handle,
-             gid,
-             title,
-             author,
-             pubinfo,
-             abbrev,
-             change,
-             private
-             ) VALUES (?,?,?,?,?,?,?,?);""",
-        handle,
-        gid,
-        title,
-        author,
-        pubinfo,
-        abbrev,
-        change,
-        private,
-    )
-
-
-def export_note(db: Database, data) -> None:
-    """Export a serialized Note tuple into the note table."""
-    (handle, gid, styled_text, format_, note_type, change, tag_list, private) = data
-    text, markup_list = styled_text
-    db.query(
-        """INSERT into note (
-                  handle,
-                  gid,
-                  text,
-                  format,
-                  note_type1,
-                  note_type2,
-                  change,
-                  private) values (?, ?, ?, ?,
-                                   ?, ?, ?, ?);""",
-        handle,
-        gid,
-        text,
-        format_,
-        note_type[0],
-        note_type[1],
-        change,
-        private,
-    )
-    for markup in markup_list:
-        markup_code, value, start_stop_list = markup
-        export_markup(
-            db,
-            "note",
-            handle,
-            markup_code[0],
-            markup_code[1],
-            value,
-            str(start_stop_list),
-        )  # Not normal form; use eval
-    export_list(db, "note", handle, "tag", tag_list)
-
-
-def export_markup(
+def export_link(
     db: Database,
     from_type: str,
     from_handle: str,
-    markup_code0,
-    markup_code1,
-    value,
-    start_stop_list,
+    to_type: str,
+    to_handle: str | None,
 ) -> None:
-    """Export a markup record for a Note."""
-    markup_handle = create_id()
-    db.query(
-        """INSERT INTO markup (
-                 handle,
-                 markup0,
-                 markup1,
-                 value,
-                 start_stop_list) VALUES (?,?,?,?,?);""",
-        markup_handle,
-        markup_code0,
-        markup_code1,
-        value,
-        start_stop_list,
-    )
-    # And finally, make a link from parent to new object
-    export_link(db, from_type, from_handle, "markup", markup_handle)
+    """Insert a single link record between two objects."""
+    if to_handle:
+        db.query(
+            """insert into link (
+                   from_type,
+                   from_handle,
+                   to_type,
+                   to_handle) values (?, ?, ?, ?)""",
+            from_type,
+            from_handle,
+            to_type,
+            to_handle,
+        )
 
 
-def export_event(db: Database, data) -> None:
-    """Export a serialized Event tuple into the event table."""
-    (
-        handle,
-        gid,
-        the_type,
-        date,
-        description,
-        place_handle,
-        citation_list,
-        note_list,
-        media_list,
-        attribute_list,
-        change,
-        tag_list,
-        private,
-    ) = data
-    db.query(
-        """INSERT INTO event (
-                 handle,
-                 gid,
-                 the_type0,
-                 the_type1,
-                 description,
-                 change,
-                 private) VALUES (?,?,?,?,?,?,?);""",
-        handle,
-        gid,
-        the_type[0],
-        the_type[1],
-        description,
-        change,
-        private,
-    )
-    export_date(db, "event", handle, date)
-    export_link(db, "event", handle, "place", place_handle)
-    export_list(db, "event", handle, "note", note_list)
-    export_list(db, "event", handle, "tag", tag_list)
-    export_attribute_list(db, "event", handle, attribute_list)
-    export_media_ref_list(db, "event", handle, media_list)
-    export_citation_list(db, "event", handle, citation_list)
-
-
-def export_event_ref(
-    db: Database, from_type: str, from_handle: str, event_ref
+def export_list(
+    db: Database, from_type: str, from_handle: str, to_type: str, handle_list: list
 ) -> None:
-    """Export a single event reference record."""
-    (private, citation_list, note_list, attribute_list, ref, role) = event_ref
-    handle = create_id()
-    db.query(
-        """insert INTO event_ref (
-                 handle,
-                 ref,
-                 role0,
-                 role1,
-                 private) VALUES (?,?,?,?,?);""",
-        handle,
-        ref,
-        role[0],
-        role[1],
-        private,
-    )
-    export_list(db, "event_ref", handle, "note", note_list)
-    export_attribute_list(db, "event_ref", handle, attribute_list)
-    export_citation_list(db, "event_ref", handle, citation_list)
-    # finally, link this to parent
-    export_link(db, from_type, from_handle, "event_ref", handle)
+    """Export a list of handle links from a parent to child objects."""
+    for to_handle in handle_list:
+        export_link(db, from_type, from_handle, to_type, to_handle)
 
 
-def export_person(db: Database, person) -> None:
-    """
-    Export a Person object into the person table and related tables.
-
-    Accesses all fields by object attribute rather than positional tuple
-    unpacking, making this forward-compatible with new Person fields (such
-    as familysearch_sync added in Gramps 6.1).
-    """
-    handle = person.handle
-    gid = person.gramps_id
-    gender = person.gender
-    primary_name = person.primary_name
-    alternate_names = person.alternate_names
-    death_ref_index = person.death_ref_index
-    birth_ref_index = person.birth_ref_index
-    event_ref_list = person.get_event_ref_list()
-    family_list = person.family_list
-    parent_family_list = person.parent_family_list
-    media_list = person.get_media_list()
-    address_list = person.get_address_list()
-    attribute_list = person.get_attribute_list()
-    urls = person.get_url_list()
-    lds_ord_list = person.get_lds_ord_list()
-    pcitation_list = person.get_citation_list()
-    pnote_list = person.get_note_list()
-    change = person.change
-    tag_list = person.get_tag_list()
-    private = person.private
-    person_ref_list = person.get_person_ref_list()
-
-    # Serialize event_ref_list for birth/death handle lookup (index -> handle)
-    serialized_event_refs = [er.serialize() for er in event_ref_list]
-
-    # familysearch_sync is a FamilySearchSync object; persist as JSON
-    fs_sync_json = json.dumps(person.familysearch_sync.serialize())
-
-    db.query(
-        """INSERT INTO person (
-                  handle,
-                  gid,
-                  gender,
-                  death_ref_handle,
-                  birth_ref_handle,
-                  change,
-                  private,
-                  familysearch_sync) values (?, ?, ?, ?, ?, ?, ?, ?);""",
-        handle,
-        gid,
-        gender,
-        lookup(death_ref_index, serialized_event_refs),
-        lookup(birth_ref_index, serialized_event_refs),
-        change,
-        private,
-        fs_sync_json,
-    )
-
-    # Event Reference information
-    for event_ref in event_ref_list:
-        export_event_ref(db, "person", handle, event_ref.serialize())
-    export_list(db, "person", handle, "family", family_list)
-    export_list(db, "person", handle, "parent_family", parent_family_list)
-    export_media_ref_list(db, "person", handle, [m.serialize() for m in media_list])
-    export_list(db, "person", handle, "note", pnote_list)
-    export_attribute_list(
-        db, "person", handle, [a.serialize() for a in attribute_list]
-    )
-    export_url_list(db, "person", handle, [u.serialize() for u in urls])
-    export_person_ref_list(
-        db, "person", handle, [pr.serialize() for pr in person_ref_list]
-    )
-    export_citation_list(db, "person", handle, pcitation_list)
-    export_list(db, "person", handle, "tag", tag_list)
-
-    # -------------------------------------
-    # Address
-    # -------------------------------------
-    for address in address_list:
-        export_address(db, "person", handle, address.serialize())
-
-    # -------------------------------------
-    # LDS ord
-    # -------------------------------------
-    for ldsord in lds_ord_list:
-        export_lds(db, "person", handle, ldsord.serialize())
-
-    # -------------------------------------
-    # Names
-    # -------------------------------------
-    export_name(db, "person", handle, True, primary_name.serialize())
-    for name in alternate_names:
-        export_name(db, "person", handle, False, name.serialize())
+def export_citation_list(
+    db: Database, from_type: str, from_handle: str, citation_list: list
+) -> None:
+    """Export all citation references for a parent object."""
+    for citation_handle in citation_list:
+        export_link(db, from_type, from_handle, "citation", citation_handle)
 
 
-def export_date(db: Database, from_type: str, from_handle: str, data) -> None:
-    """Export a serialized Date tuple into the date table."""
+def export_date(
+    db: Database, from_type: str, from_handle: str, data: dict | None
+) -> None:
+    """Export a Date DataDict into the date table."""
     if data is None:
         return
-    (calendar, modifier, quality, dateval, text, sortval, newyear) = data
+    calendar = data["calendar"]
+    modifier = data["modifier"]
+    quality = data["quality"]
+    dateval = data["dateval"]
+    text = data["text"]
+    sortval = data["sortval"]
+    newyear = data["newyear"]
+
     if len(dateval) == 4:
         day1, month1, year1, slash1 = dateval
         day2, month2, year2, slash2 = 0, 0, 0, 0
@@ -1007,11 +645,381 @@ def export_date(db: Database, from_type: str, from_handle: str, data) -> None:
     export_link(db, from_type, from_handle, "date", date_handle)
 
 
-def export_surname(db: Database, name_handle: str, surname_list) -> None:
-    """Export all surname records for a name."""
-    for data in surname_list:
+def export_markup(
+    db: Database,
+    from_type: str,
+    from_handle: str,
+    markup_code0,
+    markup_code1,
+    value,
+    start_stop_list,
+) -> None:
+    """Export a markup record for a Note."""
+    markup_handle = create_id()
+    db.query(
+        """INSERT INTO markup (
+                 handle,
+                 markup0,
+                 markup1,
+                 value,
+                 start_stop_list) VALUES (?,?,?,?,?);""",
+        markup_handle,
+        markup_code0,
+        markup_code1,
+        value,
+        start_stop_list,
+    )
+    export_link(db, from_type, from_handle, "markup", markup_handle)
+
+
+def export_attribute(
+    db: Database, from_type: str, from_handle: str, attribute: dict
+) -> None:
+    """Export a single Attribute DataDict record."""
+    private = attribute["private"]
+    citation_list = attribute["citation_list"]
+    note_list = attribute["note_list"]
+    the_type = attribute["type"]
+    value = attribute["value"]
+    handle = create_id()
+    db.query(
+        """INSERT INTO attribute (
+                 handle,
+                 the_type0,
+                 the_type1,
+                 value,
+                 private) VALUES (?,?,?,?,?);""",
+        handle,
+        the_type["value"],
+        the_type["string"],
+        value,
+        private,
+    )
+    export_citation_list(db, "attribute", handle, citation_list)
+    export_list(db, "attribute", handle, "note", note_list)
+    export_link(db, from_type, from_handle, "attribute", handle)
+
+
+def export_attribute_list(
+    db: Database, from_type: str, from_handle: str, attr_list: list
+) -> None:
+    """Export all attribute records for a parent object."""
+    for attribute in attr_list:
+        export_attribute(db, from_type, from_handle, attribute)
+
+
+def export_src_attribute_list(db: Database, from_handle: str, src_attr_list: list) -> None:
+    """Export SrcAttribute DataDicts for source/citation into the datamap table.
+
+    SrcAttribute has no citation_list or note_list; it maps to the legacy
+    datamap table that ImportSql reads back.
+    """
+    for src_attr in src_attr_list:
+        private = src_attr["private"]
+        the_type = src_attr["type"]
+        value = src_attr["value"]
+        db.query(
+            """INSERT INTO datamap (
+                     from_handle,
+                     the_type0,
+                     the_type1,
+                     value_field,
+                     private) VALUES (?,?,?,?,?);""",
+            from_handle,
+            the_type["value"],
+            the_type["string"],
+            value,
+            private,
+        )
+
+
+def export_url_list(
+    db: Database, from_type: str, from_handle: str, urls: list
+) -> None:
+    """Export all URL DataDict records for a parent object."""
+    for url in urls:
+        private = url["private"]
+        path = url["path"]
+        desc = url["desc"]
+        the_type = url["type"]
+        handle = create_id()
+        db.query(
+            """insert INTO url (
+                 handle,
+                 path,
+                 desc,
+                 type0,
+                 type1,
+                 private) VALUES (?, ?, ?, ?, ?, ?);
+                 """,
+            handle,
+            path,
+            desc,
+            the_type["value"],
+            the_type["string"],
+            private,
+        )
+        export_link(db, from_type, from_handle, "url", handle)
+
+
+def export_media_ref_list(
+    db: Database, from_type: str, from_handle: str, media_list: list
+) -> None:
+    """Export all media reference DataDict records for a parent object."""
+    for media in media_list:
+        export_media_ref(db, from_type, from_handle, media)
+
+
+def export_media_ref(
+    db: Database, from_type: str, from_handle: str, media: dict
+) -> None:
+    """Export a single MediaRef DataDict record."""
+    private = media["private"]
+    citation_list = media["citation_list"]
+    note_list = media["note_list"]
+    attribute_list = media["attribute_list"]
+    ref = media["ref"]
+    # rect is the bounding box; stored in role columns for historical reasons
+    rect = media.get("rect") or [-1, -1, -1, -1]
+    handle = create_id()
+    db.query(
+        """INSERT into media_ref (
+                 handle,
+                 ref,
+                 role0,
+                 role1,
+                 role2,
+                 role3,
+                 private) VALUES (?,?,?,?,?,?,?);""",
+        handle,
+        ref,
+        rect[0],
+        rect[1],
+        rect[2],
+        rect[3],
+        private,
+    )
+    export_list(db, "media_ref", handle, "note", note_list)
+    export_attribute_list(db, "media_ref", handle, attribute_list)
+    export_citation_list(db, "media_ref", handle, citation_list)
+    export_link(db, from_type, from_handle, "media_ref", handle)
+
+
+def export_event_ref(
+    db: Database, from_type: str, from_handle: str, event_ref: dict
+) -> None:
+    """Export a single EventRef DataDict record."""
+    private = event_ref["private"]
+    citation_list = event_ref["citation_list"]
+    note_list = event_ref["note_list"]
+    attribute_list = event_ref["attribute_list"]
+    ref = event_ref["ref"]
+    role = event_ref["role"]
+    handle = create_id()
+    db.query(
+        """insert INTO event_ref (
+                 handle,
+                 ref,
+                 role0,
+                 role1,
+                 private) VALUES (?,?,?,?,?);""",
+        handle,
+        ref,
+        role["value"],
+        role["string"],
+        private,
+    )
+    export_list(db, "event_ref", handle, "note", note_list)
+    export_attribute_list(db, "event_ref", handle, attribute_list)
+    export_citation_list(db, "event_ref", handle, citation_list)
+    export_link(db, from_type, from_handle, "event_ref", handle)
+
+
+def export_person_ref_list(
+    db: Database, from_type: str, from_handle: str, person_ref_list: list
+) -> None:
+    """Export all PersonRef DataDict records for a parent object."""
+    for person_ref in person_ref_list:
+        private = person_ref["private"]
+        citation_list = person_ref["citation_list"]
+        note_list = person_ref["note_list"]
+        ref = person_ref["ref"]
+        rel = person_ref["rel"]
+        ref_handle = create_id()
+        db.query(
+            """INSERT INTO person_ref (
+                    handle,
+                    ref,
+                    description,
+                    private) VALUES (?, ?, ?, ?);""",
+            ref_handle,
+            ref,
+            rel,
+            private,
+        )
+        export_list(db, "person_ref", ref_handle, "note", note_list)
+        export_citation_list(db, "person_ref", ref_handle, citation_list)
+        export_link(db, from_type, from_handle, "person_ref", ref_handle)
+
+
+def export_child_ref_list(
+    db: Database, from_type: str, from_handle: str, to_type: str, ref_list: list
+) -> None:
+    """Export all ChildRef DataDict records for a family."""
+    for child_ref in ref_list:
+        private = child_ref["private"]
+        citation_list = child_ref["citation_list"]
+        note_list = child_ref["note_list"]
+        ref = child_ref["ref"]
+        frel = child_ref["frel"]
+        mrel = child_ref["mrel"]
+        handle = create_id()
+        db.query(
+            """INSERT INTO child_ref (handle,
+                     ref, frel0, frel1, mrel0, mrel1, private)
+                        VALUES (?, ?, ?, ?, ?, ?, ?);""",
+            handle,
+            ref,
+            frel["value"],
+            frel["string"],
+            mrel["value"],
+            mrel["string"],
+            private,
+        )
+        export_citation_list(db, "child_ref", handle, citation_list)
+        export_list(db, "child_ref", handle, "note", note_list)
+        export_link(db, from_type, from_handle, "child_ref", handle)
+
+
+def export_lds(
+    db: Database, from_type: str, from_handle: str, ldsord: dict
+) -> None:
+    """Export a single LdsOrd DataDict record."""
+    citation_list = ldsord["citation_list"]
+    note_list = ldsord["note_list"]
+    date = ldsord["date"]
+    the_type = ldsord["type"]
+    place = ldsord["place"]
+    famc = ldsord["famc"]
+    temple = ldsord["temple"]
+    status = ldsord["status"]
+    private = ldsord["private"]
+    lds_handle = create_id()
+    db.query(
+        "INSERT into lds"
+        " (handle, type, place, famc, temple, status, private) "
+        "VALUES (?,?,?,?,?,?,?);",
+        lds_handle,
+        the_type,
+        place,
+        famc,
+        temple,
+        status,
+        private,
+    )
+    export_link(db, "lds", lds_handle, "place", place)
+    export_list(db, "lds", lds_handle, "note", note_list)
+    export_date(db, "lds", lds_handle, date)
+    export_citation_list(db, "lds", lds_handle, citation_list)
+    export_link(db, from_type, from_handle, "lds", lds_handle)
+
+
+def export_location(
+    db: Database, from_type: str, from_handle: str, location: dict | None
+) -> None:
+    """Export a location DataDict (Location or Address) into the location table."""
+    if location is None:
+        return
+    handle = create_id()
+    db.query(
+        """INSERT INTO location (
+                 handle,
+                 street,
+                 locality,
+                 city,
+                 county,
+                 state,
+                 country,
+                 postal,
+                 phone,
+                 parish) VALUES (?,?,?,?,?,?,?,?,?,?);""",
+        handle,
+        location.get("street", ""),
+        location.get("locality", ""),
+        location.get("city", ""),
+        location.get("county", ""),
+        location.get("state", ""),
+        location.get("country", ""),
+        location.get("postal", ""),
+        location.get("phone", ""),
+        location.get("parish"),
+    )
+    export_link(db, from_type, from_handle, "location", handle)
+
+
+def export_address(
+    db: Database, from_type: str, from_handle: str, address: dict
+) -> None:
+    """Export an Address DataDict record.
+
+    In Gramps 6.1, Address carries its location fields directly
+    (street, city, etc.) rather than via a nested Location object.
+    """
+    private = address["private"]
+    citation_list = address["citation_list"]
+    note_list = address["note_list"]
+    date = address["date"]
+    addr_handle = create_id()
+    db.query(
+        """INSERT INTO address (
+                handle,
+                private) VALUES (?, ?);""",
+        addr_handle,
+        private,
+    )
+    # Write inline location fields directly from the address dict
+    export_location(db, "address", addr_handle, address)
+    export_date(db, "address", addr_handle, date)
+    export_list(db, "address", addr_handle, "note", note_list)
+    export_citation_list(db, "address", addr_handle, citation_list)
+    export_link(db, from_type, from_handle, "address", addr_handle)
+
+
+def export_repository_ref_list(
+    db: Database, from_type: str, from_handle: str, reporef_list: list
+) -> None:
+    """Export all RepositoryRef DataDict records for a source."""
+    for repo in reporef_list:
+        private = repo["private"]
+        note_list = repo["note_list"]
+        ref = repo["ref"]
+        call_number = repo["call_number"]
+        media_type = repo["media_type"]
+        handle = create_id()
+        db.query(
+            """insert INTO repository_ref (
+                     handle,
+                     ref,
+                     call_number,
+                     source_media_type0,
+                     source_media_type1,
+                     private) VALUES (?,?,?,?,?,?);""",
+            handle,
+            ref,
+            call_number,
+            media_type["value"],
+            media_type["string"],
+            private,
+        )
+        export_list(db, "repository_ref", handle, "note", note_list)
+        export_link(db, from_type, from_handle, "repository_ref", handle)
+
+
+def export_surname(db: Database, name_handle: str, surname_list: list) -> None:
+    """Export all Surname DataDict records for a name."""
+    for surname in surname_list:
         surname_handle = create_id()
-        (surname, prefix, primary, origin_type, connector) = data
+        origin_type = surname["origintype"]
         db.query(
             """INSERT INTO surname (
                   handle,
@@ -1022,41 +1030,44 @@ def export_surname(db: Database, name_handle: str, surname_list) -> None:
                   origin_type1,
                   connector) VALUES (?,?,?,?,?,?,?);""",
             surname_handle,
-            surname,
-            prefix,
-            primary,
-            origin_type[0],
-            origin_type[1],
-            connector,
+            surname["surname"],
+            surname["prefix"],
+            surname["primary"],
+            origin_type["value"],
+            origin_type["string"],
+            surname["connector"],
         )
         export_link(db, "name", name_handle, "surname", surname_handle)
 
 
 def export_name(
-    db: Database, from_type: str, from_handle: str, primary: bool, data
+    db: Database,
+    from_type: str,
+    from_handle: str,
+    primary: bool,
+    name: dict | None,
 ) -> None:
-    """Export a serialized Name tuple into the name table."""
-    if data:
-        (
-            private,
-            citation_list,
-            note_list,
-            date,
-            first_name,
-            surname_list,
-            suffix,
-            title,
-            name_type,
-            group_as,
-            sort_as,
-            display_as,
-            call,
-            nick,
-            famnick,
-        ) = data
-        handle = create_id()
-        db.query(
-            """INSERT into name (
+    """Export a Name DataDict record into the name table."""
+    if not name:
+        return
+    private = name["private"]
+    citation_list = name["citation_list"]
+    note_list = name["note_list"]
+    date = name["date"]
+    first_name = name["first_name"]
+    surname_list = name["surname_list"]
+    suffix = name["suffix"]
+    title = name["title"]
+    name_type = name["type"]
+    group_as = name["group_as"]
+    sort_as = name["sort_as"]
+    display_as = name["display_as"]
+    call = name["call"]
+    nick = name["nick"]
+    famnick = name["famnick"]
+    handle = create_id()
+    db.query(
+        """INSERT into name (
                   handle,
                   primary_name,
                   private,
@@ -1073,281 +1084,542 @@ def export_name(
                   famnick
                     ) values (?, ?, ?, ?, ?, ?, ?,
                               ?, ?, ?, ?, ?, ?, ?);""",
-            handle,
-            primary,
-            private,
-            first_name,
-            suffix,
-            title,
-            name_type[0],
-            name_type[1],
-            group_as,
-            sort_as,
-            display_as,
-            call,
-            nick,
-            famnick,
-        )
-        export_surname(db, handle, surname_list)
-        export_date(db, "name", handle, date)
-        export_list(db, "name", handle, "note", note_list)
-        export_citation_list(db, "name", handle, citation_list)
-        # And finally, make a link from parent to new object
-        export_link(db, from_type, from_handle, "name", handle)
+        handle,
+        primary,
+        private,
+        first_name,
+        suffix,
+        title,
+        name_type["value"],
+        name_type["string"],
+        group_as,
+        sort_as,
+        display_as,
+        call,
+        nick,
+        famnick,
+    )
+    export_surname(db, handle, surname_list)
+    export_date(db, "name", handle, date)
+    export_list(db, "name", handle, "note", note_list)
+    export_citation_list(db, "name", handle, citation_list)
+    export_link(db, from_type, from_handle, "name", handle)
 
 
-def export_attribute(
-    db: Database, from_type: str, from_handle: str, attribute
-) -> None:
-    """Export a single serialized attribute record."""
-    (private, citation_list, note_list, the_type, value) = attribute
-    handle = create_id()
+def export_place_name(db: Database, from_handle: str, place_name: dict) -> None:
+    """Export a PlaceName DataDict record."""
+    value = place_name["value"]
+    date = place_name["date"]
+    lang = place_name["lang"]
+    ref_handle = create_id()
     db.query(
-        """INSERT INTO attribute (
+        "insert into place_name (handle, from_handle, value, lang)"
+        " VALUES (?, ?, ?, ?);",
+        ref_handle,
+        from_handle,
+        value,
+        lang,
+    )
+    export_date(db, "place_name", ref_handle, date)
+
+
+def export_place_ref(db: Database, from_handle: str, place_ref: dict) -> None:
+    """Export a PlaceRef DataDict record."""
+    to_place_handle = place_ref["ref"]
+    date = place_ref["date"]
+    ref_handle = create_id()
+    db.query(
+        "insert into place_ref"
+        " (handle, from_place_handle, to_place_handle) VALUES (?, ?, ?);",
+        ref_handle,
+        from_handle,
+        to_place_handle,
+    )
+    export_date(db, "place_ref", ref_handle, date)
+
+
+# -------------------------------------------------------------------------
+#
+# Primary object export functions
+#
+# -------------------------------------------------------------------------
+def export_note(db: Database, raw: dict) -> None:
+    """Export a Note raw DataDict into the note table."""
+    handle = raw["handle"]
+    gid = raw["gramps_id"]
+    styled_text = raw["text"]
+    format_ = raw["format"]
+    note_type = raw["type"]
+    change = raw["change"]
+    tag_list = raw["tag_list"]
+    private = raw["private"]
+
+    text = styled_text["string"]
+    markup_list = styled_text["tags"]
+
+    db.query(
+        """INSERT into note (
+                  handle,
+                  gid,
+                  text,
+                  format,
+                  note_type1,
+                  note_type2,
+                  change,
+                  private) values (?, ?, ?, ?,
+                                   ?, ?, ?, ?);""",
+        handle,
+        gid,
+        text,
+        format_,
+        note_type["value"],
+        note_type["string"],
+        change,
+        private,
+    )
+    for markup in markup_list:
+        # Each markup is a StyledTextTag DataDict:
+        # {"name": GrampsType dict, "value": ..., "ranges": [...]}
+        markup_name = markup["name"]
+        value = markup["value"]
+        ranges = markup["ranges"]
+        export_markup(
+            db,
+            "note",
+            handle,
+            markup_name["value"],
+            markup_name["string"],
+            value,
+            str(ranges),
+        )
+    export_list(db, "note", handle, "tag", tag_list)
+
+
+def export_event(db: Database, raw: dict) -> None:
+    """Export an Event raw DataDict into the event table."""
+    handle = raw["handle"]
+    gid = raw["gramps_id"]
+    the_type = raw["type"]
+    date = raw["date"]
+    description = raw["description"]
+    place_handle = raw["place"]
+    citation_list = raw["citation_list"]
+    note_list = raw["note_list"]
+    media_list = raw["media_list"]
+    attribute_list = raw["attribute_list"]
+    change = raw["change"]
+    tag_list = raw["tag_list"]
+    private = raw["private"]
+
+    db.query(
+        """INSERT INTO event (
                  handle,
+                 gid,
                  the_type0,
                  the_type1,
-                 value,
-                 private) VALUES (?,?,?,?,?);""",
-        handle,
-        the_type[0],
-        the_type[1],
-        value,
-        private,
-    )
-    export_citation_list(db, "attribute", handle, citation_list)
-    export_list(db, "attribute", handle, "note", note_list)
-    # finally, link the parent to the attribute
-    export_link(db, from_type, from_handle, "attribute", handle)
-
-
-def export_citation_list(
-    db: Database, from_type: str, from_handle: str, citation_list
-) -> None:
-    """Export all citation references for a parent object."""
-    for citation_handle in citation_list:
-        export_citation_ref(db, from_type, from_handle, citation_handle)
-
-
-def export_media_ref_list(
-    db: Database, from_type: str, from_handle: str, media_list
-) -> None:
-    """Export all media reference records for a parent object."""
-    for media in media_list:
-        export_media_ref(db, from_type, from_handle, media)
-
-
-def export_media_ref(db: Database, from_type: str, from_handle: str, media) -> None:
-    """Export a single serialized media reference record."""
-    (private, citation_list, note_list, attribute_list, ref, role) = media
-    # handle is the media_ref handle; ref is the media handle
-    handle = create_id()
-    if role is None:
-        role = (-1, -1, -1, -1)
-    db.query(
-        """INSERT into media_ref (
-                 handle,
-                 ref,
-                 role0,
-                 role1,
-                 role2,
-                 role3,
+                 description,
+                 change,
                  private) VALUES (?,?,?,?,?,?,?);""",
         handle,
-        ref,
-        role[0],
-        role[1],
-        role[2],
-        role[3],
+        gid,
+        the_type["value"],
+        the_type["string"],
+        description,
+        change,
         private,
     )
-    export_list(db, "media_ref", handle, "note", note_list)
-    export_attribute_list(db, "media_ref", handle, attribute_list)
-    export_citation_list(db, "media_ref", handle, citation_list)
-    # And finally, make a link from parent to new object
-    export_link(db, from_type, from_handle, "media_ref", handle)
+    export_date(db, "event", handle, date)
+    export_link(db, "event", handle, "place", place_handle)
+    export_list(db, "event", handle, "note", note_list)
+    export_list(db, "event", handle, "tag", tag_list)
+    export_attribute_list(db, "event", handle, attribute_list)
+    export_media_ref_list(db, "event", handle, media_list)
+    export_citation_list(db, "event", handle, citation_list)
 
 
-def export_attribute_list(
-    db: Database, from_type: str, from_handle: str, attr_list
-) -> None:
-    """Export all attribute records for a parent object."""
-    for attribute in attr_list:
-        export_attribute(db, from_type, from_handle, attribute)
+def export_person(db: Database, raw: dict) -> None:
+    """
+    Export a Person raw DataDict into the person table and related tables.
 
+    Uses get_raw_person_data() output directly — all fields accessed by name,
+    making this forward-compatible with new Person fields added in any core
+    version (e.g. familysearch_sync added in Gramps 6.1).
+    """
+    handle = raw["handle"]
+    gid = raw["gramps_id"]
+    gender = raw["gender"]
+    primary_name = raw["primary_name"]
+    alternate_names = raw["alternate_names"]
+    death_ref_index = raw["death_ref_index"]
+    birth_ref_index = raw["birth_ref_index"]
+    event_ref_list = raw["event_ref_list"]
+    family_list = raw["family_list"]
+    parent_family_list = raw["parent_family_list"]
+    media_list = raw["media_list"]
+    address_list = raw["address_list"]
+    attribute_list = raw["attribute_list"]
+    urls = raw["urls"]
+    lds_ord_list = raw["lds_ord_list"]
+    pcitation_list = raw["citation_list"]
+    pnote_list = raw["note_list"]
+    change = raw["change"]
+    tag_list = raw["tag_list"]
+    private = raw["private"]
+    person_ref_list = raw["person_ref_list"]
+    # familysearch_sync is present from Gramps 6.1; absent keys get None
+    familysearch_sync = raw.get("familysearch_sync")
 
-def export_child_ref_list(
-    db: Database, from_type: str, from_handle: str, to_type: str, ref_list
-) -> None:
-    """Export all child reference records for a family."""
-    for child_ref in ref_list:
-        # family -> child_ref
-        # (False, [], [], u'b305e96e39652d8f08c', (1, u''), (1, u''))
-        (private, citation_list, note_list, ref, frel, mrel) = child_ref
-        handle = create_id()
-        db.query(
-            """INSERT INTO child_ref (handle,
-                     ref, frel0, frel1, mrel0, mrel1, private)
-                        VALUES (?, ?, ?, ?, ?, ?, ?);""",
-            handle,
-            ref,
-            frel[0],
-            frel[1],
-            mrel[0],
-            mrel[1],
-            private,
-        )
-        export_citation_list(db, "child_ref", handle, citation_list)
-        export_list(db, "child_ref", handle, "note", note_list)
-        # And finally, make a link from parent to new object
-        export_link(db, from_type, from_handle, "child_ref", handle)
-
-
-def export_list(
-    db: Database, from_type: str, from_handle: str, to_type: str, handle_list
-) -> None:
-    """Export a list of handle links from a parent to child objects."""
-    for to_handle in handle_list:
-        export_link(db, from_type, from_handle, to_type, to_handle)
-
-
-def export_link(
-    db: Database,
-    from_type: str,
-    from_handle: str,
-    to_type: str,
-    to_handle: str | None,
-) -> None:
-    """Insert a single link record between two objects."""
-    if to_handle:
-        db.query(
-            """insert into link (
-                   from_type,
-                   from_handle,
-                   to_type,
-                   to_handle) values (?, ?, ?, ?)""",
-            from_type,
-            from_handle,
-            to_type,
-            to_handle,
-        )
-
-
-def export_datamap_list(
-    db: Database, from_type: str, from_handle: str, datamap
-) -> None:
-    """Export the datamap entries for a source or citation."""
-    for private, data_type, data in datamap:
-        db.query(
-            """INSERT INTO datamap (
-                      from_handle,
-                      the_type0,
-                      the_type1,
-                      value_field,
-                      private) values (?, ?, ?, ?, ?)""",
-            from_handle,
-            data_type[0],
-            data_type[1],
-            data,
-            private,
-        )
-
-
-def export_address(db: Database, from_type: str, from_handle: str, address) -> None:
-    """Export a single serialized address record."""
-    (private, acitation_list, anote_list, date, location) = address
-    addr_handle = create_id()
     db.query(
-        """INSERT INTO address (
-                handle,
-                private) VALUES (?, ?);""",
-        addr_handle,
-        private,
-    )
-    export_location(db, "address", addr_handle, location)
-    export_date(db, "address", addr_handle, date)
-    export_list(db, "address", addr_handle, "note", anote_list)
-    export_citation_list(db, "address", addr_handle, acitation_list)
-    # finally, link the parent to the address
-    export_link(db, from_type, from_handle, "address", addr_handle)
-
-
-def export_location(db: Database, from_type: str, from_handle: str, location) -> None:
-    """Export a single location record."""
-    if location is None:
-        return
-    if len(location) == 8:
-        (street, locality, city, county, state, country, postal, phone) = location
-        parish = None
-    elif len(location) == 2:
-        (
-            (street, locality, city, county, state, country, postal, phone),
-            parish,
-        ) = location
-    else:
-        LOG.error("what kind of location is this? %s", location)
-        return
-    handle = create_id()
-    db.query(
-        """INSERT INTO location (
-                 handle,
-                 street,
-                 locality,
-                 city,
-                 county,
-                 state,
-                 country,
-                 postal,
-                 phone,
-                 parish) VALUES (?,?,?,?,?,?,?,?,?,?);""",
+        """INSERT INTO person (
+                  handle,
+                  gid,
+                  gender,
+                  death_ref_handle,
+                  birth_ref_handle,
+                  change,
+                  private,
+                  familysearch_sync) values (?, ?, ?, ?, ?, ?, ?, ?);""",
         handle,
-        street,
-        locality,
-        city,
-        county,
-        state,
-        country,
-        postal,
-        phone,
-        parish,
+        gid,
+        gender,
+        lookup(death_ref_index, event_ref_list),
+        lookup(birth_ref_index, event_ref_list),
+        change,
+        private,
+        json.dumps(familysearch_sync) if familysearch_sync is not None else None,
     )
-    # finally, link the parent to the location
-    export_link(db, from_type, from_handle, "location", handle)
+
+    for event_ref in event_ref_list:
+        export_event_ref(db, "person", handle, event_ref)
+    export_list(db, "person", handle, "family", family_list)
+    export_list(db, "person", handle, "parent_family", parent_family_list)
+    export_media_ref_list(db, "person", handle, media_list)
+    export_list(db, "person", handle, "note", pnote_list)
+    export_attribute_list(db, "person", handle, attribute_list)
+    export_url_list(db, "person", handle, urls)
+    export_person_ref_list(db, "person", handle, person_ref_list)
+    export_citation_list(db, "person", handle, pcitation_list)
+    export_list(db, "person", handle, "tag", tag_list)
+
+    for address in address_list:
+        export_address(db, "person", handle, address)
+
+    for ldsord in lds_ord_list:
+        export_lds(db, "person", handle, ldsord)
+
+    export_name(db, "person", handle, True, primary_name)
+    for name in alternate_names:
+        export_name(db, "person", handle, False, name)
 
 
-def export_repository_ref_list(
-    db: Database, from_type: str, from_handle: str, reporef_list
-) -> None:
-    """Export all repository reference records for a source."""
-    for repo in reporef_list:
-        (
-            note_list,
-            ref,
-            call_number,
-            source_media_type,
-            private,
-        ) = repo
-        handle = create_id()
-        db.query(
-            """insert INTO repository_ref (
-                     handle,
-                     ref,
-                     call_number,
-                     source_media_type0,
-                     source_media_type1,
-                     private) VALUES (?,?,?,?,?,?);""",
+def export_family(db: Database, raw: dict) -> None:
+    """Export a Family raw DataDict into the family table and related tables."""
+    handle = raw["handle"]
+    gid = raw["gramps_id"]
+    father_handle = raw["father_handle"]
+    mother_handle = raw["mother_handle"]
+    the_type = raw["type"]
+    child_ref_list = raw["child_ref_list"]
+    event_ref_list = raw["event_ref_list"]
+    media_list = raw["media_list"]
+    attribute_list = raw["attribute_list"]
+    lds_ord_list = raw["lds_ord_list"]
+    citation_list = raw["citation_list"]
+    note_list = raw["note_list"]
+    change = raw["change"]
+    tag_list = raw["tag_list"]
+    private = raw["private"]
+
+    db.query(
+        """INSERT INTO family (
+                 handle,
+                 gid,
+                 father_handle,
+                 mother_handle,
+                 the_type0,
+                 the_type1,
+                 change,
+                 private) values (?,?,?,?,?,?,?,?);""",
+        handle,
+        gid,
+        father_handle,
+        mother_handle,
+        the_type["value"],
+        the_type["string"],
+        change,
+        private,
+    )
+
+    export_child_ref_list(db, "family", handle, "child_ref", child_ref_list)
+    export_list(db, "family", handle, "note", note_list)
+    export_attribute_list(db, "family", handle, attribute_list)
+    export_citation_list(db, "family", handle, citation_list)
+    export_media_ref_list(db, "family", handle, media_list)
+    export_list(db, "family", handle, "tag", tag_list)
+
+    for event_ref in event_ref_list:
+        export_event_ref(db, "family", handle, event_ref)
+
+    for ldsord in lds_ord_list:
+        export_lds(db, "family", handle, ldsord)
+
+
+def export_repository(db: Database, raw: dict) -> None:
+    """Export a Repository raw DataDict into the repository table."""
+    handle = raw["handle"]
+    gid = raw["gramps_id"]
+    the_type = raw["type"]
+    name = raw["name"]
+    note_list = raw["note_list"]
+    address_list = raw["address_list"]
+    urls = raw["urls"]
+    change = raw["change"]
+    tag_list = raw["tag_list"]
+    private = raw["private"]
+
+    db.query(
+        """INSERT INTO repository (
+                 handle,
+                 gid,
+                 the_type0,
+                 the_type1,
+                 name,
+                 change,
+                 private) VALUES (?,?,?,?,?,?,?);""",
+        handle,
+        gid,
+        the_type["value"],
+        the_type["string"],
+        name,
+        change,
+        private,
+    )
+
+    export_list(db, "repository", handle, "note", note_list)
+    export_url_list(db, "repository", handle, urls)
+    export_list(db, "repository", handle, "tag", tag_list)
+
+    for address in address_list:
+        export_address(db, "repository", handle, address)
+
+
+def export_place(db: Database, raw: dict) -> None:
+    """Export a Place raw DataDict into the place table and related tables."""
+    handle = raw["handle"]
+    gid = raw["gramps_id"]
+    title = raw["title"]
+    long = raw["long"]
+    lat = raw["lat"]
+    # In 6.1 DataDict: name (PlaceName dict), alt_names, placeref_list
+    place_name = raw["name"]
+    alt_names = raw["alt_names"]
+    placeref_list = raw["placeref_list"]
+    place_type = raw["place_type"]
+    code = raw["code"]
+    alt_loc = raw["alt_loc"]
+    urls = raw["urls"]
+    media_list = raw["media_list"]
+    citation_list = raw["citation_list"]
+    note_list = raw["note_list"]
+    change = raw["change"]
+    tag_list = raw["tag_list"]
+    private = raw["private"]
+
+    value = place_name["value"]
+    lang = place_name.get("lang", "")
+
+    db.query(
+        """INSERT INTO place (
+                 handle,
+                 gid,
+                 title,
+                 value,
+                 the_type0,
+                 the_type1,
+                 code,
+                 long,
+                 lat,
+                 lang,
+                 change,
+                 private) values (?,?,?,?,?,?,?,?,?,?,?,?);""",
+        handle,
+        gid,
+        title,
+        value,
+        place_type["value"],
+        place_type["string"],
+        code,
+        long,
+        lat,
+        lang,
+        change,
+        private,
+    )
+
+    export_date(db, "place", handle, place_name.get("date"))
+    export_url_list(db, "place", handle, urls)
+    export_media_ref_list(db, "place", handle, media_list)
+    export_citation_list(db, "place", handle, citation_list)
+    export_list(db, "place", handle, "note", note_list)
+    export_list(db, "place", handle, "tag", tag_list)
+
+    for alt_name in alt_names:
+        export_place_name(db, handle, alt_name)
+
+    for place_ref in placeref_list:
+        export_place_ref(db, handle, place_ref)
+
+    for location in alt_loc:
+        export_location(db, "place_alt", handle, location)
+
+
+def export_citation(db: Database, raw: dict) -> None:
+    """Export a Citation raw DataDict into the citation table."""
+    handle = raw["handle"]
+    gid = raw["gramps_id"]
+    date = raw["date"]
+    page = raw["page"]
+    confidence = raw["confidence"]
+    source_handle = raw["source_handle"]
+    note_list = raw["note_list"]
+    media_list = raw["media_list"]
+    attribute_list = raw["attribute_list"]
+    change = raw["change"]
+    tag_list = raw["tag_list"]
+    private = raw["private"]
+
+    db.query(
+        """INSERT into citation (
+                 handle,
+                 gid,
+                 confidence,
+                 page,
+                 source_handle,
+                 change,
+                 private
+                 ) VALUES (?,?,?,?,?,?,?);""",
+        handle,
+        gid,
+        confidence,
+        page,
+        source_handle,
+        change,
+        private,
+    )
+    export_src_attribute_list(db, handle, attribute_list)
+    export_date(db, "citation", handle, date)
+    export_list(db, "citation", handle, "note", note_list)
+    export_media_ref_list(db, "citation", handle, media_list)
+    export_list(db, "citation", handle, "tag", tag_list)
+
+
+def export_source(db: Database, raw: dict) -> None:
+    """Export a Source raw DataDict into the source table."""
+    handle = raw["handle"]
+    gid = raw["gramps_id"]
+    title = raw["title"]
+    author = raw["author"]
+    pubinfo = raw["pubinfo"]
+    note_list = raw["note_list"]
+    media_list = raw["media_list"]
+    abbrev = raw["abbrev"]
+    change = raw["change"]
+    attribute_list = raw["attribute_list"]
+    reporef_list = raw["reporef_list"]
+    tag_list = raw["tag_list"]
+    private = raw["private"]
+
+    db.query(
+        """INSERT into source (
+             handle,
+             gid,
+             title,
+             author,
+             pubinfo,
+             abbrev,
+             change,
+             private
+             ) VALUES (?,?,?,?,?,?,?,?);""",
+        handle,
+        gid,
+        title,
+        author,
+        pubinfo,
+        abbrev,
+        change,
+        private,
+    )
+    export_list(db, "source", handle, "note", note_list)
+    export_list(db, "source", handle, "tag", tag_list)
+    export_media_ref_list(db, "source", handle, media_list)
+    export_src_attribute_list(db, handle, attribute_list)
+    export_repository_ref_list(db, "source", handle, reporef_list)
+
+
+def export_media(db: Database, raw: dict) -> None:
+    """Export a Media raw DataDict into the media table."""
+    handle = raw["handle"]
+    gid = raw["gramps_id"]
+    path = raw["path"]
+    mime = raw["mime"]
+    desc = raw["desc"]
+    checksum = raw["checksum"]
+    attribute_list = raw["attribute_list"]
+    citation_list = raw["citation_list"]
+    note_list = raw["note_list"]
+    change = raw["change"]
+    date = raw["date"]
+    tag_list = raw["tag_list"]
+    private = raw["private"]
+
+    db.query(
+        """INSERT INTO media (
             handle,
-            ref,
-            call_number,
-            source_media_type[0],
-            source_media_type[1],
-            private,
-        )
-        export_list(db, "repository_ref", handle, "note", note_list)
-        # finally, link this to parent
-        export_link(db, from_type, from_handle, "repository_ref", handle)
+            gid,
+            path,
+            mime,
+            desc,
+            checksum,
+            change,
+            private) VALUES (?,?,?,?,?,?,?,?);""",
+        handle,
+        gid,
+        path,
+        mime,
+        desc,
+        checksum,
+        change,
+        private,
+    )
+    export_date(db, "media", handle, date)
+    export_list(db, "media", handle, "note", note_list)
+    export_citation_list(db, "media", handle, citation_list)
+    export_attribute_list(db, "media", handle, attribute_list)
+    export_list(db, "media", handle, "tag", tag_list)
 
 
+def export_tag(db: Database, raw: dict) -> None:
+    """Export a Tag raw DataDict into the tag table."""
+    db.query(
+        """INSERT INTO tag (
+            handle,
+            name,
+            color,
+            priority,
+            change) VALUES (?,?,?,?,?);""",
+        raw["handle"],
+        raw["name"],
+        raw["color"],
+        raw["priority"],
+        raw["change"],
+    )
+
+
+# -------------------------------------------------------------------------
+#
+# Dummy callback
+#
+# -------------------------------------------------------------------------
 def dummy_callback(*args) -> None:
     """No-op callback used when no real callback is provided."""
 
@@ -1361,16 +1633,20 @@ def exportData(database, filename: str, user, option_box) -> bool:
     """
     Export the Gramps database to a SQLite file.
 
+    Uses get_raw_*_data() throughout so that all object fields — including
+    any added in future core versions — are accessed by name from the raw
+    DataDict rather than by position from a serialized tuple.
+
     :param database: The Gramps database to export.
     :param filename: Path to the output SQLite file.
     :param user: User object providing a callback for progress.
     :param option_box: Optional export option box (may filter the database).
     :returns: True on success.
     """
-    if isinstance(user.callback, abc.Callable):  # is really callable
+    if isinstance(user.callback, abc.Callable):
         callback = user.callback
     else:
-        callback = dummy_callback  # dummy
+        callback = dummy_callback
 
     if option_box:
         option_box.parse_options()
@@ -1395,390 +1671,114 @@ def exportData(database, filename: str, user, option_box) -> bool:
     makeDB(db, callback)
 
     db.batch = True  # don't commit till end
+
     # ---------------------------------
     # Notes
     # ---------------------------------
-    for note_handle in database.iter_note_handles():
-        data = database.get_note_from_handle(note_handle)
-        if data is None:
+    for handle in database.iter_note_handles():
+        raw = database.get_raw_note_data(handle)
+        if raw is None:
             continue
-        export_note(db, data.serialize())
+        export_note(db, raw)
         count += 1
         callback(100 * count / total)
 
     # ---------------------------------
-    # Event
+    # Events
     # ---------------------------------
-    for event_handle in database.iter_event_handles():
-        data = database.get_event_from_handle(event_handle)
-        if data is None:
+    for handle in database.iter_event_handles():
+        raw = database.get_raw_event_data(handle)
+        if raw is None:
             continue
-        export_event(db, data.serialize())
+        export_event(db, raw)
         count += 1
         callback(100 * count / total)
 
     # ---------------------------------
-    # Person
+    # Persons
     # ---------------------------------
-    for person_handle in database.iter_person_handles():
-        person = database.get_person_from_handle(person_handle)
-        if person is None:
+    for handle in database.iter_person_handles():
+        raw = database.get_raw_person_data(handle)
+        if raw is None:
             continue
-        export_person(db, person)
+        export_person(db, raw)
         count += 1
         callback(100 * count / total)
 
     # ---------------------------------
-    # Family
+    # Families
     # ---------------------------------
-    for family_handle in database.iter_family_handles():
-        family = database.get_family_from_handle(family_handle)
-        if family is None:
+    for handle in database.iter_family_handles():
+        raw = database.get_raw_family_data(handle)
+        if raw is None:
             continue
-        handle = family.handle
-        gid = family.gramps_id
-        father_handle = family.father_handle
-        mother_handle = family.mother_handle
-        child_ref_list = family.child_ref_list
-        the_type = family.type.serialize()
-        event_ref_list = family.get_event_ref_list()
-        media_list = family.get_media_list()
-        attribute_list = family.get_attribute_list()
-        lds_seal_list = family.get_lds_ord_list()
-        citation_list = family.get_citation_list()
-        note_list = family.get_note_list()
-        change = family.change
-        tag_list = family.get_tag_list()
-        private = family.private
-
-        # father_handle and/or mother_handle can be None
-        db.query(
-            """INSERT INTO family (
-                 handle,
-                 gid,
-                 father_handle,
-                 mother_handle,
-                 the_type0,
-                 the_type1,
-                 change,
-                 private) values (?,?,?,?,?,?,?,?);""",
-            handle,
-            gid,
-            father_handle,
-            mother_handle,
-            the_type[0],
-            the_type[1],
-            change,
-            private,
-        )
-
-        export_child_ref_list(
-            db,
-            "family",
-            handle,
-            "child_ref",
-            [cr.serialize() for cr in child_ref_list],
-        )
-        export_list(db, "family", handle, "note", note_list)
-        export_attribute_list(
-            db, "family", handle, [a.serialize() for a in attribute_list]
-        )
-        export_citation_list(db, "family", handle, citation_list)
-        export_media_ref_list(
-            db, "family", handle, [m.serialize() for m in media_list]
-        )
-        export_list(db, "family", handle, "tag", tag_list)
-
-        # Event Reference information
-        for event_ref in event_ref_list:
-            export_event_ref(db, "family", handle, event_ref.serialize())
-
-        # -------------------------------------
-        # LDS
-        # -------------------------------------
-        for ldsord in lds_seal_list:
-            export_lds(db, "family", handle, ldsord.serialize())
-
+        export_family(db, raw)
         count += 1
         callback(100 * count / total)
 
     # ---------------------------------
-    # Repository
+    # Repositories
     # ---------------------------------
-    for repository_handle in database.iter_repository_handles():
-        repository = database.get_repository_from_handle(repository_handle)
-        if repository is None:
+    for handle in database.iter_repository_handles():
+        raw = database.get_raw_repository_data(handle)
+        if raw is None:
             continue
-        (
-            handle,
-            gid,
-            the_type,
-            name,
-            note_list,
-            address_list,
-            urls,
-            change,
-            tag_list,
-            private,
-        ) = repository.serialize()
-
-        db.query(
-            """INSERT INTO repository (
-                 handle,
-                 gid,
-                 the_type0,
-                 the_type1,
-                 name,
-                 change,
-                 private) VALUES (?,?,?,?,?,?,?);""",
-            handle,
-            gid,
-            the_type[0],
-            the_type[1],
-            name,
-            change,
-            private,
-        )
-
-        export_list(db, "repository", handle, "note", note_list)
-        export_url_list(db, "repository", handle, urls)
-        export_list(db, "repository", handle, "tag", tag_list)
-
-        for address in address_list:
-            export_address(db, "repository", handle, address)
-
+        export_repository(db, raw)
         count += 1
         callback(100 * count / total)
 
     # ---------------------------------
-    # Place
+    # Places
     # ---------------------------------
-    for place_handle in database.iter_place_handles():
-        place = database.get_place_from_handle(place_handle)
-        if place is None:
+    for handle in database.iter_place_handles():
+        raw = database.get_raw_place_data(handle)
+        if raw is None:
             continue
-        (
-            handle,
-            gid,
-            title,
-            long,
-            lat,
-            place_ref_list,
-            place_name,
-            alt_place_name_list,
-            place_type,
-            code,
-            alt_location_list,
-            urls,
-            media_list,
-            citation_list,
-            note_list,
-            change,
-            tag_list,
-            private,
-        ) = place.serialize()
-
-        value, date, lang = place_name
-
-        db.query(
-            """INSERT INTO place (
-                 handle,
-                 gid,
-                 title,
-                 value,
-                 the_type0,
-                 the_type1,
-                 code,
-                 long,
-                 lat,
-                 lang,
-                 change,
-                 private) values (?,?,?,?,?,?,?,?,?,?,?,?);""",
-            handle,
-            gid,
-            title,
-            value,
-            place_type[0],
-            place_type[1],
-            code,
-            long,
-            lat,
-            lang,
-            change,
-            private,
-        )
-
-        export_date(db, "place", handle, date)
-        export_url_list(db, "place", handle, urls)
-        export_media_ref_list(db, "place", handle, media_list)
-        export_citation_list(db, "place", handle, citation_list)
-        export_list(db, "place", handle, "note", note_list)
-        export_list(db, "place", handle, "tag", tag_list)
-
-        # 1. alt_place_name_list = [('Ohio', None, ''), ...]
-        # [(value, date, lang)...]
-        # 2. place_ref_list = Enclosed by:  [('4ECKQCWCLO5YIHXEXC', None)]
-        # [(handle, date)...]
-
-        export_alt_place_name_list(db, handle, alt_place_name_list)
-        export_place_ref_list(db, handle, place_ref_list)
-
-        # But we need to link these:
-        export_location_list(db, "place_alt", handle, alt_location_list)
-
+        export_place(db, raw)
         count += 1
         callback(100 * count / total)
 
     # ---------------------------------
-    # Citation
+    # Citations
     # ---------------------------------
-    for citation_handle in database.iter_citation_handles():
-        citation = database.get_citation_from_handle(citation_handle)
-        if citation is None:
+    for handle in database.iter_citation_handles():
+        raw = database.get_raw_citation_data(handle)
+        if raw is None:
             continue
-        (
-            handle,  # 0
-            gid,  # 1
-            date,  # 2
-            page,  # 3
-            confidence,  # 4
-            source_handle,  # 5
-            note_list,  # 6
-            media_list,  # 7
-            datamap,  # 8
-            change,  # 9
-            tag_list,
-            private,
-        ) = citation.serialize()
-        db.query(
-            """INSERT into citation (
-                 handle,
-                 gid,
-                 confidence,
-                 page,
-                 source_handle,
-                 change,
-                 private
-                 ) VALUES (?,?,?,?,?,?,?);""",
-            handle,
-            gid,
-            confidence,
-            page,
-            source_handle,
-            change,
-            private,
-        )
-        export_datamap_list(db, "citation", handle, datamap)
-        export_date(db, "citation", handle, date)
-        export_list(db, "citation", handle, "note", note_list)
-        export_media_ref_list(db, "citation", handle, media_list)
-        export_list(db, "citation", handle, "tag", tag_list)
+        export_citation(db, raw)
         count += 1
         callback(100 * count / total)
 
     # ---------------------------------
-    # Source
+    # Sources
     # ---------------------------------
-    for source_handle in database.iter_source_handles():
-        source = database.get_source_from_handle(source_handle)
-        if source is None:
+    for handle in database.iter_source_handles():
+        raw = database.get_raw_source_data(handle)
+        if raw is None:
             continue
-        (
-            handle,
-            gid,
-            title,
-            author,
-            pubinfo,
-            note_list,
-            media_list,
-            abbrev,
-            change,
-            datamap,
-            reporef_list,
-            tag_list,
-            private,
-        ) = source.serialize()
-
-        export_source(db, handle, gid, title, author, pubinfo, abbrev, change, private)
-        export_list(db, "source", handle, "note", note_list)
-        export_list(db, "source", handle, "tag", tag_list)
-        export_media_ref_list(db, "source", handle, media_list)
-        export_datamap_list(db, "source", handle, datamap)
-        export_repository_ref_list(db, "source", handle, reporef_list)
+        export_source(db, raw)
         count += 1
         callback(100 * count / total)
 
     # ---------------------------------
     # Media
     # ---------------------------------
-    for media_handle in database.iter_media_handles():
-        media = database.get_media_from_handle(media_handle)
-        if media is None:
+    for handle in database.iter_media_handles():
+        raw = database.get_raw_media_data(handle)
+        if raw is None:
             continue
-        (
-            handle,
-            gid,
-            path,
-            mime,
-            desc,
-            checksum,
-            attribute_list,
-            citation_list,
-            note_list,
-            change,
-            date,
-            tag_list,
-            private,
-        ) = media.serialize()
-
-        db.query(
-            """INSERT INTO media (
-            handle,
-            gid,
-            path,
-            mime,
-            desc,
-            checksum,
-            change,
-            private) VALUES (?,?,?,?,?,?,?,?);""",
-            handle,
-            gid,
-            path,
-            mime,
-            desc,
-            checksum,
-            change,
-            private,
-        )
-        export_date(db, "media", handle, date)
-        export_list(db, "media", handle, "note", note_list)
-        export_citation_list(db, "media", handle, citation_list)
-        export_attribute_list(db, "media", handle, attribute_list)
-        export_list(db, "media", handle, "tag", tag_list)
+        export_media(db, raw)
         count += 1
         callback(100 * count / total)
 
     # ---------------------------------
     # Tags
     # ---------------------------------
-    for tag_handle in database.iter_tag_handles():
-        tag_object = database.get_tag_from_handle(tag_handle)
-        if tag_object is None:
+    for handle in database.iter_tag_handles():
+        raw = database.get_raw_tag_data(handle)
+        if raw is None:
             continue
-        (handle, name, color, priority, change) = tag_object.serialize()
-        db.query(
-            """INSERT INTO tag (
-            handle,
-            name,
-            color,
-            priority,
-            change) VALUES (?,?,?,?,?);""",
-            handle,
-            name,
-            color,
-            priority,
-            change,
-        )
+        export_tag(db, raw)
         count += 1
         callback(100 * count / total)
 

--- a/Sqlite/ExportSql.py
+++ b/Sqlite/ExportSql.py
@@ -1783,7 +1783,7 @@ def exportData(database, filename: str, user, option_box) -> bool:
     db.db.commit()  # commit all changes
     db.db.close()
 
-    total_time = time.time() - start
+    total_time = round(time.time() - start)
     msg = (
         ngettext(
             "Export Complete: %d second", "Export Complete: %d seconds", total_time

--- a/Sqlite/ExportSql.py
+++ b/Sqlite/ExportSql.py
@@ -100,6 +100,10 @@ class Database(object):
         self.database = database
         self.db = sqlite.connect(self.database)
         self.cursor = self.db.cursor()
+        # Per (from_type, from_handle, to_type) counters, so each link
+        # written to the `link` table records its position within its
+        # list -- preserving any GUI-driven reordering on round trip.
+        self.link_seq: dict[tuple[str, str, str], int] = {}
 
     def query(self, q: str, *args):
         """Execute a query and return all results."""
@@ -375,7 +379,8 @@ def makeDB(db: Database, callback) -> None:
                  from_type CHARACTER(25),
                  from_handle CHARACTER(25),
                  to_type CHARACTER(25),
-                 to_handle CHARACTER(25));"""
+                 to_handle CHARACTER(25),
+                 seq INTEGER);"""
     )
     count += 1
     callback(100 * count / total)
@@ -611,16 +616,21 @@ def export_link(
 ) -> None:
     """Insert a single link record between two objects."""
     if to_handle:
+        key = (from_type, from_handle, to_type)
+        seq = db.link_seq.get(key, 0)
+        db.link_seq[key] = seq + 1
         db.query(
             """insert into link (
                    from_type,
                    from_handle,
                    to_type,
-                   to_handle) values (?, ?, ?, ?)""",
+                   to_handle,
+                   seq) values (?, ?, ?, ?, ?)""",
             from_type,
             from_handle,
             to_type,
             to_handle,
+            seq,
         )
 
 

--- a/Sqlite/ExportSql.py
+++ b/Sqlite/ExportSql.py
@@ -85,11 +85,8 @@ class Database(object):
         """Execute a query and return all results."""
         args = list(args)
         if q.strip().upper().startswith("DROP"):
-            try:
-                self.cursor.execute(q, args)
-                self.db.commit()
-            except Exception:
-                LOG.warning("no such table to drop: '%s'", q)
+            self.cursor.execute(q, args)
+            self.db.commit()
         else:
             try:
                 self.cursor.execute(q, args)
@@ -117,7 +114,7 @@ def makeDB(db: Database, callback) -> None:
     count = 0
     total = 28
 
-    db.query("""drop table note;""")
+    db.query("""drop table if exists note;""")
     db.query(
         """CREATE TABLE note (
                   handle CHARACTER(25) PRIMARY KEY,
@@ -132,7 +129,7 @@ def makeDB(db: Database, callback) -> None:
     count += 1
     callback(100 * count / total)
 
-    db.query("""drop table name;""")
+    db.query("""drop table if exists name;""")
     db.query(
         """CREATE TABLE name (
                   handle CHARACTER(25) PRIMARY KEY,
@@ -153,7 +150,7 @@ def makeDB(db: Database, callback) -> None:
     count += 1
     callback(100 * count / total)
 
-    db.query("""drop table surname;""")
+    db.query("""drop table if exists surname;""")
     db.query(
         """CREATE TABLE surname (
                   handle CHARACTER(25),
@@ -174,7 +171,7 @@ def makeDB(db: Database, callback) -> None:
     count += 1
     callback(100 * count / total)
 
-    db.query("""drop table date;""")
+    db.query("""drop table if exists date;""")
     db.query(
         """CREATE TABLE date (
                   handle CHARACTER(25) PRIMARY KEY,
@@ -196,7 +193,7 @@ def makeDB(db: Database, callback) -> None:
     count += 1
     callback(100 * count / total)
 
-    db.query("""drop table person;""")
+    db.query("""drop table if exists person;""")
     db.query(
         """CREATE TABLE person (
                   handle CHARACTER(25) PRIMARY KEY,
@@ -211,7 +208,7 @@ def makeDB(db: Database, callback) -> None:
     count += 1
     callback(100 * count / total)
 
-    db.query("""drop table family;""")
+    db.query("""drop table if exists family;""")
     db.query(
         """CREATE TABLE family (
                  handle CHARACTER(25) PRIMARY KEY,
@@ -226,7 +223,7 @@ def makeDB(db: Database, callback) -> None:
     count += 1
     callback(100 * count / total)
 
-    db.query("""drop table place;""")
+    db.query("""drop table if exists place;""")
     db.query(
         """CREATE TABLE place (
                  handle CHARACTER(25) PRIMARY KEY,
@@ -245,7 +242,7 @@ def makeDB(db: Database, callback) -> None:
     count += 1
     callback(100 * count / total)
 
-    db.query("""drop table place_ref;""")
+    db.query("""drop table if exists place_ref;""")
     db.query(
         """CREATE TABLE place_ref (
                    handle             CHARACTER(25) PRIMARY KEY,
@@ -255,7 +252,7 @@ def makeDB(db: Database, callback) -> None:
     count += 1
     callback(100 * count / total)
 
-    db.query("""drop table place_name;""")
+    db.query("""drop table if exists place_name;""")
     db.query(
         """CREATE TABLE place_name (
                   handle        CHARACTER(25) PRIMARY KEY,
@@ -266,7 +263,7 @@ def makeDB(db: Database, callback) -> None:
     count += 1
     callback(100 * count / total)
 
-    db.query("""drop table event;""")
+    db.query("""drop table if exists event;""")
     db.query(
         """CREATE TABLE event (
                  handle CHARACTER(25) PRIMARY KEY,
@@ -280,7 +277,7 @@ def makeDB(db: Database, callback) -> None:
     count += 1
     callback(100 * count / total)
 
-    db.query("""drop table citation;""")
+    db.query("""drop table if exists citation;""")
     db.query(
         """CREATE TABLE citation (
                  handle CHARACTER(25) PRIMARY KEY,
@@ -294,7 +291,7 @@ def makeDB(db: Database, callback) -> None:
     count += 1
     callback(100 * count / total)
 
-    db.query("""drop table source;""")
+    db.query("""drop table if exists source;""")
     db.query(
         """CREATE TABLE source (
                  handle CHARACTER(25) PRIMARY KEY,
@@ -309,7 +306,7 @@ def makeDB(db: Database, callback) -> None:
     count += 1
     callback(100 * count / total)
 
-    db.query("""drop table media;""")
+    db.query("""drop table if exists media;""")
     db.query(
         """CREATE TABLE media (
                  handle CHARACTER(25) PRIMARY KEY,
@@ -324,7 +321,7 @@ def makeDB(db: Database, callback) -> None:
     count += 1
     callback(100 * count / total)
 
-    db.query("""drop table repository_ref;""")
+    db.query("""drop table if exists repository_ref;""")
     db.query(
         """CREATE TABLE repository_ref (
                  handle CHARACTER(25) PRIMARY KEY,
@@ -337,7 +334,7 @@ def makeDB(db: Database, callback) -> None:
     count += 1
     callback(100 * count / total)
 
-    db.query("""drop table repository;""")
+    db.query("""drop table if exists repository;""")
     db.query(
         """CREATE TABLE repository (
                  handle CHARACTER(25) PRIMARY KEY,
@@ -352,7 +349,7 @@ def makeDB(db: Database, callback) -> None:
     callback(100 * count / total)
 
     # One link to link them all
-    db.query("""drop table link;""")
+    db.query("""drop table if exists link;""")
     db.query(
         """CREATE TABLE link (
                  from_type CHARACTER(25),
@@ -370,7 +367,7 @@ def makeDB(db: Database, callback) -> None:
     count += 1
     callback(100 * count / total)
 
-    db.query("""drop table markup;""")
+    db.query("""drop table if exists markup;""")
     db.query(
         """CREATE TABLE markup (
                  handle CHARACTER(25) PRIMARY KEY,
@@ -382,7 +379,7 @@ def makeDB(db: Database, callback) -> None:
     count += 1
     callback(100 * count / total)
 
-    db.query("""drop table event_ref;""")
+    db.query("""drop table if exists event_ref;""")
     db.query(
         """CREATE TABLE event_ref (
                  handle CHARACTER(25) PRIMARY KEY,
@@ -394,7 +391,7 @@ def makeDB(db: Database, callback) -> None:
     count += 1
     callback(100 * count / total)
 
-    db.query("""drop table person_ref;""")
+    db.query("""drop table if exists person_ref;""")
     db.query(
         """CREATE TABLE person_ref (
                  handle CHARACTER(25) PRIMARY KEY,
@@ -405,7 +402,7 @@ def makeDB(db: Database, callback) -> None:
     count += 1
     callback(100 * count / total)
 
-    db.query("""drop table child_ref;""")
+    db.query("""drop table if exists child_ref;""")
     db.query(
         """CREATE TABLE child_ref (
                  handle CHARACTER(25) PRIMARY KEY,
@@ -419,7 +416,7 @@ def makeDB(db: Database, callback) -> None:
     count += 1
     callback(100 * count / total)
 
-    db.query("""drop table lds;""")
+    db.query("""drop table if exists lds;""")
     db.query(
         """CREATE TABLE lds (
                  handle CHARACTER(25) PRIMARY KEY,
@@ -433,7 +430,7 @@ def makeDB(db: Database, callback) -> None:
     count += 1
     callback(100 * count / total)
 
-    db.query("""drop table media_ref;""")
+    db.query("""drop table if exists media_ref;""")
     db.query(
         """CREATE TABLE media_ref (
                  handle CHARACTER(25) PRIMARY KEY,
@@ -447,7 +444,7 @@ def makeDB(db: Database, callback) -> None:
     count += 1
     callback(100 * count / total)
 
-    db.query("""drop table address;""")
+    db.query("""drop table if exists address;""")
     db.query(
         """CREATE TABLE address (
                 handle CHARACTER(25) PRIMARY KEY,
@@ -456,7 +453,7 @@ def makeDB(db: Database, callback) -> None:
     count += 1
     callback(100 * count / total)
 
-    db.query("""drop table location;""")
+    db.query("""drop table if exists location;""")
     db.query(
         """CREATE TABLE location (
                  handle CHARACTER(25) PRIMARY KEY,
@@ -473,7 +470,7 @@ def makeDB(db: Database, callback) -> None:
     count += 1
     callback(100 * count / total)
 
-    db.query("""drop table attribute;""")
+    db.query("""drop table if exists attribute;""")
     db.query(
         """CREATE TABLE attribute (
                  handle CHARACTER(25) PRIMARY KEY,
@@ -485,7 +482,7 @@ def makeDB(db: Database, callback) -> None:
     count += 1
     callback(100 * count / total)
 
-    db.query("""drop table url;""")
+    db.query("""drop table if exists url;""")
     db.query(
         """CREATE TABLE url (
                  handle CHARACTER(25) PRIMARY KEY,
@@ -499,7 +496,7 @@ def makeDB(db: Database, callback) -> None:
     count += 1
     callback(100 * count / total)
 
-    db.query("""drop table datamap;""")
+    db.query("""drop table if exists datamap;""")
     db.query(
         """CREATE TABLE datamap (
                  from_handle CHARACTER(25),
@@ -512,7 +509,7 @@ def makeDB(db: Database, callback) -> None:
     count += 1
     callback(100 * count / total)
 
-    db.query("""drop table tag;""")
+    db.query("""drop table if exists tag;""")
     db.query(
         """CREATE TABLE tag (
                  handle CHARACTER(25) PRIMARY KEY,

--- a/Sqlite/ExportSql.py
+++ b/Sqlite/ExportSql.py
@@ -28,32 +28,35 @@
 #   Name formats
 #   Namemaps?
 #   GRAMPS Version #, date, exporter
-#------------------------------------------------------------------------
-#
-# Standard Python Modules
-#
-#------------------------------------------------------------------------
 
+# -------------------------------------------------------------------------
+#
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import json
 import sqlite3 as sqlite
 import time
 from collections import abc
 
-#------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Set up logging
 #
-#------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import logging
-log = logging.getLogger(".ExportSql")
 
-#------------------------------------------------------------------------
+LOG = logging.getLogger(__name__)
+
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 from gramps.gen.utils.id import create_id
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 from gramps.gui.plug.export import WriterOptionBox  # don't remove, used!!!
+
 try:
     trans = glocale.get_addon_translator(__file__)
 except ValueError:
@@ -62,33 +65,62 @@ _ = trans.gettext
 ngettext = trans.ngettext
 
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
-# Export functions
+# Database
 #
-#-------------------------------------------------------------------------
-def lookup(index, event_ref_list):
+# -------------------------------------------------------------------------
+class Database(object):
     """
-    Get the unserialized event_ref in an list of them and return it.
+    The SQLite db connection wrapper.
     """
-    if index < 0:
-        return None
-    else:
-        count = 0
-        for event_ref in event_ref_list:
-            (_private, _citation_list, _note_list, _attribute_list, ref, _role) = event_ref
-            if index == count:
-                return ref
-            count += 1
-        return None
+
+    def __init__(self, database: str) -> None:
+        """Open the SQLite database file."""
+        self.batch = False
+        self.database = database
+        self.db = sqlite.connect(self.database)
+        self.cursor = self.db.cursor()
+
+    def query(self, q: str, *args):
+        """Execute a query and return all results."""
+        args = list(args)
+        if q.strip().upper().startswith("DROP"):
+            try:
+                self.cursor.execute(q, args)
+                self.db.commit()
+            except Exception:
+                LOG.warning("no such table to drop: '%s'", q)
+        else:
+            try:
+                self.cursor.execute(q, args)
+                if not self.batch:
+                    self.db.commit()
+            except Exception:
+                LOG.error("query: %s", q)
+                LOG.error("values: %s", args)
+                raise
+            return self.cursor.fetchall()
+
+    def close(self) -> None:
+        """Close and write out tables."""
+        self.cursor.close()
+        self.db.close()
 
 
-def makeDB(db, callback):
+# -------------------------------------------------------------------------
+#
+# Schema creation
+#
+# -------------------------------------------------------------------------
+def makeDB(db: Database, callback) -> None:
+    """Create all SQLite tables needed by the Sqlite export."""
     count = 0
     total = 28
 
     db.query("""drop table note;""")
-    db.query("""CREATE TABLE note (
+    db.query(
+        """CREATE TABLE note (
                   handle CHARACTER(25) PRIMARY KEY,
                   gid    CHARACTER(25),
                   text   TEXT,
@@ -96,12 +128,14 @@ def makeDB(db, callback):
                   note_type1   INTEGER,
                   note_type2   TEXT,
                   change INTEGER,
-                  private BOOLEAN);""")
+                  private BOOLEAN);"""
+    )
     count += 1
     callback(100 * count / total)
 
     db.query("""drop table name;""")
-    db.query("""CREATE TABLE name (
+    db.query(
+        """CREATE TABLE name (
                   handle CHARACTER(25) PRIMARY KEY,
                   primary_name BOOLEAN,
                   private BOOLEAN,
@@ -115,29 +149,35 @@ def makeDB(db, callback):
                   display_as INTEGER,
                   call TEXT,
                   nick TEXT,
-                  famnick TEXT);""")
+                  famnick TEXT);"""
+    )
     count += 1
     callback(100 * count / total)
 
     db.query("""drop table surname;""")
-    db.query("""CREATE TABLE surname (
+    db.query(
+        """CREATE TABLE surname (
                   handle CHARACTER(25),
                   surname TEXT,
                   prefix TEXT,
                   primary_surname BOOLEAN,
                   origin_type0 INTEGER,
                   origin_type1 TEXT,
-                  connector TEXT);""")
+                  connector TEXT);"""
+    )
     count += 1
     callback(100 * count / total)
 
-    db.query("""CREATE INDEX idx_surname_handle ON
-                  surname(handle);""")
+    db.query(
+        """CREATE INDEX idx_surname_handle ON
+                  surname(handle);"""
+    )
     count += 1
     callback(100 * count / total)
 
     db.query("""drop table date;""")
-    db.query("""CREATE TABLE date (
+    db.query(
+        """CREATE TABLE date (
                   handle CHARACTER(25) PRIMARY KEY,
                   calendar INTEGER,
                   modifier INTEGER,
@@ -152,24 +192,29 @@ def makeDB(db, callback):
                   slash2 BOOLEAN,
                   text TEXT,
                   sortval INTEGER,
-                  newyear INTEGER);""")
+                  newyear INTEGER);"""
+    )
     count += 1
     callback(100 * count / total)
 
     db.query("""drop table person;""")
-    db.query("""CREATE TABLE person (
+    db.query(
+        """CREATE TABLE person (
                   handle CHARACTER(25) PRIMARY KEY,
                   gid CHARACTER(25),
                   gender INTEGER,
                   death_ref_handle TEXT,
                   birth_ref_handle TEXT,
                   change INTEGER,
-                  private BOOLEAN);""")
+                  private BOOLEAN,
+                  familysearch_sync TEXT);"""
+    )
     count += 1
     callback(100 * count / total)
 
     db.query("""drop table family;""")
-    db.query("""CREATE TABLE family (
+    db.query(
+        """CREATE TABLE family (
                  handle CHARACTER(25) PRIMARY KEY,
                  gid CHARACTER(25),
                  father_handle CHARACTER(25),
@@ -177,12 +222,14 @@ def makeDB(db, callback):
                  the_type0 INTEGER,
                  the_type1 TEXT,
                  change INTEGER,
-                 private BOOLEAN);""")
+                 private BOOLEAN);"""
+    )
     count += 1
     callback(100 * count / total)
 
     db.query("""drop table place;""")
-    db.query("""CREATE TABLE place (
+    db.query(
+        """CREATE TABLE place (
                  handle CHARACTER(25) PRIMARY KEY,
                  gid CHARACTER(25),
                  title TEXT,
@@ -194,53 +241,63 @@ def makeDB(db, callback):
                  lat TEXT,
                  lang TEXT,
                  change INTEGER,
-                 private BOOLEAN);""")
+                 private BOOLEAN);"""
+    )
     count += 1
     callback(100 * count / total)
 
     db.query("""drop table place_ref;""")
-    db.query("""CREATE TABLE place_ref (
+    db.query(
+        """CREATE TABLE place_ref (
                    handle             CHARACTER(25) PRIMARY KEY,
                    from_place_handle  CHARACTER(25),
-                   to_place_handle    CHARACTER(25));""")
+                   to_place_handle    CHARACTER(25));"""
+    )
     count += 1
     callback(100 * count / total)
 
     db.query("""drop table place_name;""")
-    db.query("""CREATE TABLE place_name (
+    db.query(
+        """CREATE TABLE place_name (
                   handle        CHARACTER(25) PRIMARY KEY,
                   from_handle   CHARACTER(25),
                   value         CHARACTER(25),
-                  lang          CHARACTER(25));""")
+                  lang          CHARACTER(25));"""
+    )
     count += 1
     callback(100 * count / total)
 
     db.query("""drop table event;""")
-    db.query("""CREATE TABLE event (
+    db.query(
+        """CREATE TABLE event (
                  handle CHARACTER(25) PRIMARY KEY,
                  gid CHARACTER(25),
                  the_type0 INTEGER,
                  the_type1 TEXT,
                  description TEXT,
                  change INTEGER,
-                 private BOOLEAN);""")
+                 private BOOLEAN);"""
+    )
     count += 1
     callback(100 * count / total)
 
     db.query("""drop table citation;""")
-    db.query("""CREATE TABLE citation (
+    db.query(
+        """CREATE TABLE citation (
                  handle CHARACTER(25) PRIMARY KEY,
                  gid CHARACTER(25),
                  confidence INTEGER,
                  page CHARACTER(25),
                  source_handle CHARACTER(25),
                  change INTEGER,
-                 private BOOLEAN);""")
+                 private BOOLEAN);"""
+    )
     count += 1
     callback(100 * count / total)
 
     db.query("""drop table source;""")
-    db.query("""CREATE TABLE source (
+    db.query(
+        """CREATE TABLE source (
                  handle CHARACTER(25) PRIMARY KEY,
                  gid CHARACTER(25),
                  title TEXT,
@@ -248,12 +305,14 @@ def makeDB(db, callback):
                  pubinfo TEXT,
                  abbrev TEXT,
                  change INTEGER,
-                 private BOOLEAN);""")
+                 private BOOLEAN);"""
+    )
     count += 1
     callback(100 * count / total)
 
     db.query("""drop table media;""")
-    db.query("""CREATE TABLE media (
+    db.query(
+        """CREATE TABLE media (
                  handle CHARACTER(25) PRIMARY KEY,
                  gid CHARACTER(25),
                  path TEXT,
@@ -261,122 +320,146 @@ def makeDB(db, callback):
                  desc TEXT,
                  checksum INTEGER,
                  change INTEGER,
-                 private BOOLEAN);""")
+                 private BOOLEAN);"""
+    )
     count += 1
     callback(100 * count / total)
 
     db.query("""drop table repository_ref;""")
-    db.query("""CREATE TABLE repository_ref (
+    db.query(
+        """CREATE TABLE repository_ref (
                  handle CHARACTER(25) PRIMARY KEY,
                  ref CHARACTER(25),
                  call_number TEXT,
                  source_media_type0 INTEGER,
                  source_media_type1 TEXT,
-                 private BOOLEAN);""")
+                 private BOOLEAN);"""
+    )
     count += 1
     callback(100 * count / total)
 
     db.query("""drop table repository;""")
-    db.query("""CREATE TABLE repository (
+    db.query(
+        """CREATE TABLE repository (
                  handle CHARACTER(25) PRIMARY KEY,
                  gid CHARACTER(25),
                  the_type0 INTEGER,
                  the_type1 TEXT,
                  name TEXT,
                  change INTEGER,
-                 private BOOLEAN);""")
+                 private BOOLEAN);"""
+    )
     count += 1
     callback(100 * count / total)
 
     # One link to link them all
     db.query("""drop table link;""")
-    db.query("""CREATE TABLE link (
+    db.query(
+        """CREATE TABLE link (
                  from_type CHARACTER(25),
                  from_handle CHARACTER(25),
                  to_type CHARACTER(25),
-                 to_handle CHARACTER(25));""")
+                 to_handle CHARACTER(25));"""
+    )
     count += 1
     callback(100 * count / total)
 
-    db.query("""CREATE INDEX idx_link_to ON
-                  link(from_type, from_handle, to_type);""")
+    db.query(
+        """CREATE INDEX idx_link_to ON
+                  link(from_type, from_handle, to_type);"""
+    )
     count += 1
     callback(100 * count / total)
 
     db.query("""drop table markup;""")
-    db.query("""CREATE TABLE markup (
+    db.query(
+        """CREATE TABLE markup (
                  handle CHARACTER(25) PRIMARY KEY,
                  markup0 INTEGER,
                  markup1 TEXT,
                  value INTEGER,
-                 start_stop_list TEXT);""")
+                 start_stop_list TEXT);"""
+    )
     count += 1
     callback(100 * count / total)
 
     db.query("""drop table event_ref;""")
-    db.query("""CREATE TABLE event_ref (
+    db.query(
+        """CREATE TABLE event_ref (
                  handle CHARACTER(25) PRIMARY KEY,
                  ref CHARACTER(25),
                  role0 INTEGER,
                  role1 TEXT,
-                 private BOOLEAN);""")
+                 private BOOLEAN);"""
+    )
     count += 1
     callback(100 * count / total)
 
     db.query("""drop table person_ref;""")
-    db.query("""CREATE TABLE person_ref (
+    db.query(
+        """CREATE TABLE person_ref (
                  handle CHARACTER(25) PRIMARY KEY,
                  ref CHARACTER(25),
                  description TEXT,
-                 private BOOLEAN);""")
+                 private BOOLEAN);"""
+    )
     count += 1
     callback(100 * count / total)
 
     db.query("""drop table child_ref;""")
-    db.query("""CREATE TABLE child_ref (
+    db.query(
+        """CREATE TABLE child_ref (
                  handle CHARACTER(25) PRIMARY KEY,
                  ref CHARACTER(25),
                  frel0 INTEGER,
                  frel1 CHARACTER(25),
                  mrel0 INTEGER,
                  mrel1 CHARACTER(25),
-                 private BOOLEAN);""")
+                 private BOOLEAN);"""
+    )
     count += 1
     callback(100 * count / total)
 
     db.query("""drop table lds;""")
-    db.query("""CREATE TABLE lds (
+    db.query(
+        """CREATE TABLE lds (
                  handle CHARACTER(25) PRIMARY KEY,
                  type INTEGER,
                  place CHARACTER(25),
                  famc CHARACTER(25),
                  temple TEXT,
                  status INTEGER,
-                 private BOOLEAN);""")
+                 private BOOLEAN);"""
+    )
     count += 1
     callback(100 * count / total)
 
     db.query("""drop table media_ref;""")
-    db.query("""CREATE TABLE media_ref (
+    db.query(
+        """CREATE TABLE media_ref (
                  handle CHARACTER(25) PRIMARY KEY,
                  ref CHARACTER(25),
                  role0 INTEGER,
                  role1 INTEGER,
                  role2 INTEGER,
                  role3 INTEGER,
-                 private BOOLEAN);""")
+                 private BOOLEAN);"""
+    )
     count += 1
     callback(100 * count / total)
 
     db.query("""drop table address;""")
-    db.query("""CREATE TABLE address (
+    db.query(
+        """CREATE TABLE address (
                 handle CHARACTER(25) PRIMARY KEY,
-                private BOOLEAN);""")
+                private BOOLEAN);"""
+    )
     count += 1
     callback(100 * count / total)
 
     db.query("""drop table location;""")
-    db.query("""CREATE TABLE location (
+    db.query(
+        """CREATE TABLE location (
                  handle CHARACTER(25) PRIMARY KEY,
                  street TEXT,
                  locality TEXT,
@@ -386,131 +469,151 @@ def makeDB(db, callback):
                  country TEXT,
                  postal TEXT,
                  phone TEXT,
-                 parish TEXT);""")
+                 parish TEXT);"""
+    )
     count += 1
     callback(100 * count / total)
 
     db.query("""drop table attribute;""")
-    db.query("""CREATE TABLE attribute (
+    db.query(
+        """CREATE TABLE attribute (
                  handle CHARACTER(25) PRIMARY KEY,
                  the_type0 INTEGER,
                  the_type1 TEXT,
                  value TEXT,
-                 private BOOLEAN);""")
+                 private BOOLEAN);"""
+    )
     count += 1
     callback(100 * count / total)
 
     db.query("""drop table url;""")
-    db.query("""CREATE TABLE url (
+    db.query(
+        """CREATE TABLE url (
                  handle CHARACTER(25) PRIMARY KEY,
                  path TEXT,
                  desc TEXT,
                  type0 INTEGER,
                  type1 TEXT,
                  private BOOLEAN);
-                 """)
+                 """
+    )
     count += 1
     callback(100 * count / total)
 
     db.query("""drop table datamap;""")
-    db.query("""CREATE TABLE datamap (
+    db.query(
+        """CREATE TABLE datamap (
                  from_handle CHARACTER(25),
                  the_type0 INTEGER,
                  the_type1 TEXT,
                  value_field TXT,
                  private BOOLEAN);
-                 """)
+                 """
+    )
     count += 1
     callback(100 * count / total)
 
     db.query("""drop table tag;""")
-    db.query("""CREATE TABLE tag (
+    db.query(
+        """CREATE TABLE tag (
                  handle CHARACTER(25) PRIMARY KEY,
                  name TEXT,
                  color TEXT,
                  priority INTEGER,
                  change INTEGER);
-                 """)
+                 """
+    )
     count += 1
     callback(100 * count / total)
 
 
-class Database(object):
+# -------------------------------------------------------------------------
+#
+# Helper lookup
+#
+# -------------------------------------------------------------------------
+def lookup(index: int, event_ref_list) -> str | None:
     """
-    The db connection.
+    Return the event handle at the given index in a serialized event_ref_list.
     """
-    def __init__(self, database):
-        self.batch = False
-        self.database = database
-        self.db = sqlite.connect(self.database)
-        self.cursor = self.db.cursor()
-
-    def query(self, q, *args):
-        args = list(args)
-        if q.strip().upper().startswith("DROP"):
-            try:
-                self.cursor.execute(q, args)
-                self.db.commit()
-            except:
-                "WARN: no such table to drop: '%s'" % q
-        else:
-            try:
-                self.cursor.execute(q, args)
-                if not self.batch:
-                    self.db.commit()
-            except:
-                print("ERROR: query :", q)
-                print("ERROR: values:", args)
-                raise
-            return self.cursor.fetchall()
-
-    def close(self):
-        """ Closes and writes out tables """
-        self.cursor.close()
-        self.db.close()
+    if index < 0:
+        return None
+    count = 0
+    for event_ref in event_ref_list:
+        (_private, _citation_list, _note_list, _attribute_list, ref, _role) = event_ref
+        if index == count:
+            return ref
+        count += 1
+    return None
 
 
-def export_alt_place_name_list(db, handle, alt_place_name_list):
+# -------------------------------------------------------------------------
+#
+# Export helper functions
+#
+# -------------------------------------------------------------------------
+def export_alt_place_name_list(
+    db: Database, handle: str, alt_place_name_list
+) -> None:
+    """Export all alternate place names for a place."""
     for place_name in alt_place_name_list:
         export_place_name(db, handle, place_name)
 
 
-def export_place_name(db, handle, place_name):
+def export_place_name(db: Database, handle: str, place_name) -> None:
+    """Export a single place name record."""
     # alt_place_name_list = [('Ohio', None, ''), ...] [(value, date, lang)...]
     (value, date, lang) = place_name
     ref_handle = create_id()
-    db.query("insert into place_name (handle, from_handle, value, lang)"
-             " VALUES (?, ?, ?, ?);", ref_handle, handle, value, lang)
+    db.query(
+        "insert into place_name (handle, from_handle, value, lang)"
+        " VALUES (?, ?, ?, ?);",
+        ref_handle,
+        handle,
+        value,
+        lang,
+    )
     export_date(db, "place_name", ref_handle, date)
 
 
-def export_place_ref_list(db, handle, place_ref_list):
+def export_place_ref_list(db: Database, handle: str, place_ref_list) -> None:
+    """Export all place reference records for a place."""
     # place_ref_list = Enclosed by:  [('4ECKQCWCLO5YIHXEXC', None)]
     # [(handle, date)...]
     for place_ref in place_ref_list:
         export_place_ref(db, handle, place_ref)
 
 
-def export_place_ref(db, handle, place_ref):
+def export_place_ref(db: Database, handle: str, place_ref) -> None:
+    """Export a single place reference."""
     (to_place_handle, date) = place_ref
     ref_handle = create_id()
-    db.query("insert into place_ref"
-             " (handle, from_place_handle, to_place_handle) VALUES (?, ?, ?);",
-             ref_handle, handle, to_place_handle)
+    db.query(
+        "insert into place_ref"
+        " (handle, from_place_handle, to_place_handle) VALUES (?, ?, ?);",
+        ref_handle,
+        handle,
+        to_place_handle,
+    )
     export_date(db, "place_ref", ref_handle, date)
 
 
-def export_location_list(db, from_type, from_handle, locations):
+def export_location_list(
+    db: Database, from_type: str, from_handle: str, locations
+) -> None:
+    """Export a list of location records."""
     for location in locations:
         export_location(db, from_type, from_handle, location)
 
 
-def export_url_list(db, from_type, from_handle, urls):
+def export_url_list(db: Database, from_type: str, from_handle: str, urls) -> None:
+    """Export all URL records for a parent object."""
     for url in urls:
         # (False, 'http://www.gramps-project.org/', 'loleach', (0, 'kaabgo'))
         (private, path, desc, type_) = url
         handle = create_id()
-        db.query("""insert INTO url (
+        db.query(
+            """insert INTO url (
                  handle,
                  path,
                  desc,
@@ -518,47 +621,65 @@ def export_url_list(db, from_type, from_handle, urls):
                  type1,
                  private) VALUES (?, ?, ?, ?, ?, ?);
                  """,
-                 handle,
-                 path,
-                 desc,
-                 type_[0],
-                 type_[1],
-                 private)
+            handle,
+            path,
+            desc,
+            type_[0],
+            type_[1],
+            private,
+        )
         # finally, link this to parent
         export_link(db, from_type, from_handle, "url", handle)
 
 
-def export_person_ref_list(db, from_type, from_handle, person_ref_list):
+def export_person_ref_list(
+    db: Database, from_type: str, from_handle: str, person_ref_list
+) -> None:
+    """Export all person reference records for a parent object."""
     for person_ref in person_ref_list:
-        (private,
-         citation_list,
-         note_list,
-         handle,
-         desc) = person_ref
+        (
+            private,
+            citation_list,
+            note_list,
+            handle,
+            desc,
+        ) = person_ref
         ref_handle = create_id()
-        db.query("""INSERT INTO person_ref (
+        db.query(
+            """INSERT INTO person_ref (
                     handle,
                     ref,
                     description,
                     private) VALUES (?, ?, ?, ?);""",
-                 ref_handle, handle,
-                 desc,
-                 private
-                 )
+            ref_handle,
+            handle,
+            desc,
+            private,
+        )
         export_list(db, "person_ref", ref_handle, "note", note_list)
         export_citation_list(db, "person_ref", ref_handle, citation_list)
         # And finally, make a link from parent to new object
         export_link(db, from_type, from_handle, "person_ref", ref_handle)
 
 
-def export_lds(db, from_type, from_handle, data):
-    (lcitation_list, lnote_list, date, type_, place,
-     famc, temple, status, private) = data
+def export_lds(db: Database, from_type: str, from_handle: str, data) -> None:
+    """Export a single LDS ordinance record."""
+    (lcitation_list, lnote_list, date, type_, place, famc, temple, status, private) = (
+        data
+    )
     lds_handle = create_id()
-    db.query("INSERT into lds"
-             " (handle, type, place, famc, temple, status, private) "
-             "VALUES (?,?,?,?,?,?,?);",
-             lds_handle, type_, place, famc, temple, status, private)
+    db.query(
+        "INSERT into lds"
+        " (handle, type, place, famc, temple, status, private) "
+        "VALUES (?,?,?,?,?,?,?);",
+        lds_handle,
+        type_,
+        place,
+        famc,
+        temple,
+        status,
+        private,
+    )
     export_link(db, "lds", lds_handle, "place", place)
     export_list(db, "lds", lds_handle, "note", lnote_list)
     export_date(db, "lds", lds_handle, date)
@@ -567,13 +688,27 @@ def export_lds(db, from_type, from_handle, data):
     export_link(db, from_type, from_handle, "lds", lds_handle)
 
 
-def export_citation_ref(db, from_type, from_handle, citation_handle):
+def export_citation_ref(
+    db: Database, from_type: str, from_handle: str, citation_handle: str
+) -> None:
+    """Export a single citation reference link."""
     export_link(db, from_type, from_handle, "citation", citation_handle)
 
 
-def export_source(db, handle, gid, title, author, pubinfo, abbrev, change,
-                  private):
-    db.query("""INSERT into source (
+def export_source(
+    db: Database,
+    handle: str,
+    gid: str,
+    title: str,
+    author: str,
+    pubinfo: str,
+    abbrev: str,
+    change: int,
+    private: bool,
+) -> None:
+    """Insert a source record into the source table."""
+    db.query(
+        """INSERT into source (
              handle,
              gid,
              title,
@@ -583,21 +718,23 @@ def export_source(db, handle, gid, title, author, pubinfo, abbrev, change,
              change,
              private
              ) VALUES (?,?,?,?,?,?,?,?);""",
-             handle,
-             gid,
-             title,
-             author,
-             pubinfo,
-             abbrev,
-             change,
-             private)
+        handle,
+        gid,
+        title,
+        author,
+        pubinfo,
+        abbrev,
+        change,
+        private,
+    )
 
 
-def export_note(db, data):
-    (handle, gid, styled_text, format_, note_type,
-     change, tag_list, private) = data
+def export_note(db: Database, data) -> None:
+    """Export a serialized Note tuple into the note table."""
+    (handle, gid, styled_text, format_, note_type, change, tag_list, private) = data
     text, markup_list = styled_text
-    db.query("""INSERT into note (
+    db.query(
+        """INSERT into note (
                   handle,
                   gid,
                   text,
@@ -607,35 +744,76 @@ def export_note(db, data):
                   change,
                   private) values (?, ?, ?, ?,
                                    ?, ?, ?, ?);""",
-             handle, gid, text, format_, note_type[0],
-             note_type[1], change, private)
+        handle,
+        gid,
+        text,
+        format_,
+        note_type[0],
+        note_type[1],
+        change,
+        private,
+    )
     for markup in markup_list:
         markup_code, value, start_stop_list = markup
-        export_markup(db, "note", handle, markup_code[0], markup_code[1],
-                      value, str(start_stop_list))  # Not normal form; use eval
+        export_markup(
+            db,
+            "note",
+            handle,
+            markup_code[0],
+            markup_code[1],
+            value,
+            str(start_stop_list),
+        )  # Not normal form; use eval
     export_list(db, "note", handle, "tag", tag_list)
 
 
-def export_markup(db, from_type, from_handle,  markup_code0, markup_code1,
-                  value, start_stop_list):
+def export_markup(
+    db: Database,
+    from_type: str,
+    from_handle: str,
+    markup_code0,
+    markup_code1,
+    value,
+    start_stop_list,
+) -> None:
+    """Export a markup record for a Note."""
     markup_handle = create_id()
-    db.query("""INSERT INTO markup (
+    db.query(
+        """INSERT INTO markup (
                  handle,
                  markup0,
                  markup1,
                  value,
                  start_stop_list) VALUES (?,?,?,?,?);""",
-             markup_handle, markup_code0, markup_code1, value,
-             start_stop_list)
+        markup_handle,
+        markup_code0,
+        markup_code1,
+        value,
+        start_stop_list,
+    )
     # And finally, make a link from parent to new object
     export_link(db, from_type, from_handle, "markup", markup_handle)
 
 
-def export_event(db, data):
-    (handle, gid, the_type, date, description, place_handle,
-     citation_list, note_list, media_list, attribute_list,
-     change, tag_list, private) = data
-    db.query("""INSERT INTO event (
+def export_event(db: Database, data) -> None:
+    """Export a serialized Event tuple into the event table."""
+    (
+        handle,
+        gid,
+        the_type,
+        date,
+        description,
+        place_handle,
+        citation_list,
+        note_list,
+        media_list,
+        attribute_list,
+        change,
+        tag_list,
+        private,
+    ) = data
+    db.query(
+        """INSERT INTO event (
                  handle,
                  gid,
                  the_type0,
@@ -643,13 +821,14 @@ def export_event(db, data):
                  description,
                  change,
                  private) VALUES (?,?,?,?,?,?,?);""",
-             handle,
-             gid,
-             the_type[0],
-             the_type[1],
-             description,
-             change,
-             private)
+        handle,
+        gid,
+        the_type[0],
+        the_type[1],
+        description,
+        change,
+        private,
+    )
     export_date(db, "event", handle, date)
     export_link(db, "event", handle, "place", place_handle)
     export_list(db, "event", handle, "note", note_list)
@@ -659,20 +838,25 @@ def export_event(db, data):
     export_citation_list(db, "event", handle, citation_list)
 
 
-def export_event_ref(db, from_type, from_handle, event_ref):
+def export_event_ref(
+    db: Database, from_type: str, from_handle: str, event_ref
+) -> None:
+    """Export a single event reference record."""
     (private, citation_list, note_list, attribute_list, ref, role) = event_ref
     handle = create_id()
-    db.query("""insert INTO event_ref (
+    db.query(
+        """insert INTO event_ref (
                  handle,
                  ref,
                  role0,
                  role1,
                  private) VALUES (?,?,?,?,?);""",
-             handle,
-             ref,
-             role[0],
-             role[1],
-             private)
+        handle,
+        ref,
+        role[0],
+        role[1],
+        private,
+    )
     export_list(db, "event_ref", handle, "note", note_list)
     export_attribute_list(db, "event_ref", handle, attribute_list)
     export_citation_list(db, "event_ref", handle, citation_list)
@@ -680,55 +864,76 @@ def export_event_ref(db, from_type, from_handle, event_ref):
     export_link(db, from_type, from_handle, "event_ref", handle)
 
 
-def export_person(db, person):
-    (handle,              # 0
-     gid,                 # 1
-     gender,              # 2
-     primary_name,        # 3
-     alternate_names,     # 4
-     death_ref_index,     # 5
-     birth_ref_index,     # 6
-     event_ref_list,      # 7
-     family_list,         # 8
-     parent_family_list,  # 9
-     media_list,          # 10
-     address_list,        # 11
-     attribute_list,      # 12
-     urls,                # 13
-     lds_ord_list,        # 14
-     pcitation_list,      # 15
-     pnote_list,          # 16
-     change,              # 17
-     tag_list,            # 18
-     private,             # 19
-     person_ref_list,     # 20
-     ) = person
-    db.query("""INSERT INTO person (
+def export_person(db: Database, person) -> None:
+    """
+    Export a Person object into the person table and related tables.
+
+    Accesses all fields by object attribute rather than positional tuple
+    unpacking, making this forward-compatible with new Person fields (such
+    as familysearch_sync added in Gramps 6.1).
+    """
+    handle = person.handle
+    gid = person.gramps_id
+    gender = person.gender
+    primary_name = person.primary_name
+    alternate_names = person.alternate_names
+    death_ref_index = person.death_ref_index
+    birth_ref_index = person.birth_ref_index
+    event_ref_list = person.get_event_ref_list()
+    family_list = person.family_list
+    parent_family_list = person.parent_family_list
+    media_list = person.get_media_list()
+    address_list = person.get_address_list()
+    attribute_list = person.get_attribute_list()
+    urls = person.get_url_list()
+    lds_ord_list = person.get_lds_ord_list()
+    pcitation_list = person.get_citation_list()
+    pnote_list = person.get_note_list()
+    change = person.change
+    tag_list = person.get_tag_list()
+    private = person.private
+    person_ref_list = person.get_person_ref_list()
+
+    # Serialize event_ref_list for birth/death handle lookup (index -> handle)
+    serialized_event_refs = [er.serialize() for er in event_ref_list]
+
+    # familysearch_sync is a FamilySearchSync object; persist as JSON
+    fs_sync_json = json.dumps(person.familysearch_sync.serialize())
+
+    db.query(
+        """INSERT INTO person (
                   handle,
                   gid,
                   gender,
                   death_ref_handle,
                   birth_ref_handle,
                   change,
-                  private) values (?, ?, ?, ?, ?, ?, ?);""",
-             handle,
-             gid,
-             gender,
-             lookup(death_ref_index, event_ref_list),
-             lookup(birth_ref_index, event_ref_list),
-             change,
-             private)
+                  private,
+                  familysearch_sync) values (?, ?, ?, ?, ?, ?, ?, ?);""",
+        handle,
+        gid,
+        gender,
+        lookup(death_ref_index, serialized_event_refs),
+        lookup(birth_ref_index, serialized_event_refs),
+        change,
+        private,
+        fs_sync_json,
+    )
 
     # Event Reference information
     for event_ref in event_ref_list:
-        export_event_ref(db, "person", handle, event_ref)
+        export_event_ref(db, "person", handle, event_ref.serialize())
     export_list(db, "person", handle, "family", family_list)
     export_list(db, "person", handle, "parent_family", parent_family_list)
-    export_media_ref_list(db, "person", handle, media_list)
+    export_media_ref_list(db, "person", handle, [m.serialize() for m in media_list])
     export_list(db, "person", handle, "note", pnote_list)
-    export_attribute_list(db, "person", handle, attribute_list)
-    export_url_list(db, "person", handle, urls)
-    export_person_ref_list(db, "person", handle, person_ref_list)
+    export_attribute_list(
+        db, "person", handle, [a.serialize() for a in attribute_list]
+    )
+    export_url_list(db, "person", handle, [u.serialize() for u in urls])
+    export_person_ref_list(
+        db, "person", handle, [pr.serialize() for pr in person_ref_list]
+    )
     export_citation_list(db, "person", handle, pcitation_list)
     export_list(db, "person", handle, "tag", tag_list)
 
@@ -736,23 +941,24 @@ def export_person(db, person):
     # Address
     # -------------------------------------
     for address in address_list:
-        export_address(db, "person", handle, address)
+        export_address(db, "person", handle, address.serialize())
 
     # -------------------------------------
     # LDS ord
     # -------------------------------------
     for ldsord in lds_ord_list:
-        export_lds(db, "person", handle, ldsord)
+        export_lds(db, "person", handle, ldsord.serialize())
 
     # -------------------------------------
     # Names
     # -------------------------------------
-    export_name(db, "person", handle, True, primary_name)
+    export_name(db, "person", handle, True, primary_name.serialize())
     for name in alternate_names:
-        export_name(db, "person", handle, False, name)
+        export_name(db, "person", handle, False, name.serialize())
 
 
-def export_date(db, from_type, from_handle, data):
+def export_date(db: Database, from_type: str, from_handle: str, data) -> None:
+    """Export a serialized Date tuple into the date table."""
     if data is None:
         return
     (calendar, modifier, quality, dateval, text, sortval, newyear) = data
@@ -762,9 +968,10 @@ def export_date(db, from_type, from_handle, data):
     elif len(dateval) == 8:
         day1, month1, year1, slash1, day2, month2, year2, slash2 = dateval
     else:
-        raise ("ERROR: date dateval format", dateval)
+        raise ValueError("ERROR: date dateval format: %s" % (dateval,))
     date_handle = create_id()
-    db.query("""INSERT INTO date (
+    db.query(
+        """INSERT INTO date (
                   handle,
                   calendar,
                   modifier,
@@ -781,18 +988,32 @@ def export_date(db, from_type, from_handle, data):
                   sortval,
                   newyear) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?,
                                    ?, ?, ?, ?, ?, ?);""",
-             date_handle, calendar, modifier, quality,
-             day1, month1, year1, slash1,
-             day2, month2, year2, slash2,
-             text, sortval, newyear)
+        date_handle,
+        calendar,
+        modifier,
+        quality,
+        day1,
+        month1,
+        year1,
+        slash1,
+        day2,
+        month2,
+        year2,
+        slash2,
+        text,
+        sortval,
+        newyear,
+    )
     export_link(db, from_type, from_handle, "date", date_handle)
 
 
-def export_surname(db, name_handle, surname_list):
+def export_surname(db: Database, name_handle: str, surname_list) -> None:
+    """Export all surname records for a name."""
     for data in surname_list:
         surname_handle = create_id()
         (surname, prefix, primary, origin_type, connector) = data
-        db.query("""INSERT INTO surname (
+        db.query(
+            """INSERT INTO surname (
                   handle,
                   surname,
                   prefix,
@@ -800,20 +1021,42 @@ def export_surname(db, name_handle, surname_list):
                   origin_type0,
                   origin_type1,
                   connector) VALUES (?,?,?,?,?,?,?);""",
-                 surname_handle, surname, prefix, primary, origin_type[0],
-                 origin_type[1], connector)
+            surname_handle,
+            surname,
+            prefix,
+            primary,
+            origin_type[0],
+            origin_type[1],
+            connector,
+        )
         export_link(db, "name", name_handle, "surname", surname_handle)
 
 
-def export_name(db, from_type, from_handle, primary, data):
+def export_name(
+    db: Database, from_type: str, from_handle: str, primary: bool, data
+) -> None:
+    """Export a serialized Name tuple into the name table."""
     if data:
-        (private, citation_list, note_list, date,
-         first_name, surname_list, suffix, title,
-         name_type,
-         group_as, sort_as, display_as,
-         call, nick, famnick) = data
+        (
+            private,
+            citation_list,
+            note_list,
+            date,
+            first_name,
+            surname_list,
+            suffix,
+            title,
+            name_type,
+            group_as,
+            sort_as,
+            display_as,
+            call,
+            nick,
+            famnick,
+        ) = data
         handle = create_id()
-        db.query("""INSERT into name (
+        db.query(
+            """INSERT into name (
                   handle,
                   primary_name,
                   private,
@@ -830,9 +1073,21 @@ def export_name(db, from_type, from_handle, primary, data):
                   famnick
                     ) values (?, ?, ?, ?, ?, ?, ?,
                               ?, ?, ?, ?, ?, ?, ?);""",
-                 handle, primary, private, first_name, suffix, title,
-                 name_type[0], name_type[1], group_as,
-                 sort_as, display_as, call, nick, famnick)
+            handle,
+            primary,
+            private,
+            first_name,
+            suffix,
+            title,
+            name_type[0],
+            name_type[1],
+            group_as,
+            sort_as,
+            display_as,
+            call,
+            nick,
+            famnick,
+        )
         export_surname(db, handle, surname_list)
         export_date(db, "name", handle, date)
         export_list(db, "name", handle, "note", note_list)
@@ -841,40 +1096,56 @@ def export_name(db, from_type, from_handle, primary, data):
         export_link(db, from_type, from_handle, "name", handle)
 
 
-def export_attribute(db, from_type, from_handle, attribute):
+def export_attribute(
+    db: Database, from_type: str, from_handle: str, attribute
+) -> None:
+    """Export a single serialized attribute record."""
     (private, citation_list, note_list, the_type, value) = attribute
     handle = create_id()
-    db.query("""INSERT INTO attribute (
+    db.query(
+        """INSERT INTO attribute (
                  handle,
                  the_type0,
                  the_type1,
                  value,
                  private) VALUES (?,?,?,?,?);""",
-             handle, the_type[0], the_type[1], value, private)
+        handle,
+        the_type[0],
+        the_type[1],
+        value,
+        private,
+    )
     export_citation_list(db, "attribute", handle, citation_list)
     export_list(db, "attribute", handle, "note", note_list)
-    # finally, link the parent to the address
+    # finally, link the parent to the attribute
     export_link(db, from_type, from_handle, "attribute", handle)
 
 
-def export_citation_list(db, from_type, from_handle, citation_list):
+def export_citation_list(
+    db: Database, from_type: str, from_handle: str, citation_list
+) -> None:
+    """Export all citation references for a parent object."""
     for citation_handle in citation_list:
         export_citation_ref(db, from_type, from_handle, citation_handle)
 
 
-def export_media_ref_list(db, from_type, from_handle, media_list):
+def export_media_ref_list(
+    db: Database, from_type: str, from_handle: str, media_list
+) -> None:
+    """Export all media reference records for a parent object."""
     for media in media_list:
         export_media_ref(db, from_type, from_handle, media)
 
 
-def export_media_ref(db, from_type, from_handle, media):
+def export_media_ref(db: Database, from_type: str, from_handle: str, media) -> None:
+    """Export a single serialized media reference record."""
     (private, citation_list, note_list, attribute_list, ref, role) = media
-    # handle is the media_ref handle
-    # ref is the media handle
+    # handle is the media_ref handle; ref is the media handle
     handle = create_id()
     if role is None:
         role = (-1, -1, -1, -1)
-    db.query("""INSERT into media_ref (
+    db.query(
+        """INSERT into media_ref (
                  handle,
                  ref,
                  role0,
@@ -882,7 +1153,14 @@ def export_media_ref(db, from_type, from_handle, media):
                  role2,
                  role3,
                  private) VALUES (?,?,?,?,?,?,?);""",
-             handle, ref, role[0], role[1], role[2], role[3], private)
+        handle,
+        ref,
+        role[0],
+        role[1],
+        role[2],
+        role[3],
+        private,
+    )
     export_list(db, "media_ref", handle, "note", note_list)
     export_attribute_list(db, "media_ref", handle, attribute_list)
     export_citation_list(db, "media_ref", handle, citation_list)
@@ -890,61 +1168,102 @@ def export_media_ref(db, from_type, from_handle, media):
     export_link(db, from_type, from_handle, "media_ref", handle)
 
 
-def export_attribute_list(db, from_type, from_handle, attr_list):
+def export_attribute_list(
+    db: Database, from_type: str, from_handle: str, attr_list
+) -> None:
+    """Export all attribute records for a parent object."""
     for attribute in attr_list:
         export_attribute(db, from_type, from_handle, attribute)
 
 
-def export_child_ref_list(db, from_type, from_handle, to_type, ref_list):
+def export_child_ref_list(
+    db: Database, from_type: str, from_handle: str, to_type: str, ref_list
+) -> None:
+    """Export all child reference records for a family."""
     for child_ref in ref_list:
         # family -> child_ref
         # (False, [], [], u'b305e96e39652d8f08c', (1, u''), (1, u''))
         (private, citation_list, note_list, ref, frel, mrel) = child_ref
         handle = create_id()
-        db.query("""INSERT INTO child_ref (handle,
+        db.query(
+            """INSERT INTO child_ref (handle,
                      ref, frel0, frel1, mrel0, mrel1, private)
                         VALUES (?, ?, ?, ?, ?, ?, ?);""",
-                 handle, ref, frel[0], frel[1],
-                 mrel[0], mrel[1], private)
+            handle,
+            ref,
+            frel[0],
+            frel[1],
+            mrel[0],
+            mrel[1],
+            private,
+        )
         export_citation_list(db, "child_ref", handle, citation_list)
         export_list(db, "child_ref", handle, "note", note_list)
         # And finally, make a link from parent to new object
         export_link(db, from_type, from_handle, "child_ref", handle)
 
 
-def export_list(db, from_type, from_handle, to_type, handle_list):
+def export_list(
+    db: Database, from_type: str, from_handle: str, to_type: str, handle_list
+) -> None:
+    """Export a list of handle links from a parent to child objects."""
     for to_handle in handle_list:
         export_link(db, from_type, from_handle, to_type, to_handle)
 
 
-def export_link(db, from_type, from_handle, to_type, to_handle):
+def export_link(
+    db: Database,
+    from_type: str,
+    from_handle: str,
+    to_type: str,
+    to_handle: str | None,
+) -> None:
+    """Insert a single link record between two objects."""
     if to_handle:
-        db.query("""insert into link (
+        db.query(
+            """insert into link (
                    from_type,
                    from_handle,
                    to_type,
                    to_handle) values (?, ?, ?, ?)""",
-                 from_type, from_handle, to_type, to_handle)
+            from_type,
+            from_handle,
+            to_type,
+            to_handle,
+        )
 
 
-def export_datamap_list(db, from_type, from_handle, datamap):
+def export_datamap_list(
+    db: Database, from_type: str, from_handle: str, datamap
+) -> None:
+    """Export the datamap entries for a source or citation."""
     for private, data_type, data in datamap:
-        db.query("""INSERT INTO datamap (
+        db.query(
+            """INSERT INTO datamap (
                       from_handle,
                       the_type0,
                       the_type1,
                       value_field,
                       private) values (?, ?, ?, ?, ?)""",
-                 from_handle, data_type[0], data_type[1],
-                 data, private)
+            from_handle,
+            data_type[0],
+            data_type[1],
+            data,
+            private,
+        )
 
 
-def export_address(db, from_type, from_handle, address):
+def export_address(db: Database, from_type: str, from_handle: str, address) -> None:
+    """Export a single serialized address record."""
     (private, acitation_list, anote_list, date, location) = address
     addr_handle = create_id()
-    db.query("""INSERT INTO address (
+    db.query(
+        """INSERT INTO address (
                 handle,
-                private) VALUES (?, ?);""", addr_handle, private)
+                private) VALUES (?, ?);""",
+        addr_handle,
+        private,
+    )
     export_location(db, "address", addr_handle, location)
     export_date(db, "address", addr_handle, date)
     export_list(db, "address", addr_handle, "note", anote_list)
@@ -953,21 +1272,24 @@ def export_address(db, from_type, from_handle, address):
     export_link(db, from_type, from_handle, "address", addr_handle)
 
 
-def export_location(db, from_type, from_handle, location):
+def export_location(db: Database, from_type: str, from_handle: str, location) -> None:
+    """Export a single location record."""
     if location is None:
         return
     if len(location) == 8:
-        (street, locality, city, county, state, country, postal,
-         phone) = location
+        (street, locality, city, county, state, country, postal, phone) = location
         parish = None
     elif len(location) == 2:
-        ((street, locality, city, county, state, country, postal,
-          phone), parish) = location
+        (
+            (street, locality, city, county, state, country, postal, phone),
+            parish,
+        ) = location
     else:
-        print("ERROR: what kind of location is this?", location)
+        LOG.error("what kind of location is this? %s", location)
         return
     handle = create_id()
-    db.query("""INSERT INTO location (
+    db.query(
+        """INSERT INTO location (
                  handle,
                  street,
                  locality,
@@ -978,43 +1300,73 @@ def export_location(db, from_type, from_handle, location):
                  postal,
                  phone,
                  parish) VALUES (?,?,?,?,?,?,?,?,?,?);""",
-             handle, street, locality, city, county, state, country,
-             postal, phone, parish)
-    # finally, link the parent to the address
+        handle,
+        street,
+        locality,
+        city,
+        county,
+        state,
+        country,
+        postal,
+        phone,
+        parish,
+    )
+    # finally, link the parent to the location
     export_link(db, from_type, from_handle, "location", handle)
 
 
-def export_repository_ref_list(db, from_type, from_handle, reporef_list):
+def export_repository_ref_list(
+    db: Database, from_type: str, from_handle: str, reporef_list
+) -> None:
+    """Export all repository reference records for a source."""
     for repo in reporef_list:
-        (note_list,
-         ref,
-         call_number,
-         source_media_type,
-         private) = repo
+        (
+            note_list,
+            ref,
+            call_number,
+            source_media_type,
+            private,
+        ) = repo
         handle = create_id()
-        db.query("""insert INTO repository_ref (
+        db.query(
+            """insert INTO repository_ref (
                      handle,
                      ref,
                      call_number,
                      source_media_type0,
                      source_media_type1,
                      private) VALUES (?,?,?,?,?,?);""",
-                 handle,
-                 ref,
-                 call_number,
-                 source_media_type[0],
-                 source_media_type[1],
-                 private)
+            handle,
+            ref,
+            call_number,
+            source_media_type[0],
+            source_media_type[1],
+            private,
+        )
         export_list(db, "repository_ref", handle, "note", note_list)
         # finally, link this to parent
         export_link(db, from_type, from_handle, "repository_ref", handle)
 
 
-def dummy_callback():
-    pass
+def dummy_callback(*args) -> None:
+    """No-op callback used when no real callback is provided."""
 
 
-def exportData(database, filename, user, option_box):
+# -------------------------------------------------------------------------
+#
+# Main export entry point
+#
+# -------------------------------------------------------------------------
+def exportData(database, filename: str, user, option_box) -> bool:
+    """
+    Export the Gramps database to a SQLite file.
+
+    :param database: The Gramps database to export.
+    :param filename: Path to the output SQLite file.
+    :param user: User object providing a callback for progress.
+    :param option_box: Optional export option box (may filter the database).
+    :returns: True on success.
+    """
     if isinstance(user.callback, abc.Callable):  # is really callable
         callback = user.callback
     else:
@@ -1025,16 +1377,18 @@ def exportData(database, filename, user, option_box):
         database = option_box.get_filtered_database(database)
 
     start = time.time()
-    total = (len(database.get_note_handles()) +
-             len(database.get_person_handles()) +
-             len(database.get_event_handles()) +
-             len(database.get_family_handles()) +
-             len(database.get_repository_handles()) +
-             len(database.get_place_handles()) +
-             len(database.get_media_handles()) +
-             len(database.get_tag_handles()) +
-             len(database.get_citation_handles()) +
-             len(database.get_source_handles()))
+    total = (
+        len(database.get_note_handles())
+        + len(database.get_person_handles())
+        + len(database.get_event_handles())
+        + len(database.get_family_handles())
+        + len(database.get_repository_handles())
+        + len(database.get_place_handles())
+        + len(database.get_media_handles())
+        + len(database.get_tag_handles())
+        + len(database.get_citation_handles())
+        + len(database.get_source_handles())
+    )
     count = 0.0
 
     db = Database(filename)
@@ -1070,7 +1424,7 @@ def exportData(database, filename, user, option_box):
         person = database.get_person_from_handle(person_handle)
         if person is None:
             continue
-        export_person(db, person.serialize())
+        export_person(db, person)
         count += 1
         callback(100 * count / total)
 
@@ -1081,12 +1435,25 @@ def exportData(database, filename, user, option_box):
         family = database.get_family_from_handle(family_handle)
         if family is None:
             continue
-        (handle, gid, father_handle, mother_handle,
-         child_ref_list, the_type, event_ref_list, media_list,
-         attribute_list, lds_seal_list, citation_list, note_list,
-         change, tag_list, private) = family.serialize()
+        handle = family.handle
+        gid = family.gramps_id
+        father_handle = family.father_handle
+        mother_handle = family.mother_handle
+        child_ref_list = family.child_ref_list
+        the_type = family.type.serialize()
+        event_ref_list = family.get_event_ref_list()
+        media_list = family.get_media_list()
+        attribute_list = family.get_attribute_list()
+        lds_seal_list = family.get_lds_ord_list()
+        citation_list = family.get_citation_list()
+        note_list = family.get_note_list()
+        change = family.change
+        tag_list = family.get_tag_list()
+        private = family.private
+
         # father_handle and/or mother_handle can be None
-        db.query("""INSERT INTO family (
+        db.query(
+            """INSERT INTO family (
                  handle,
                  gid,
                  father_handle,
@@ -1095,27 +1462,42 @@ def exportData(database, filename, user, option_box):
                  the_type1,
                  change,
                  private) values (?,?,?,?,?,?,?,?);""",
-                 handle, gid, father_handle, mother_handle,
-                 the_type[0], the_type[1], change,
-                 private)
+            handle,
+            gid,
+            father_handle,
+            mother_handle,
+            the_type[0],
+            the_type[1],
+            change,
+            private,
+        )
 
-        export_child_ref_list(db, "family", handle, "child_ref",
-                              child_ref_list)
+        export_child_ref_list(
+            db,
+            "family",
+            handle,
+            "child_ref",
+            [cr.serialize() for cr in child_ref_list],
+        )
         export_list(db, "family", handle, "note", note_list)
-        export_attribute_list(db, "family", handle, attribute_list)
+        export_attribute_list(
+            db, "family", handle, [a.serialize() for a in attribute_list]
+        )
         export_citation_list(db, "family", handle, citation_list)
-        export_media_ref_list(db, "family", handle, media_list)
+        export_media_ref_list(
+            db, "family", handle, [m.serialize() for m in media_list]
+        )
         export_list(db, "family", handle, "tag", tag_list)
 
         # Event Reference information
         for event_ref in event_ref_list:
-            export_event_ref(db, "family", handle, event_ref)
+            export_event_ref(db, "family", handle, event_ref.serialize())
 
         # -------------------------------------
         # LDS
         # -------------------------------------
         for ldsord in lds_seal_list:
-            export_lds(db, "family", handle, ldsord)
+            export_lds(db, "family", handle, ldsord.serialize())
 
         count += 1
         callback(100 * count / total)
@@ -1127,10 +1509,21 @@ def exportData(database, filename, user, option_box):
         repository = database.get_repository_from_handle(repository_handle)
         if repository is None:
             continue
-        (handle, gid, the_type, name, note_list, address_list,
-         urls, change, tag_list, private) = repository.serialize()
+        (
+            handle,
+            gid,
+            the_type,
+            name,
+            note_list,
+            address_list,
+            urls,
+            change,
+            tag_list,
+            private,
+        ) = repository.serialize()
 
-        db.query("""INSERT INTO repository (
+        db.query(
+            """INSERT INTO repository (
                  handle,
                  gid,
                  the_type0,
@@ -1138,8 +1531,14 @@ def exportData(database, filename, user, option_box):
                  name,
                  change,
                  private) VALUES (?,?,?,?,?,?,?);""",
-                 handle, gid, the_type[0], the_type[1],
-                 name, change, private)
+            handle,
+            gid,
+            the_type[0],
+            the_type[1],
+            name,
+            change,
+            private,
+        )
 
         export_list(db, "repository", handle, "note", note_list)
         export_url_list(db, "repository", handle, urls)
@@ -1158,22 +1557,31 @@ def exportData(database, filename, user, option_box):
         place = database.get_place_from_handle(place_handle)
         if place is None:
             continue
-        (handle, gid, title, long, lat,
-         place_ref_list,
-         place_name,
-         alt_place_name_list,
-         place_type,
-         code,
-         alt_location_list,
-         urls,
-         media_list,
-         citation_list,
-         note_list,
-         change, tag_list, private) = place.serialize()
+        (
+            handle,
+            gid,
+            title,
+            long,
+            lat,
+            place_ref_list,
+            place_name,
+            alt_place_name_list,
+            place_type,
+            code,
+            alt_location_list,
+            urls,
+            media_list,
+            citation_list,
+            note_list,
+            change,
+            tag_list,
+            private,
+        ) = place.serialize()
 
         value, date, lang = place_name
 
-        db.query("""INSERT INTO place (
+        db.query(
+            """INSERT INTO place (
                  handle,
                  gid,
                  title,
@@ -1186,12 +1594,19 @@ def exportData(database, filename, user, option_box):
                  lang,
                  change,
                  private) values (?,?,?,?,?,?,?,?,?,?,?,?);""",
-                 handle, gid, title, value,
-                 place_type[0], place_type[1],
-                 code,
-                 long, lat,
-                 lang,
-                 change, private)
+            handle,
+            gid,
+            title,
+            value,
+            place_type[0],
+            place_type[1],
+            code,
+            long,
+            lat,
+            lang,
+            change,
+            private,
+        )
 
         export_date(db, "place", handle, date)
         export_url_list(db, "place", handle, urls)
@@ -1200,9 +1615,9 @@ def exportData(database, filename, user, option_box):
         export_list(db, "place", handle, "note", note_list)
         export_list(db, "place", handle, "tag", tag_list)
 
-        #1. alt_place_name_list = [('Ohio', None, ''), ...]
+        # 1. alt_place_name_list = [('Ohio', None, ''), ...]
         # [(value, date, lang)...]
-        #2. place_ref_list = Enclosed by:  [('4ECKQCWCLO5YIHXEXC', None)]
+        # 2. place_ref_list = Enclosed by:  [('4ECKQCWCLO5YIHXEXC', None)]
         # [(handle, date)...]
 
         export_alt_place_name_list(db, handle, alt_place_name_list)
@@ -1221,19 +1636,22 @@ def exportData(database, filename, user, option_box):
         citation = database.get_citation_from_handle(citation_handle)
         if citation is None:
             continue
-        (handle,         # 0
-         gid,            # 1
-         date,           # 2
-         page,           # 3
-         confidence,     # 4
-         source_handle,  # 5
-         note_list,      # 6
-         media_list,     # 7
-         datamap,        # 8
-         change,         # 9
-         tag_list,
-         private) = citation.serialize()
-        db.query("""INSERT into citation (
+        (
+            handle,  # 0
+            gid,  # 1
+            date,  # 2
+            page,  # 3
+            confidence,  # 4
+            source_handle,  # 5
+            note_list,  # 6
+            media_list,  # 7
+            datamap,  # 8
+            change,  # 9
+            tag_list,
+            private,
+        ) = citation.serialize()
+        db.query(
+            """INSERT into citation (
                  handle,
                  gid,
                  confidence,
@@ -1242,13 +1660,14 @@ def exportData(database, filename, user, option_box):
                  change,
                  private
                  ) VALUES (?,?,?,?,?,?,?);""",
-                 handle,
-                 gid,
-                 confidence,
-                 page,
-                 source_handle,
-                 change,
-                 private)
+            handle,
+            gid,
+            confidence,
+            page,
+            source_handle,
+            change,
+            private,
+        )
         export_datamap_list(db, "citation", handle, datamap)
         export_date(db, "citation", handle, date)
         export_list(db, "citation", handle, "note", note_list)
@@ -1264,18 +1683,23 @@ def exportData(database, filename, user, option_box):
         source = database.get_source_from_handle(source_handle)
         if source is None:
             continue
-        (handle, gid, title,
-         author, pubinfo,
-         note_list,
-         media_list,
-         abbrev,
-         change, datamap,
-         reporef_list,
-         tag_list,
-         private) = source.serialize()
+        (
+            handle,
+            gid,
+            title,
+            author,
+            pubinfo,
+            note_list,
+            media_list,
+            abbrev,
+            change,
+            datamap,
+            reporef_list,
+            tag_list,
+            private,
+        ) = source.serialize()
 
-        export_source(db, handle, gid, title, author, pubinfo, abbrev,
-                      change, private)
+        export_source(db, handle, gid, title, author, pubinfo, abbrev, change, private)
         export_list(db, "source", handle, "note", note_list)
         export_list(db, "source", handle, "tag", tag_list)
         export_media_ref_list(db, "source", handle, media_list)
@@ -1291,17 +1715,24 @@ def exportData(database, filename, user, option_box):
         media = database.get_media_from_handle(media_handle)
         if media is None:
             continue
-        (handle, gid, path, mime, desc,
-         checksum,
-         attribute_list,
-         citation_list,
-         note_list,
-         change,
-         date,
-         tag_list,
-         private) = media.serialize()
+        (
+            handle,
+            gid,
+            path,
+            mime,
+            desc,
+            checksum,
+            attribute_list,
+            citation_list,
+            note_list,
+            change,
+            date,
+            tag_list,
+            private,
+        ) = media.serialize()
 
-        db.query("""INSERT INTO media (
+        db.query(
+            """INSERT INTO media (
             handle,
             gid,
             path,
@@ -1310,8 +1741,15 @@ def exportData(database, filename, user, option_box):
             checksum,
             change,
             private) VALUES (?,?,?,?,?,?,?,?);""",
-                 handle, gid, path, mime, desc, checksum,
-                 change, private)
+            handle,
+            gid,
+            path,
+            mime,
+            desc,
+            checksum,
+            change,
+            private,
+        )
         export_date(db, "media", handle, date)
         export_list(db, "media", handle, "note", note_list)
         export_citation_list(db, "media", handle, citation_list)
@@ -1328,13 +1766,19 @@ def exportData(database, filename, user, option_box):
         if tag_object is None:
             continue
         (handle, name, color, priority, change) = tag_object.serialize()
-        db.query("""INSERT INTO tag (
+        db.query(
+            """INSERT INTO tag (
             handle,
             name,
             color,
             priority,
             change) VALUES (?,?,?,?,?);""",
-                 handle, name, color, priority, change)
+            handle,
+            name,
+            color,
+            priority,
+            change,
+        )
         count += 1
         callback(100 * count / total)
 
@@ -1343,7 +1787,11 @@ def exportData(database, filename, user, option_box):
     db.db.close()
 
     total_time = time.time() - start
-    msg = ngettext('Export Complete: %d second',
-                   'Export Complete: %d seconds', total_time) % total_time
-    print(msg)
+    msg = (
+        ngettext(
+            "Export Complete: %d second", "Export Complete: %d seconds", total_time
+        )
+        % total_time
+    )
+    LOG.info(msg)
     return True

--- a/Sqlite/ExportSql.py
+++ b/Sqlite/ExportSql.py
@@ -55,6 +55,24 @@ LOG = logging.getLogger(__name__)
 from gramps.gen.utils.id import create_id
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 from gramps.gui.plug.export import WriterOptionBox  # don't remove, used!!!
+from gramps.gen.lib.attrtype import AttributeType
+from gramps.gen.lib.childreftype import ChildRefType
+from gramps.gen.lib.citation import Citation
+from gramps.gen.lib.date import Date
+from gramps.gen.lib.eventroletype import EventRoleType
+from gramps.gen.lib.eventtype import EventType
+from gramps.gen.lib.familyreltype import FamilyRelType
+from gramps.gen.lib.ldsord import LdsOrd
+from gramps.gen.lib.nameorigintype import NameOriginType
+from gramps.gen.lib.nametype import NameType
+from gramps.gen.lib.notetype import NoteType
+from gramps.gen.lib.person import Person
+from gramps.gen.lib.placetype import PlaceType
+from gramps.gen.lib.repotype import RepositoryType
+from gramps.gen.lib.srcattrtype import SrcAttributeType
+from gramps.gen.lib.srcmediatype import SourceMediaType
+from gramps.gen.lib.styledtexttagtype import StyledTextTagType
+from gramps.gen.lib.urltype import UrlType
 
 try:
     trans = glocale.get_addon_translator(__file__)
@@ -112,7 +130,7 @@ class Database(object):
 def makeDB(db: Database, callback) -> None:
     """Create all SQLite tables needed by the Sqlite export."""
     count = 0
-    total = 28
+    total = 30
 
     db.query("""drop table if exists note;""")
     db.query(
@@ -522,12 +540,49 @@ def makeDB(db: Database, callback) -> None:
     count += 1
     callback(100 * count / total)
 
+    # Lookup table describing integer codes that are not GrampsType
+    # instances (date calendar/modifier/quality, gender, confidence,
+    # LDS ordinance type/status), so a code's meaning can be read
+    # directly from the exported database.
+    db.query("""drop table if exists constants;""")
+    db.query(
+        """CREATE TABLE constants (
+                 table_name CHARACTER(25),
+                 column_name CHARACTER(25),
+                 code INTEGER,
+                 value TEXT);"""
+    )
+    count += 1
+    callback(100 * count / total)
+
+    # Copy of Gramps' name_group table, mapping a surname to the
+    # header it is grouped under (e.g. for accented/variant spellings).
+    db.query("""drop table if exists name_group;""")
+    db.query(
+        """CREATE TABLE name_group (
+                 name CHARACTER(50) PRIMARY KEY,
+                 grouping TEXT);"""
+    )
+    count += 1
+    callback(100 * count / total)
+
 
 # -------------------------------------------------------------------------
 #
 # Helper lookup
 #
 # -------------------------------------------------------------------------
+def type_string(cls: type, type_dict: dict) -> str:
+    """
+    Return the translated display string for a GrampsType DataDict.
+
+    The raw DataDict's "string" key only holds text for CUSTOM types; for
+    standard types it is empty, so it must be resolved through the
+    GrampsType subclass to get the readable name (e.g. "Birth").
+    """
+    return str(cls((type_dict["value"], type_dict["string"])))
+
+
 def lookup(index: int, event_ref_list: list) -> str | None:
     """
     Return the event handle at position index in the event_ref_list DataDicts.
@@ -688,7 +743,7 @@ def export_attribute(
                  private) VALUES (?,?,?,?,?);""",
         handle,
         the_type["value"],
-        the_type["string"],
+        type_string(AttributeType, the_type),
         value,
         private,
     )
@@ -724,7 +779,7 @@ def export_src_attribute_list(db: Database, from_handle: str, src_attr_list: lis
                      private) VALUES (?,?,?,?,?);""",
             from_handle,
             the_type["value"],
-            the_type["string"],
+            type_string(SrcAttributeType, the_type),
             value,
             private,
         )
@@ -753,7 +808,7 @@ def export_url_list(
             path,
             desc,
             the_type["value"],
-            the_type["string"],
+            type_string(UrlType, the_type),
             private,
         )
         export_link(db, from_type, from_handle, "url", handle)
@@ -823,7 +878,7 @@ def export_event_ref(
         handle,
         ref,
         role["value"],
-        role["string"],
+        type_string(EventRoleType, role),
         private,
     )
     export_list(db, "event_ref", handle, "note", note_list)
@@ -878,9 +933,9 @@ def export_child_ref_list(
             handle,
             ref,
             frel["value"],
-            frel["string"],
+            type_string(ChildRefType, frel),
             mrel["value"],
-            mrel["string"],
+            type_string(ChildRefType, mrel),
             private,
         )
         export_citation_list(db, "child_ref", handle, citation_list)
@@ -1005,7 +1060,7 @@ def export_repository_ref_list(
             ref,
             call_number,
             media_type["value"],
-            media_type["string"],
+            type_string(SourceMediaType, media_type),
             private,
         )
         export_list(db, "repository_ref", handle, "note", note_list)
@@ -1031,7 +1086,7 @@ def export_surname(db: Database, name_handle: str, surname_list: list) -> None:
             surname["prefix"],
             surname["primary"],
             origin_type["value"],
-            origin_type["string"],
+            type_string(NameOriginType, origin_type),
             surname["connector"],
         )
         export_link(db, "name", name_handle, "surname", surname_handle)
@@ -1088,7 +1143,7 @@ def export_name(
         suffix,
         title,
         name_type["value"],
-        name_type["string"],
+        type_string(NameType, name_type),
         group_as,
         sort_as,
         display_as,
@@ -1170,7 +1225,7 @@ def export_note(db: Database, raw: dict) -> None:
         text,
         format_,
         note_type["value"],
-        note_type["string"],
+        type_string(NoteType, note_type),
         change,
         private,
     )
@@ -1185,7 +1240,7 @@ def export_note(db: Database, raw: dict) -> None:
             "note",
             handle,
             markup_name["value"],
-            markup_name["string"],
+            type_string(StyledTextTagType, markup_name),
             value,
             str(ranges),
         )
@@ -1220,7 +1275,7 @@ def export_event(db: Database, raw: dict) -> None:
         handle,
         gid,
         the_type["value"],
-        the_type["string"],
+        type_string(EventType, the_type),
         description,
         change,
         private,
@@ -1342,7 +1397,7 @@ def export_family(db: Database, raw: dict) -> None:
         father_handle,
         mother_handle,
         the_type["value"],
-        the_type["string"],
+        type_string(FamilyRelType, the_type),
         change,
         private,
     )
@@ -1386,7 +1441,7 @@ def export_repository(db: Database, raw: dict) -> None:
         handle,
         gid,
         the_type["value"],
-        the_type["string"],
+        type_string(RepositoryType, the_type),
         name,
         change,
         private,
@@ -1444,7 +1499,7 @@ def export_place(db: Database, raw: dict) -> None:
         title,
         value,
         place_type["value"],
-        place_type["string"],
+        type_string(PlaceType, place_type),
         code,
         long,
         lat,
@@ -1614,6 +1669,84 @@ def export_tag(db: Database, raw: dict) -> None:
 
 # -------------------------------------------------------------------------
 #
+# Constants and name_group export
+#
+# -------------------------------------------------------------------------
+def export_constants(db: Database) -> None:
+    """
+    Export the meaning of integer codes that are not GrampsType instances.
+
+    Date calendar/modifier/quality, person gender, citation confidence,
+    and LDS ordinance type/status are plain integer constants defined in
+    Gramps core rather than per-record GrampsType DataDicts, so their
+    names can't be resolved via type_string(). Record them once here
+    instead of leaving bare integers in those columns.
+    """
+    rows = []
+    for code, name in enumerate(Date.ui_calendar_names):
+        rows.append(("date", "calendar", code, name))
+    for code, name in (
+        (Date.MOD_NONE, _("Regular")),
+        (Date.MOD_BEFORE, _("Before")),
+        (Date.MOD_AFTER, _("After")),
+        (Date.MOD_ABOUT, _("About")),
+        (Date.MOD_RANGE, _("Range")),
+        (Date.MOD_FROM, _("From")),
+        (Date.MOD_TO, _("To")),
+        (Date.MOD_SPAN, _("Span")),
+        (Date.MOD_TEXTONLY, _("Text only")),
+    ):
+        rows.append(("date", "modifier", code, name))
+    for code, name in (
+        (Date.QUAL_NONE, _("Regular")),
+        (Date.QUAL_ESTIMATED, _("Estimated")),
+        (Date.QUAL_CALCULATED, _("Calculated")),
+    ):
+        rows.append(("date", "quality", code, name))
+    for code, name in (
+        (Person.FEMALE, _("female")),
+        (Person.MALE, _("male")),
+        (Person.UNKNOWN, _("unknown")),
+        (Person.OTHER, _("other")),
+    ):
+        rows.append(("person", "gender", code, name))
+    for code, name in (
+        (Citation.CONF_VERY_LOW, _("Very Low")),
+        (Citation.CONF_LOW, _("Low")),
+        (Citation.CONF_NORMAL, _("Normal")),
+        (Citation.CONF_HIGH, _("High")),
+        (Citation.CONF_VERY_HIGH, _("Very High")),
+    ):
+        rows.append(("citation", "confidence", code, name))
+    for code, name, _xml in LdsOrd._TYPE_MAP:
+        rows.append(("lds", "type", code, name))
+    for code, name, _xml in LdsOrd._STATUS_MAP:
+        rows.append(("lds", "status", code, name))
+
+    for table_name, column_name, code, value in rows:
+        db.query(
+            """INSERT INTO constants (
+                     table_name, column_name, code, value) VALUES (?,?,?,?);""",
+            table_name,
+            column_name,
+            code,
+            str(value),
+        )
+
+
+def export_name_group(db: Database, database) -> None:
+    """Export Gramps' name_group table, mapping surnames to their grouping."""
+    for name in database.get_name_group_keys():
+        grouping = database.get_name_group_mapping(name)
+        db.query(
+            "INSERT INTO name_group (name, grouping) VALUES (?, ?);",
+            name,
+            grouping,
+        )
+
+
+# -------------------------------------------------------------------------
+#
 # Dummy callback
 #
 # -------------------------------------------------------------------------
@@ -1668,6 +1801,9 @@ def exportData(database, filename: str, user, option_box) -> bool:
     makeDB(db, callback)
 
     db.batch = True  # don't commit till end
+
+    export_constants(db)
+    export_name_group(db, database)
 
     # ---------------------------------
     # Notes

--- a/Sqlite/ExportSql.py
+++ b/Sqlite/ExportSql.py
@@ -65,8 +65,10 @@ from gramps.gen.lib.familyreltype import FamilyRelType
 from gramps.gen.lib.ldsord import LdsOrd
 from gramps.gen.lib.nameorigintype import NameOriginType
 from gramps.gen.lib.nametype import NameType
+from gramps.gen.lib.note import Note
 from gramps.gen.lib.notetype import NoteType
 from gramps.gen.lib.person import Person
+from gramps.gen.display.name import displayer as name_displayer
 from gramps.gen.lib.placetype import PlaceType
 from gramps.gen.lib.repotype import RepositoryType
 from gramps.gen.lib.srcattrtype import SrcAttributeType
@@ -1676,11 +1678,12 @@ def export_constants(db: Database) -> None:
     """
     Export the meaning of integer codes that are not GrampsType instances.
 
-    Date calendar/modifier/quality, person gender, citation confidence,
-    and LDS ordinance type/status are plain integer constants defined in
-    Gramps core rather than per-record GrampsType DataDicts, so their
-    names can't be resolved via type_string(). Record them once here
-    instead of leaving bare integers in those columns.
+    Date calendar/modifier/quality/newyear, person gender, citation
+    confidence, LDS ordinance type/status, name display_as/sort_as, and
+    note format are plain integer constants defined in Gramps core
+    rather than per-record GrampsType DataDicts, so their names can't be
+    resolved via type_string(). Record them once here, translated into
+    the user's locale, instead of leaving bare integers in those columns.
     """
     rows = []
     for code, name in enumerate(Date.ui_calendar_names):
@@ -1704,6 +1707,13 @@ def export_constants(db: Database) -> None:
     ):
         rows.append(("date", "quality", code, name))
     for code, name in (
+        (Date.NEWYEAR_JAN1, _("January 1")),
+        (Date.NEWYEAR_MAR1, _("March 1")),
+        (Date.NEWYEAR_MAR25, _("March 25")),
+        (Date.NEWYEAR_SEP1, _("September 1")),
+    ):
+        rows.append(("date", "newyear", code, name))
+    for code, name in (
         (Person.FEMALE, _("female")),
         (Person.MALE, _("male")),
         (Person.UNKNOWN, _("unknown")),
@@ -1722,6 +1732,14 @@ def export_constants(db: Database) -> None:
         rows.append(("lds", "type", code, name))
     for code, name, _xml in LdsOrd._STATUS_MAP:
         rows.append(("lds", "status", code, name))
+    for code, name, _format, _active in name_displayer.STANDARD_FORMATS:
+        rows.append(("name", "display_as", code, name))
+        rows.append(("name", "sort_as", code, name))
+    for code, name in (
+        (Note.FLOWED, _("Flowed")),
+        (Note.FORMATTED, _("Preformatted")),
+    ):
+        rows.append(("note", "format", code, name))
 
     for table_name, column_name, code, value in rows:
         db.query(

--- a/Sqlite/ImportSql.py
+++ b/Sqlite/ImportSql.py
@@ -17,7 +17,6 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
-# $Id: ImportSql.py 189 2010-02-13 07:08:48Z dsblank $
 
 "Import from SQLite Database"
 
@@ -45,28 +44,8 @@ LOG = logging.getLogger(__name__)
 # Gramps modules
 #
 # -------------------------------------------------------------------------
-from gramps.gen.lib import (
-    Address,
-    Attribute,
-    Citation,
-    Event,
-    EventRef,
-    Family,
-    LdsOrd,
-    Media,
-    MediaRef,
-    Name,
-    Note,
-    Person,
-    PersonRef,
-    Place,
-    PlaceName,
-    Repository,
-    Source,
-    Tag,
-    Url,
-)
 from gramps.gen.db import DbTxn
+from gramps.gen.lib.json_utils import data_to_object
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 
 try:
@@ -79,21 +58,23 @@ ngettext = trans.ngettext
 
 # -------------------------------------------------------------------------
 #
-# Helper lookup
+# Helper
 #
 # -------------------------------------------------------------------------
-def lookup(handle: str | None, event_ref_list) -> int:
+def _gtype(class_name: str, value: int, string: str) -> dict:
+    """Return a GrampsType DataDict."""
+    return {"_class": class_name, "value": value, "string": string}
+
+
+def lookup(handle: str | None, event_ref_list: list) -> int:
     """
-    Find the handle in an unserialized event_ref_list and return its index.
+    Find the handle in a DataDict event_ref_list and return its index, or -1.
     """
     if handle is None:
         return -1
-    count = 0
-    for event_ref in event_ref_list:
-        (_private, _citation_list, _note_list, _attribute_list, ref, _role) = event_ref
-        if handle == ref:
+    for count, event_ref in enumerate(event_ref_list):
+        if handle == event_ref["ref"]:
             return count
-        count += 1
     return -1
 
 
@@ -145,18 +126,22 @@ class Database(object):
 class SQLReader(object):
     """
     Reads a Gramps SQLite export file and populates a Gramps database.
+
+    All sub-object helpers return DataDicts (named-key dicts) compatible with
+    ``data_to_object()`` from ``gramps.gen.lib.json_utils``.  This avoids
+    positional tuple unpacking, making the import forward-compatible with
+    any future schema additions in Gramps core.
     """
 
     def __init__(self, db, filename: str, user) -> None:
         """Initialise the reader with a target database and source file."""
-        if isinstance(user.callback, abc.Callable):  # is really callable
+        if isinstance(user.callback, abc.Callable):
             callback = user.callback
         else:
-            callback = self.dummy_callback  # dummy
+            callback = self.dummy_callback
         self.db = db
         self.filename = filename
         self.callback = callback
-        self.debug = 0
 
     def dummy_callback(self, *args) -> None:
         """No-op progress callback."""
@@ -177,545 +162,386 @@ class SQLReader(object):
         return sql
 
     # -----------------------------------------------
-    # Get methods to retrieve data from the tables
+    # Link helpers
     # -----------------------------------------------
 
-    def get_address_list(self, sql, from_type: str, from_handle: str, with_parish: bool):
-        """Return a list of serialized address tuples for a parent object."""
-        results = self.get_links(sql, from_type, from_handle, "address")
-        retval = []
-        for handle in results:
-            result = sql.query("select * from address where handle = ?;", handle)
-            retval.append(self.pack_address(sql, result[0], with_parish))
-        return retval
-
-    def get_attribute_list(self, sql, from_type: str, from_handle: str):
-        """Return a list of serialized attribute tuples for a parent object."""
-        handles = self.get_links(sql, from_type, from_handle, "attribute")
-        retval = []
-        for handle in handles:
-            rows = sql.query("select * from attribute where handle = ?;", handle)
-            for row in rows:
-                (handle, the_type0, the_type1, value, private) = row
-                citation_list = self.get_citation_list(sql, "attribute", handle)
-                note_list = self.get_note_list(sql, "attribute", handle)
-                retval.append(
-                    (bool(private), citation_list, note_list, (the_type0, the_type1), value)
-                )
-        return retval
-
-    def get_child_ref_list(self, sql, from_type: str, from_handle: str):
-        """Return a list of serialized child-ref tuples for a family."""
-        results = self.get_links(sql, from_type, from_handle, "child_ref")
-        retval = []
-        for handle in results:
-            rows = sql.query("select * from child_ref where handle = ?;", handle)
-            for row in rows:
-                (handle, ref, frel0, frel1, mrel0, mrel1, private) = row
-                citation_list = self.get_citation_list(sql, "child_ref", handle)
-                note_list = self.get_note_list(sql, "child_ref", handle)
-                retval.append(
-                    (
-                        bool(private),
-                        citation_list,
-                        note_list,
-                        ref,
-                        (frel0, frel1),
-                        (mrel0, mrel1),
-                    )
-                )
-        return retval
-
-    def get_datamap_list(self, sql, from_type: str, from_handle: str):
-        """Return a list of datamap tuples for a source or citation."""
-        datamap = []
-        rows = sql.query("select * from datamap where from_handle = ?;", from_handle)
-        for row in rows:
-            (
-                from_handle,
-                the_type0,
-                the_type1,
-                value_field,
-                private,
-            ) = row
-            datamap.append((private, (the_type0, the_type1), value_field))
-        return datamap
-
-    def get_event_ref_list(self, sql, from_type: str, from_handle: str):
-        """Return a list of serialized event-ref tuples for a parent object."""
-        results = self.get_links(sql, from_type, from_handle, "event_ref")
-        retval = []
-        for handle in results:
-            result = sql.query("select * from event_ref where handle = ?;", handle)
-            retval.append(self.pack_event_ref(sql, result[0]))
-        return retval
-
-    def get_family_list(self, sql, from_type: str, from_handle: str):
-        """Return a list of family handles for a person."""
-        return self.get_links(sql, from_type, from_handle, "family")
-
-    def get_parent_family_list(self, sql, from_type: str, from_handle: str):
-        """Return a list of parent-family handles for a person."""
-        return self.get_links(sql, from_type, from_handle, "parent_family")
-
-    def get_person_ref_list(self, sql, from_type: str, from_handle: str):
-        """Return a list of serialized person-ref tuples for a parent object."""
-        handles = self.get_links(sql, from_type, from_handle, "person_ref")
-        retval = []
-        for ref_handle in handles:
-            rows = sql.query(
-                "select * from person_ref where handle = ?;", ref_handle
-            )
-            for row in rows:
-                (
-                    handle,
-                    ref,
-                    description,
-                    private,
-                ) = row
-                citation_list = self.get_citation_list(sql, "person_ref", handle)
-                note_list = self.get_note_list(sql, "person_ref", handle)
-                retval.append(
-                    (bool(private), citation_list, note_list, ref, description)
-                )
-        return retval
-
-    def get_location_list(self, sql, from_type: str, from_handle: str, with_parish: bool):
-        """Return a list of serialized location tuples for a parent object."""
-        handles = self.get_links(sql, from_type, from_handle, "location")
-        results = []
-        for handle in handles:
-            results += sql.query("select * from location where handle = ?;", handle)
-        return [self.pack_location(sql, result, with_parish) for result in results]
-
-    def get_lds_list(self, sql, from_type: str, from_handle: str):
-        """Return a list of serialized LDS ordinance tuples for a parent object."""
-        handles = self.get_links(sql, from_type, from_handle, "lds")
-        results = []
-        for handle in handles:
-            results += sql.query("""select * from lds where handle = ?;""", handle)
-        return [self.pack_lds(sql, result) for result in results]
-
-    def get_media_list(self, sql, from_type: str, from_handle: str):
-        """Return a list of serialized media-ref tuples for a parent object."""
-        handles = self.get_links(sql, from_type, from_handle, "media_ref")
-        results = []
-        for handle in handles:
-            results += sql.query(
-                "select * from media_ref where handle = ?;", handle
-            )
-        return [self.pack_media_ref(sql, result) for result in results]
-
-    def get_surname_list(self, sql, handle: str):
-        """Return a list of serialized surname tuples for a name."""
-        results = sql.query(
-            "select s.* from surname s inner join link l ON l.to_handle = "
-            "s.handle where l.from_handle = ?;",
-            handle,
-        )
-        return [self.pack_surnames(sql, result) for result in results]
-
-    def get_note_list(self, sql, from_type: str, from_handle: str):
-        """Return a list of note handles for a parent object."""
-        return self.get_links(sql, from_type, from_handle, "note")
-
-    def get_repository_ref_list(self, sql, from_type: str, from_handle: str):
-        """Return a list of serialized repository-ref tuples for a source."""
-        handles = self.get_links(sql, from_type, from_handle, "repository_ref")
-        results = []
-        for handle in handles:
-            results += sql.query(
-                """select * from repository_ref where handle = ?;""", handle
-            )
-        return [self.pack_repository_ref(sql, result) for result in results]
-
-    def get_citation_list(self, sql, from_type: str, from_handle: str):
-        """Return a list of citation handles for a parent object."""
-        handles = self.get_links(sql, from_type, from_handle, "citation")
-        return handles
-
-    def get_url_list(self, sql, from_type: str, from_handle: str):
-        """Return a list of serialized URL tuples for a parent object."""
-        handles = self.get_links(sql, from_type, from_handle, "url")
-        results = []
-        for handle in handles:
-            results += sql.query("""select * from url where handle = ?;""", handle)
-        return [self.pack_url(sql, result) for result in results]
-
-    # ---------------------------------
-    # Helpers
-    # ---------------------------------
-
-    def pack_address(self, sql, data, with_parish: bool):
-        """Pack raw address row data into a serialized address tuple."""
-        (handle, private) = data
-        citation_list = self.get_citation_list(sql, "address", handle)
-        date_handle = self.get_link(sql, "address", handle, "date")
-        date = self.get_date(sql, date_handle)
-        note_list = self.get_note_list(sql, "address", handle)
-        location = self.get_location(sql, "address", handle, with_parish)
-        return (bool(private), citation_list, note_list, date, location)
-
-    def pack_lds(self, sql, data):
-        """Pack raw LDS ordinance row data into a serialized tuple."""
-        (handle, type_, place, famc, temple, status, private) = data
-        citation_list = self.get_citation_list(sql, "lds", handle)
-        note_list = self.get_note_list(sql, "lds", handle)
-        date_handle = self.get_link(sql, "lds", handle, "date")
-        date = self.get_date(sql, date_handle)
-        return (citation_list, note_list, date, type_, place, famc, temple, status, bool(private))
-
-    def pack_surnames(self, sql, data):
-        """Pack raw surname row data into a serialized tuple."""
-        (
-            _handle,
-            surname,
-            prefix,
-            primary_surname,
-            origin_type0,
-            origin_type1,
-            connector,
-        ) = data
-        return (
-            surname,
-            prefix,
-            bool(primary_surname),
-            (origin_type0, origin_type1),
-            connector,
-        )
-
-    def pack_media_ref(self, sql, data):
-        """Pack raw media_ref row data into a serialized tuple."""
-        (
-            handle,
-            ref,
-            role0,
-            role1,
-            role2,
-            role3,
-            private,
-        ) = data
-        citation_list = self.get_citation_list(sql, "media_ref", handle)
-        note_list = self.get_note_list(sql, "media_ref", handle)
-        attribute_list = self.get_attribute_list(sql, "media_ref", handle)
-        if role0 == role1 == role2 == role3 == -1:
-            role = None
-        else:
-            role = (role0, role1, role2, role3)
-        return (bool(private), citation_list, note_list, attribute_list, ref, role)
-
-    def pack_repository_ref(self, sql, data):
-        """Pack raw repository_ref row data into a serialized tuple."""
-        (
-            handle,
-            ref,
-            call_number,
-            source_media_type0,
-            source_media_type1,
-            private,
-        ) = data
-        note_list = self.get_note_list(sql, "repository_ref", handle)
-        return (
-            note_list,
-            ref,
-            call_number,
-            (source_media_type0, source_media_type1),
-            bool(private),
-        )
-
-    def pack_url(self, sql, data):
-        """Pack raw url row data into a serialized tuple."""
-        (
-            _handle,
-            path,
-            desc,
-            type0,
-            type1,
-            private,
-        ) = data
-        return (bool(private), path, desc, (type0, type1))
-
-    def pack_event_ref(self, sql, data):
-        """Pack raw event_ref row data into a serialized tuple."""
-        (
-            handle,
-            ref,
-            role0,
-            role1,
-            private,
-        ) = data
-        note_list = self.get_note_list(sql, "event_ref", handle)
-        attribute_list = self.get_attribute_list(sql, "event_ref", handle)
-        citation_list = self.get_citation_list(sql, "event_ref", handle)
-        role = (role0, role1)
-        return (bool(private), citation_list, note_list, attribute_list, ref, role)
-
-    def pack_citation(self, sql, data):
-        """Pack raw citation row data into a serialized tuple."""
-        (
-            handle,
-            ref,
-            confidence,
-            page,
-            private,
-        ) = data
-        date_handle = self.get_link(sql, "citation", handle, "date")
-        date = self.get_date(sql, date_handle)
-        note_list = self.get_note_list(sql, "citation", handle)
-        return (date, bool(private), note_list, confidence, ref, page)
-
-    def pack_source(self, sql, data):
-        """Pack raw source row data into a serialized tuple."""
-        (
-            handle,
-            gid,
-            title,
-            author,
-            pubinfo,
-            abbrev,
-            change,
-            private,
-        ) = data
-        note_list = self.get_note_list(sql, "source", handle)
-        media_list = self.get_media_list(sql, "source", handle)
-        reporef_list = self.get_repository_ref_list(sql, "source", handle)
-        datamap = self.get_datamap_list(sql, "source", handle)
-        return (
-            handle,
-            gid,
-            title,
-            author,
-            pubinfo,
-            note_list,
-            media_list,
-            abbrev,
-            change,
-            datamap,
-            reporef_list,
-            bool(private),
-        )
-
-    def get_location(self, sql, from_type: str, from_handle: str, with_parish: bool):
-        """Return a single serialized location tuple for a parent object."""
-        handle = self.get_link(sql, from_type, from_handle, "location")
-        if handle:
-            results = sql.query(
-                """select * from location where handle = ?;""", handle
-            )
-            if len(results) == 1:
-                return self.pack_location(sql, results[0], with_parish)
-        return None
-
-    def get_names(self, sql, from_type: str, from_handle: str, primary: bool):
-        """
-        Return the primary Name object or a list of alternate Name objects.
-
-        When primary is True, a single serialized name tuple is returned.
-        When primary is False, a list of serialized name tuples is returned.
-        """
-        handles = self.get_links(sql, from_type, from_handle, "name")
-        names = []
-        for handle in handles:
-            results = sql.query(
-                "select * from name where handle = ? and primary_name = ?;",
-                handle,
-                primary,
-            )
-            if len(results) > 0:
-                names += results
-        result = [self.pack_name(sql, name) for name in names]
-        if primary:
-            if len(result) == 1:
-                return result[0]
-            elif len(result) == 0:
-                return Name().serialize()
-            else:
-                raise Exception("too many primary names")
-        else:
-            return result
-
-    def pack_name(self, sql, data):
-        """Pack raw name row data into a serialized tuple."""
-        # unpack name from SQL table:
-        (
-            handle,
-            _primary_name,
-            private,
-            first_name,
-            suffix,
-            title,
-            name_type0,
-            name_type1,
-            group_as,
-            sort_as,
-            display_as,
-            call,
-            nick,
-            famnick,
-        ) = data
-        # build up a GRAMPS object:
-        surname_list = self.get_surname_list(sql, handle)
-        citation_list = self.get_citation_list(sql, "name", handle)
-        note_list = self.get_note_list(sql, "name", handle)
-        date_handle = self.get_link(sql, "name", handle, "date")
-        date = self.get_date(sql, date_handle)
-        return (
-            bool(private),
-            citation_list,
-            note_list,
-            date,
-            first_name,
-            surname_list,
-            suffix,
-            title,
-            (name_type0, name_type1),
-            group_as,
-            sort_as,
-            display_as,
-            call,
-            nick,
-            famnick,
-        )
-
-    def pack_location(self, sql, data, with_parish: bool):
-        """Pack raw location row data into a serialized tuple."""
-        (_handle, street, locality, city, county, state, country, postal, phone, parish) = (
-            data
-        )
-        if with_parish:
-            return (
-                (street, locality, city, county, state, country, postal, phone),
-                parish,
-            )
-        else:
-            return (street, locality, city, county, state, country, postal, phone)
-
-    def get_place_from_handle(self, sql, ref_handle: str | None) -> str:
-        """Return the place handle for a given place row handle, or ''."""
-        if ref_handle:
-            place_row = sql.query(
-                "select * from place where handle = ?;", ref_handle
-            )
-            if len(place_row) == 1:
-                # return just the handle here:
-                return place_row[0][0]
-            elif len(place_row) == 0:
-                LOG.error(
-                    "get_place_from_handle('%s'), no such handle.", ref_handle
-                )
-            else:
-                LOG.error(
-                    "get_place_from_handle('%s') should be unique; returned %d records.",
-                    ref_handle,
-                    len(place_row),
-                )
-        return ""
-
-    def get_alt_place_name_list(self, sql, handle: str):
-        """Return a list of alternate place name tuples for a place."""
-        place_name_list = sql.query(
-            """select * from place_name where from_handle = ?;""", handle
-        )
-        retval = []
-        for place_name_data in place_name_list:
-            ref_handle, handle, value, lang = place_name_data
-            date_handle = self.get_link(sql, "place_name", ref_handle, "date")
-            date = self.get_date(sql, date_handle)
-            retval.append((value, date, lang))
-        return retval
-
-    def get_place_ref_list(self, sql, handle: str):
-        """Return a list of place-ref tuples for a place."""
-        # place_ref_list = Enclosed by:  [('4ECKQCWCLO5YIHXEXC', None)]
-        # [(handle, date)...]
-        place_ref_list = sql.query(
-            """select * from place_ref where from_place_handle = ?;""", handle
-        )
-        retval = []
-        for place_ref_data in place_ref_list:
-            ref_handle, handle, to_place_handle = place_ref_data
-            date_handle = self.get_link(sql, "place_ref", ref_handle, "date")
-            date = self.get_date(sql, date_handle)
-            retval.append((to_place_handle, date))
-        return retval
-
     def get_link(self, sql, from_type: str, from_handle: str, to_link: str) -> str | None:
-        """
-        Return a single link handle from the link table, or None.
-        """
+        """Return a single linked handle, or None."""
         if from_handle is None:
             return None
-        assert type(from_handle) == str, "from_handle is wrong type: %s is %s" % (
-            from_handle,
-            type(from_handle),
-        )
         rows = self.get_links(sql, from_type, from_handle, to_link)
         if len(rows) == 1:
             return rows[0]
         elif len(rows) > 1:
             LOG.error(
                 "too many links %s:%s -> %s (%d)",
-                from_type,
-                from_handle,
-                to_link,
-                len(rows),
+                from_type, from_handle, to_link, len(rows),
             )
         return None
 
-    def get_links(self, sql, from_type: str, from_handle: str, to_link: str):
-        """
-        Return a list of handles from the link table (possibly empty).
-        """
+    def get_links(self, sql, from_type: str, from_handle: str, to_link: str) -> list:
+        """Return all linked handles (possibly empty)."""
         results = sql.query(
-            """select to_handle from link where from_type = ? and """
-            """from_handle = ? and to_type = ?;""",
-            from_type,
-            from_handle,
-            to_link,
+            "select to_handle from link where from_type = ? "
+            "and from_handle = ? and to_type = ?;",
+            from_type, from_handle, to_link,
         )
-        return [result[0] for result in results]
+        return [r[0] for r in results]
 
-    def get_date(self, sql, handle: str | None):
-        """Return a serialized date tuple for a given date handle, or None."""
-        assert type(handle) in [str, type(None)], "handle is wrong type: %s" % handle
-        if handle:
-            rows = sql.query("select * from date where handle = ?;", handle)
-            if len(rows) == 1:
+    # -----------------------------------------------
+    # DataDict builders for sub-objects
+    # -----------------------------------------------
+
+    def get_date(self, sql, handle: str | None) -> dict | None:
+        """Return a Date DataDict for *handle*, or None."""
+        if not handle:
+            return None
+        rows = sql.query("select * from date where handle = ?;", handle)
+        if not rows:
+            return None
+        (
+            _handle, calendar, modifier, quality,
+            day1, month1, year1, slash1,
+            day2, month2, year2, slash2,
+            text, sortval, newyear,
+        ) = rows[0]
+        if day2 == month2 == year2 == 0 and not slash2:
+            dateval = [day1, month1, year1, bool(slash1)]
+        else:
+            dateval = [day1, month1, year1, bool(slash1),
+                       day2, month2, year2, bool(slash2)]
+        return {
+            "_class": "Date",
+            "calendar": calendar,
+            "modifier": modifier,
+            "quality": quality,
+            "dateval": dateval,
+            "text": text,
+            "sortval": sortval,
+            "newyear": newyear,
+        }
+
+    def get_attribute_list(self, sql, from_type: str, from_handle: str) -> list:
+        """Return a list of Attribute DataDicts for *from_handle*."""
+        result = []
+        for handle in self.get_links(sql, from_type, from_handle, "attribute"):
+            rows = sql.query("select * from attribute where handle = ?;", handle)
+            for row in rows:
+                (handle, the_type0, the_type1, value, private) = row
+                result.append({
+                    "_class": "Attribute",
+                    "private": bool(private),
+                    "citation_list": self.get_links(sql, "attribute", handle, "citation"),
+                    "note_list": self.get_links(sql, "attribute", handle, "note"),
+                    "type": _gtype("AttributeType", the_type0, the_type1),
+                    "value": value,
+                })
+        return result
+
+    def get_src_attribute_list(self, sql, from_handle: str) -> list:
+        """Return a list of SrcAttribute DataDicts from the datamap table."""
+        result = []
+        rows = sql.query(
+            "select from_handle, the_type0, the_type1, value_field, private "
+            "from datamap where from_handle = ?;", from_handle
+        )
+        for (_fh, the_type0, the_type1, value_field, private) in (rows or []):
+            result.append({
+                "_class": "SrcAttribute",
+                "private": bool(private),
+                "type": _gtype("SrcAttributeType", the_type0, the_type1),
+                "value": value_field,
+            })
+        return result
+
+    def get_child_ref_list(self, sql, from_type: str, from_handle: str) -> list:
+        """Return a list of ChildRef DataDicts for *from_handle*."""
+        result = []
+        for handle in self.get_links(sql, from_type, from_handle, "child_ref"):
+            rows = sql.query("select * from child_ref where handle = ?;", handle)
+            for row in rows:
+                (handle, ref, frel0, frel1, mrel0, mrel1, private) = row
+                result.append({
+                    "_class": "ChildRef",
+                    "private": bool(private),
+                    "citation_list": self.get_links(sql, "child_ref", handle, "citation"),
+                    "note_list": self.get_links(sql, "child_ref", handle, "note"),
+                    "ref": ref,
+                    "frel": _gtype("ChildRefType", frel0, frel1),
+                    "mrel": _gtype("ChildRefType", mrel0, mrel1),
+                })
+        return result
+
+    def get_event_ref_list(self, sql, from_type: str, from_handle: str) -> list:
+        """Return a list of EventRef DataDicts for *from_handle*."""
+        result = []
+        for handle in self.get_links(sql, from_type, from_handle, "event_ref"):
+            rows = sql.query("select * from event_ref where handle = ?;", handle)
+            for row in rows:
+                (handle, ref, role0, role1, private) = row
+                result.append({
+                    "_class": "EventRef",
+                    "private": bool(private),
+                    "citation_list": self.get_links(sql, "event_ref", handle, "citation"),
+                    "note_list": self.get_links(sql, "event_ref", handle, "note"),
+                    "attribute_list": self.get_attribute_list(sql, "event_ref", handle),
+                    "ref": ref,
+                    "role": _gtype("EventRoleType", role0, role1),
+                })
+        return result
+
+    def get_person_ref_list(self, sql, from_type: str, from_handle: str) -> list:
+        """Return a list of PersonRef DataDicts for *from_handle*."""
+        result = []
+        for handle in self.get_links(sql, from_type, from_handle, "person_ref"):
+            rows = sql.query("select * from person_ref where handle = ?;", handle)
+            for row in rows:
+                (handle, ref, description, private) = row
+                result.append({
+                    "_class": "PersonRef",
+                    "private": bool(private),
+                    "citation_list": self.get_links(sql, "person_ref", handle, "citation"),
+                    "note_list": self.get_links(sql, "person_ref", handle, "note"),
+                    "ref": ref,
+                    "rel": description,
+                })
+        return result
+
+    def get_media_list(self, sql, from_type: str, from_handle: str) -> list:
+        """Return a list of MediaRef DataDicts for *from_handle*."""
+        result = []
+        for handle in self.get_links(sql, from_type, from_handle, "media_ref"):
+            rows = sql.query("select * from media_ref where handle = ?;", handle)
+            for row in rows:
+                (handle, ref, role0, role1, role2, role3, private) = row
+                rect = None if role0 == role1 == role2 == role3 == -1 \
+                    else [role0, role1, role2, role3]
+                result.append({
+                    "_class": "MediaRef",
+                    "private": bool(private),
+                    "citation_list": self.get_links(sql, "media_ref", handle, "citation"),
+                    "note_list": self.get_links(sql, "media_ref", handle, "note"),
+                    "attribute_list": self.get_attribute_list(sql, "media_ref", handle),
+                    "ref": ref,
+                    "rect": rect,
+                })
+        return result
+
+    def get_url_list(self, sql, from_type: str, from_handle: str) -> list:
+        """Return a list of Url DataDicts for *from_handle*."""
+        result = []
+        for handle in self.get_links(sql, from_type, from_handle, "url"):
+            rows = sql.query("select * from url where handle = ?;", handle)
+            for row in rows:
+                (_handle, path, desc, type0, type1, private) = row
+                result.append({
+                    "_class": "Url",
+                    "private": bool(private),
+                    "path": path,
+                    "desc": desc,
+                    "type": _gtype("UrlType", type0, type1),
+                })
+        return result
+
+    def get_repository_ref_list(self, sql, from_type: str, from_handle: str) -> list:
+        """Return a list of RepoRef DataDicts for *from_handle*."""
+        result = []
+        for handle in self.get_links(sql, from_type, from_handle, "repository_ref"):
+            rows = sql.query(
+                "select * from repository_ref where handle = ?;", handle
+            )
+            for row in rows:
+                (handle, ref, call_number, smt0, smt1, private) = row
+                result.append({
+                    "_class": "RepoRef",
+                    "private": bool(private),
+                    "note_list": self.get_links(sql, "repository_ref", handle, "note"),
+                    "ref": ref,
+                    "call_number": call_number,
+                    "media_type": _gtype("SourceMediaType", smt0, smt1),
+                })
+        return result
+
+    def get_lds_list(self, sql, from_type: str, from_handle: str) -> list:
+        """Return a list of LdsOrd DataDicts for *from_handle*."""
+        result = []
+        for handle in self.get_links(sql, from_type, from_handle, "lds"):
+            rows = sql.query("select * from lds where handle = ?;", handle)
+            for row in rows:
+                (handle, type_, place, famc, temple, status, private) = row
+                date_handle = self.get_link(sql, "lds", handle, "date")
+                result.append({
+                    "_class": "LdsOrd",
+                    "citation_list": self.get_links(sql, "lds", handle, "citation"),
+                    "note_list": self.get_links(sql, "lds", handle, "note"),
+                    "date": self.get_date(sql, date_handle),
+                    # type_ is stored as a plain int in the SQLite schema
+                    "type": type_,
+                    "place": place,
+                    "famc": famc,
+                    "temple": temple,
+                    "status": status,
+                    "private": bool(private),
+                })
+        return result
+
+    def get_location(self, sql, handle: str) -> dict | None:
+        """Return a Location DataDict for *handle*, or None."""
+        rows = sql.query("select * from location where handle = ?;", handle)
+        if not rows:
+            return None
+        (_handle, street, locality, city, county, state, country, postal, phone, parish) = rows[0]
+        return {
+            "_class": "Location",
+            "street": street or "",
+            "locality": locality or "",
+            "city": city or "",
+            "county": county or "",
+            "state": state or "",
+            "country": country or "",
+            "postal": postal or "",
+            "phone": phone or "",
+            "parish": parish or "",
+        }
+
+    def get_address_list(self, sql, from_type: str, from_handle: str) -> list:
+        """Return a list of Address DataDicts for *from_handle*.
+
+        In Gramps 6.1, Address carries location fields directly.  These are
+        stored in the linked location row and merged back into the Address dict
+        on import.
+        """
+        result = []
+        for handle in self.get_links(sql, from_type, from_handle, "address"):
+            rows = sql.query("select * from address where handle = ?;", handle)
+            for row in rows:
+                (handle, private) = row
+                date_handle = self.get_link(sql, "address", handle, "date")
+                loc_handle = self.get_link(sql, "address", handle, "location")
+                loc = self.get_location(sql, loc_handle) if loc_handle else {}
+                addr = {
+                    "_class": "Address",
+                    "private": bool(private),
+                    "citation_list": self.get_links(sql, "address", handle, "citation"),
+                    "note_list": self.get_links(sql, "address", handle, "note"),
+                    "date": self.get_date(sql, date_handle),
+                    "street": (loc or {}).get("street", ""),
+                    "locality": (loc or {}).get("locality", ""),
+                    "city": (loc or {}).get("city", ""),
+                    "county": (loc or {}).get("county", ""),
+                    "state": (loc or {}).get("state", ""),
+                    "country": (loc or {}).get("country", ""),
+                    "postal": (loc or {}).get("postal", ""),
+                    "phone": (loc or {}).get("phone", ""),
+                }
+                result.append(addr)
+        return result
+
+    def get_alt_location_list(self, sql, from_type: str, from_handle: str) -> list:
+        """Return a list of Location DataDicts for Place alt_loc."""
+        result = []
+        for handle in self.get_links(sql, from_type, from_handle, "location"):
+            loc = self.get_location(sql, handle)
+            if loc:
+                result.append(loc)
+        return result
+
+    def get_surname_list(self, sql, name_handle: str) -> list:
+        """Return a list of Surname DataDicts for *name_handle*."""
+        rows = sql.query(
+            "select s.* from surname s inner join link l "
+            "ON l.to_handle = s.handle where l.from_handle = ?;",
+            name_handle,
+        )
+        result = []
+        for row in rows:
+            (_handle, surname, prefix, primary_surname, ot0, ot1, connector) = row
+            result.append({
+                "_class": "Surname",
+                "surname": surname,
+                "prefix": prefix,
+                "primary": bool(primary_surname),
+                "origintype": _gtype("NameOriginType", ot0, ot1),
+                "connector": connector,
+            })
+        return result
+
+    def get_names(self, sql, from_type: str, from_handle: str, primary: bool):
+        """
+        Return the primary Name DataDict or a list of alternate Name DataDicts.
+        """
+        handles = self.get_links(sql, from_type, from_handle, "name")
+        result = []
+        for handle in handles:
+            rows = sql.query(
+                "select * from name where handle = ? and primary_name = ?;",
+                handle, primary,
+            )
+            for row in rows:
                 (
-                    handle,
-                    calendar,
-                    modifier,
-                    quality,
-                    day1,
-                    month1,
-                    year1,
-                    slash1,
-                    day2,
-                    month2,
-                    year2,
-                    slash2,
-                    text,
-                    sortval,
-                    newyear,
-                ) = rows[0]
-                dateval = (
-                    day1,
-                    month1,
-                    year1,
-                    bool(slash1),
-                    day2,
-                    month2,
-                    year2,
-                    bool(slash2),
-                )
-                if day2 == month2 == year2 == 0 and not slash2:
-                    dateval = day1, month1, year1, bool(slash1)
-                return (calendar, modifier, quality, dateval, text, sortval, newyear)
-            elif len(rows) == 0:
-                return None
-            else:
-                LOG.error("wrong number of dates: %s", rows)
-        return None
+                    handle, _primary_flag, priv, first_name, suffix, title,
+                    name_type0, name_type1, group_as, sort_as, display_as,
+                    call, nick, famnick,
+                ) = row
+                date_handle = self.get_link(sql, "name", handle, "date")
+                result.append({
+                    "_class": "Name",
+                    "private": bool(priv),
+                    "citation_list": self.get_links(sql, "name", handle, "citation"),
+                    "note_list": self.get_links(sql, "name", handle, "note"),
+                    "date": self.get_date(sql, date_handle),
+                    "first_name": first_name,
+                    "surname_list": self.get_surname_list(sql, handle),
+                    "suffix": suffix,
+                    "title": title,
+                    "type": _gtype("NameType", name_type0, name_type1),
+                    "group_as": group_as,
+                    "sort_as": sort_as,
+                    "display_as": display_as,
+                    "call": call,
+                    "nick": nick,
+                    "famnick": famnick,
+                })
+        if primary:
+            return result[0] if result else data_to_object({"_class": "Name"})
+        return result
+
+    def get_alt_place_name_list(self, sql, handle: str) -> list:
+        """Return a list of PlaceName DataDicts for alternate place names."""
+        rows = sql.query(
+            "select * from place_name where from_handle = ?;", handle
+        )
+        result = []
+        for row in rows:
+            (ref_handle, _from_handle, value, lang) = row
+            date_handle = self.get_link(sql, "place_name", ref_handle, "date")
+            result.append({
+                "_class": "PlaceName",
+                "value": value,
+                "date": self.get_date(sql, date_handle),
+                "lang": lang,
+            })
+        return result
+
+    def get_place_ref_list(self, sql, handle: str) -> list:
+        """Return a list of PlaceRef DataDicts for a place."""
+        rows = sql.query(
+            "select * from place_ref where from_place_handle = ?;", handle
+        )
+        result = []
+        for row in rows:
+            (ref_handle, _from_handle, to_place_handle) = row
+            date_handle = self.get_link(sql, "place_ref", ref_handle, "date")
+            result.append({
+                "_class": "PlaceRef",
+                "ref": to_place_handle,
+                "date": self.get_date(sql, date_handle),
+            })
+        return result
+
+    # -----------------------------------------------
+    # Main import loop
+    # -----------------------------------------------
 
     def process(self) -> None:
         """Process the SQL file and import all objects into the Gramps database."""
@@ -734,431 +560,328 @@ class SQLReader(object):
         )
         with DbTxn(_("CSV import"), self.db, batch=True) as self.trans:
             self.db.disable_signals()
-            count = 0.0
             self.t = time.time()
-            self._process(count, total, sql)
+            self._process(0.0, total, sql)
         sql.db.commit()
         sql.db.close()
-        return None
 
     def _process(self, count: float, total: int, sql) -> None:
         """Import all object types from the SQL database into Gramps."""
+
         # ---------------------------------
-        # Process note
+        # Notes
         # ---------------------------------
-        notes = sql.query("""select * from note;""")
-        for note in notes:
-            (
-                handle,
-                gid,
-                text,
-                _format,
-                note_type1,
-                note_type2,
-                change,
-                private,
-            ) = note
-            styled_text = [text, []]
-            markups = sql.query(
-                """select * from link where from_handle = ? """
-                """and to_type = 'markup';""",
-                handle,
+        for note in sql.query("select * from note;"):
+            (handle, gid, text, format_, note_type1, note_type2, change, private) = note
+
+            markup_rows = sql.query(
+                "select to_handle from link where from_handle = ? "
+                "and to_type = 'markup';", handle,
             )
-            for markup_link in markups:
-                _from_type, _from_handle, _to_type, to_handle = markup_link
+            tags_list = []
+            for (to_handle,) in (markup_rows or []):
                 markup_detail = sql.query(
-                    """select * from markup where handle = ?;""", to_handle
+                    "select * from markup where handle = ?;", to_handle
                 )
-                for markup in markup_detail:
-                    (
-                        _mhandle,
-                        markup0,
-                        markup1,
-                        value,
-                        start_stop_list,
-                    ) = markup
+                for (_mh, markup0, markup1, value, start_stop_list) in (markup_detail or []):
                     ss_list = eval(start_stop_list)
-                    styled_text[1] += [((markup0, markup1), value, ss_list)]
+                    tags_list.append({
+                        "_class": "StyledTextTag",
+                        "name": _gtype("StyledTextTagType", markup0, markup1),
+                        "value": value,
+                        "ranges": ss_list,
+                    })
 
-            tags = self.get_links(sql, "note", handle, "tag")
-
-            g_note = Note()
-            g_note.unserialize(
-                (
-                    handle,
-                    gid,
-                    styled_text,
-                    _format,
-                    (note_type1, note_type2),
-                    change,
-                    tags,
-                    bool(private),
-                )
-            )
-            self.db.add_note(g_note, self.trans)
+            raw = {
+                "_class": "Note",
+                "handle": handle,
+                "gramps_id": gid,
+                "text": {
+                    "_class": "StyledText",
+                    "string": text,
+                    "tags": tags_list,
+                },
+                "format": format_,
+                "type": _gtype("NoteType", note_type1, note_type2),
+                "change": change,
+                "tag_list": self.get_links(sql, "note", handle, "tag"),
+                "private": bool(private),
+            }
+            self.db.add_note(data_to_object(raw), self.trans)
             count += 1
             self.callback(100 * count / total)
 
         # ---------------------------------
-        # Process event
+        # Events
         # ---------------------------------
-        events = sql.query("""select * from event;""")
-        for event in events:
+        for event in sql.query("select * from event;"):
             (handle, gid, the_type0, the_type1, description, change, private) = event
-
-            note_list = self.get_note_list(sql, "event", handle)
-            citation_list = self.get_citation_list(sql, "event", handle)
-            media_list = self.get_media_list(sql, "event", handle)
-            attribute_list = self.get_attribute_list(sql, "event", handle)
-
             date_handle = self.get_link(sql, "event", handle, "date")
-            date = self.get_date(sql, date_handle)
-
             place_handle = self.get_link(sql, "event", handle, "place")
-            place = self.get_place_from_handle(sql, place_handle)
 
-            tags = self.get_links(sql, "event", handle, "tag")
-            data = (
-                handle,
-                gid,
-                (the_type0, the_type1),
-                date,
-                description,
-                place,
-                citation_list,
-                note_list,
-                media_list,
-                attribute_list,
-                change,
-                tags,
-                bool(private),
-            )
-
-            g_event = Event()
-            g_event.unserialize(data)
-            self.db.add_event(g_event, self.trans)
-
+            raw = {
+                "_class": "Event",
+                "handle": handle,
+                "gramps_id": gid,
+                "type": _gtype("EventType", the_type0, the_type1),
+                "date": self.get_date(sql, date_handle),
+                "description": description,
+                "place": place_handle or "",
+                "citation_list": self.get_links(sql, "event", handle, "citation"),
+                "note_list": self.get_links(sql, "event", handle, "note"),
+                "media_list": self.get_media_list(sql, "event", handle),
+                "attribute_list": self.get_attribute_list(sql, "event", handle),
+                "change": change,
+                "tag_list": self.get_links(sql, "event", handle, "tag"),
+                "private": bool(private),
+            }
+            self.db.add_event(data_to_object(raw), self.trans)
             count += 1
             self.callback(100 * count / total)
 
         # ---------------------------------
-        # Process person
+        # Persons
         # ---------------------------------
         people = sql.query(
-            """select handle, gid, gender, death_ref_handle, birth_ref_handle,
-                      change, private, familysearch_sync from person;"""
+            "select handle, gid, gender, death_ref_handle, birth_ref_handle, "
+            "change, private, familysearch_sync from person;"
         )
-        for person_row in people:
+        for person_row in (people or []):
             if person_row is None:
                 continue
-            # Column order matches the SELECT above
             if len(person_row) == 8:
-                (
-                    handle,
-                    gid,
-                    gender,
-                    death_ref_handle,
-                    birth_ref_handle,
-                    change,
-                    private,
-                    familysearch_sync_json,
-                ) = person_row
+                (handle, gid, gender, death_ref_handle, birth_ref_handle,
+                 change, private, familysearch_sync_json) = person_row
             else:
-                # Older schema without familysearch_sync column
-                (
-                    handle,
-                    gid,
-                    gender,
-                    death_ref_handle,
-                    birth_ref_handle,
-                    change,
-                    private,
-                ) = person_row
+                (handle, gid, gender, death_ref_handle, birth_ref_handle,
+                 change, private) = person_row
                 familysearch_sync_json = None
 
-            primary_name_data = self.get_names(sql, "person", handle, True)  # one
-            alternate_names_data = self.get_names(sql, "person", handle, False)
             event_ref_list = self.get_event_ref_list(sql, "person", handle)
-            family_list = self.get_family_list(sql, "person", handle)
-            parent_family_list = self.get_parent_family_list(sql, "person", handle)
-            media_list = self.get_media_list(sql, "person", handle)
-            address_list = self.get_address_list(sql, "person", handle, with_parish=False)
-            attribute_list = self.get_attribute_list(sql, "person", handle)
-            urls = self.get_url_list(sql, "person", handle)
-            lds_ord_list = self.get_lds_list(sql, "person", handle)
-            pcitation_list = self.get_citation_list(sql, "person", handle)
-            pnote_list = self.get_note_list(sql, "person", handle)
-            person_ref_list = self.get_person_ref_list(sql, "person", handle)
-            death_ref_index = lookup(death_ref_handle, event_ref_list)
-            birth_ref_index = lookup(birth_ref_handle, event_ref_list)
-            tags = self.get_links(sql, "person", handle, "tag")
 
-            # Build the Person object directly by attribute assignment,
-            # avoiding positional tuple unpacking of serialize() output.
-            g_pers = Person()
-            g_pers.handle = handle
-            g_pers.gramps_id = gid
-            g_pers.gender = int(gender)
-            g_pers.primary_name.unserialize(primary_name_data)
-            g_pers.alternate_names = [
-                Name().unserialize(n) for n in alternate_names_data
-            ]
-            g_pers.death_ref_index = death_ref_index
-            g_pers.birth_ref_index = birth_ref_index
-            g_pers.event_ref_list = [EventRef().unserialize(er) for er in event_ref_list]
-            g_pers.family_list = list(family_list)
-            g_pers.parent_family_list = list(parent_family_list)
-            g_pers.media_list = [MediaRef().unserialize(m) for m in media_list]
-            g_pers.address_list = [Address().unserialize(a) for a in address_list]
-            g_pers.attribute_list = [Attribute().unserialize(a) for a in attribute_list]
-            g_pers.urls = [Url().unserialize(u) for u in urls]
-            g_pers.lds_ord_list = [LdsOrd().unserialize(lo) for lo in lds_ord_list]
-            g_pers.citation_list = list(pcitation_list)
-            g_pers.note_list = list(pnote_list)
-            g_pers.change = int(change)
-            g_pers.tag_list = list(tags)
-            g_pers.private = bool(private)
-            g_pers.person_ref_list = [PersonRef().unserialize(pr) for pr in person_ref_list]
-
-            # familysearch_sync (Gramps 6.1+): restore from JSON if present
-            if familysearch_sync_json:
-                g_pers.familysearch_sync.unserialize(json.loads(familysearch_sync_json))
+            raw = {
+                "_class": "Person",
+                "handle": handle,
+                "gramps_id": gid,
+                "gender": int(gender),
+                "primary_name": self.get_names(sql, "person", handle, True),
+                "alternate_names": self.get_names(sql, "person", handle, False),
+                "death_ref_index": lookup(death_ref_handle, event_ref_list),
+                "birth_ref_index": lookup(birth_ref_handle, event_ref_list),
+                "event_ref_list": event_ref_list,
+                "family_list": self.get_links(sql, "person", handle, "family"),
+                "parent_family_list": self.get_links(sql, "person", handle, "parent_family"),
+                "media_list": self.get_media_list(sql, "person", handle),
+                "address_list": self.get_address_list(sql, "person", handle),
+                "attribute_list": self.get_attribute_list(sql, "person", handle),
+                "urls": self.get_url_list(sql, "person", handle),
+                "lds_ord_list": self.get_lds_list(sql, "person", handle),
+                "citation_list": self.get_links(sql, "person", handle, "citation"),
+                "note_list": self.get_links(sql, "person", handle, "note"),
+                "change": int(change),
+                "tag_list": self.get_links(sql, "person", handle, "tag"),
+                "private": bool(private),
+                "person_ref_list": self.get_person_ref_list(sql, "person", handle),
+                # familysearch_sync: use stored JSON or default empty state
+                "familysearch_sync": (
+                    json.loads(familysearch_sync_json) if familysearch_sync_json
+                    else {
+                        "_class": "FamilySearchSync",
+                        "fsid": None, "is_root": False,
+                        "status_ts": None, "confirmed_ts": None,
+                        "gramps_modified_ts": None, "fs_modified_ts": None,
+                        "essential_conflict": False, "conflict": False,
+                    }
+                ),
+            }
+            g_pers = data_to_object(raw)
 
             self.db.add_person(g_pers, self.trans)
             count += 1
             self.callback(100 * count / total)
 
         # ---------------------------------
-        # Process family
+        # Families
         # ---------------------------------
-        families = sql.query("""select * from family;""")
-        for family in families:
-            (handle, gid, father_handle, mother_handle, the_type0, the_type1, change, private) = (
-                family
-            )
+        for family in sql.query("select * from family;"):
+            (handle, gid, father_handle, mother_handle,
+             the_type0, the_type1, change, private) = family
 
-            child_ref_list = self.get_child_ref_list(sql, "family", handle)
-            event_ref_list = self.get_event_ref_list(sql, "family", handle)
-            media_list = self.get_media_list(sql, "family", handle)
-            attribute_list = self.get_attribute_list(sql, "family", handle)
-            lds_seal_list = self.get_lds_list(sql, "family", handle)
-            citation_list = self.get_citation_list(sql, "family", handle)
-            note_list = self.get_note_list(sql, "family", handle)
-            tags = self.get_links(sql, "family", handle, "tag")
-
-            data = (
-                handle,
-                gid,
-                father_handle,
-                mother_handle,
-                child_ref_list,
-                (the_type0, the_type1),
-                event_ref_list,
-                media_list,
-                attribute_list,
-                lds_seal_list,
-                citation_list,
-                note_list,
-                change,
-                tags,
-                private,
-            )
-            g_fam = Family()
-            g_fam.unserialize(data)
-            self.db.add_family(g_fam, self.trans)
-
+            raw = {
+                "_class": "Family",
+                "handle": handle,
+                "gramps_id": gid,
+                "father_handle": father_handle,
+                "mother_handle": mother_handle,
+                "child_ref_list": self.get_child_ref_list(sql, "family", handle),
+                "type": _gtype("FamilyRelType", the_type0, the_type1),
+                "event_ref_list": self.get_event_ref_list(sql, "family", handle),
+                "media_list": self.get_media_list(sql, "family", handle),
+                "attribute_list": self.get_attribute_list(sql, "family", handle),
+                "lds_ord_list": self.get_lds_list(sql, "family", handle),
+                "citation_list": self.get_links(sql, "family", handle, "citation"),
+                "note_list": self.get_links(sql, "family", handle, "note"),
+                "change": change,
+                "tag_list": self.get_links(sql, "family", handle, "tag"),
+                "private": bool(private),
+            }
+            self.db.add_family(data_to_object(raw), self.trans)
             count += 1
             self.callback(100 * count / total)
 
         # ---------------------------------
-        # Process repository
+        # Repositories
         # ---------------------------------
-        repositories = sql.query("""select * from repository;""")
-        for repo in repositories:
+        for repo in sql.query("select * from repository;"):
             (handle, gid, the_type0, the_type1, name, change, private) = repo
 
-            note_list = self.get_note_list(sql, "repository", handle)
-            address_list = self.get_address_list(
-                sql, "repository", handle, with_parish=False
-            )
-            urls = self.get_url_list(sql, "repository", handle)
-            tags = self.get_links(sql, "repository", handle, "tag")
-            data = (
-                handle,
-                gid,
-                (the_type0, the_type1),
-                name,
-                note_list,
-                address_list,
-                urls,
-                change,
-                tags,
-                private,
-            )
-            g_rep = Repository()
-            g_rep.unserialize(data)
-            self.db.add_repository(g_rep, self.trans)
+            raw = {
+                "_class": "Repository",
+                "handle": handle,
+                "gramps_id": gid,
+                "type": _gtype("RepositoryType", the_type0, the_type1),
+                "name": name,
+                "note_list": self.get_links(sql, "repository", handle, "note"),
+                "address_list": self.get_address_list(sql, "repository", handle),
+                "urls": self.get_url_list(sql, "repository", handle),
+                "change": change,
+                "tag_list": self.get_links(sql, "repository", handle, "tag"),
+                "private": bool(private),
+            }
+            self.db.add_repository(data_to_object(raw), self.trans)
             count += 1
             self.callback(100 * count / total)
 
         # ---------------------------------
-        # Process place
+        # Places
         # ---------------------------------
-        places = sql.query("""select * from place;""")
-        for place in places:
+        for place in sql.query("select * from place;"):
             count += 1
-            (handle, gid, title, value, the_type0, the_type1, code, long, lat, lang, change, private) = (
-                place
-            )
+            (handle, gid, title, value, the_type0, the_type1,
+             code, long_, lat, lang, change, private) = place
 
-            alt_loc_list = self.get_location_list(
-                sql, "place_alt", handle, with_parish=True
-            )
-            urls = self.get_url_list(sql, "place", handle)
-            media_list = self.get_media_list(sql, "place", handle)
-            citation_list = self.get_citation_list(sql, "place", handle)
-            note_list = self.get_note_list(sql, "place", handle)
-            tags = self.get_links(sql, "place", handle, "tag")
-            place_type = (the_type0, the_type1)
-            alt_place_name_list = self.get_alt_place_name_list(sql, handle)
-            place_ref_list = self.get_place_ref_list(sql, handle)
-            data = (
-                handle,
-                gid,
-                title,
-                long,
-                lat,
-                place_ref_list,
-                PlaceName(value=value, lang=lang).serialize(),
-                alt_place_name_list,
-                place_type,
-                code,
-                alt_loc_list,
-                urls,
-                media_list,
-                citation_list,
-                note_list,
-                change,
-                tags,
-                private,
-            )
-            g_plac = Place()
-            g_plac.unserialize(data)
-            self.db.commit_place(g_plac, self.trans)
+            raw = {
+                "_class": "Place",
+                "handle": handle,
+                "gramps_id": gid,
+                "title": title,
+                "long": long_,
+                "lat": lat,
+                "placeref_list": self.get_place_ref_list(sql, handle),
+                "name": {
+                    "_class": "PlaceName",
+                    "value": value,
+                    "date": None,
+                    "lang": lang,
+                },
+                "alt_names": self.get_alt_place_name_list(sql, handle),
+                "place_type": _gtype("PlaceType", the_type0, the_type1),
+                "code": code,
+                "alt_loc": self.get_alt_location_list(sql, "place_alt", handle),
+                "urls": self.get_url_list(sql, "place", handle),
+                "media_list": self.get_media_list(sql, "place", handle),
+                "citation_list": self.get_links(sql, "place", handle, "citation"),
+                "note_list": self.get_links(sql, "place", handle, "note"),
+                "change": change,
+                "tag_list": self.get_links(sql, "place", handle, "tag"),
+                "private": bool(private),
+            }
+            self.db.commit_place(data_to_object(raw), self.trans)
             self.callback(100 * count / total)
 
         # ---------------------------------
-        # Process citation
+        # Citations
         # ---------------------------------
-        citations = sql.query("""select * from citation;""")
-        for citation in citations:
+        for citation in sql.query("select * from citation;"):
             (handle, gid, confidence, page, source_handle, change, private) = citation
             date_handle = self.get_link(sql, "citation", handle, "date")
-            date = self.get_date(sql, date_handle)
-            note_list = self.get_note_list(sql, "citation", handle)
-            media_list = self.get_media_list(sql, "citation", handle)
-            datamap = self.get_datamap_list(sql, "citation", handle)
-            tags = self.get_links(sql, "citation", handle, "tag")
-            data = (
-                handle,
-                gid,
-                date,
-                page,
-                confidence,
-                source_handle,
-                note_list,
-                media_list,
-                datamap,
-                change,
-                tags,
-                private,
-            )
-            g_cit = Citation()
-            g_cit.unserialize(data)
-            self.db.commit_citation(g_cit, self.trans)
+
+            raw = {
+                "_class": "Citation",
+                "handle": handle,
+                "gramps_id": gid,
+                "date": self.get_date(sql, date_handle),
+                "page": page,
+                "confidence": confidence,
+                "source_handle": source_handle,
+                "note_list": self.get_links(sql, "citation", handle, "note"),
+                "media_list": self.get_media_list(sql, "citation", handle),
+                "attribute_list": self.get_src_attribute_list(sql, handle),
+                "change": change,
+                "tag_list": self.get_links(sql, "citation", handle, "tag"),
+                "private": bool(private),
+            }
+            self.db.commit_citation(data_to_object(raw), self.trans)
             count += 1
             self.callback(100 * count / total)
 
         # ---------------------------------
-        # Process source
+        # Sources
         # ---------------------------------
-        sources = sql.query("""select * from source;""")
-        for source in sources:
+        for source in sql.query("select * from source;"):
             (handle, gid, title, author, pubinfo, abbrev, change, private) = source
-            note_list = self.get_note_list(sql, "source", handle)
-            media_list = self.get_media_list(sql, "source", handle)
-            datamap = self.get_datamap_list(sql, "source", handle)
-            reporef_list = self.get_repository_ref_list(sql, "source", handle)
-            tags = self.get_links(sql, "source", handle, "tag")
 
-            data = (
-                handle,
-                gid,
-                title,
-                author,
-                pubinfo,
-                note_list,
-                media_list,
-                abbrev,
-                change,
-                datamap,
-                reporef_list,
-                tags,
-                private,
-            )
-            g_src = Source()
-            g_src.unserialize(data)
-            self.db.commit_source(g_src, self.trans)
+            raw = {
+                "_class": "Source",
+                "handle": handle,
+                "gramps_id": gid,
+                "title": title,
+                "author": author,
+                "pubinfo": pubinfo,
+                "note_list": self.get_links(sql, "source", handle, "note"),
+                "media_list": self.get_media_list(sql, "source", handle),
+                "abbrev": abbrev,
+                "change": change,
+                "attribute_list": self.get_src_attribute_list(sql, handle),
+                "reporef_list": self.get_repository_ref_list(sql, "source", handle),
+                "tag_list": self.get_links(sql, "source", handle, "tag"),
+                "private": bool(private),
+            }
+            self.db.commit_source(data_to_object(raw), self.trans)
             count += 1
             self.callback(100 * count / total)
 
         # ---------------------------------
-        # Process media
+        # Media
         # ---------------------------------
-        media = sql.query("""select * from media;""")
-        for med in media:
+        for med in sql.query("select * from media;"):
             (handle, gid, path, mime, desc, checksum, change, private) = med
-
-            attribute_list = self.get_attribute_list(sql, "media", handle)
-            citation_list = self.get_citation_list(sql, "media", handle)
-            note_list = self.get_note_list(sql, "media", handle)
-
             date_handle = self.get_link(sql, "media", handle, "date")
-            date = self.get_date(sql, date_handle)
-            tags = self.get_links(sql, "media", handle, "tag")
 
-            data = (
-                handle,
-                gid,
-                path,
-                mime,
-                desc,
-                checksum,
-                attribute_list,
-                citation_list,
-                note_list,
-                change,
-                date,
-                tags,
-                private,
-            )
-            g_med = Media()
-            g_med.unserialize(data)
-            self.db.commit_media(g_med, self.trans)
+            raw = {
+                "_class": "Media",
+                "handle": handle,
+                "gramps_id": gid,
+                "path": path,
+                "mime": mime,
+                "desc": desc,
+                "checksum": checksum,
+                "attribute_list": self.get_attribute_list(sql, "media", handle),
+                "citation_list": self.get_links(sql, "media", handle, "citation"),
+                "note_list": self.get_links(sql, "media", handle, "note"),
+                "change": change,
+                "date": self.get_date(sql, date_handle),
+                "tag_list": self.get_links(sql, "media", handle, "tag"),
+                "private": bool(private),
+            }
+            self.db.commit_media(data_to_object(raw), self.trans)
             count += 1
             self.callback(100 * count / total)
 
         # ---------------------------------
-        # Process tag
+        # Tags
         # ---------------------------------
-        tags = sql.query("""select * from tag;""")
-        for tag in tags:
+        for tag in sql.query("select * from tag;"):
             (handle, name, color, priority, change) = tag
-
-            data = (handle, name, color, priority, change)
-            g_tag = Tag()
-            g_tag.unserialize(data)
-            self.db.commit_tag(g_tag, self.trans)
+            raw = {
+                "_class": "Tag",
+                "handle": handle,
+                "name": name,
+                "color": color,
+                "priority": priority,
+                "change": change,
+            }
+            self.db.commit_tag(data_to_object(raw), self.trans)
             count += 1
             self.callback(100 * count / total)
 

--- a/Sqlite/ImportSql.py
+++ b/Sqlite/ImportSql.py
@@ -183,7 +183,7 @@ class SQLReader(object):
         """Return all linked handles (possibly empty)."""
         results = sql.query(
             "select to_handle from link where from_type = ? "
-            "and from_handle = ? and to_type = ?;",
+            "and from_handle = ? and to_type = ? order by seq;",
             from_type, from_handle, to_link,
         )
         return [r[0] for r in results]
@@ -450,7 +450,8 @@ class SQLReader(object):
         """Return a list of Surname DataDicts for *name_handle*."""
         rows = sql.query(
             "select s.* from surname s inner join link l "
-            "ON l.to_handle = s.handle where l.from_handle = ?;",
+            "ON l.to_handle = s.handle where l.from_handle = ? "
+            "order by l.seq;",
             name_handle,
         )
         result = []
@@ -576,7 +577,7 @@ class SQLReader(object):
 
             markup_rows = sql.query(
                 "select to_handle from link where from_handle = ? "
-                "and to_type = 'markup';", handle,
+                "and to_type = 'markup' order by seq;", handle,
             )
             tags_list = []
             for (to_handle,) in (markup_rows or []):

--- a/Sqlite/ImportSql.py
+++ b/Sqlite/ImportSql.py
@@ -21,33 +21,54 @@
 
 "Import from SQLite Database"
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
-# Standard Python Modules
+# Standard Python modules
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
+import json
 import sqlite3 as sqlite
 import time
 from collections import abc
 
-#------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
 # Set up logging
 #
-#------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 import logging
-log = logging.getLogger(".ImportSql")
 
-#-------------------------------------------------------------------------
+LOG = logging.getLogger(__name__)
+
+# -------------------------------------------------------------------------
 #
 # Gramps modules
 #
-#-------------------------------------------------------------------------
-from gramps.gen.lib import (Person, Family, Note, Media, Place, Citation,
-                            Source, Tag, Event, Repository, Name, Location,
-                            PlaceName)
+# -------------------------------------------------------------------------
+from gramps.gen.lib import (
+    Address,
+    Attribute,
+    Citation,
+    Event,
+    EventRef,
+    Family,
+    LdsOrd,
+    Media,
+    MediaRef,
+    Name,
+    Note,
+    Person,
+    PersonRef,
+    Place,
+    PlaceName,
+    Repository,
+    Source,
+    Tag,
+    Url,
+)
 from gramps.gen.db import DbTxn
 from gramps.gen.const import GRAMPS_LOCALE as glocale
+
 try:
     trans = glocale.get_addon_translator(__file__)
 except ValueError:
@@ -56,71 +77,78 @@ _ = trans.gettext
 ngettext = trans.ngettext
 
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
-# Import functions
+# Helper lookup
 #
-#-------------------------------------------------------------------------
-def lookup(handle, event_ref_list):
+# -------------------------------------------------------------------------
+def lookup(handle: str | None, event_ref_list) -> int:
     """
-    Find the handle in a unserialized event_ref_list and return code.
+    Find the handle in an unserialized event_ref_list and return its index.
     """
     if handle is None:
         return -1
-    else:
-        count = 0
-        for event_ref in event_ref_list:
-            (_private, _citation_list, _note_list, _attribute_list, ref, _role) = event_ref
-            if handle == ref:
-                return count
-            count += 1
-        return -1
+    count = 0
+    for event_ref in event_ref_list:
+        (_private, _citation_list, _note_list, _attribute_list, ref, _role) = event_ref
+        if handle == ref:
+            return count
+        count += 1
+    return -1
 
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
-# SQLite DB Class
+# Database
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class Database(object):
     """
-    The db connection.
+    The SQLite db connection wrapper.
     """
-    def __init__(self, database):
+
+    def __init__(self, database: str) -> None:
+        """Open the SQLite database file."""
         self.database = database
         self.db = sqlite.connect(self.database)
         self.cursor = self.db.cursor()
 
-    def query(self, q, *args):
+    def query(self, q: str, *args):
+        """Execute a query and return all results."""
         if q.strip().upper().startswith("DROP"):
             try:
                 self.cursor.execute(q, args)
                 self.db.commit()
-            except:
-                "WARN: no such table to drop: '%s'" % q
+            except Exception:
+                LOG.warning("no such table to drop: '%s'", q)
         else:
             try:
                 self.cursor.execute(q, args)
                 self.db.commit()
-            except:
-                print("ERROR: query :", q)
-                print("ERROR: values:", args)
+            except Exception:
+                LOG.error("query: %s", q)
+                LOG.error("values: %s", args)
                 raise
             return self.cursor.fetchall()
 
-    def close(self):
-        """ Closes and writes out tables """
+    def close(self) -> None:
+        """Close and write out tables."""
         self.cursor.close()
         self.db.close()
 
 
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 #
-# SQL Reader
+# SQLReader
 #
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 class SQLReader(object):
-    def __init__(self, db, filename, user):
+    """
+    Reads a Gramps SQLite export file and populates a Gramps database.
+    """
+
+    def __init__(self, db, filename: str, user) -> None:
+        """Initialise the reader with a target database and source file."""
         if isinstance(user.callback, abc.Callable):  # is really callable
             callback = user.callback
         else:
@@ -130,11 +158,15 @@ class SQLReader(object):
         self.callback = callback
         self.debug = 0
 
+    def dummy_callback(self, *args) -> None:
+        """No-op progress callback."""
+
     def openSQL(self):
+        """Open the SQLite source file and return a Database connection."""
         try:
             from gramps.gui.dialog import ErrorDialog
-        except:
-            ErrorDialog = print
+        except Exception:
+            ErrorDialog = LOG.error
         sql = None
         try:
             sql = Database(self.filename)
@@ -148,153 +180,174 @@ class SQLReader(object):
     # Get methods to retrieve data from the tables
     # -----------------------------------------------
 
-    def get_address_list(self, sql, from_type, from_handle, with_parish):
+    def get_address_list(self, sql, from_type: str, from_handle: str, with_parish: bool):
+        """Return a list of serialized address tuples for a parent object."""
         results = self.get_links(sql, from_type, from_handle, "address")
         retval = []
         for handle in results:
-            result = sql.query("select * from address where handle = ?;",
-                               handle)
+            result = sql.query("select * from address where handle = ?;", handle)
             retval.append(self.pack_address(sql, result[0], with_parish))
         return retval
 
-    def get_attribute_list(self, sql, from_type, from_handle):
+    def get_attribute_list(self, sql, from_type: str, from_handle: str):
+        """Return a list of serialized attribute tuples for a parent object."""
         handles = self.get_links(sql, from_type, from_handle, "attribute")
         retval = []
         for handle in handles:
-            rows = sql.query("select * from attribute where handle = ?;",
-                             handle)
+            rows = sql.query("select * from attribute where handle = ?;", handle)
             for row in rows:
                 (handle, the_type0, the_type1, value, private) = row
-                citation_list = self.get_citation_list(sql, "attribute",
-                                                       handle)
+                citation_list = self.get_citation_list(sql, "attribute", handle)
                 note_list = self.get_note_list(sql, "attribute", handle)
-                retval.append((bool(private), citation_list, note_list,
-                               (the_type0, the_type1), value))
+                retval.append(
+                    (bool(private), citation_list, note_list, (the_type0, the_type1), value)
+                )
         return retval
 
-    def get_child_ref_list(self, sql, from_type, from_handle):
+    def get_child_ref_list(self, sql, from_type: str, from_handle: str):
+        """Return a list of serialized child-ref tuples for a family."""
         results = self.get_links(sql, from_type, from_handle, "child_ref")
         retval = []
         for handle in results:
-            rows = sql.query("select * from child_ref where handle = ?;",
-                             handle)
+            rows = sql.query("select * from child_ref where handle = ?;", handle)
             for row in rows:
                 (handle, ref, frel0, frel1, mrel0, mrel1, private) = row
-                citation_list = self.get_citation_list(sql, "child_ref",
-                                                       handle)
+                citation_list = self.get_citation_list(sql, "child_ref", handle)
                 note_list = self.get_note_list(sql, "child_ref", handle)
-                retval.append((bool(private), citation_list, note_list, ref,
-                               (frel0, frel1), (mrel0, mrel1)))
+                retval.append(
+                    (
+                        bool(private),
+                        citation_list,
+                        note_list,
+                        ref,
+                        (frel0, frel1),
+                        (mrel0, mrel1),
+                    )
+                )
         return retval
 
-    def get_datamap_list(self, sql, from_type, from_handle):
+    def get_datamap_list(self, sql, from_type: str, from_handle: str):
+        """Return a list of datamap tuples for a source or citation."""
         datamap = []
-        rows = sql.query("select * from datamap where from_handle = ?;",
-                         from_handle)
+        rows = sql.query("select * from datamap where from_handle = ?;", from_handle)
         for row in rows:
-            (from_handle,
-             the_type0,
-             the_type1,
-             value_field,
-             private) = row
+            (
+                from_handle,
+                the_type0,
+                the_type1,
+                value_field,
+                private,
+            ) = row
             datamap.append((private, (the_type0, the_type1), value_field))
         return datamap
 
-    def get_event_ref_list(self, sql, from_type, from_handle):
+    def get_event_ref_list(self, sql, from_type: str, from_handle: str):
+        """Return a list of serialized event-ref tuples for a parent object."""
         results = self.get_links(sql, from_type, from_handle, "event_ref")
         retval = []
         for handle in results:
-            result = sql.query("select * from event_ref where handle = ?;",
-                               handle)
+            result = sql.query("select * from event_ref where handle = ?;", handle)
             retval.append(self.pack_event_ref(sql, result[0]))
         return retval
 
-    def get_family_list(self, sql, from_type, from_handle):
+    def get_family_list(self, sql, from_type: str, from_handle: str):
+        """Return a list of family handles for a person."""
         return self.get_links(sql, from_type, from_handle, "family")
 
-    def get_parent_family_list(self, sql, from_type, from_handle):
+    def get_parent_family_list(self, sql, from_type: str, from_handle: str):
+        """Return a list of parent-family handles for a person."""
         return self.get_links(sql, from_type, from_handle, "parent_family")
 
-    def get_person_ref_list(self, sql, from_type, from_handle):
+    def get_person_ref_list(self, sql, from_type: str, from_handle: str):
+        """Return a list of serialized person-ref tuples for a parent object."""
         handles = self.get_links(sql, from_type, from_handle, "person_ref")
         retval = []
         for ref_handle in handles:
-            rows = sql.query("select * from person_ref where handle = ?;",
-                             ref_handle)
+            rows = sql.query(
+                "select * from person_ref where handle = ?;", ref_handle
+            )
             for row in rows:
-                (handle,
-                 ref,
-                 description,
-                 private) = row
-                citation_list = self.get_citation_list(sql, "person_ref",
-                                                       handle)
+                (
+                    handle,
+                    ref,
+                    description,
+                    private,
+                ) = row
+                citation_list = self.get_citation_list(sql, "person_ref", handle)
                 note_list = self.get_note_list(sql, "person_ref", handle)
-                retval.append((bool(private),
-                               citation_list,
-                               note_list,
-                               ref,
-                               description))
+                retval.append(
+                    (bool(private), citation_list, note_list, ref, description)
+                )
         return retval
 
-    def get_location_list(self, sql, from_type, from_handle, with_parish):
+    def get_location_list(self, sql, from_type: str, from_handle: str, with_parish: bool):
+        """Return a list of serialized location tuples for a parent object."""
         handles = self.get_links(sql, from_type, from_handle, "location")
         results = []
         for handle in handles:
-            results += sql.query("select * from location where handle = ?;",
-                                 handle)
-        return [self.pack_location(sql, result, with_parish) for
-                result in results]
+            results += sql.query("select * from location where handle = ?;", handle)
+        return [self.pack_location(sql, result, with_parish) for result in results]
 
-    def get_lds_list(self, sql, from_type, from_handle):
+    def get_lds_list(self, sql, from_type: str, from_handle: str):
+        """Return a list of serialized LDS ordinance tuples for a parent object."""
         handles = self.get_links(sql, from_type, from_handle, "lds")
         results = []
         for handle in handles:
-            results += sql.query("""select * from lds where handle = ?;""",
-                                 handle)
+            results += sql.query("""select * from lds where handle = ?;""", handle)
         return [self.pack_lds(sql, result) for result in results]
 
-    def get_media_list(self, sql, from_type, from_handle):
+    def get_media_list(self, sql, from_type: str, from_handle: str):
+        """Return a list of serialized media-ref tuples for a parent object."""
         handles = self.get_links(sql, from_type, from_handle, "media_ref")
         results = []
         for handle in handles:
-            results += sql.query("select * from media_ref where handle = ?;",
-                                 handle)
+            results += sql.query(
+                "select * from media_ref where handle = ?;", handle
+            )
         return [self.pack_media_ref(sql, result) for result in results]
 
-    def get_surname_list(self, sql, handle):
+    def get_surname_list(self, sql, handle: str):
+        """Return a list of serialized surname tuples for a name."""
         results = sql.query(
             "select s.* from surname s inner join link l ON l.to_handle = "
-            "s.handle where l.from_handle = ?;", handle)
+            "s.handle where l.from_handle = ?;",
+            handle,
+        )
         return [self.pack_surnames(sql, result) for result in results]
 
-    def get_note_list(self, sql, from_type, from_handle):
+    def get_note_list(self, sql, from_type: str, from_handle: str):
+        """Return a list of note handles for a parent object."""
         return self.get_links(sql, from_type, from_handle, "note")
 
-    def get_repository_ref_list(self, sql, from_type, from_handle):
+    def get_repository_ref_list(self, sql, from_type: str, from_handle: str):
+        """Return a list of serialized repository-ref tuples for a source."""
         handles = self.get_links(sql, from_type, from_handle, "repository_ref")
         results = []
         for handle in handles:
             results += sql.query(
-                """select * from repository_ref where handle = ?;""", handle)
+                """select * from repository_ref where handle = ?;""", handle
+            )
         return [self.pack_repository_ref(sql, result) for result in results]
 
-    def get_citation_list(self, sql, from_type, from_handle):
+    def get_citation_list(self, sql, from_type: str, from_handle: str):
+        """Return a list of citation handles for a parent object."""
         handles = self.get_links(sql, from_type, from_handle, "citation")
         return handles
 
-    def get_url_list(self, sql, from_type, from_handle):
+    def get_url_list(self, sql, from_type: str, from_handle: str):
+        """Return a list of serialized URL tuples for a parent object."""
         handles = self.get_links(sql, from_type, from_handle, "url")
         results = []
         for handle in handles:
-            results += sql.query("""select * from url where handle = ?;""",
-                                 handle)
+            results += sql.query("""select * from url where handle = ?;""", handle)
         return [self.pack_url(sql, result) for result in results]
 
     # ---------------------------------
     # Helpers
     # ---------------------------------
 
-    def pack_address(self, sql, data, with_parish):
+    def pack_address(self, sql, data, with_parish: bool):
+        """Pack raw address row data into a serialized address tuple."""
         (handle, private) = data
         citation_list = self.get_citation_list(sql, "address", handle)
         date_handle = self.get_link(sql, "address", handle, "date")
@@ -304,33 +357,44 @@ class SQLReader(object):
         return (bool(private), citation_list, note_list, date, location)
 
     def pack_lds(self, sql, data):
+        """Pack raw LDS ordinance row data into a serialized tuple."""
         (handle, type_, place, famc, temple, status, private) = data
         citation_list = self.get_citation_list(sql, "lds", handle)
         note_list = self.get_note_list(sql, "lds", handle)
         date_handle = self.get_link(sql, "lds", handle, "date")
         date = self.get_date(sql, date_handle)
-        return (citation_list, note_list, date, type_, place,
-                famc, temple, status, bool(private))
+        return (citation_list, note_list, date, type_, place, famc, temple, status, bool(private))
 
     def pack_surnames(self, sql, data):
-        (_handle,
-         surname,
-         prefix,
-         primary_surname,
-         origin_type0,
-         origin_type1,
-         connector) = data
-        return (surname, prefix, bool(primary_surname),
-                (origin_type0, origin_type1), connector)
+        """Pack raw surname row data into a serialized tuple."""
+        (
+            _handle,
+            surname,
+            prefix,
+            primary_surname,
+            origin_type0,
+            origin_type1,
+            connector,
+        ) = data
+        return (
+            surname,
+            prefix,
+            bool(primary_surname),
+            (origin_type0, origin_type1),
+            connector,
+        )
 
     def pack_media_ref(self, sql, data):
-        (handle,
-         ref,
-         role0,
-         role1,
-         role2,
-         role3,
-         private) = data
+        """Pack raw media_ref row data into a serialized tuple."""
+        (
+            handle,
+            ref,
+            role0,
+            role1,
+            role2,
+            role3,
+            private,
+        ) = data
         citation_list = self.get_citation_list(sql, "media_ref", handle)
         note_list = self.get_note_list(sql, "media_ref", handle)
         attribute_list = self.get_attribute_list(sql, "media_ref", handle)
@@ -338,38 +402,48 @@ class SQLReader(object):
             role = None
         else:
             role = (role0, role1, role2, role3)
-        return (bool(private), citation_list, note_list, attribute_list,
-                ref, role)
+        return (bool(private), citation_list, note_list, attribute_list, ref, role)
 
     def pack_repository_ref(self, sql, data):
-        (handle,
-         ref,
-         call_number,
-         source_media_type0,
-         source_media_type1,
-         private) = data
+        """Pack raw repository_ref row data into a serialized tuple."""
+        (
+            handle,
+            ref,
+            call_number,
+            source_media_type0,
+            source_media_type1,
+            private,
+        ) = data
         note_list = self.get_note_list(sql, "repository_ref", handle)
-        return (note_list,
-                ref,
-                call_number,
-                (source_media_type0, source_media_type1),
-                bool(private))
+        return (
+            note_list,
+            ref,
+            call_number,
+            (source_media_type0, source_media_type1),
+            bool(private),
+        )
 
     def pack_url(self, sql, data):
-        (_handle,
-         path,
-         desc,
-         type0,
-         type1,
-         private) = data
+        """Pack raw url row data into a serialized tuple."""
+        (
+            _handle,
+            path,
+            desc,
+            type0,
+            type1,
+            private,
+        ) = data
         return (bool(private), path, desc, (type0, type1))
 
     def pack_event_ref(self, sql, data):
-        (handle,
-         ref,
-         role0,
-         role1,
-         private) = data
+        """Pack raw event_ref row data into a serialized tuple."""
+        (
+            handle,
+            ref,
+            role0,
+            role1,
+            private,
+        ) = data
         note_list = self.get_note_list(sql, "event_ref", handle)
         attribute_list = self.get_attribute_list(sql, "event_ref", handle)
         citation_list = self.get_citation_list(sql, "event_ref", handle)
@@ -377,53 +451,76 @@ class SQLReader(object):
         return (bool(private), citation_list, note_list, attribute_list, ref, role)
 
     def pack_citation(self, sql, data):
-        (handle,
-         ref,
-         confidence,
-         page,
-         private) = data
+        """Pack raw citation row data into a serialized tuple."""
+        (
+            handle,
+            ref,
+            confidence,
+            page,
+            private,
+        ) = data
         date_handle = self.get_link(sql, "citation", handle, "date")
         date = self.get_date(sql, date_handle)
         note_list = self.get_note_list(sql, "citation", handle)
         return (date, bool(private), note_list, confidence, ref, page)
 
     def pack_source(self, sql, data):
-        (handle,
-         gid,
-         title,
-         author,
-         pubinfo,
-         abbrev,
-         change,
-         private) = data
+        """Pack raw source row data into a serialized tuple."""
+        (
+            handle,
+            gid,
+            title,
+            author,
+            pubinfo,
+            abbrev,
+            change,
+            private,
+        ) = data
         note_list = self.get_note_list(sql, "source", handle)
         media_list = self.get_media_list(sql, "source", handle)
         reporef_list = self.get_repository_ref_list(sql, "source", handle)
         datamap = self.get_datamap_list(sql, "source", handle)
-        return (handle, gid, title,
-                author, pubinfo,
-                note_list,
-                media_list,
-                abbrev,
-                change, datamap,
-                reporef_list,
-                bool(private))
+        return (
+            handle,
+            gid,
+            title,
+            author,
+            pubinfo,
+            note_list,
+            media_list,
+            abbrev,
+            change,
+            datamap,
+            reporef_list,
+            bool(private),
+        )
 
-    def get_location(self, sql, from_type, from_handle, with_parish):
+    def get_location(self, sql, from_type: str, from_handle: str, with_parish: bool):
+        """Return a single serialized location tuple for a parent object."""
         handle = self.get_link(sql, from_type, from_handle, "location")
         if handle:
-            results = sql.query("""select * from location where handle = ?;""",
-                                handle)
+            results = sql.query(
+                """select * from location where handle = ?;""", handle
+            )
             if len(results) == 1:
                 return self.pack_location(sql, results[0], with_parish)
+        return None
 
-    def get_names(self, sql, from_type, from_handle, primary):
+    def get_names(self, sql, from_type: str, from_handle: str, primary: bool):
+        """
+        Return the primary Name object or a list of alternate Name objects.
+
+        When primary is True, a single serialized name tuple is returned.
+        When primary is False, a list of serialized name tuples is returned.
+        """
         handles = self.get_links(sql, from_type, from_handle, "name")
         names = []
         for handle in handles:
             results = sql.query(
                 "select * from name where handle = ? and primary_name = ?;",
-                handle, primary)
+                handle,
+                primary,
+            )
             if len(results) > 0:
                 names += results
         result = [self.pack_name(sql, name) for name in names]
@@ -438,48 +535,87 @@ class SQLReader(object):
             return result
 
     def pack_name(self, sql, data):
+        """Pack raw name row data into a serialized tuple."""
         # unpack name from SQL table:
-        (handle, _primary_name, private, first_name, suffix, title, name_type0,
-         name_type1, group_as, sort_as, display_as, call, nick, famnick) = data
+        (
+            handle,
+            _primary_name,
+            private,
+            first_name,
+            suffix,
+            title,
+            name_type0,
+            name_type1,
+            group_as,
+            sort_as,
+            display_as,
+            call,
+            nick,
+            famnick,
+        ) = data
         # build up a GRAMPS object:
         surname_list = self.get_surname_list(sql, handle)
         citation_list = self.get_citation_list(sql, "name", handle)
         note_list = self.get_note_list(sql, "name", handle)
         date_handle = self.get_link(sql, "name", handle, "date")
         date = self.get_date(sql, date_handle)
-        return (bool(private), citation_list, note_list, date,
-                first_name, surname_list, suffix, title,
-                (name_type0, name_type1),
-                group_as, sort_as, display_as, call, nick, famnick)
+        return (
+            bool(private),
+            citation_list,
+            note_list,
+            date,
+            first_name,
+            surname_list,
+            suffix,
+            title,
+            (name_type0, name_type1),
+            group_as,
+            sort_as,
+            display_as,
+            call,
+            nick,
+            famnick,
+        )
 
-    def pack_location(self, sql, data, with_parish):
-        (_handle, street, locality, city, county, state, country, postal,
-         phone, parish) = data
+    def pack_location(self, sql, data, with_parish: bool):
+        """Pack raw location row data into a serialized tuple."""
+        (_handle, street, locality, city, county, state, country, postal, phone, parish) = (
+            data
+        )
         if with_parish:
-            return ((street, locality, city, county, state, country, postal,
-                     phone), parish)
+            return (
+                (street, locality, city, county, state, country, postal, phone),
+                parish,
+            )
         else:
-            return (street, locality, city, county, state, country, postal,
-                    phone)
+            return (street, locality, city, county, state, country, postal, phone)
 
-    def get_place_from_handle(self, sql, ref_handle):
+    def get_place_from_handle(self, sql, ref_handle: str | None) -> str:
+        """Return the place handle for a given place row handle, or ''."""
         if ref_handle:
-            place_row = sql.query("select * from place where handle = ?;",
-                                  ref_handle)
+            place_row = sql.query(
+                "select * from place where handle = ?;", ref_handle
+            )
             if len(place_row) == 1:
                 # return just the handle here:
                 return place_row[0][0]
             elif len(place_row) == 0:
-                print("ERROR: get_place_from_handle('%s'), no such handle." %
-                      (ref_handle, ))
+                LOG.error(
+                    "get_place_from_handle('%s'), no such handle.", ref_handle
+                )
             else:
-                print("ERROR: get_place_from_handle('%s') should be unique;"
-                      " returned %d records." % (ref_handle, len(place_row)))
-        return ''
+                LOG.error(
+                    "get_place_from_handle('%s') should be unique; returned %d records.",
+                    ref_handle,
+                    len(place_row),
+                )
+        return ""
 
-    def get_alt_place_name_list(self, sql, handle):
+    def get_alt_place_name_list(self, sql, handle: str):
+        """Return a list of alternate place name tuples for a place."""
         place_name_list = sql.query(
-            """select * from place_name where from_handle = ?;""", handle)
+            """select * from place_name where from_handle = ?;""", handle
+        )
         retval = []
         for place_name_data in place_name_list:
             ref_handle, handle, value, lang = place_name_data
@@ -488,11 +624,13 @@ class SQLReader(object):
             retval.append((value, date, lang))
         return retval
 
-    def get_place_ref_list(self, sql, handle):
+    def get_place_ref_list(self, sql, handle: str):
+        """Return a list of place-ref tuples for a place."""
         # place_ref_list = Enclosed by:  [('4ECKQCWCLO5YIHXEXC', None)]
         # [(handle, date)...]
         place_ref_list = sql.query(
-            """select * from place_ref where from_place_handle = ?;""", handle)
+            """select * from place_ref where from_place_handle = ?;""", handle
+        )
         retval = []
         for place_ref_data in place_ref_list:
             ref_handle, handle, to_place_handle = place_ref_data
@@ -501,92 +639,99 @@ class SQLReader(object):
             retval.append((to_place_handle, date))
         return retval
 
-    def get_main_location(self, sql, from_handle, with_parish):
-        ref_handle = self.get_link(sql, "place_main", from_handle, "location")
-        if ref_handle:
-            place_row = sql.query("select * from location where handle = ?;",
-                                  ref_handle)
-            if len(place_row) == 1:
-                return self.pack_location(sql, place_row[0], with_parish)
-            elif len(place_row) == 0:
-                print("ERROR: get_main_location('%s'), no such handle." %
-                      (ref_handle, ))
-            else:
-                print("ERROR: get_main_location('%s') should be unique; "
-                      "returned %d records." % (ref_handle, len(place_row)))
-        return Location().serialize()
-
-    def get_link(self, sql, from_type, from_handle, to_link):
+    def get_link(self, sql, from_type: str, from_handle: str, to_link: str) -> str | None:
         """
-        Return a link, and return handle.
+        Return a single link handle from the link table, or None.
         """
         if from_handle is None:
-            return
-        assert type(from_handle) == str, \
-            ("from_handle is wrong type: %s is %s" %
-             (from_handle, type(from_handle)))
+            return None
+        assert type(from_handle) == str, "from_handle is wrong type: %s is %s" % (
+            from_handle,
+            type(from_handle),
+        )
         rows = self.get_links(sql, from_type, from_handle, to_link)
         if len(rows) == 1:
             return rows[0]
         elif len(rows) > 1:
-            print("ERROR: too many links %s:%s -> %s (%d)" %
-                  (from_type, from_handle, to_link, len(rows)))
+            LOG.error(
+                "too many links %s:%s -> %s (%d)",
+                from_type,
+                from_handle,
+                to_link,
+                len(rows),
+            )
         return None
 
-    def get_links(self, sql, from_type, from_handle, to_link):
+    def get_links(self, sql, from_type: str, from_handle: str, to_link: str):
         """
-        Return a list of handles (possibly none).
+        Return a list of handles from the link table (possibly empty).
         """
         results = sql.query(
             """select to_handle from link where from_type = ? and """
             """from_handle = ? and to_type = ?;""",
-            from_type, from_handle, to_link)
+            from_type,
+            from_handle,
+            to_link,
+        )
         return [result[0] for result in results]
 
-    def get_date(self, sql, handle):
-        assert type(handle) in [str, type(None)], ("handle is wrong type: %s" %
-                                                   handle)
+    def get_date(self, sql, handle: str | None):
+        """Return a serialized date tuple for a given date handle, or None."""
+        assert type(handle) in [str, type(None)], "handle is wrong type: %s" % handle
         if handle:
             rows = sql.query("select * from date where handle = ?;", handle)
             if len(rows) == 1:
-                (handle,
-                 calendar,
-                 modifier,
-                 quality,
-                 day1,
-                 month1,
-                 year1,
-                 slash1,
-                 day2,
-                 month2,
-                 year2,
-                 slash2,
-                 text,
-                 sortval,
-                 newyear) = rows[0]
-                dateval = (day1, month1, year1, bool(slash1), day2, month2,
-                           year2, bool(slash2))
+                (
+                    handle,
+                    calendar,
+                    modifier,
+                    quality,
+                    day1,
+                    month1,
+                    year1,
+                    slash1,
+                    day2,
+                    month2,
+                    year2,
+                    slash2,
+                    text,
+                    sortval,
+                    newyear,
+                ) = rows[0]
+                dateval = (
+                    day1,
+                    month1,
+                    year1,
+                    bool(slash1),
+                    day2,
+                    month2,
+                    year2,
+                    bool(slash2),
+                )
                 if day2 == month2 == year2 == 0 and not slash2:
                     dateval = day1, month1, year1, bool(slash1)
-                return (calendar, modifier, quality, dateval, text, sortval,
-                        newyear)
+                return (calendar, modifier, quality, dateval, text, sortval, newyear)
             elif len(rows) == 0:
                 return None
             else:
-                print(Exception("ERROR, wrong number of dates: %s" % rows))
+                LOG.error("wrong number of dates: %s", rows)
+        return None
 
-    def process(self):
+    def process(self) -> None:
+        """Process the SQL file and import all objects into the Gramps database."""
         sql = self.openSQL()
-        total = (sql.query("select count(*) from note;")[0][0] +
-                 sql.query("select count(*) from person;")[0][0] +
-                 sql.query("select count(*) from event;")[0][0] +
-                 sql.query("select count(*) from family;")[0][0] +
-                 sql.query("select count(*) from repository;")[0][0] +
-                 sql.query("select count(*) from place;")[0][0] +
-                 sql.query("select count(*) from media;")[0][0] +
-                 sql.query("select count(*) from tag;")[0][0] +
-                 sql.query("select count(*) from citation;")[0][0] +
-                 sql.query("select count(*) from source;")[0][0])
+        total = (
+            sql.query("select count(*) from note;")[0][0]
+            + sql.query("select count(*) from person;")[0][0]
+            + sql.query("select count(*) from event;")[0][0]
+            + sql.query("select count(*) from family;")[0][0]
+            + sql.query("select count(*) from repository;")[0][0]
+            + sql.query("select count(*) from place;")[0][0]
+            + sql.query("select count(*) from media;")[0][0]
+            + sql.query("select count(*) from tag;")[0][0]
+            + sql.query("select count(*) from citation;")[0][0]
+            + sql.query("select count(*) from source;")[0][0]
+        )
         with DbTxn(_("CSV import"), self.db, batch=True) as self.trans:
             self.db.disable_signals()
             count = 0.0
@@ -596,43 +741,60 @@ class SQLReader(object):
         sql.db.close()
         return None
 
-    def _process(self, count, total, sql):
+    def _process(self, count: float, total: int, sql) -> None:
+        """Import all object types from the SQL database into Gramps."""
         # ---------------------------------
         # Process note
         # ---------------------------------
         notes = sql.query("""select * from note;""")
         for note in notes:
-            (handle,
-             gid,
-             text,
-             _format,
-             note_type1,
-             note_type2,
-             change,
-             private) = note
+            (
+                handle,
+                gid,
+                text,
+                _format,
+                note_type1,
+                note_type2,
+                change,
+                private,
+            ) = note
             styled_text = [text, []]
-            markups = sql.query("""select * from link where from_handle = ? """
-                                """and to_type = 'markup';""",
-                                handle)
+            markups = sql.query(
+                """select * from link where from_handle = ? """
+                """and to_type = 'markup';""",
+                handle,
+            )
             for markup_link in markups:
                 _from_type, _from_handle, _to_type, to_handle = markup_link
                 markup_detail = sql.query(
-                    """select * from markup where handle = ?;""", to_handle)
+                    """select * from markup where handle = ?;""", to_handle
+                )
                 for markup in markup_detail:
-                    (_mhandle,
-                     markup0,
-                     markup1,
-                     value,
-                     start_stop_list) = markup
+                    (
+                        _mhandle,
+                        markup0,
+                        markup1,
+                        value,
+                        start_stop_list,
+                    ) = markup
                     ss_list = eval(start_stop_list)
                     styled_text[1] += [((markup0, markup1), value, ss_list)]
 
             tags = self.get_links(sql, "note", handle, "tag")
 
             g_note = Note()
-            g_note.unserialize((handle, gid, styled_text, _format,
-                                (note_type1, note_type2), change,
-                                tags, bool(private)))
+            g_note.unserialize(
+                (
+                    handle,
+                    gid,
+                    styled_text,
+                    _format,
+                    (note_type1, note_type2),
+                    change,
+                    tags,
+                    bool(private),
+                )
+            )
             self.db.add_note(g_note, self.trans)
             count += 1
             self.callback(100 * count / total)
@@ -642,8 +804,7 @@ class SQLReader(object):
         # ---------------------------------
         events = sql.query("""select * from event;""")
         for event in events:
-            (handle, gid, the_type0, the_type1, description, change,
-             private) = event
+            (handle, gid, the_type0, the_type1, description, change, private) = event
 
             note_list = self.get_note_list(sql, "event", handle)
             citation_list = self.get_citation_list(sql, "event", handle)
@@ -657,9 +818,21 @@ class SQLReader(object):
             place = self.get_place_from_handle(sql, place_handle)
 
             tags = self.get_links(sql, "event", handle, "tag")
-            data = (handle, gid, (the_type0, the_type1), date, description,
-                    place, citation_list, note_list, media_list,
-                    attribute_list, change, tags, bool(private))
+            data = (
+                handle,
+                gid,
+                (the_type0, the_type1),
+                date,
+                description,
+                place,
+                citation_list,
+                note_list,
+                media_list,
+                attribute_list,
+                change,
+                tags,
+                bool(private),
+            )
 
             g_event = Event()
             g_event.unserialize(data)
@@ -671,27 +844,45 @@ class SQLReader(object):
         # ---------------------------------
         # Process person
         # ---------------------------------
-        people = sql.query("""select * from person;""")
-        for person in people:
-            if person is None:
+        people = sql.query(
+            """select handle, gid, gender, death_ref_handle, birth_ref_handle,
+                      change, private, familysearch_sync from person;"""
+        )
+        for person_row in people:
+            if person_row is None:
                 continue
-            (handle,             # 0
-             gid,                # 1
-             gender,             # 2
-             death_ref_handle,   # 5
-             birth_ref_handle,   # 6
-             change,             # 17
-             private,            # 19
-             ) = person
-            primary_name = self.get_names(sql, "person", handle, True)  # one
-            alternate_names = self.get_names(sql, "person", handle, False)
+            # Column order matches the SELECT above
+            if len(person_row) == 8:
+                (
+                    handle,
+                    gid,
+                    gender,
+                    death_ref_handle,
+                    birth_ref_handle,
+                    change,
+                    private,
+                    familysearch_sync_json,
+                ) = person_row
+            else:
+                # Older schema without familysearch_sync column
+                (
+                    handle,
+                    gid,
+                    gender,
+                    death_ref_handle,
+                    birth_ref_handle,
+                    change,
+                    private,
+                ) = person_row
+                familysearch_sync_json = None
+
+            primary_name_data = self.get_names(sql, "person", handle, True)  # one
+            alternate_names_data = self.get_names(sql, "person", handle, False)
             event_ref_list = self.get_event_ref_list(sql, "person", handle)
             family_list = self.get_family_list(sql, "person", handle)
-            parent_family_list = self.get_parent_family_list(sql, "person",
-                                                             handle)
+            parent_family_list = self.get_parent_family_list(sql, "person", handle)
             media_list = self.get_media_list(sql, "person", handle)
-            address_list = self.get_address_list(sql, "person", handle,
-                                                 with_parish=False)
+            address_list = self.get_address_list(sql, "person", handle, with_parish=False)
             attribute_list = self.get_attribute_list(sql, "person", handle)
             urls = self.get_url_list(sql, "person", handle)
             lds_ord_list = self.get_lds_list(sql, "person", handle)
@@ -702,41 +893,49 @@ class SQLReader(object):
             birth_ref_index = lookup(birth_ref_handle, event_ref_list)
             tags = self.get_links(sql, "person", handle, "tag")
 
-            data = (
-                handle,             # 0
-                gid,                # 1
-                gender,             # 2
-                primary_name,       # 3
-                alternate_names,    # 4
-                death_ref_index,    # 5
-                birth_ref_index,    # 6
-                event_ref_list,     # 7
-                family_list,        # 8
-                parent_family_list,  # 9
-                media_list,         # 10
-                address_list,       # 11
-                attribute_list,     # 12
-                urls,               # 13
-                lds_ord_list,       # 14
-                pcitation_list,     # 15
-                pnote_list,         # 16
-                change,             # 17
-                tags,
-                bool(private),      # 19
-                person_ref_list,)   # 20
-
+            # Build the Person object directly by attribute assignment,
+            # avoiding positional tuple unpacking of serialize() output.
             g_pers = Person()
-            g_pers.unserialize(data)
+            g_pers.handle = handle
+            g_pers.gramps_id = gid
+            g_pers.gender = int(gender)
+            g_pers.primary_name.unserialize(primary_name_data)
+            g_pers.alternate_names = [
+                Name().unserialize(n) for n in alternate_names_data
+            ]
+            g_pers.death_ref_index = death_ref_index
+            g_pers.birth_ref_index = birth_ref_index
+            g_pers.event_ref_list = [EventRef().unserialize(er) for er in event_ref_list]
+            g_pers.family_list = list(family_list)
+            g_pers.parent_family_list = list(parent_family_list)
+            g_pers.media_list = [MediaRef().unserialize(m) for m in media_list]
+            g_pers.address_list = [Address().unserialize(a) for a in address_list]
+            g_pers.attribute_list = [Attribute().unserialize(a) for a in attribute_list]
+            g_pers.urls = [Url().unserialize(u) for u in urls]
+            g_pers.lds_ord_list = [LdsOrd().unserialize(lo) for lo in lds_ord_list]
+            g_pers.citation_list = list(pcitation_list)
+            g_pers.note_list = list(pnote_list)
+            g_pers.change = int(change)
+            g_pers.tag_list = list(tags)
+            g_pers.private = bool(private)
+            g_pers.person_ref_list = [PersonRef().unserialize(pr) for pr in person_ref_list]
+
+            # familysearch_sync (Gramps 6.1+): restore from JSON if present
+            if familysearch_sync_json:
+                g_pers.familysearch_sync.unserialize(json.loads(familysearch_sync_json))
+
             self.db.add_person(g_pers, self.trans)
             count += 1
             self.callback(100 * count / total)
+
         # ---------------------------------
         # Process family
         # ---------------------------------
         families = sql.query("""select * from family;""")
         for family in families:
-            (handle, gid, father_handle, mother_handle, the_type0, the_type1,
-             change, private) = family
+            (handle, gid, father_handle, mother_handle, the_type0, the_type1, change, private) = (
+                family
+            )
 
             child_ref_list = self.get_child_ref_list(sql, "family", handle)
             event_ref_list = self.get_event_ref_list(sql, "family", handle)
@@ -747,16 +946,30 @@ class SQLReader(object):
             note_list = self.get_note_list(sql, "family", handle)
             tags = self.get_links(sql, "family", handle, "tag")
 
-            data = (handle, gid, father_handle, mother_handle, child_ref_list,
-                    (the_type0, the_type1), event_ref_list, media_list,
-                    attribute_list, lds_seal_list, citation_list, note_list,
-                    change, tags, private)
+            data = (
+                handle,
+                gid,
+                father_handle,
+                mother_handle,
+                child_ref_list,
+                (the_type0, the_type1),
+                event_ref_list,
+                media_list,
+                attribute_list,
+                lds_seal_list,
+                citation_list,
+                note_list,
+                change,
+                tags,
+                private,
+            )
             g_fam = Family()
             g_fam.unserialize(data)
             self.db.add_family(g_fam, self.trans)
 
             count += 1
             self.callback(100 * count / total)
+
         # ---------------------------------
         # Process repository
         # ---------------------------------
@@ -765,33 +978,42 @@ class SQLReader(object):
             (handle, gid, the_type0, the_type1, name, change, private) = repo
 
             note_list = self.get_note_list(sql, "repository", handle)
-            address_list = self.get_address_list(sql, "repository", handle,
-                                                 with_parish=False)
+            address_list = self.get_address_list(
+                sql, "repository", handle, with_parish=False
+            )
             urls = self.get_url_list(sql, "repository", handle)
             tags = self.get_links(sql, "repository", handle, "tag")
-            data = (handle, gid,
-                    (the_type0, the_type1),
-                    name, note_list,
-                    address_list, urls, change,
-                    tags, private)
+            data = (
+                handle,
+                gid,
+                (the_type0, the_type1),
+                name,
+                note_list,
+                address_list,
+                urls,
+                change,
+                tags,
+                private,
+            )
             g_rep = Repository()
             g_rep.unserialize(data)
             self.db.add_repository(g_rep, self.trans)
             count += 1
             self.callback(100 * count / total)
+
         # ---------------------------------
         # Process place
         # ---------------------------------
         places = sql.query("""select * from place;""")
         for place in places:
             count += 1
-            (handle, gid, title, value, the_type0, the_type1, code, long, lat,
-             lang, change, private) = place
+            (handle, gid, title, value, the_type0, the_type1, code, long, lat, lang, change, private) = (
+                place
+            )
 
-            # We could look this up by "place_main", but we have the handle:
-            #main_loc = self.get_main_location(sql, handle, with_parish=True)
-            alt_loc_list = self.get_location_list(sql, "place_alt", handle,
-                                                  with_parish=True)
+            alt_loc_list = self.get_location_list(
+                sql, "place_alt", handle, with_parish=True
+            )
             urls = self.get_url_list(sql, "place", handle)
             media_list = self.get_media_list(sql, "place", handle)
             citation_list = self.get_citation_list(sql, "place", handle)
@@ -800,11 +1022,26 @@ class SQLReader(object):
             place_type = (the_type0, the_type1)
             alt_place_name_list = self.get_alt_place_name_list(sql, handle)
             place_ref_list = self.get_place_ref_list(sql, handle)
-            data = (handle, gid, title, long, lat, place_ref_list,
-                    PlaceName(value=value, lang=lang).serialize(),
-                    alt_place_name_list, place_type, code, alt_loc_list,
-                    urls, media_list, citation_list, note_list,
-                    change, tags, private)
+            data = (
+                handle,
+                gid,
+                title,
+                long,
+                lat,
+                place_ref_list,
+                PlaceName(value=value, lang=lang).serialize(),
+                alt_place_name_list,
+                place_type,
+                code,
+                alt_loc_list,
+                urls,
+                media_list,
+                citation_list,
+                note_list,
+                change,
+                tags,
+                private,
+            )
             g_plac = Place()
             g_plac.unserialize(data)
             self.db.commit_place(g_plac, self.trans)
@@ -815,16 +1052,27 @@ class SQLReader(object):
         # ---------------------------------
         citations = sql.query("""select * from citation;""")
         for citation in citations:
-            (handle, gid, confidence, page, source_handle, change,
-             private) = citation
+            (handle, gid, confidence, page, source_handle, change, private) = citation
             date_handle = self.get_link(sql, "citation", handle, "date")
             date = self.get_date(sql, date_handle)
             note_list = self.get_note_list(sql, "citation", handle)
             media_list = self.get_media_list(sql, "citation", handle)
             datamap = self.get_datamap_list(sql, "citation", handle)
             tags = self.get_links(sql, "citation", handle, "tag")
-            data = (handle, gid, date, page, confidence, source_handle,
-                    note_list, media_list, datamap, change, tags, private)
+            data = (
+                handle,
+                gid,
+                date,
+                page,
+                confidence,
+                source_handle,
+                note_list,
+                media_list,
+                datamap,
+                change,
+                tags,
+                private,
+            )
             g_cit = Citation()
             g_cit.unserialize(data)
             self.db.commit_citation(g_cit, self.trans)
@@ -836,22 +1084,34 @@ class SQLReader(object):
         # ---------------------------------
         sources = sql.query("""select * from source;""")
         for source in sources:
-            (handle, gid, title, author, pubinfo, abbrev, change,
-             private) = source
+            (handle, gid, title, author, pubinfo, abbrev, change, private) = source
             note_list = self.get_note_list(sql, "source", handle)
             media_list = self.get_media_list(sql, "source", handle)
             datamap = self.get_datamap_list(sql, "source", handle)
             reporef_list = self.get_repository_ref_list(sql, "source", handle)
             tags = self.get_links(sql, "source", handle, "tag")
 
-            data = (handle, gid, title, author, pubinfo, note_list,
-                    media_list, abbrev, change, datamap, reporef_list,
-                    tags, private)
+            data = (
+                handle,
+                gid,
+                title,
+                author,
+                pubinfo,
+                note_list,
+                media_list,
+                abbrev,
+                change,
+                datamap,
+                reporef_list,
+                tags,
+                private,
+            )
             g_src = Source()
             g_src.unserialize(data)
             self.db.commit_source(g_src, self.trans)
             count += 1
             self.callback(100 * count / total)
+
         # ---------------------------------
         # Process media
         # ---------------------------------
@@ -867,13 +1127,27 @@ class SQLReader(object):
             date = self.get_date(sql, date_handle)
             tags = self.get_links(sql, "media", handle, "tag")
 
-            data = (handle, gid, path, mime, desc, checksum, attribute_list,
-                    citation_list, note_list, change, date, tags, private)
+            data = (
+                handle,
+                gid,
+                path,
+                mime,
+                desc,
+                checksum,
+                attribute_list,
+                citation_list,
+                note_list,
+                change,
+                date,
+                tags,
+                private,
+            )
             g_med = Media()
             g_med.unserialize(data)
             self.db.commit_media(g_med, self.trans)
             count += 1
             self.callback(100 * count / total)
+
         # ---------------------------------
         # Process tag
         # ---------------------------------
@@ -888,16 +1162,25 @@ class SQLReader(object):
             count += 1
             self.callback(100 * count / total)
 
-    def cleanup(self):
+    def cleanup(self) -> None:
+        """Finalize import: re-enable signals and report elapsed time."""
         self.t = time.time() - self.t
-        msg = ngettext('Import Complete: %d second',
-                       'Import Complete: %d seconds', self.t) % self.t
+        msg = (
+            ngettext("Import Complete: %d second", "Import Complete: %d seconds", self.t)
+            % self.t
+        )
         self.db.enable_signals()
         self.db.request_rebuild()
-        print(msg)
+        LOG.info(msg)
 
 
-def importData(db, filename, user):
+# -------------------------------------------------------------------------
+#
+# Entry point
+#
+# -------------------------------------------------------------------------
+def importData(db, filename: str, user) -> None:
+    """Import a Gramps SQLite export file into the given database."""
     g = SQLReader(db, filename, user)
     g.process()
     g.cleanup()

--- a/Sqlite/ImportSql.py
+++ b/Sqlite/ImportSql.py
@@ -885,6 +885,12 @@ class SQLReader(object):
             count += 1
             self.callback(100 * count / total)
 
+        # ---------------------------------
+        # Name group (surname groupings)
+        # ---------------------------------
+        for name, grouping in sql.query("select * from name_group;") or []:
+            self.db.set_name_group_mapping(name, grouping)
+
     def cleanup(self) -> None:
         """Finalize import: re-enable signals and report elapsed time."""
         self.t = round(time.time() - self.t)

--- a/Sqlite/ImportSql.py
+++ b/Sqlite/ImportSql.py
@@ -887,7 +887,7 @@ class SQLReader(object):
 
     def cleanup(self) -> None:
         """Finalize import: re-enable signals and report elapsed time."""
-        self.t = time.time() - self.t
+        self.t = round(time.time() - self.t)
         msg = (
             ngettext("Import Complete: %d second", "Import Complete: %d seconds", self.t)
             % self.t

--- a/Sqlite/tests/test_sqlite.py
+++ b/Sqlite/tests/test_sqlite.py
@@ -16,169 +16,161 @@ except (ImportError, ValueError, AttributeError) as err:
 
 import os
 
+from gramps.gen.db import DbTxn
 from gramps.gen.db.utils import make_database
-from gramps.gen.lib import Event, EventRef, EventType, Family, FamilyRelType, Name, Person
-from gramps.gen.lib import Surname
-from gramps.plugins.importer.importxml import importData as importXML
+from gramps.gen.lib import (
+    Event,
+    EventRef,
+    EventType,
+    Family,
+    FamilyRelType,
+    Name,
+    Person,
+    Surname,
+)
 from gramps.cli.user import User
 
 from ..ImportSql import importData as importSQL
 from ..ExportSql import exportData as exportSQL
 
-gramps_path = os.environ["GRAMPS_RESOURCES"]
+
+def _make_person(db, txn, gid, first, surname_str, gender=Person.MALE, fsid=None):
+    """Add a minimal Person to *db* inside *txn*, return the handle."""
+    person = Person()
+    person.gramps_id = gid
+    person.gender = gender
+    name = Name()
+    name.set_first_name(first)
+    sn = Surname()
+    sn.set_surname(surname_str)
+    name.set_surname_list([sn])
+    person.set_primary_name(name)
+    if fsid is not None:
+        person.familysearch_sync.fsid = fsid
+        person.familysearch_sync.is_root = True
+    db.add_person(person, txn)
+    return person.handle
+
+
+def _make_family(db, txn, gid, father_h, mother_h):
+    """Add a minimal Family to *db* inside *txn*, return the handle."""
+    fam = Family()
+    fam.gramps_id = gid
+    fam.set_father_handle(father_h)
+    fam.set_mother_handle(mother_h)
+    fam.set_relationship(FamilyRelType(FamilyRelType.MARRIED))
+    db.add_family(fam, txn)
+    return fam.handle
+
+
+def _make_event(db, txn, gid, etype=EventType.BIRTH):
+    """Add a minimal Event to *db* inside *txn*, return the handle."""
+    evt = Event()
+    evt.gramps_id = gid
+    evt.set_type(EventType(etype))
+    db.add_event(evt, txn)
+    return evt.handle
+
+
+def _build_source_db(path):
+    """Build a minimal source Gramps database at *path* and return it."""
+    db = make_database("sqlite")
+    os.makedirs(path, exist_ok=True)
+    db.load(path)
+    with DbTxn("build test db", db) as txn:
+        father_h = _make_person(db, txn, "I0001", "Alice", "Smith",
+                                gender=Person.FEMALE, fsid="FS-ALICE-001")
+        mother_h = _make_person(db, txn, "I0002", "Bob", "Jones",
+                                gender=Person.MALE)
+        child_h = _make_person(db, txn, "I0003", "Carol", "Smith",
+                               gender=Person.FEMALE)
+        _make_family(db, txn, "F0001", father_h, mother_h)
+        _make_event(db, txn, "E0001", EventType.BIRTH)
+    return db
 
 
 # -------------------------------------------------------------------------
 #
-# ExportSQLTestCase
+# SqliteRoundTripTest
 #
 # -------------------------------------------------------------------------
-class ExportSQLTestCase(unittest.TestCase):
-    """Round-trip export/import tests for the SQLite addon."""
+class SqliteRoundTripTest(unittest.TestCase):
+    """Fast round-trip tests using a small synthetic database."""
 
     def setUp(self):
-        """Set up source and destination databases loaded with example data."""
-        self.database1 = make_database("sqlite")
-        try:
-            os.mkdir("/tmp/bsddb_exportsql_1")
-        except Exception:
-            pass
-        self.database1.load("/tmp/bsddb_exportsql_1")
+        self.src_db = _build_source_db("/tmp/sqlite_rt_src")
+        exportSQL(self.src_db, "/tmp/sqlite_rt.sql", User(), None)
 
-        importXML(
-            self.database1,
-            gramps_path + "/example/gramps/example.gramps",
-            User(),
+        self.dst_db = make_database("sqlite")
+        os.makedirs("/tmp/sqlite_rt_dst", exist_ok=True)
+        self.dst_db.load("/tmp/sqlite_rt_dst")
+        importSQL(self.dst_db, "/tmp/sqlite_rt.sql", User())
+
+    def test_person_count(self):
+        """Person count must match after round-trip."""
+        self.assertEqual(
+            self.dst_db.get_number_of_people(),
+            self.src_db.get_number_of_people(),
         )
-        exportSQL(self.database1, "/tmp/exported1.sql", User(), None)
 
-        self.database2 = make_database("sqlite")
-        try:
-            os.mkdir("/tmp/bsddb_exportsql_2")
-        except Exception:
-            pass
-        self.database2.load("/tmp/bsddb_exportsql_2")
-
-    def test_person_count_round_trip(self):
-        """Person count must match after export/import round-trip."""
-        importSQL(self.database2, "/tmp/exported1.sql", User())
-        src_count = self.database1.get_number_of_people()
-        self.assertGreater(src_count, 0)
-        self.assertEqual(self.database2.get_number_of_people(), src_count)
-
-    def test_person_identity_round_trip(self):
-        """Every person must survive round-trip with identical core fields."""
-        importSQL(self.database2, "/tmp/exported1.sql", User())
-        for handle in self.database1.get_person_handles():
-            src = self.database1.get_person_from_handle(handle)
-            dst = self.database2.get_person_from_handle(handle)
-            self.assertIsNotNone(dst, "person %s missing after round-trip" % handle)
+    def test_person_identity(self):
+        """Person gramps_id, gender, and primary name must survive round-trip."""
+        for handle in self.src_db.get_person_handles():
+            src = self.src_db.get_person_from_handle(handle)
+            dst = self.dst_db.get_person_from_handle(handle)
+            self.assertIsNotNone(dst, "person %s missing" % handle)
             self.assertEqual(src.get_gramps_id(), dst.get_gramps_id())
             self.assertEqual(src.get_gender(), dst.get_gender())
-            src_name = src.get_primary_name()
-            dst_name = dst.get_primary_name()
-            self.assertEqual(src_name.get_first_name(), dst_name.get_first_name())
-            self.assertEqual(src_name.get_surname(), dst_name.get_surname())
-
-    def test_familysearch_sync_round_trip(self):
-        """familysearch_sync data must survive the SQLite round-trip."""
-        importSQL(self.database2, "/tmp/exported1.sql", User())
-        for handle in self.database1.get_person_handles():
-            src = self.database1.get_person_from_handle(handle)
-            dst = self.database2.get_person_from_handle(handle)
-            if dst is None:
-                continue
-            src_fs = src.familysearch_sync
-            dst_fs = dst.familysearch_sync
             self.assertEqual(
-                src_fs.serialize(),
-                dst_fs.serialize(),
-                "familysearch_sync mismatch for person %s" % handle,
+                src.get_primary_name().get_first_name(),
+                dst.get_primary_name().get_first_name(),
+            )
+            self.assertEqual(
+                src.get_primary_name().get_surname(),
+                dst.get_primary_name().get_surname(),
             )
 
-    def test_family_count_round_trip(self):
-        """Family count must match after export/import round-trip."""
-        importSQL(self.database2, "/tmp/exported1.sql", User())
-        src_count = self.database1.get_number_of_families()
-        self.assertGreater(src_count, 0)
-        self.assertEqual(self.database2.get_number_of_families(), src_count)
+    def test_family_count(self):
+        """Family count must match after round-trip."""
+        self.assertEqual(
+            self.dst_db.get_number_of_families(),
+            self.src_db.get_number_of_families(),
+        )
 
-    def test_family_identity_round_trip(self):
-        """Every family must survive round-trip with same father/mother handles."""
-        importSQL(self.database2, "/tmp/exported1.sql", User())
-        for handle in self.database1.get_family_handles():
-            src = self.database1.get_family_from_handle(handle)
-            dst = self.database2.get_family_from_handle(handle)
-            self.assertIsNotNone(
-                dst, "family %s missing after round-trip" % handle
-            )
-            self.assertEqual(src.get_gramps_id(), dst.get_gramps_id())
+    def test_family_identity(self):
+        """Father/mother handles must survive round-trip."""
+        for handle in self.src_db.get_family_handles():
+            src = self.src_db.get_family_from_handle(handle)
+            dst = self.dst_db.get_family_from_handle(handle)
+            self.assertIsNotNone(dst, "family %s missing" % handle)
             self.assertEqual(src.get_father_handle(), dst.get_father_handle())
             self.assertEqual(src.get_mother_handle(), dst.get_mother_handle())
 
-    def test_event_count_round_trip(self):
-        """Event count must match after export/import round-trip."""
-        importSQL(self.database2, "/tmp/exported1.sql", User())
-        src_count = self.database1.get_number_of_events()
-        self.assertGreater(src_count, 0)
-        self.assertEqual(self.database2.get_number_of_events(), src_count)
+    def test_event_count(self):
+        """Event count must match after round-trip."""
+        self.assertEqual(
+            self.dst_db.get_number_of_events(),
+            self.src_db.get_number_of_events(),
+        )
 
-
-# -------------------------------------------------------------------------
-#
-# FamilySearchSyncRoundTripTest
-#
-# -------------------------------------------------------------------------
-class FamilySearchSyncRoundTripTest(unittest.TestCase):
-    """
-    Unit test for familysearch_sync round-trip on a synthetic Person with
-    non-default FamilySearchSync values.  Does not require the example file.
-    """
-
-    def setUp(self):
-        """Create a minimal database with one person containing fs sync data."""
-        self.database1 = make_database("sqlite")
-        try:
-            os.mkdir("/tmp/bsddb_fssync_1")
-        except Exception:
-            pass
-        self.database1.load("/tmp/bsddb_fssync_1")
-
-        self.database2 = make_database("sqlite")
-        try:
-            os.mkdir("/tmp/bsddb_fssync_2")
-        except Exception:
-            pass
-        self.database2.load("/tmp/bsddb_fssync_2")
-
-        # Create a person with a non-trivial familysearch_sync state
-        from gramps.gen.db import DbTxn
-
-        with DbTxn("add test person", self.database1) as txn:
-            person = Person()
-            person.gramps_id = "I9999"
-            person.gender = Person.MALE
-            primary_name = Name()
-            primary_name.set_first_name("Test")
-            surname = Surname()
-            surname.set_surname("Sync")
-            primary_name.set_surname_list([surname])
-            person.set_primary_name(primary_name)
-            # Set some familysearch_sync data
-            person.familysearch_sync.fsid = "FS-TESTID-001"
-            person.familysearch_sync.is_root = True
-            person.familysearch_sync.conflict = False
-            self.database1.add_person(person, txn)
-            self.person_handle = person.handle
-
-    def test_familysearch_sync_preserved(self):
-        """Non-default familysearch_sync fields must survive the SQL round-trip."""
-        exportSQL(self.database1, "/tmp/fssync_test.sql", User(), None)
-        importSQL(self.database2, "/tmp/fssync_test.sql", User())
-
-        dst = self.database2.get_person_from_handle(self.person_handle)
-        self.assertIsNotNone(dst, "person missing after round-trip")
-        self.assertEqual(dst.gramps_id, "I9999")
-        self.assertEqual(dst.familysearch_sync.fsid, "FS-TESTID-001")
-        self.assertTrue(dst.familysearch_sync.is_root)
-        self.assertFalse(dst.familysearch_sync.conflict)
+    def test_familysearch_sync(self):
+        """familysearch_sync fields must survive round-trip."""
+        for handle in self.src_db.get_person_handles():
+            src = self.src_db.get_person_from_handle(handle)
+            dst = self.dst_db.get_person_from_handle(handle)
+            if dst is None:
+                continue
+            self.assertEqual(
+                src.familysearch_sync.serialize(),
+                dst.familysearch_sync.serialize(),
+                "familysearch_sync mismatch for %s" % src.get_gramps_id(),
+            )
+        # Explicit check for the person we know has a non-default fsid
+        alice_src = next(
+            p for h in self.src_db.get_person_handles()
+            if (p := self.src_db.get_person_from_handle(h)).get_gramps_id() == "I0001"
+        )
+        alice_dst = self.dst_db.get_person_from_handle(alice_src.handle)
+        self.assertIsNotNone(alice_dst)
+        self.assertEqual(alice_dst.familysearch_sync.fsid, "FS-ALICE-001")
+        self.assertTrue(alice_dst.familysearch_sync.is_root)

--- a/Sqlite/tests/test_sqlite.py
+++ b/Sqlite/tests/test_sqlite.py
@@ -4,6 +4,8 @@
 # import (mirrors what gramps.grampsapp does at startup); otherwise
 # PyGObject loads GTK4 and the gramps.gui import chain crashes on
 # Gtk.IconSize.MENU (a GTK3-only enum).
+import unittest
+
 try:
     import gi
 
@@ -12,41 +14,171 @@ try:
 except (ImportError, ValueError, AttributeError) as err:
     raise unittest.SkipTest("GTK 3.0 / PyGObject not available: %s" % err)
 
+import os
+
 from gramps.gen.db.utils import make_database
+from gramps.gen.lib import Event, EventRef, EventType, Family, FamilyRelType, Name, Person
+from gramps.gen.lib import Surname
 from gramps.plugins.importer.importxml import importData as importXML
 from gramps.cli.user import User
 
 from ..ImportSql import importData as importSQL
 from ..ExportSql import exportData as exportSQL
 
-import unittest
-import os
-
 gramps_path = os.environ["GRAMPS_RESOURCES"]
 
-class ExportSQLTestCase (unittest.TestCase):
+
+# -------------------------------------------------------------------------
+#
+# ExportSQLTestCase
+#
+# -------------------------------------------------------------------------
+class ExportSQLTestCase(unittest.TestCase):
+    """Round-trip export/import tests for the SQLite addon."""
 
     def setUp(self):
+        """Set up source and destination databases loaded with example data."""
         self.database1 = make_database("sqlite")
         try:
             os.mkdir("/tmp/bsddb_exportsql_1")
-        except:
+        except Exception:
             pass
         self.database1.load("/tmp/bsddb_exportsql_1")
 
-        importXML(self.database1, gramps_path +
-                  "/example/gramps/example.gramps", User())
+        importXML(
+            self.database1,
+            gramps_path + "/example/gramps/example.gramps",
+            User(),
+        )
         exportSQL(self.database1, "/tmp/exported1.sql", User(), None)
 
         self.database2 = make_database("sqlite")
         try:
             os.mkdir("/tmp/bsddb_exportsql_2")
-        except:
+        except Exception:
             pass
-
         self.database2.load("/tmp/bsddb_exportsql_2")
 
-    def test_export_sql(self):
+    def test_person_count_round_trip(self):
+        """Person count must match after export/import round-trip."""
         importSQL(self.database2, "/tmp/exported1.sql", User())
+        src_count = self.database1.get_number_of_people()
+        self.assertGreater(src_count, 0)
+        self.assertEqual(self.database2.get_number_of_people(), src_count)
+
+    def test_person_identity_round_trip(self):
+        """Every person must survive round-trip with identical core fields."""
+        importSQL(self.database2, "/tmp/exported1.sql", User())
+        for handle in self.database1.get_person_handles():
+            src = self.database1.get_person_from_handle(handle)
+            dst = self.database2.get_person_from_handle(handle)
+            self.assertIsNotNone(dst, "person %s missing after round-trip" % handle)
+            self.assertEqual(src.get_gramps_id(), dst.get_gramps_id())
+            self.assertEqual(src.get_gender(), dst.get_gender())
+            src_name = src.get_primary_name()
+            dst_name = dst.get_primary_name()
+            self.assertEqual(src_name.get_first_name(), dst_name.get_first_name())
+            self.assertEqual(src_name.get_surname(), dst_name.get_surname())
+
+    def test_familysearch_sync_round_trip(self):
+        """familysearch_sync data must survive the SQLite round-trip."""
+        importSQL(self.database2, "/tmp/exported1.sql", User())
+        for handle in self.database1.get_person_handles():
+            src = self.database1.get_person_from_handle(handle)
+            dst = self.database2.get_person_from_handle(handle)
+            if dst is None:
+                continue
+            src_fs = src.familysearch_sync
+            dst_fs = dst.familysearch_sync
+            self.assertEqual(
+                src_fs.serialize(),
+                dst_fs.serialize(),
+                "familysearch_sync mismatch for person %s" % handle,
+            )
+
+    def test_family_count_round_trip(self):
+        """Family count must match after export/import round-trip."""
+        importSQL(self.database2, "/tmp/exported1.sql", User())
+        src_count = self.database1.get_number_of_families()
+        self.assertGreater(src_count, 0)
+        self.assertEqual(self.database2.get_number_of_families(), src_count)
+
+    def test_family_identity_round_trip(self):
+        """Every family must survive round-trip with same father/mother handles."""
+        importSQL(self.database2, "/tmp/exported1.sql", User())
+        for handle in self.database1.get_family_handles():
+            src = self.database1.get_family_from_handle(handle)
+            dst = self.database2.get_family_from_handle(handle)
+            self.assertIsNotNone(
+                dst, "family %s missing after round-trip" % handle
+            )
+            self.assertEqual(src.get_gramps_id(), dst.get_gramps_id())
+            self.assertEqual(src.get_father_handle(), dst.get_father_handle())
+            self.assertEqual(src.get_mother_handle(), dst.get_mother_handle())
+
+    def test_event_count_round_trip(self):
+        """Event count must match after export/import round-trip."""
+        importSQL(self.database2, "/tmp/exported1.sql", User())
+        src_count = self.database1.get_number_of_events()
+        self.assertGreater(src_count, 0)
+        self.assertEqual(self.database2.get_number_of_events(), src_count)
 
 
+# -------------------------------------------------------------------------
+#
+# FamilySearchSyncRoundTripTest
+#
+# -------------------------------------------------------------------------
+class FamilySearchSyncRoundTripTest(unittest.TestCase):
+    """
+    Unit test for familysearch_sync round-trip on a synthetic Person with
+    non-default FamilySearchSync values.  Does not require the example file.
+    """
+
+    def setUp(self):
+        """Create a minimal database with one person containing fs sync data."""
+        self.database1 = make_database("sqlite")
+        try:
+            os.mkdir("/tmp/bsddb_fssync_1")
+        except Exception:
+            pass
+        self.database1.load("/tmp/bsddb_fssync_1")
+
+        self.database2 = make_database("sqlite")
+        try:
+            os.mkdir("/tmp/bsddb_fssync_2")
+        except Exception:
+            pass
+        self.database2.load("/tmp/bsddb_fssync_2")
+
+        # Create a person with a non-trivial familysearch_sync state
+        from gramps.gen.db import DbTxn
+
+        with DbTxn("add test person", self.database1) as txn:
+            person = Person()
+            person.gramps_id = "I9999"
+            person.gender = Person.MALE
+            primary_name = Name()
+            primary_name.set_first_name("Test")
+            surname = Surname()
+            surname.set_surname("Sync")
+            primary_name.set_surname_list([surname])
+            person.set_primary_name(primary_name)
+            # Set some familysearch_sync data
+            person.familysearch_sync.fsid = "FS-TESTID-001"
+            person.familysearch_sync.is_root = True
+            person.familysearch_sync.conflict = False
+            self.database1.add_person(person, txn)
+            self.person_handle = person.handle
+
+    def test_familysearch_sync_preserved(self):
+        """Non-default familysearch_sync fields must survive the SQL round-trip."""
+        exportSQL(self.database1, "/tmp/fssync_test.sql", User(), None)
+        importSQL(self.database2, "/tmp/fssync_test.sql", User())
+
+        dst = self.database2.get_person_from_handle(self.person_handle)
+        self.assertIsNotNone(dst, "person missing after round-trip")
+        self.assertEqual(dst.gramps_id, "I9999")
+        self.assertEqual(dst.familysearch_sync.fsid, "FS-TESTID-001")
+        self.assertTrue(dst.familysearch_sync.is_root)
+        self.assertFalse(dst.familysearch_sync.conflict)

--- a/Sqlite/tests/test_sqlite.py
+++ b/Sqlite/tests/test_sqlite.py
@@ -15,10 +15,12 @@ except (ImportError, ValueError, AttributeError) as err:
     raise unittest.SkipTest("GTK 3.0 / PyGObject not available: %s" % err)
 
 import os
+import shutil
 
 from gramps.gen.db import DbTxn
 from gramps.gen.db.utils import make_database
 from gramps.gen.lib import (
+    ChildRef,
     Event,
     EventRef,
     EventType,
@@ -174,3 +176,103 @@ class SqliteRoundTripTest(unittest.TestCase):
         self.assertIsNotNone(alice_dst)
         self.assertEqual(alice_dst.familysearch_sync.fsid, "FS-ALICE-001")
         self.assertTrue(alice_dst.familysearch_sync.is_root)
+
+
+# -------------------------------------------------------------------------
+#
+# SqliteOrderRoundTripTest
+#
+# -------------------------------------------------------------------------
+class SqliteOrderRoundTripTest(unittest.TestCase):
+    """Round-trip tests for GUI-reorderable lists (children, spouses).
+
+    Every such list is stored in the generic `link` table on export and
+    read back with no ordering guarantee beyond a `seq` column; these
+    tests catch a regression to that unordered behavior.
+    """
+
+    def setUp(self):
+        for path in ("/tmp/sqlite_order_rt_src", "/tmp/sqlite_order_rt_dst"):
+            shutil.rmtree(path, ignore_errors=True)
+        if os.path.exists("/tmp/sqlite_order_rt.sql"):
+            os.remove("/tmp/sqlite_order_rt.sql")
+
+        self.src_db = make_database("sqlite")
+        os.makedirs("/tmp/sqlite_order_rt_src", exist_ok=True)
+        self.src_db.load("/tmp/sqlite_order_rt_src")
+
+        with DbTxn("build order test db", self.src_db) as txn:
+            father_h = _make_person(self.src_db, txn, "I0001", "Dad", "Smith")
+            mother_h = _make_person(self.src_db, txn, "I0002", "Mom", "Smith")
+            # Created in this order, but birth order (set below) differs.
+            self.alpha_h = _make_person(self.src_db, txn, "I0003", "Alpha", "Smith")
+            self.beta_h = _make_person(self.src_db, txn, "I0004", "Beta", "Smith")
+            self.gamma_h = _make_person(self.src_db, txn, "I0005", "Gamma", "Smith")
+
+            fam = Family()
+            fam.gramps_id = "F0001"
+            fam.set_father_handle(father_h)
+            fam.set_mother_handle(mother_h)
+            fam.set_relationship(FamilyRelType(FamilyRelType.MARRIED))
+            # Birth order: Gamma, Alpha, Beta -- not creation order.
+            for h in (self.gamma_h, self.alpha_h, self.beta_h):
+                cref = ChildRef()
+                cref.set_reference_handle(h)
+                fam.add_child_ref(cref)
+            self.src_db.add_family(fam, txn)
+            self.fam_handle = fam.handle
+
+            for h in (self.alpha_h, self.beta_h, self.gamma_h):
+                p = self.src_db.get_person_from_handle(h)
+                p.add_family_handle(self.fam_handle)
+                self.src_db.commit_person(p, txn)
+
+            self.person_h = _make_person(self.src_db, txn, "I0006", "Ivan", "Jones")
+            w1_h = _make_person(self.src_db, txn, "I0007", "Wilma1", "Brown",
+                                gender=Person.FEMALE)
+            w2_h = _make_person(self.src_db, txn, "I0008", "Wilma2", "Green",
+                                gender=Person.FEMALE)
+            w3_h = _make_person(self.src_db, txn, "I0009", "Wilma3", "White",
+                                gender=Person.FEMALE)
+            self.fam1 = _make_family(self.src_db, txn, "F0002", self.person_h, w1_h)
+            self.fam2 = _make_family(self.src_db, txn, "F0003", self.person_h, w2_h)
+            self.fam3 = _make_family(self.src_db, txn, "F0004", self.person_h, w3_h)
+            p = self.src_db.get_person_from_handle(self.person_h)
+            p.add_family_handle(self.fam1)
+            p.add_family_handle(self.fam2)
+            p.add_family_handle(self.fam3)
+            self.src_db.commit_person(p, txn)
+
+        # Simulate the "Reorder families" tool with a second commit that
+        # doesn't touch object identity, only list order.
+        with DbTxn("reorder families", self.src_db) as txn:
+            p = self.src_db.get_person_from_handle(self.person_h)
+            p.set_family_handle_list([self.fam3, self.fam1, self.fam2])
+            self.src_db.commit_person(p, txn)
+
+        exportSQL(self.src_db, "/tmp/sqlite_order_rt.sql", User(), None)
+
+        self.dst_db = make_database("sqlite")
+        os.makedirs("/tmp/sqlite_order_rt_dst", exist_ok=True)
+        self.dst_db.load("/tmp/sqlite_order_rt_dst")
+        importSQL(self.dst_db, "/tmp/sqlite_order_rt.sql", User())
+
+    def test_child_ref_order(self):
+        """Family child_ref_list order (birth order) must survive round-trip."""
+        src_family = self.src_db.get_family_from_handle(self.fam_handle)
+        dst_family = self.dst_db.get_family_from_handle(self.fam_handle)
+        self.assertIsNotNone(dst_family)
+        src_order = [cr.ref for cr in src_family.get_child_ref_list()]
+        dst_order = [cr.ref for cr in dst_family.get_child_ref_list()]
+        self.assertEqual(src_order, [self.gamma_h, self.alpha_h, self.beta_h])
+        self.assertEqual(dst_order, src_order)
+
+    def test_family_list_order(self):
+        """Person family_list order (spouse order) must survive round-trip."""
+        src_person = self.src_db.get_person_from_handle(self.person_h)
+        dst_person = self.dst_db.get_person_from_handle(self.person_h)
+        self.assertIsNotNone(dst_person)
+        src_order = src_person.get_family_handle_list()
+        dst_order = dst_person.get_family_handle_list()
+        self.assertEqual(src_order, [self.fam3, self.fam1, self.fam2])
+        self.assertEqual(dst_order, src_order)


### PR DESCRIPTION
## Summary

Fixes the export/import round-trip broken by new fields added in Gramps 6.1. See also #953 which identified the original crash.

- **Export rewritten to use `get_raw_*_data(handle)` → DataDict** throughout.  All primary-object exporters (`export_person`, `export_family`, `export_event`, `export_place`, `export_citation`, `export_source`, `export_media`, `export_repository`, `export_tag`) now receive the raw named-key dict returned by the DB API instead of a live Gramps object.  Dict-key access is forward-compatible with any future schema additions — no more positional tuple unpacking that silently drops new fields.
- **`familysearch_sync` preserved** (added in Gramps 6.1): stored as JSON in a new `familysearch_sync TEXT` column on the `person` table and restored on import via `unserialize()`.
- **Import rewritten to use explicit column access** instead of positional `SELECT *` unpacking, so new columns never cause index errors.
- **`SrcAttribute`** (`Citation`/`Source` `attribute_list`) written to the legacy `datamap` table — it has no `citation_list`/`note_list` and round-trips correctly with the existing `get_datamap_list` import path.
- **Tests replaced** with a fast synthetic database (no `example.gramps`): 6 tests complete in ~1 s instead of ~30 s.

## GrampsType codes now resolve to translated names

Raised on the [Discourse thread on extracting constants from Python code](https://gramps.discourse.group/t/extracting-constants-from-python-code/675): the raw DataDict's `"string"` key is only populated for `CUSTOM` type values — for standard types (e.g. `EventType.BIRTH`) it was an empty string, so every `*_type1` TEXT column in the export was blank except for custom types. Added a `type_string(cls, type_dict)` helper that reconstructs the proper `GrampsType` subclass from `(value, string)` and resolves its translated display name via `str()`. Applied at all 14 GrampsType export sites (event, name, attribute, url, note, child_ref, surname origin, event_ref role, family, place, repository, repository_ref media, src_attribute, markup).

## New `constants` and `name_group` tables

- **`constants` table** (`table_name, column_name, code, value`): documents the meaning of integer codes that aren't `GrampsType` DataDicts and so can't be resolved by `type_string()` — date calendar/modifier/quality/newyear, person gender, citation confidence, LDS ordinance type/status, and name `display_as`/`sort_as`, and note format. Values are pulled programmatically from Gramps core (e.g. `Date.ui_calendar_names`, `LdsOrd._TYPE_MAP`/`_STATUS_MAP`, `NameDisplayer.STANDARD_FORMATS`) rather than hardcoded, so labels stay in sync with Gramps and are translated per the user's locale.
- **`name_group` table**: a direct copy of Gramps' surname-grouping table (`get_name_group_keys()` / `get_name_group_mapping()`), mapping a surname to the header it's grouped under (e.g. for accented/variant spellings).

## Notable Gramps 6.1 DataDict quirks handled

| Field | Old assumption | Actual 6.1 format |
|---|---|---|
| `Name.sort_as` / `display_as` | GrampsType dict | plain `int` |
| `LdsOrd.type` | GrampsType dict | plain `int` |
| `Address` location fields | nested Location object | inline on the Address dict |
| `Citation`/`Source` attributes | `datamap` list | `attribute_list` of `SrcAttribute` |
| `Place` ref list key | `place_ref_list` | `placeref_list` |
| `Place` alt names key | `alt_place_name_list` | `alt_names` |

## List ordering now guaranteed on round-trip

Every GUI-reorderable list (children, spouses/families, event refs, names, surnames, addresses, media refs, associations, attributes, URLs, repo refs, notes, tags, markup ranges) is flattened into a generic `link(from_type, from_handle, to_type, to_handle)` table on export. Reads had no `ORDER BY` and the table had no ordinal column, so round-trip order relied entirely on incidental SQLite rowid tie-breaking rather than a guaranteed contract — e.g. manually reordering a family's children or a person's marriages in the Gramps GUI was at risk of silently reverting to handle-creation order after an export/import round trip.

Added a `seq INTEGER` column to `link`, stamped per `(from_type, from_handle, to_type)` group as each row is written on export, and every read of `link` (`get_links`, the surname join, the note-markup lookup) now orders by it explicitly.

## Mantis bugs fixed

* [0012620: Include type descriptions in SQLite Export addon](https://gramps-project.org/bugs/view.php?id=12620) — fixed by the `type_string()` translated-name resolution above.
* [0012765: Include name_group table in SQLite Export](https://gramps-project.org/bugs/view.php?id=12765) — fixed by the new `name_group` table.
* [0012766: Add table of constants to SQLite Export](https://gramps-project.org/bugs/view.php?id=12766) — fixed by the new `constants` table.
* [0009148: Sqlite export followed by re-import not idempotent](https://gramps-project.org/bugs/view.php?id=9148) — substantially addressed: the previously-blank type columns, missing constants/name_group tables, and unordered lists were all sources of round-trip drift, and are all fixed here. Not marking this fully closed since idempotency across every field/edge case hasn't been exhaustively verified.

## Test plan

- [x] `python -m pytest Sqlite/tests/test_sqlite.py -v` — 8 tests, all pass in ~2 s
- [ ] Export a real Gramps 6.1 database to SQLite and re-import; verify person/family/event counts match
- [x] Verify `familysearch_sync` fields survive the round-trip for persons that have them set
- [x] Verify `constants` table is populated with translated labels and `name_group` mappings survive export
- [x] Verify a manually reordered family's `child_ref_list` and a person's `family_list` (via "Reorder families") survive the round trip in original order

🤖 Generated with [Claude Code](https://claude.com/claude-code)

