### PR TITLE
Fix DescendantsLines graphic name persisting across sessions

### DIFF
--- a/DescendantsLines/DescendantsLines.py
+++ b/DescendantsLines/DescendantsLines.py
@@ -95,6 +95,7 @@ import gramps.gen.lib
 from gramps.plugins.lib.libtreebase import *    # for CalcLines
 from gramps.plugins.lib.libsubstkeyword import SubstKeywords
 from substkw import SubstKeywords2  # Modified version of libsubstkeywords.py
+from descendantslines_output import derive_output_filename
 from gramps.gen.lib.eventtype import EventType      # for selecting event types
 from gramps.gen.lib.eventroletype import EventRoleType  # for PRIMARY, FAMILY
 # for sorting events with unknown dates
@@ -315,9 +316,13 @@ class DescendantsLinesReport(Report):
         _event_cache = {}
 
         self.output_fmt = self.options['output_fmt']
-        self.output_fn = self.options['output_fn']
-        self.output_fn = '%s.%s' % (os.path.splitext(self.output_fn)[0],
-                                    self.output_fmt.lower())
+        # Bug 5965: derive the graphic filename from the destination chosen for
+        # the CURRENT run (the report document's output) rather than the report's
+        # own persisted "Destination" option, which retains a previous session's
+        # value and would carry that stale name over to this run.
+        self.output_fn = derive_output_filename(self.options_class.get_output(),
+                                                self.options['output_fn'],
+                                                self.output_fmt)
         self.max_gen = self.options['max_gen']
         self.gender_colors = self.options['gender_colors']
         self.inc_dnum = self.options['inc_dnum']

--- a/DescendantsLines/descendantslines_output.py
+++ b/DescendantsLines/descendantslines_output.py
@@ -1,0 +1,69 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Gramps Development Team
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+"""
+Output-filename derivation for the DescendantsLines report.
+
+This module is deliberately free of any ``gi`` / ``gramps.gui`` imports so the
+filename logic can be unit-tested headlessly. The report
+(``DescendantsLines.py``) routes through :func:`derive_output_filename`, so the
+test exercises the very code the production report runs (no parallel copy).
+
+Bug 5965: the DescendantsLines graphic was always written to the report's own
+persisted "Destination" option (``output_fn``). That option keeps its value
+across Gramps sessions, so a graphic produced this run carried the *previous*
+session's name, ignoring the filename the user chose for the current run in the
+standard report dialog's "Document Options". The fix derives the graphic name
+from the destination selected for the *current* run, falling back to the
+persisted option only when the current run supplies no destination.
+"""
+
+import os
+
+
+def derive_output_filename(current_destination, option_destination, output_fmt):
+    """
+    Return the graphic output filename for the *current* report run.
+
+    :param current_destination: the output destination selected for this run
+        (the report document's output, i.e. ``options_class.get_output()``).
+        Reflects the name the user picked in the current invocation; may be
+        ``None``/empty when no document destination was given (e.g. CLI without
+        an explicit ``-O``).
+    :param option_destination: the report's own persisted "Destination" option
+        value (``output_fn``). Retained across sessions, so on its own it is a
+        *stale* source for the current run's name.
+    :param output_fmt: the addon's chosen output format ("PNG", "PDF", ...).
+        Forced onto the filename so it is named for *this* run's format.
+    :returns: the filename to write the graphic to.
+
+    The destination chosen for the current run takes precedence over the
+    persisted option, so the graphic never carries a prior session's name. When
+    the current destination is what the standard report document is also written
+    to, the graphic is given a distinct ``-chart`` suffix: the document is closed
+    (and thus written) *after* the graphic is drawn, so sharing the exact path
+    would let the document's close() clobber the graphic.
+    """
+    base = current_destination or option_destination or ""
+    ext = output_fmt.lower()
+    root = os.path.splitext(base)[0]
+    candidate = "%s.%s" % (root, ext)
+    if current_destination and candidate == current_destination:
+        candidate = "%s-chart.%s" % (root, ext)
+    return candidate

--- a/DescendantsLines/tests/test_descendantslines_name.py
+++ b/DescendantsLines/tests/test_descendantslines_name.py
@@ -1,0 +1,121 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Gramps Development Team
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Regression test for Mantis bug 5965.
+
+The DescendantsLines report wrote its graphic to the report's own persisted
+"Destination" option (``output_fn``). That option keeps its value across Gramps
+sessions, so the graphic produced for the current run carried the *previous*
+session's name instead of the destination the user chose for the current run.
+
+The production report (``DescendantsLines.py``) derives the graphic filename
+through ``descendantslines_output.derive_output_filename``; this test drives
+that same function directly (the report module itself imports ``cairo`` and
+``gramps.gui``-adjacent modules at load and cannot be imported headlessly).
+
+Pre-fix the module / function does not exist, so the import fails (RED). Post-
+fix the function exists and the current-run destination wins over the stale
+option (GREEN).
+"""
+
+import os
+import sys
+import unittest
+
+# Make the addon's sibling modules importable from the addon directory, matching
+# the JSON / DescendantBooks test convention (the modules are imported by their
+# bare name, the way Gramps loads them with the addon dir on sys.path).
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from descendantslines_output import derive_output_filename
+
+
+class TestDescendantsLinesOutputName(unittest.TestCase):
+    """The graphic must be named for the CURRENT run, not a prior session."""
+
+    def test_current_run_destination_overrides_stale_option(self):
+        """The destination chosen for this run wins over the persisted option.
+
+        Bug 5965: ``option_destination`` holds the previous session's name. The
+        derived filename must reflect the current run's destination and carry no
+        trace of the stale option's basename.
+        """
+        stale_option = os.path.join("/home", "user", "prev_session_name.png")
+        current_run = os.path.join("/home", "user", "this_run_name")
+
+        result = derive_output_filename(current_run, stale_option, "PNG")
+
+        self.assertEqual(result, os.path.join("/home", "user", "this_run_name.png"))
+        self.assertNotIn(
+            "prev_session_name",
+            result,
+            "graphic carried the previous session's stale name",
+        )
+
+    def test_running_twice_tracks_each_runs_name(self):
+        """Two runs with different current destinations yield different names.
+
+        The persisted option is identical across both runs (it is the stale
+        carry-over); only the current-run destination differs, and the output
+        name must follow it each time — the success criterion's "run twice".
+        """
+        stale_option = os.path.join("/home", "user", "DescendantsLines.png")
+
+        first = derive_output_filename(
+            os.path.join("/home", "user", "alice_tree"), stale_option, "PNG"
+        )
+        second = derive_output_filename(
+            os.path.join("/home", "user", "bob_tree"), stale_option, "PNG"
+        )
+
+        self.assertEqual(first, os.path.join("/home", "user", "alice_tree.png"))
+        self.assertEqual(second, os.path.join("/home", "user", "bob_tree.png"))
+        self.assertNotEqual(first, second)
+
+    def test_falls_back_to_option_when_no_current_destination(self):
+        """With no current-run destination, the persisted option is used.
+
+        (e.g. CLI without an explicit document output) — behaviour unchanged
+        from before the fix, with the format extension forced.
+        """
+        option = os.path.join("/home", "user", "DescendantsLines.png")
+
+        result = derive_output_filename(None, option, "PDF")
+
+        self.assertEqual(result, os.path.join("/home", "user", "DescendantsLines.pdf"))
+
+    def test_distinct_from_document_destination_to_avoid_clobber(self):
+        """The graphic name must differ from the document's own output path.
+
+        The standard report document is written/closed AFTER the graphic is
+        drawn; if the graphic shared the document's exact path the document's
+        close() would clobber it. A ``-chart`` suffix keeps them distinct.
+        """
+        doc_path = os.path.join("/home", "user", "tree.png")
+
+        result = derive_output_filename(doc_path, "", "PNG")
+
+        self.assertNotEqual(result, doc_path)
+        self.assertEqual(result, os.path.join("/home", "user", "tree-chart.png"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Root cause

The DescendantsLines report derives the graphic's output filename solely from its persisted "Destination" option (`DescendantsLines.py:316-320`), which is saved in the report's option state and persists across Gramps sessions. The addon ignores the destination the user selects for the current run in the standard report dialog's "Document Options" (`gramps/gen/plug/report/_reportbase.py:56-59`), so the graphic always lands on the previous session's name.

## Fix

Extract the filename derivation into a pure helper module `descendantslines_output.py` (free of `gi` imports so it can be unit-tested headlessly) and route production through `derive_output_filename` (`DescendantsLines.py:316-324`). The function sources the current run's destination (`options_class.get_output()`, `gramps/gen/plug/report/_options.py:914-920`) instead of the persisted option, falling back to the persisted option only when no current destination is given. When the derived name would equal the document's own output path, a `-chart` suffix is added to avoid clobbering by the document's `close()`.

## Verified against

- `DescendantsLines.py:316-320` — the original code deriving filename from the persisted option only
- `DescendantsLines.py:1548-1551` — the `DestinationOption` definition and its persistence across sessions
- `DescendantsLines.py:455` — where the graphic is written via `draw_file(p, self.output_fn, …)`
- `gramps/gen/plug/report/_reportbase.py:56-59` — the framework obtaining the current run's document destination
- `gramps/gen/plug/report/_options.py:914-920` — `get_output()` returning the user's chosen destination for this invocation

## Test

`DescendantsLines/tests/test_descendantslines_name.py` (new regression test file, `test_*.py` prefix per addon convention) drives `derive_output_filename` directly with four test cases: (1) current-run destination overrides stale option with no carry-over; (2) two runs with different current destinations yield different names; (3) fallback to persisted option when no current destination; (4) distinct naming from document path (clobber guard). The production report (`DescendantsLines.py:318`) and the test both call the same function (`descendantslines_output.derive_output_filename`), so the test exercises the exact code path the report runs — no parallel copy. Verified locally: RED without the helper (ModuleNotFoundError), GREEN with it (all 4 tests pass). The cross-GUI session behavior (open, run, reopen with different name, run again) cannot be automated headlessly but is described in the build notes for manual verification.

Fixes #5965
