### PR TITLE
Gram.py Script: add evaluate_expression, fix bugs, add tests, target gramps 6.1

### DIFF
--- a/GrampyScript/GrampyScript.gpr.py
+++ b/GrampyScript/GrampyScript.gpr.py
@@ -23,7 +23,7 @@ register(
     name=_("Gram.py Script"),
     description=_("Run a special Gramps Python script"),
     status=STABLE,
-    version = '0.0.5',
+    version = '0.0.3',
     fname="GrampyScript.py",
     authors=["Doug Blank"],
     authors_email=["doug.blank@gmail.com"],

--- a/GrampyScript/GrampyScript.gpr.py
+++ b/GrampyScript/GrampyScript.gpr.py
@@ -23,7 +23,7 @@ register(
     name=_("Gram.py Script"),
     description=_("Run a special Gramps Python script"),
     status=STABLE,
-    version = '0.0.3',
+    version = '0.0.6',
     fname="GrampyScript.py",
     authors=["Doug Blank"],
     authors_email=["doug.blank@gmail.com"],

--- a/GrampyScript/GrampyScript.py
+++ b/GrampyScript/GrampyScript.py
@@ -65,6 +65,9 @@ config.register("defaults.encoding", "utf-8")
 config.register("defaults.delimiter", "comma")
 config.register("defaults.last_filename", "")
 
+_instance = None
+
+
 def contains_any_none_data(args):
     if isinstance(args, list):
         return any(contains_any_none_data(arg) for arg in args)
@@ -80,7 +83,8 @@ def get_columns(source, func_name):
                 if hasattr(node.func, "id") and node.func.id == func_name:
                     return [ast.unparse(arg) for arg in node.args]
     except Exception:
-        return []
+        pass
+    return []
 
 
 class ScriptOpenFileChooserDialog(Gtk.FileChooserDialog):
@@ -193,6 +197,8 @@ class CsvFileChooserDialog(Gtk.FileChooserDialog):
 
 class GrampyScript(Gramplet):
     def init(self):
+        global _instance
+        _instance = self
         self.keywords = [
             "_",
             "and",
@@ -462,6 +468,9 @@ for person in people():
         choose_file_dialog.destroy()
 
     def save_script(self, widget):
+        if not self.last_filename:
+            self.save_as_script(widget)
+            return
         with open(self.last_filename, "w") as fp:
             fp.write(self.get_text())
         self.statusmsg.set_text("Saved %r" % self.last_filename)
@@ -1011,6 +1020,10 @@ for person in people():
             cr.rectangle(0, 0, width, height)
             cr.fill()
 
+    def evaluate_expression(self, code):
+        """Run code in the full GrampyScript scope and return stdout."""
+        return self.execute_code(code)
+
     def execute_filename(self, filename):
         if os.path.exists(filename):
             with open(filename) as file:
@@ -1126,6 +1139,8 @@ for person in people():
                     data = get_data(handle)
                     yield DataDict2(dict(data), callback=self.callback)
 
+        database = self.db
+
         today = Date(
             datetime.datetime.today().year,
             datetime.datetime.today().month,
@@ -1187,3 +1202,5 @@ for person in people():
         else:
             self.notebook.set_current_page(1)
             self.statusmsg.set_text("Completed")
+
+        return STDOUT

--- a/GrampyScript/tests/conftest.py
+++ b/GrampyScript/tests/conftest.py
@@ -1,7 +1,1 @@
-"""Shared pytest configuration for GrampyScript tests."""
-
-import sys
-import os
-
-# Make GrampyScript importable without installing it.
-sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+# conftest.py intentionally empty — sys.path setup is in each test file.

--- a/GrampyScript/tests/conftest.py
+++ b/GrampyScript/tests/conftest.py
@@ -1,0 +1,7 @@
+"""Shared pytest configuration for GrampyScript tests."""
+
+import sys
+import os
+
+# Make GrampyScript importable without installing it.
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))

--- a/GrampyScript/tests/test_datadict2.py
+++ b/GrampyScript/tests/test_datadict2.py
@@ -4,28 +4,17 @@ Tests for datadict2.py — DataDict2, DataList2, and NoneData.
 Uses real Gramps gen-lib objects (no GTK required).
 """
 
-import pytest
+import os
+import sys
+import unittest
 from unittest.mock import MagicMock
 
-from gramps.gen.lib import Person, Name, Surname, Family, Event, EventRef, EventType
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from gramps.gen.lib import Person, Name, Surname, Family
 from gramps.gen.simple import SimpleAccess
 
 from datadict2 import DataDict2, DataList2, NoneData, set_sa
-
-
-# ---------------------------------------------------------------------------
-# Fixture: minimal SimpleAccess so property methods don't crash
-# ---------------------------------------------------------------------------
-
-@pytest.fixture(autouse=True)
-def mock_sa():
-    db = MagicMock()
-    db.get_event_from_handle.return_value = None   # no birth/death events
-    db.get_place_from_handle.return_value = None
-    db.get_source_from_handle.return_value = None
-    sa = SimpleAccess(db)
-    set_sa(sa)
-    yield sa
 
 
 # ---------------------------------------------------------------------------
@@ -50,184 +39,188 @@ def _make_family(gramps_id="F0001"):
     return f
 
 
+class _MockSaBase(unittest.TestCase):
+    """Base class that sets up a minimal SimpleAccess mock before each test."""
+
+    def setUp(self):
+        db = MagicMock()
+        db.get_event_from_handle.return_value = None
+        db.get_place_from_handle.return_value = None
+        db.get_source_from_handle.return_value = None
+        sa = SimpleAccess(db)
+        set_sa(sa)
+
+
 # ---------------------------------------------------------------------------
 # NoneData
 # ---------------------------------------------------------------------------
 
-class TestNoneData:
+class TestNoneData(unittest.TestCase):
     def test_is_falsy(self):
-        assert not NoneData()
+        self.assertFalse(NoneData())
 
     def test_str_is_empty(self):
-        assert str(NoneData()) == ""
+        self.assertEqual(str(NoneData()), "")
 
     def test_attribute_chain_returns_none_data(self):
         result = NoneData().foo.bar.baz
-        assert isinstance(result, NoneData)
+        self.assertIsInstance(result, NoneData)
 
     def test_callable_returns_empty_string(self):
-        assert NoneData()() == ""
+        self.assertEqual(NoneData()(), "")
 
     def test_iter_yields_nothing(self):
-        assert list(NoneData()) == []
+        self.assertEqual(list(NoneData()), [])
 
 
 # ---------------------------------------------------------------------------
 # DataDict2 — basic attribute access
 # ---------------------------------------------------------------------------
 
-class TestDataDict2BasicAccess:
+class TestDataDict2BasicAccess(_MockSaBase):
     def test_gramps_id_via_attribute(self):
         dd = DataDict2(_make_person(gramps_id="I0042"))
-        assert dd.gramps_id == "I0042"
+        self.assertEqual(dd.gramps_id, "I0042")
 
     def test_class_key(self):
         dd = DataDict2(_make_person())
-        assert dd["_class"] == "Person"
+        self.assertEqual(dd["_class"], "Person")
 
     def test_missing_key_returns_none_data(self):
         dd = DataDict2(_make_person())
-        result = dd.nonexistent_field
-        assert isinstance(result, NoneData)
+        self.assertIsInstance(dd.nonexistent_field, NoneData)
 
     def test_nested_dict_wraps_as_datadict2(self):
         dd = DataDict2(_make_person())
-        # primary_name is a dict in the serialised form
-        assert isinstance(dd.primary_name, DataDict2)
+        self.assertIsInstance(dd.primary_name, DataDict2)
 
     def test_nested_list_wraps_as_datalist2(self):
         dd = DataDict2(_make_person())
-        assert isinstance(dd.primary_name.surname_list, DataList2)
+        self.assertIsInstance(dd.primary_name.surname_list, DataList2)
 
     def test_scalar_returned_directly(self):
         dd = DataDict2(_make_person(gramps_id="I0001"))
-        assert isinstance(dd.gramps_id, str)
+        self.assertIsInstance(dd.gramps_id, str)
 
 
 # ---------------------------------------------------------------------------
 # DataDict2 — genealogy properties
 # ---------------------------------------------------------------------------
 
-class TestDataDict2GenealogyProperties:
+class TestDataDict2GenealogyProperties(_MockSaBase):
     def test_name_property_returns_primary_name_for_person(self):
         dd = DataDict2(_make_person())
-        assert dd.name == dd.primary_name
+        self.assertEqual(dd.name, dd.primary_name)
 
     def test_name_first_name(self):
         dd = DataDict2(_make_person(first="Alice"))
-        assert dd.name.first_name == "Alice"
+        self.assertEqual(dd.name.first_name, "Alice")
 
     def test_surname_via_surname_list(self):
         dd = DataDict2(_make_person(surname="Jones"))
-        assert dd.name.surname_list[0].surname == "Jones"
+        self.assertEqual(dd.name.surname_list[0].surname, "Jones")
 
     def test_birth_returns_none_data_when_absent(self):
         dd = DataDict2(_make_person())
-        assert not dd.birth
+        self.assertFalse(dd.birth)
 
     def test_death_returns_none_data_when_absent(self):
         dd = DataDict2(_make_person())
-        assert not dd.death
+        self.assertFalse(dd.death)
 
     def test_birth_chain_attribute_access_is_safe(self):
         # Attribute chaining on NoneData is safe — returns falsy NoneData each step.
         dd = DataDict2(_make_person())
-        assert not dd.birth          # NoneData
-        assert not dd.birth.date     # still NoneData
+        self.assertFalse(dd.birth)
+        self.assertFalse(dd.birth.date)
 
     def test_birth_guard_before_method_call(self):
-        # NoneData().__call__ returns "", not NoneData, so calling methods on the
-        # result of a method call is not safe. Always guard with `if birth:` first.
+        # Always guard with `if birth:` before calling methods on it.
         dd = DataDict2(_make_person())
         birth = dd.birth
         year = birth.get_date_object().get_year() if birth else 0
-        assert year == 0
+        self.assertEqual(year, 0)
 
     def test_notes_is_list(self):
         dd = DataDict2(_make_person())
-        assert isinstance(dd.notes, (list, DataList2))
+        self.assertIsInstance(dd.notes, (list, DataList2))
 
     def test_tags_is_list(self):
         dd = DataDict2(_make_person())
-        assert isinstance(dd.tags, (list, DataList2))
+        self.assertIsInstance(dd.tags, (list, DataList2))
 
     def test_citations_is_list(self):
         dd = DataDict2(_make_person())
-        assert isinstance(dd.citations, (list, DataList2))
+        self.assertIsInstance(dd.citations, (list, DataList2))
 
     def test_private_default_false(self):
         dd = DataDict2(_make_person())
-        assert dd.private == False
+        self.assertEqual(dd.private, False)
 
     def test_family_gramps_id(self):
         dd = DataDict2(_make_family(gramps_id="F0007"))
-        assert dd.gramps_id == "F0007"
-        assert dd["_class"] == "Family"
+        self.assertEqual(dd.gramps_id, "F0007")
+        self.assertEqual(dd["_class"], "Family")
 
 
 # ---------------------------------------------------------------------------
 # DataDict2 — null-safe chaining
 # ---------------------------------------------------------------------------
 
-class TestDataDict2NullSafeChaining:
+class TestDataDict2NullSafeChaining(_MockSaBase):
     def test_missing_birth_place_title_is_safe(self):
         dd = DataDict2(_make_person())
         result = dd.birth.place.title
-        # Must not raise; returns "" or NoneData
-        assert not result or isinstance(result, (str, NoneData))
+        self.assertTrue(not result or isinstance(result, (str, NoneData)))
 
     def test_none_data_in_chain_stays_falsy(self):
         dd = DataDict2(_make_person())
-        assert not dd.birth
-        assert not dd.birth.date
-        assert not dd.birth.date.dateval
+        self.assertFalse(dd.birth)
+        self.assertFalse(dd.birth.date)
+        self.assertFalse(dd.birth.date.dateval)
 
     def test_non_existent_deeply_nested(self):
         dd = DataDict2(_make_person())
-        result = dd.a.b.c.d.e
-        assert not result
+        self.assertFalse(dd.a.b.c.d.e)
 
 
 # ---------------------------------------------------------------------------
 # DataList2
 # ---------------------------------------------------------------------------
 
-class TestDataList2:
+class TestDataList2(_MockSaBase):
     def _make_list(self):
         p1 = DataDict2(_make_person(gramps_id="I0001", first="Alice"))
         p2 = DataDict2(_make_person(gramps_id="I0002", first="Bob"))
         return DataList2([p1, p2])
 
     def test_len(self):
-        dl = self._make_list()
-        assert len(dl) == 2
+        self.assertEqual(len(self._make_list()), 2)
 
     def test_getitem_wraps_dict(self):
-        dl = self._make_list()
-        assert isinstance(dl[0], DataDict2)
+        self.assertIsInstance(self._make_list()[0], DataDict2)
 
     def test_getitem_out_of_range_returns_none_data(self):
-        dl = self._make_list()
-        assert isinstance(dl[99], NoneData)
+        self.assertIsInstance(self._make_list()[99], NoneData)
 
     def test_iter_yields_all_items(self):
-        dl = self._make_list()
-        items = list(dl)
-        assert len(items) == 2
+        self.assertEqual(len(list(self._make_list())), 2)
 
     def test_getattr_fans_out_across_items(self):
-        dl = self._make_list()
-        ids = dl.gramps_id
-        assert "I0001" in ids
-        assert "I0002" in ids
+        ids = self._make_list().gramps_id
+        self.assertIn("I0001", ids)
+        self.assertIn("I0002", ids)
 
     def test_add_concatenates(self):
         dl1 = DataList2([DataDict2(_make_person(gramps_id="I0001"))])
         dl2 = DataList2([DataDict2(_make_person(gramps_id="I0002"))])
-        combined = dl1 + dl2
-        assert len(combined) == 2
+        self.assertEqual(len(dl1 + dl2), 2)
 
     def test_empty_list(self):
         dl = DataList2([])
-        assert len(dl) == 0
-        assert list(dl) == []
+        self.assertEqual(len(dl), 0)
+        self.assertEqual(list(dl), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/GrampyScript/tests/test_datadict2.py
+++ b/GrampyScript/tests/test_datadict2.py
@@ -1,0 +1,233 @@
+"""
+Tests for datadict2.py — DataDict2, DataList2, and NoneData.
+
+Uses real Gramps gen-lib objects (no GTK required).
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+from gramps.gen.lib import Person, Name, Surname, Family, Event, EventRef, EventType
+from gramps.gen.simple import SimpleAccess
+
+from datadict2 import DataDict2, DataList2, NoneData, set_sa
+
+
+# ---------------------------------------------------------------------------
+# Fixture: minimal SimpleAccess so property methods don't crash
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def mock_sa():
+    db = MagicMock()
+    db.get_event_from_handle.return_value = None   # no birth/death events
+    db.get_place_from_handle.return_value = None
+    db.get_source_from_handle.return_value = None
+    sa = SimpleAccess(db)
+    set_sa(sa)
+    yield sa
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_person(gramps_id="I0001", first="John", surname="Smith"):
+    p = Person()
+    p.set_gramps_id(gramps_id)
+    n = Name()
+    sn = Surname()
+    sn.set_surname(surname)
+    n.add_surname(sn)
+    n.set_first_name(first)
+    p.set_primary_name(n)
+    return p
+
+
+def _make_family(gramps_id="F0001"):
+    f = Family()
+    f.set_gramps_id(gramps_id)
+    return f
+
+
+# ---------------------------------------------------------------------------
+# NoneData
+# ---------------------------------------------------------------------------
+
+class TestNoneData:
+    def test_is_falsy(self):
+        assert not NoneData()
+
+    def test_str_is_empty(self):
+        assert str(NoneData()) == ""
+
+    def test_attribute_chain_returns_none_data(self):
+        result = NoneData().foo.bar.baz
+        assert isinstance(result, NoneData)
+
+    def test_callable_returns_empty_string(self):
+        assert NoneData()() == ""
+
+    def test_iter_yields_nothing(self):
+        assert list(NoneData()) == []
+
+
+# ---------------------------------------------------------------------------
+# DataDict2 — basic attribute access
+# ---------------------------------------------------------------------------
+
+class TestDataDict2BasicAccess:
+    def test_gramps_id_via_attribute(self):
+        dd = DataDict2(_make_person(gramps_id="I0042"))
+        assert dd.gramps_id == "I0042"
+
+    def test_class_key(self):
+        dd = DataDict2(_make_person())
+        assert dd["_class"] == "Person"
+
+    def test_missing_key_returns_none_data(self):
+        dd = DataDict2(_make_person())
+        result = dd.nonexistent_field
+        assert isinstance(result, NoneData)
+
+    def test_nested_dict_wraps_as_datadict2(self):
+        dd = DataDict2(_make_person())
+        # primary_name is a dict in the serialised form
+        assert isinstance(dd.primary_name, DataDict2)
+
+    def test_nested_list_wraps_as_datalist2(self):
+        dd = DataDict2(_make_person())
+        assert isinstance(dd.primary_name.surname_list, DataList2)
+
+    def test_scalar_returned_directly(self):
+        dd = DataDict2(_make_person(gramps_id="I0001"))
+        assert isinstance(dd.gramps_id, str)
+
+
+# ---------------------------------------------------------------------------
+# DataDict2 — genealogy properties
+# ---------------------------------------------------------------------------
+
+class TestDataDict2GenealogyProperties:
+    def test_name_property_returns_primary_name_for_person(self):
+        dd = DataDict2(_make_person())
+        assert dd.name == dd.primary_name
+
+    def test_name_first_name(self):
+        dd = DataDict2(_make_person(first="Alice"))
+        assert dd.name.first_name == "Alice"
+
+    def test_surname_via_surname_list(self):
+        dd = DataDict2(_make_person(surname="Jones"))
+        assert dd.name.surname_list[0].surname == "Jones"
+
+    def test_birth_returns_none_data_when_absent(self):
+        dd = DataDict2(_make_person())
+        assert not dd.birth
+
+    def test_death_returns_none_data_when_absent(self):
+        dd = DataDict2(_make_person())
+        assert not dd.death
+
+    def test_birth_chain_attribute_access_is_safe(self):
+        # Attribute chaining on NoneData is safe — returns falsy NoneData each step.
+        dd = DataDict2(_make_person())
+        assert not dd.birth          # NoneData
+        assert not dd.birth.date     # still NoneData
+
+    def test_birth_guard_before_method_call(self):
+        # NoneData().__call__ returns "", not NoneData, so calling methods on the
+        # result of a method call is not safe. Always guard with `if birth:` first.
+        dd = DataDict2(_make_person())
+        birth = dd.birth
+        year = birth.get_date_object().get_year() if birth else 0
+        assert year == 0
+
+    def test_notes_is_list(self):
+        dd = DataDict2(_make_person())
+        assert isinstance(dd.notes, (list, DataList2))
+
+    def test_tags_is_list(self):
+        dd = DataDict2(_make_person())
+        assert isinstance(dd.tags, (list, DataList2))
+
+    def test_citations_is_list(self):
+        dd = DataDict2(_make_person())
+        assert isinstance(dd.citations, (list, DataList2))
+
+    def test_private_default_false(self):
+        dd = DataDict2(_make_person())
+        assert dd.private == False
+
+    def test_family_gramps_id(self):
+        dd = DataDict2(_make_family(gramps_id="F0007"))
+        assert dd.gramps_id == "F0007"
+        assert dd["_class"] == "Family"
+
+
+# ---------------------------------------------------------------------------
+# DataDict2 — null-safe chaining
+# ---------------------------------------------------------------------------
+
+class TestDataDict2NullSafeChaining:
+    def test_missing_birth_place_title_is_safe(self):
+        dd = DataDict2(_make_person())
+        result = dd.birth.place.title
+        # Must not raise; returns "" or NoneData
+        assert not result or isinstance(result, (str, NoneData))
+
+    def test_none_data_in_chain_stays_falsy(self):
+        dd = DataDict2(_make_person())
+        assert not dd.birth
+        assert not dd.birth.date
+        assert not dd.birth.date.dateval
+
+    def test_non_existent_deeply_nested(self):
+        dd = DataDict2(_make_person())
+        result = dd.a.b.c.d.e
+        assert not result
+
+
+# ---------------------------------------------------------------------------
+# DataList2
+# ---------------------------------------------------------------------------
+
+class TestDataList2:
+    def _make_list(self):
+        p1 = DataDict2(_make_person(gramps_id="I0001", first="Alice"))
+        p2 = DataDict2(_make_person(gramps_id="I0002", first="Bob"))
+        return DataList2([p1, p2])
+
+    def test_len(self):
+        dl = self._make_list()
+        assert len(dl) == 2
+
+    def test_getitem_wraps_dict(self):
+        dl = self._make_list()
+        assert isinstance(dl[0], DataDict2)
+
+    def test_getitem_out_of_range_returns_none_data(self):
+        dl = self._make_list()
+        assert isinstance(dl[99], NoneData)
+
+    def test_iter_yields_all_items(self):
+        dl = self._make_list()
+        items = list(dl)
+        assert len(items) == 2
+
+    def test_getattr_fans_out_across_items(self):
+        dl = self._make_list()
+        ids = dl.gramps_id
+        assert "I0001" in ids
+        assert "I0002" in ids
+
+    def test_add_concatenates(self):
+        dl1 = DataList2([DataDict2(_make_person(gramps_id="I0001"))])
+        dl2 = DataList2([DataDict2(_make_person(gramps_id="I0002"))])
+        combined = dl1 + dl2
+        assert len(combined) == 2
+
+    def test_empty_list(self):
+        dl = DataList2([])
+        assert len(dl) == 0
+        assert list(dl) == []

--- a/GrampyScript/tests/test_get_columns.py
+++ b/GrampyScript/tests/test_get_columns.py
@@ -8,11 +8,11 @@ it directly from the module source via ast/importlib.
 """
 
 import ast
-import importlib.util
 import os
 import sys
+import unittest
 
-import pytest
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 
 # ---------------------------------------------------------------------------
@@ -21,18 +21,17 @@ import pytest
 # ---------------------------------------------------------------------------
 
 _SOURCE = os.path.join(
-    os.path.dirname(os.path.dirname(__file__)), "GrampyScript.py"
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "GrampyScript.py"
 )
 
 
 def _load_get_columns():
     src = open(_SOURCE).read()
     tree = ast.parse(src)
-    # Extract the get_columns function definition
     for node in ast.walk(tree):
         if isinstance(node, ast.FunctionDef) and node.name == "get_columns":
             snippet = ast.unparse(node)
-            ns = {"ast": ast}   # function body uses ast.parse / ast.walk / ast.unparse
+            ns = {"ast": ast}
             exec(snippet, ns)
             return ns["get_columns"]
     raise RuntimeError("get_columns not found in GrampyScript.py")
@@ -45,42 +44,46 @@ get_columns = _load_get_columns()
 # Tests
 # ---------------------------------------------------------------------------
 
-class TestGetColumns:
+class TestGetColumns(unittest.TestCase):
     def test_single_row_call_simple_names(self):
         code = "for p in people():\n    row(p.gramps_id, p.name)"
         cols = get_columns(code, "row")
-        assert cols == ["p.gramps_id", "p.name"]
+        self.assertEqual(cols, ["p.gramps_id", "p.name"])
 
     def test_no_row_call_returns_empty(self):
         code = "for p in people():\n    print(p.gramps_id)"
-        assert get_columns(code, "row") == []
+        self.assertEqual(get_columns(code, "row"), [])
 
     def test_multiple_row_calls_returns_first(self):
         # get_columns walks all calls; first match wins in ast.walk order
         code = "row(a, b)\nrow(c, d)"
         cols = get_columns(code, "row")
-        assert "a" in cols or "c" in cols  # at least one match
+        self.assertTrue("a" in cols or "c" in cols)
 
     def test_columns_function_name(self):
         code = "columns('ID', 'Name')\nfor p in people():\n    row(p.gramps_id, p.name)"
         cols = get_columns(code, "columns")
-        assert cols == ["'ID'", "'Name'"]
+        self.assertEqual(cols, ["'ID'", "'Name'"])
 
     def test_single_arg(self):
         code = "row(p)"
-        assert get_columns(code, "row") == ["p"]
+        self.assertEqual(get_columns(code, "row"), ["p"])
 
     def test_nested_expression_as_arg(self):
         code = "row(len(p.children))"
         cols = get_columns(code, "row")
-        assert cols == ["len(p.children)"]
+        self.assertEqual(cols, ["len(p.children)"])
 
     def test_invalid_syntax_returns_empty(self):
-        assert get_columns("def (broken:", "row") == []
+        self.assertEqual(get_columns("def (broken:", "row"), [])
 
     def test_empty_code_returns_empty(self):
-        assert get_columns("", "row") == []
+        self.assertEqual(get_columns("", "row"), [])
 
     def test_function_name_not_in_code_returns_empty(self):
         code = "for p in people():\n    print(p)"
-        assert get_columns(code, "row") == []
+        self.assertEqual(get_columns(code, "row"), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/GrampyScript/tests/test_get_columns.py
+++ b/GrampyScript/tests/test_get_columns.py
@@ -1,0 +1,86 @@
+"""
+Tests for the get_columns() utility from GrampyScript.
+
+get_columns parses Python source and extracts argument expressions from all
+calls to a given function name (typically "row").  It is pure ast — no GTK
+or Gramps imports required — so the function is tested here by reimporting
+it directly from the module source via ast/importlib.
+"""
+
+import ast
+import importlib.util
+import os
+import sys
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Load get_columns without importing the full GrampyScript module
+# (which needs GTK). We parse the source and exec just the function.
+# ---------------------------------------------------------------------------
+
+_SOURCE = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)), "GrampyScript.py"
+)
+
+
+def _load_get_columns():
+    src = open(_SOURCE).read()
+    tree = ast.parse(src)
+    # Extract the get_columns function definition
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "get_columns":
+            snippet = ast.unparse(node)
+            ns = {"ast": ast}   # function body uses ast.parse / ast.walk / ast.unparse
+            exec(snippet, ns)
+            return ns["get_columns"]
+    raise RuntimeError("get_columns not found in GrampyScript.py")
+
+
+get_columns = _load_get_columns()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestGetColumns:
+    def test_single_row_call_simple_names(self):
+        code = "for p in people():\n    row(p.gramps_id, p.name)"
+        cols = get_columns(code, "row")
+        assert cols == ["p.gramps_id", "p.name"]
+
+    def test_no_row_call_returns_empty(self):
+        code = "for p in people():\n    print(p.gramps_id)"
+        assert get_columns(code, "row") == []
+
+    def test_multiple_row_calls_returns_first(self):
+        # get_columns walks all calls; first match wins in ast.walk order
+        code = "row(a, b)\nrow(c, d)"
+        cols = get_columns(code, "row")
+        assert "a" in cols or "c" in cols  # at least one match
+
+    def test_columns_function_name(self):
+        code = "columns('ID', 'Name')\nfor p in people():\n    row(p.gramps_id, p.name)"
+        cols = get_columns(code, "columns")
+        assert cols == ["'ID'", "'Name'"]
+
+    def test_single_arg(self):
+        code = "row(p)"
+        assert get_columns(code, "row") == ["p"]
+
+    def test_nested_expression_as_arg(self):
+        code = "row(len(p.children))"
+        cols = get_columns(code, "row")
+        assert cols == ["len(p.children)"]
+
+    def test_invalid_syntax_returns_empty(self):
+        assert get_columns("def (broken:", "row") == []
+
+    def test_empty_code_returns_empty(self):
+        assert get_columns("", "row") == []
+
+    def test_function_name_not_in_code_returns_empty(self):
+        code = "for p in people():\n    print(p)"
+        assert get_columns(code, "row") == []


### PR DESCRIPTION
## Summary

- Add `evaluate_expression()` method — runs code in the full GrampyScript scope and returns stdout immediately (used by GrampsAssistant to introspect the database without user interaction)
- Add `_instance` singleton — allows other addons (e.g. GrampsAssistant) to get a reference to the active GrampyScript gramplet
- Add `database` variable to script execution scope, giving scripts direct access to the Gramps DB object
- Fix `save_script` crash with `FileNotFoundError` when no filename has been set yet — falls through to Save As instead
- Fix `get_columns()` returning `None` implicitly when no `row()` call is found — now consistently returns `[]`
- Update `gramps_target_version` to `6.1`
- Add `tests/` with unit tests for `DataDict2`, `DataList2`, `NoneData`, and `get_columns`

## Dependents

**#960 (GrampsAssistant) depends on this PR** — it uses `_instance` and `evaluate_expression()` added here. Merge this first.

## Test plan

- [ ] Run `python -m pytest tests/` in `GrampyScript/` — all 42 tests pass
- [ ] Open GrampyScript sidebar panel, click Script → Save without having saved before — should open Save As dialog instead of crashing
- [ ] Run a script with no `row()` calls — `get_columns` returns `[]` (no crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)