### PR TITLE
DWR tree: preserve hyphens in displayed names

### DIFF
--- a/DynamicWeb/templates/dwr_default/data/dwr_svg.js
+++ b/DynamicWeb/templates/dwr_default/data/dwr_svg.js
@@ -2936,7 +2936,11 @@ function textLine(x, y, a, txt, w, h, x_elt)
 {
 	var idx = svgElts[x_elt][SVGELT_IDX];
 	// Calcul de la taille de police et des lignes
-	var tab = txt.split(/[ \-]+/g);
+	// Split for line-wrapping on spaces only: a hyphen is a valid name
+	// character (e.g. "Jan-Åke", "HAMILTON-SMITH") and must not be treated as
+	// a word separator, or calcTextTab() rejoins the fragments with a space and
+	// the tree silently rewrites the hyphen to a space (Mantis 11437).
+	var tab = txt.split(/ +/g);
 	var fs = 0;
 	var i, fi = 0;
 	for (i = 0; i < tab.length; i++)

--- a/DynamicWeb/tests/test_dwr_tree_names.py
+++ b/DynamicWeb/tests/test_dwr_tree_names.py
@@ -1,0 +1,105 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026  Gramps developers
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Regression test for Mantis 11437 — the Dynamic Web Report tree (SVG) view must
+not rewrite a hyphen inside a name to a space.
+
+The hyphen->space rewrite lives entirely in the SVG renderer
+``templates/dwr_default/data/dwr_svg.js``: ``textLine()`` splits a tree-node
+name into words for line-wrapping and historically used ``/[ \\-]+/g`` — which
+treats a hyphen as a word separator exactly like a space. ``calcTextTab()`` then
+rejoins the same-line fragments with a single space (``t[o] += ' ' + tab[i]``),
+so "HAMILTON-SMITH" is rendered "HAMILTON SMITH". Every other DWR surface keeps
+the hyphen because they emit the Python-side name string verbatim; only the tree
+passes the name through this splitter.
+
+There is no Python production seam for the rewrite, and ``textLine()`` itself is
+GUI-entangled (Raphael/SVG DOM), so it cannot be executed headless. This test
+therefore drives the **actual production splitter regex read from the shipped
+dwr_svg.js** and reproduces production's same-line join, asserting the hyphen
+survives. Reverting the JS fix flips the regex back to ``/[ \\-]+/g`` and turns
+this test red; the fix turns it green.
+"""
+
+import os
+import re
+import unittest
+
+# The production SVG renderer, relative to this test file.
+_DWR_SVG_JS = os.path.normpath(
+    os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "..",
+        "templates",
+        "dwr_default",
+        "data",
+        "dwr_svg.js",
+    )
+)
+
+
+def _textline_split_pattern(js_source):
+    """Return the word-split regex body that production ``textLine()`` applies
+    to a tree-node name, read live from the shipped dwr_svg.js.
+
+    ``textLine()`` is the only place that does ``txt.split(/.../g)``, so the
+    assignment uniquely identifies the splitter the tree uses.
+    """
+    match = re.search(r"txt\.split\(\s*/(?P<body>.+?)/g\s*\)", js_source)
+    if not match:
+        raise AssertionError(
+            "could not locate the textLine() name splitter "
+            "(txt.split(/.../g)) in %s" % _DWR_SVG_JS
+        )
+    return match.group("body")
+
+
+class TreeNameHyphenTest(unittest.TestCase):
+    """The DWR tree splitter must preserve hyphens inside names."""
+
+    # Names a user may enter; each must render in the tree exactly as stored.
+    HYPHENATED_NAMES = ["Jan-Åke", "HAMILTON-SMITH", "Joe St-Pierre"]
+
+    def setUp(self):
+        with open(_DWR_SVG_JS, encoding="utf-8") as handle:
+            self.js_source = handle.read()
+        self.split_re = re.compile(_textline_split_pattern(self.js_source))
+
+    def _render_single_line(self, name):
+        """Reproduce what the tree draws for a name that fits on one line:
+        ``textLine()`` splits the name, then ``calcTextTab()`` rejoins same-line
+        fragments with a single space (dwr_svg.js: ``t[o] += ' ' + tab[i]``)."""
+        fragments = [frag for frag in self.split_re.split(name) if frag]
+        return " ".join(fragments)
+
+    def test_tree_node_name_keeps_hyphen(self):
+        for name in self.HYPHENATED_NAMES:
+            with self.subTest(name=name):
+                self.assertEqual(
+                    self._render_single_line(name),
+                    name,
+                    "DWR tree splitter rewrote %r -> %r (hyphen lost)"
+                    % (name, self._render_single_line(name)),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# DWR tree: preserve hyphens in displayed names

## Root cause

The SVG tree renderer in `DynamicWeb/templates/dwr_default/data/dwr_svg.js` splits tree-node names for line-wrapping using a regex that treats hyphens as word separators. The fragments are then rejoined with a space, converting hyphens to spaces in the rendered output. Every other DWR surface (indexes, tabs, mouse-over) emits the Python-side name string verbatim, which is why the hyphen survives elsewhere — only the tree passes the name through this destructive splitter.

## Fix

Change `dwr_svg.js:2939` to split on spaces only (`/ +/g` instead of `/[ \-]+/g`), so hyphens become ordinary characters inside words and render intact. This is the minimal change that restores the invariant: a rendered name preserves the stored characters. The trade-off is that a very long hyphenated word can no longer wrap *at* its hyphen (it wraps only at spaces), but that layout nicety is explicitly out of scope.

## Verified against

- `DynamicWeb/templates/dwr_default/data/dwr_svg.js:2939` — the buggy regex split that treats hyphens as word separators
- `DynamicWeb/templates/dwr_default/data/dwr_svg.js:2862` — the same-line fragment join that combines the split tokens with a space
- `DynamicWeb/templates/dwr_default/data/dwr_svg.js:2835` — the `calcTextTab()` function context
- `DynamicWeb/dynamicweb.py:1052–1055` — the `get_name()` method that exports the hyphen-bearing name to the tree
- `DynamicWeb/dynamicweb.py:923–924` — the `jdata["name"]` assignment that feeds the same name to both the tree and indexes

## Test

`DynamicWeb/tests/test_dwr_tree_names.py` — a regression test that reads the production splitter regex live from the shipped `dwr_svg.js` file and reproduces the tree's same-line join logic (mirroring `dwr_svg.js:2862`). The test asserts that hyphenated names like "Jan-Åke", "HAMILTON-SMITH", and "Joe St-Pierre" survive the split→join cycle intact. Reverting the JS fix flips the regex back to `/[ \-]+/g`, and the test turns red; the fix turns it green. The test is stdlib-only (`os`/`re`/`unittest`) and can run headless.

Fixes #11437
