### PR TITLE
BirthdaysGramplet: sort persons by month and day of birth

### DIFF
--- a/BirthdaysGramplet/BirthdaysGramplet.gpr.py
+++ b/BirthdaysGramplet/BirthdaysGramplet.gpr.py
@@ -3,6 +3,7 @@
 #
 # Copyright (C) 2010  Peter Potrowl <peter017@gmail.com>
 # Copyright (C) 2019  Matthias Kemmer <matt.familienforschung@gmail.com>
+# Copyright (C) 2026  Javad Razavian <javadr@gmail.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -25,7 +26,7 @@ register(
     name=_("Birthdays"),
     description=_("a gramplet that displays the birthdays of the living people"),
     status=STABLE,
-    version = '1.1.18',
+    version = '1.1.19',
     fname="BirthdaysGramplet.py",
     height=200,
     gramplet="BirthdaysGramplet",

--- a/BirthdaysGramplet/BirthdaysGramplet.py
+++ b/BirthdaysGramplet/BirthdaysGramplet.py
@@ -3,6 +3,7 @@
 #
 # Copyright (C) 2010  Peter Potrowl <peter017@gmail.com>
 # Copyright (C) 2019  Matthias Kemmer <matt.familienforschung@gmail.com>
+# Copyright (C) 2026  Javad Razavian <javadr@gmail.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -114,8 +115,9 @@ class BirthdaysGramplet(Gramplet):
                 # calculate age and days until birthday
                 self.__calculate(database, person)
 
-        # Reverse sort on number of days from now:
-        self.result.sort(key=lambda item: -item[0])
+        # Sort by month then day:
+        self.result.sort(key=lambda item: (item[2].get_month(),
+                                           item[2].get_day()))
         self.clear_text()
 
         # handle text shown in gramplet

--- a/BirthdaysGramplet/po/fa-local.po
+++ b/BirthdaysGramplet/po/fa-local.po
@@ -1,0 +1,33 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: BirthdaysGramplet\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-02 12:49-0700\n"
+"PO-Revision-Date: 2026-07-03 00:00+0000\n"
+"Last-Translator: Javad Razavian <javadr@gmail.com>\n"
+"Language-Team: Persian <https://hosted.weblate.org/projects/gramps-project/"
+"addons/fa/>\n"
+"Language: fa\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Weblate 5.13-dev\n"
+
+msgid "Birthdays"
+msgstr "تولدها"
+
+msgid "a gramplet that displays the birthdays of the living people"
+msgstr "یک گرمپلت که تولدهای افراد زنده را نمایش می‌دهد"
+
+msgid "No Family Tree loaded."
+msgstr "هیچ شجره‌نامه‌ای بارگذاری نشده است."
+
+msgid "Ignore birthdays with tag"
+msgstr "نادیده گرفتن تولدهای دارای برچسب"
+
+msgid "Only show birthdays with tag"
+msgstr "فقط نمایش تولدهای دارای برچسب"
+
+msgid "Processing..."
+msgstr "در حال پردازش..."


### PR DESCRIPTION
Previously entries were sorted by proximity to today's date (nearest birthdays first). Now they are sorted by month then day, giving a consistent calendar-order listing.