### PR TITLE
FilterRules (DegreesOfSeparation): siblings unreachable when their family has no parents

### DIFF
--- a/FilterRules/degreesofseparation.py
+++ b/FilterRules/degreesofseparation.py
@@ -132,6 +132,8 @@ class DegreesOfSeparation(Rule):
         fam_list = person.parent_family_list
         for fam_h in fam_list:
             fam = self.db.get_raw_family_data(fam_h)
+            for child_ref in fam.child_ref_list:
+                self.persons.add(child_ref.ref)
             father_h = fam.father_handle
             if father_h:
                 father = self.db.get_raw_person_data(father_h)


### PR DESCRIPTION
## DegreesOfSeparation: siblings unreachable when their family has no parents

FilterRules/degreesofseparation.py `get_siblings()` finds siblings only via `get_children(father)` / `get_children(mother)`. If the shared family has neither, siblings (and everyone reachable only through them) are excluded. Fix is to also add the parent family's own children directly:

    for fam_h in fam_list:
        fam = self.db.get_family_from_handle(fam_h)
        for child_ref in fam.get_child_ref_list():
            self.persons.add(child_ref.ref)
        father_h = fam.get_father_handle()
        ...

This keeps half-sibling expansion via parents intact and doesn't change degree semantics (siblings were already reached in one iteration). Affects Gramps Web's relationship chart, which queries this rule.