### PR TITLE
Gramplet/birthdays gramplet

### DIFF
--- a/BirthdaysGramplet/BirthdaysGramplet.gpr.py
+++ b/BirthdaysGramplet/BirthdaysGramplet.gpr.py
@@ -3,6 +3,7 @@
 #
 # Copyright (C) 2010  Peter Potrowl <peter017@gmail.com>
 # Copyright (C) 2019  Matthias Kemmer <matt.familienforschung@gmail.com>
+# Copyright (C) 2026  Javad Razavian <javadr@gmail.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -25,7 +26,7 @@ register(
     name=_("Birthdays"),
     description=_("a gramplet that displays the birthdays of the living people"),
     status=STABLE,
-    version = '1.1.18',
+    version = '1.1.19',
     fname="BirthdaysGramplet.py",
     height=200,
     gramplet="BirthdaysGramplet",

--- a/BirthdaysGramplet/BirthdaysGramplet.py
+++ b/BirthdaysGramplet/BirthdaysGramplet.py
@@ -38,10 +38,17 @@ class BirthdaysGramplet(Gramplet):
     def init(self):
         self.set_text(_("No Family Tree loaded."))
         self.max_age = config.get('behavior.max-age-prob-alive')
+        self.sort_mode = 'month_day'
 
     def build_options(self):
         """Build the configuration options"""
         db = self.dbstate.db
+
+        name_sort = _("Sort birthdays by")
+        self.opt_sort = EnumeratedListOption(name_sort, self.sort_mode)
+        self.opt_sort.add_item("proximity", _("Proximity to current date"))
+        self.opt_sort.add_item("month_day", _("Month and day"))
+
 
         name_ignore = _("Ignore birthdays with tag")
         name_only = _("Only show birthdays with tag")
@@ -57,26 +64,30 @@ class BirthdaysGramplet(Gramplet):
                 self.opt_ignore.add_item(tag_name, tag_name)
                 self.opt_only.add_item(tag_name, tag_name)
 
+        self.add_option(self.opt_sort)
         self.add_option(self.opt_ignore)
         self.add_option(self.opt_only)
 
     def save_options(self):
         """Save gramplet configuration data"""
+        self.sort_mode = self.opt_sort.get_value()
         self.ignore_tag = self.opt_ignore.get_value()
         self.only_tag = self.opt_only.get_value()
 
     def save_update_options(self, obj):
         """Save a gramplet's options to file"""
         self.save_options()
-        self.gui.data = [self.ignore_tag, self.only_tag]
+        self.gui.data = [self.sort_mode, self.ignore_tag, self.only_tag]
         self.update()
 
     def on_load(self):
         """Load stored configuration data"""
-        if len(self.gui.data) == 2:
-            self.ignore_tag = self.gui.data[0]
-            self.only_tag = self.gui.data[1]
+        if len(self.gui.data) == 3:
+            self.sort_mode = self.gui.data[0]
+            self.ignore_tag = self.gui.data[1]
+            self.only_tag = self.gui.data[2]
         else:
+            self.sort_mode = 'proximity'
             self.ignore_tag = ''
             self.only_tag = ''
 
@@ -115,9 +126,13 @@ class BirthdaysGramplet(Gramplet):
                 # calculate age and days until birthday
                 self.__calculate(database, person)
 
-        # Sort by month then day:
-        self.result.sort(key=lambda item: (item[2].get_month(),
-                                           item[2].get_day()))
+        # Sort based on user preference:
+        sort_by = self.opt_sort.get_value()
+        if sort_by == "proximity":
+            self.result.sort(key=lambda item: -item[0])
+        else:
+            self.result.sort(key=lambda item: (item[2].get_month(),
+                                               item[2].get_day()))
         self.clear_text()
 
         # handle text shown in gramplet

--- a/BirthdaysGramplet/BirthdaysGramplet.py
+++ b/BirthdaysGramplet/BirthdaysGramplet.py
@@ -3,6 +3,7 @@
 #
 # Copyright (C) 2010  Peter Potrowl <peter017@gmail.com>
 # Copyright (C) 2019  Matthias Kemmer <matt.familienforschung@gmail.com>
+# Copyright (C) 2026  Javad Razavian <javadr@gmail.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -114,8 +115,9 @@ class BirthdaysGramplet(Gramplet):
                 # calculate age and days until birthday
                 self.__calculate(database, person)
 
-        # Reverse sort on number of days from now:
-        self.result.sort(key=lambda item: -item[0])
+        # Sort by month then day:
+        self.result.sort(key=lambda item: (item[2].get_month(),
+                                           item[2].get_day()))
         self.clear_text()
 
         # handle text shown in gramplet

--- a/BirthdaysGramplet/BirthdaysGramplet.py
+++ b/BirthdaysGramplet/BirthdaysGramplet.py
@@ -23,7 +23,7 @@
 from gramps.gen.plug import Gramplet
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 from gramps.gen.display.name import displayer as name_displayer
-from gramps.gen.lib.date import Today, Date
+from gramps.gen.lib.date import Today, Date, gregorian
 import gramps.gen.datehandler
 from gramps.gen.config import config
 from gramps.gen.plug.menu import EnumeratedListOption
@@ -154,9 +154,10 @@ class BirthdaysGramplet(Gramplet):
             birth = database.get_event_from_handle(birth_ref.ref)
             birth_date = birth.get_date_object()
             if birth_date.is_regular():
+                birth_greg = gregorian(birth_date)
                 birthday_this_year = Date(today.get_year(),
-                                          birth_date.get_month(),
-                                          birth_date.get_day())
+                                          birth_greg.get_month(),
+                                          birth_greg.get_day())
                 next_age = birthday_this_year - birth_date
                 # (0 year, months, days) between now and birthday of this
                 # year (positive if passed):

--- a/BirthdaysGramplet/BirthdaysGramplet.py
+++ b/BirthdaysGramplet/BirthdaysGramplet.py
@@ -38,7 +38,7 @@ class BirthdaysGramplet(Gramplet):
     def init(self):
         self.set_text(_("No Family Tree loaded."))
         self.max_age = config.get('behavior.max-age-prob-alive')
-        self.sort_mode = 'month_day'
+        self.sort_mode = 'proximity'
 
     def build_options(self):
         """Build the configuration options"""

--- a/BirthdaysGramplet/po/ca-local.po
+++ b/BirthdaysGramplet/po/ca-local.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ca\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-06 08:56-0800\n"
+"POT-Creation-Date: 2026-07-04 00:00-0000\n"
 "PO-Revision-Date: 2025-09-03 03:01+0000\n"
 "Last-Translator: Adolfo Jayme Barrientos <fitojb@ubuntu.com>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/gramps-project/"
@@ -16,3 +16,27 @@ msgstr ""
 
 msgid "Birthdays"
 msgstr "Aniversaris"
+
+msgid "a gramplet that displays the birthdays of the living people"
+msgstr "un grample que mostra els aniversaris de les persones vives"
+
+msgid "No Family Tree loaded."
+msgstr "No s'ha carregat cap arbre genealògic."
+
+msgid "Sort birthdays by"
+msgstr "Ordena els aniversaris per"
+
+msgid "Month and day"
+msgstr "Mes i dia"
+
+msgid "Proximity to current date"
+msgstr "Proximitat a la data actual"
+
+msgid "Ignore birthdays with tag"
+msgstr "Ignora els aniversaris amb l'etiqueta"
+
+msgid "Only show birthdays with tag"
+msgstr "Mostra només els aniversaris amb etiqueta"
+
+msgid "Processing..."
+msgstr "S'està processant..."

--- a/BirthdaysGramplet/po/da-local.po
+++ b/BirthdaysGramplet/po/da-local.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-06 08:56-0800\n"
+"POT-Creation-Date: 2026-07-04 00:00-0000\n"
 "PO-Revision-Date: 2025-02-25 16:12+0000\n"
 "Last-Translator: Kaj Arne Mikkelsen <kmi@vgdata.dk>\n"
 "Language-Team: Danish <https://hosted.weblate.org/projects/gramps-project/"
@@ -20,8 +20,23 @@ msgstr "Fødseldage"
 msgid "a gramplet that displays the birthdays of the living people"
 msgstr "en gramplet der viser fødselsdage for levende persone"
 
+msgid "No Family Tree loaded."
+msgstr "Intet stamtræ er indlæst."
+
+msgid "Sort birthdays by"
+msgstr "Sorter fødselsdage efter"
+
+msgid "Month and day"
+msgstr "Måned og dag"
+
+msgid "Proximity to current date"
+msgstr "Nærhed til nuværende dato"
+
 msgid "Ignore birthdays with tag"
 msgstr "Undlad fødseldage med ettiket"
 
 msgid "Only show birthdays with tag"
 msgstr "Vis kun fødseldage med ettiket"
+
+msgid "Processing..."
+msgstr "Forarbejdning..."

--- a/BirthdaysGramplet/po/de-local.po
+++ b/BirthdaysGramplet/po/de-local.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: de\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-06 08:56-0800\n"
+"POT-Creation-Date: 2026-07-04 00:00-0000\n"
 "PO-Revision-Date: 2025-05-19 21:02+0000\n"
 "Last-Translator: Mirko Leonhäuser <mirko@leonhaeuser.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/gramps-project/"
@@ -20,8 +20,23 @@ msgstr "Geburtstage"
 msgid "a gramplet that displays the birthdays of the living people"
 msgstr "ein Gramplet, das die Geburtstage der lebenden Personen anzeigt"
 
+msgid "No Family Tree loaded."
+msgstr "Kein Stammbaum geladen."
+
+msgid "Sort birthdays by"
+msgstr "Geburtstage sortieren nach"
+
+msgid "Month and day"
+msgstr "Monat und Tag"
+
+msgid "Proximity to current date"
+msgstr "Nähe zum aktuellen Datum"
+
 msgid "Ignore birthdays with tag"
 msgstr "Geburtstage mit Etikett ignorieren"
 
 msgid "Only show birthdays with tag"
 msgstr "Nur Geburtstage mit Etikett anzeigen"
+
+msgid "Processing..."
+msgstr "Verarbeitung..."

--- a/BirthdaysGramplet/po/es-local.po
+++ b/BirthdaysGramplet/po/es-local.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GRAMPS 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-06 08:56-0800\n"
+"POT-Creation-Date: 2026-07-04 00:00-0000\n"
 "PO-Revision-Date: 2026-05-04 21:37+0000\n"
 "Last-Translator: Francisco Serrador <fserrador@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/gramps-project/"
@@ -20,8 +20,23 @@ msgstr "Cumpleaños"
 msgid "a gramplet that displays the birthdays of the living people"
 msgstr "un gramplet que exhibe los cumpleaños de la gente viva"
 
+msgid "No Family Tree loaded."
+msgstr "No se ha cargado ningún árbol genealógico."
+
+msgid "Sort birthdays by"
+msgstr "Ordenar cumpleaños por"
+
+msgid "Month and day"
+msgstr "mes y dia"
+
+msgid "Proximity to current date"
+msgstr "Proximidad a la fecha actual"
+
 msgid "Ignore birthdays with tag"
 msgstr "Ignorar cumpleaños con etiqueta"
 
 msgid "Only show birthdays with tag"
 msgstr "Solo mostrar cumpleaños con etiqueta"
+
+msgid "Processing..."
+msgstr "Tratamiento..."

--- a/BirthdaysGramplet/po/fa-local.po
+++ b/BirthdaysGramplet/po/fa-local.po
@@ -1,0 +1,33 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: BirthdaysGramplet\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-02 12:49-0700\n"
+"PO-Revision-Date: 2026-07-03 00:00+0000\n"
+"Last-Translator: Javad Razavian <javadr@gmail.com>\n"
+"Language-Team: Persian <https://hosted.weblate.org/projects/gramps-project/"
+"addons/fa/>\n"
+"Language: fa\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Weblate 5.13-dev\n"
+
+msgid "Birthdays"
+msgstr "تولدها"
+
+msgid "a gramplet that displays the birthdays of the living people"
+msgstr "یک گرمپلت که تولدهای افراد زنده را نمایش می‌دهد"
+
+msgid "No Family Tree loaded."
+msgstr "هیچ شجره‌نامه‌ای بارگذاری نشده است."
+
+msgid "Ignore birthdays with tag"
+msgstr "نادیده گرفتن تولدهای دارای برچسب"
+
+msgid "Only show birthdays with tag"
+msgstr "فقط نمایش تولدهای دارای برچسب"
+
+msgid "Processing..."
+msgstr "در حال پردازش..."

--- a/BirthdaysGramplet/po/fa-local.po
+++ b/BirthdaysGramplet/po/fa-local.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: BirthdaysGramplet\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-02 12:49-0700\n"
+"POT-Creation-Date: 2026-07-04 00:00-0000\n"
 "PO-Revision-Date: 2026-07-03 00:00+0000\n"
 "Last-Translator: Javad Razavian <javadr@gmail.com>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/gramps-project/"
@@ -22,6 +22,15 @@ msgstr "یک گرمپلت که تولدهای افراد زنده را نمای�
 
 msgid "No Family Tree loaded."
 msgstr "هیچ شجره‌نامه‌ای بارگذاری نشده است."
+
+msgid "Sort birthdays by"
+msgstr "مرتب‌سازی تولدها بر اساس"
+
+msgid "Month and day"
+msgstr "ماه و روز"
+
+msgid "Proximity to current date"
+msgstr "نزدیکی به تاریخ فعلی"
 
 msgid "Ignore birthdays with tag"
 msgstr "نادیده گرفتن تولدهای دارای برچسب"

--- a/BirthdaysGramplet/po/fi-local.po
+++ b/BirthdaysGramplet/po/fi-local.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: fi\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-06 08:56-0800\n"
+"POT-Creation-Date: 2026-07-04 00:00-0000\n"
 "PO-Revision-Date: 2025-02-20 13:28+0000\n"
 "Last-Translator: Matti Niemelä <niememat@gmail.com>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/gramps-project/"
@@ -21,8 +21,23 @@ msgstr "Syntymäpäivät"
 msgid "a gramplet that displays the birthdays of the living people"
 msgstr "Gramplet, joka näyttää elävien ihmisten syntymä päivät ja iät"
 
+msgid "No Family Tree loaded."
+msgstr "Sukupuuta ei ladattu."
+
+msgid "Sort birthdays by"
+msgstr "Lajittele syntymäpäivät"
+
+msgid "Month and day"
+msgstr "Kuukausi ja päivä"
+
+msgid "Proximity to current date"
+msgstr "Läheisyys nykyiseen päivämäärään"
+
 msgid "Ignore birthdays with tag"
 msgstr "Jätä pois syntymäpäivät, joissa on tagi"
 
 msgid "Only show birthdays with tag"
 msgstr "Näytä vain syntymäpäivät, joissa on tagi"
+
+msgid "Processing..."
+msgstr "Käsitellään..."

--- a/BirthdaysGramplet/po/fr-local.po
+++ b/BirthdaysGramplet/po/fr-local.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: trunk\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-02 12:49-0700\n"
+"POT-Creation-Date: 2026-07-04 00:00-0000\n"
 "PO-Revision-Date: 2026-05-14 19:17+0000\n"
 "Last-Translator: \"David D.\" <dadu042@users.noreply.hosted.weblate.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/gramps-project/"
@@ -20,8 +20,23 @@ msgstr "Jours de naissance"
 msgid "a gramplet that displays the birthdays of the living people"
 msgstr "Ce Gramplet affiche les anniversaires des personnes en vie"
 
+msgid "No Family Tree loaded."
+msgstr "Aucun arbre généalogique chargé."
+
+msgid "Sort birthdays by"
+msgstr "Trier les anniversaires par"
+
+msgid "Month and day"
+msgstr "Mois et jour"
+
+msgid "Proximity to current date"
+msgstr "Proximité à la date actuelle"
+
 msgid "Ignore birthdays with tag"
 msgstr "Ignorer les anniversaires avec cette étiquette"
 
 msgid "Only show birthdays with tag"
 msgstr "Montrer seulement les anniversaires avec cette étiquette"
+
+msgid "Processing..."
+msgstr "Traitement..."

--- a/BirthdaysGramplet/po/he-local.po
+++ b/BirthdaysGramplet/po/he-local.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Gramps 5.2.0 – mediamerge\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-06 08:56-0800\n"
+"POT-Creation-Date: 2026-07-04 00:00-0000\n"
 "PO-Revision-Date: 2025-08-11 18:01+0000\n"
 "Last-Translator: Avi Markovitz <avi.markovitz@gmail.com>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/gramps-project/"
@@ -21,8 +21,23 @@ msgstr "ימי הולדת"
 msgid "a gramplet that displays the birthdays of the living people"
 msgstr "גרמפלט שמציג את ימי ההולדת של האנשים החיים"
 
+msgid "No Family Tree loaded."
+msgstr "לא נטען אילן יוחסין."
+
+msgid "Sort birthdays by"
+msgstr "מיין ימי הולדת לפי"
+
+msgid "Month and day"
+msgstr "חודש ויום"
+
+msgid "Proximity to current date"
+msgstr "קרבה לתאריך הנוכחי"
+
 msgid "Ignore birthdays with tag"
 msgstr "להתעלם מימי הולדת מתוייגים בתג"
 
 msgid "Only show birthdays with tag"
 msgstr "להציג רק ימי הולדת מתוייגים בתג"
+
+msgid "Processing..."
+msgstr "מעבד..."

--- a/BirthdaysGramplet/po/hr-local.po
+++ b/BirthdaysGramplet/po/hr-local.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Gramps 5.x\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-06 08:56-0800\n"
+"POT-Creation-Date: 2026-07-04 00:00-0000\n"
 "PO-Revision-Date: 2025-03-02 14:58+0000\n"
 "Last-Translator: Milo Ivir <mail@milotype.de>\n"
 "Language-Team: Croatian <https://hosted.weblate.org/projects/gramps-project/"
@@ -21,8 +21,23 @@ msgstr "Rođendani"
 msgid "a gramplet that displays the birthdays of the living people"
 msgstr "gramplet prikazuje rođendane živih osoba"
 
+msgid "No Family Tree loaded."
+msgstr "Nije učitano obiteljsko stablo."
+
+msgid "Sort birthdays by"
+msgstr "Poredaj rođendane po"
+
+msgid "Month and day"
+msgstr "Mjesec i dan"
+
+msgid "Proximity to current date"
+msgstr "Blizina trenutnog datuma"
+
 msgid "Ignore birthdays with tag"
 msgstr "Zanemari rođendane s oznakom"
 
 msgid "Only show birthdays with tag"
 msgstr "Prikaži samo rođendane s oznakom"
+
+msgid "Processing..."
+msgstr "Obrada..."

--- a/BirthdaysGramplet/po/hu-local.po
+++ b/BirthdaysGramplet/po/hu-local.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: hu\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-06 08:56-0800\n"
+"POT-Creation-Date: 2026-07-04 00:00-0000\n"
 "PO-Revision-Date: 2026-02-21 14:09+0000\n"
 "Last-Translator: Daniel Szollosi-Nagy <dsn-weblate@kdconsulting.net>\n"
 "Language-Team: Hungarian <https://hosted.weblate.org/projects/gramps-project/"
@@ -16,3 +16,27 @@ msgstr ""
 
 msgid "Birthdays"
 msgstr "Születésnapok"
+
+msgid "a gramplet that displays the birthdays of the living people"
+msgstr "egy gramplet, amely megjeleníti az élő emberek születésnapját"
+
+msgid "No Family Tree loaded."
+msgstr "Nincs betöltve családfa."
+
+msgid "Sort birthdays by"
+msgstr "Születésnapok rendezése szerint"
+
+msgid "Month and day"
+msgstr "Hónap és nap"
+
+msgid "Proximity to current date"
+msgstr "Az aktuális dátum közelsége"
+
+msgid "Ignore birthdays with tag"
+msgstr "A címkével ellátott születésnapok figyelmen kívül hagyása"
+
+msgid "Only show birthdays with tag"
+msgstr "Csak a címkével ellátott születésnapokat jelenítse meg"
+
+msgid "Processing..."
+msgstr "Feldolgozás..."

--- a/BirthdaysGramplet/po/it-local.po
+++ b/BirthdaysGramplet/po/it-local.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gramps 3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-06 08:56-0800\n"
+"POT-Creation-Date: 2026-07-04 00:00-0000\n"
 "PO-Revision-Date: 2025-09-06 11:01+0000\n"
 "Last-Translator: Luigi Toscano <luigi.toscano@tiscali.it>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/gramps-project/"
@@ -20,8 +20,23 @@ msgstr "Compleanni"
 msgid "a gramplet that displays the birthdays of the living people"
 msgstr "un gramplet che mostra i compleanni delle persone in vita"
 
+msgid "No Family Tree loaded."
+msgstr "Nessun albero genealogico caricato."
+
+msgid "Sort birthdays by"
+msgstr "Ordina i compleanni per"
+
+msgid "Month and day"
+msgstr "Mese e giorno"
+
+msgid "Proximity to current date"
+msgstr "Prossimità alla data attuale"
+
 msgid "Ignore birthdays with tag"
 msgstr "Ignora compleanni con etichetta"
 
 msgid "Only show birthdays with tag"
 msgstr "Mostra solo compleanni con etichetta"
+
+msgid "Processing..."
+msgstr "Elaborazione..."

--- a/BirthdaysGramplet/po/lt-local.po
+++ b/BirthdaysGramplet/po/lt-local.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lt\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-06 08:56-0800\n"
+"POT-Creation-Date: 2026-07-04 00:00-0000\n"
 "PO-Revision-Date: 2025-08-27 08:02+0000\n"
 "Last-Translator: Tadas Masiulionis <tadzikaz@gmail.com>\n"
 "Language-Team: Lithuanian <https://hosted.weblate.org/projects/gramps-"
@@ -24,8 +24,23 @@ msgstr "Gimtadieniai"
 msgid "a gramplet that displays the birthdays of the living people"
 msgstr "grampletas, rodanti gyvų žmonių gimtadienius"
 
+msgid "No Family Tree loaded."
+msgstr "Šeimos medis neįkeltas."
+
+msgid "Sort birthdays by"
+msgstr "Rūšiuoti gimtadienius pagal"
+
+msgid "Month and day"
+msgstr "Mėnuo ir diena"
+
+msgid "Proximity to current date"
+msgstr "Artumas iki dabartinės datos"
+
 msgid "Ignore birthdays with tag"
 msgstr "Nepaisyti gimtadienių su gairėmis"
 
 msgid "Only show birthdays with tag"
 msgstr "Rodyti tik gimimo datas su gaire"
+
+msgid "Processing..."
+msgstr "Apdorojama..."

--- a/BirthdaysGramplet/po/nb-local.po
+++ b/BirthdaysGramplet/po/nb-local.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: nb\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-02 12:49-0700\n"
+"POT-Creation-Date: 2026-07-04 00:00-0000\n"
 "PO-Revision-Date: 2026-06-01 12:35+0000\n"
 "Last-Translator: Harald Herreros <h.herreros@proton.me>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/gramps-"
@@ -21,8 +21,23 @@ msgstr "Bursdager"
 msgid "a gramplet that displays the birthdays of the living people"
 msgstr "en gramplet som viser bursdager for levende personer"
 
+msgid "No Family Tree loaded."
+msgstr "Ingen slektstre lastet."
+
+msgid "Sort birthdays by"
+msgstr "Sorter bursdager etter"
+
+msgid "Month and day"
+msgstr "Måned og dag"
+
+msgid "Proximity to current date"
+msgstr "Nærhet til gjeldende dato"
+
 msgid "Ignore birthdays with tag"
 msgstr "Ignorer bursdager med merke"
 
 msgid "Only show birthdays with tag"
 msgstr "Vis kun bursdager med merke"
+
+msgid "Processing..."
+msgstr "Behandling..."

--- a/BirthdaysGramplet/po/nl-local.po
+++ b/BirthdaysGramplet/po/nl-local.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MediaMerge 5.x\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-06 08:56-0800\n"
+"POT-Creation-Date: 2026-07-04 00:00-0000\n"
 "PO-Revision-Date: 2025-04-14 22:32+0000\n"
 "Last-Translator: Stephan Paternotte <stephan@paternottes.net>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/gramps-project/"
@@ -18,11 +18,26 @@ msgid "Birthdays"
 msgstr "Verjaardagen"
 
 msgid "a gramplet that displays the birthdays of the living people"
-msgstr ""
+msgstr "een gramplet die de verjaardagen van de levende mensen weergeeft"
 "een gramplet dat de verjaardagen van de nog in leven zijnde personen toont"
+
+msgid "No Family Tree loaded."
+msgstr "Geen stamboom geladen."
+
+msgid "Sort birthdays by"
+msgstr "Sorteer verjaardagen op"
+
+msgid "Month and day"
+msgstr "Maand en dag"
+
+msgid "Proximity to current date"
+msgstr "Nabijheid tot de huidige datum"
 
 msgid "Ignore birthdays with tag"
 msgstr "Verjaardagen met label negeren"
 
 msgid "Only show birthdays with tag"
 msgstr "Alleen verjaardagen met label weergeven"
+
+msgid "Processing..."
+msgstr "Verwerken..."

--- a/BirthdaysGramplet/po/pl-local.po
+++ b/BirthdaysGramplet/po/pl-local.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GRAMPS 3.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-06 08:56-0800\n"
+"POT-Creation-Date: 2026-07-04 00:00-0000\n"
 "PO-Revision-Date: 2025-08-23 15:02+0000\n"
 "Last-Translator: Krystian Safjan <ksafjan@gmail.com>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/gramps-project/"
@@ -25,8 +25,23 @@ msgstr "Urodziny"
 msgid "a gramplet that displays the birthdays of the living people"
 msgstr "gramplet wyświetlający urodziny osób żyjących"
 
+msgid "No Family Tree loaded."
+msgstr "Nie załadowano żadnego drzewa genealogicznego."
+
+msgid "Sort birthdays by"
+msgstr "Sortuj urodziny według"
+
+msgid "Month and day"
+msgstr "Miesiąc i dzień"
+
+msgid "Proximity to current date"
+msgstr "Bliskość aktualnej daty"
+
 msgid "Ignore birthdays with tag"
 msgstr "Ignoruj urodziny z etykietą"
 
 msgid "Only show birthdays with tag"
 msgstr "Pokazuj tylko urodziny z etykietą"
+
+msgid "Processing..."
+msgstr "Przetwarzanie..."

--- a/BirthdaysGramplet/po/pt_BR-local.po
+++ b/BirthdaysGramplet/po/pt_BR-local.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: trunk\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-06 08:56-0800\n"
+"POT-Creation-Date: 2026-07-04 00:00-0000\n"
 "PO-Revision-Date: 2012-08-26 20:57-0300\n"
 "Last-Translator: André Marcelo Alvarenga <andrealvarenga@gmx.net>\n"
 "Language-Team: Brazilian Portuguese>\n"
@@ -13,5 +13,29 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Lokalize 1.0\n"
 
+msgid "Birthdays"
+msgstr "Aniversários"
+
 msgid "a gramplet that displays the birthdays of the living people"
 msgstr "Gramplet que mostra os aniversários das pessoas vivas"
+
+msgid "No Family Tree loaded."
+msgstr "Nenhuma árvore genealógica carregada."
+
+msgid "Sort birthdays by"
+msgstr "Classificar aniversários por"
+
+msgid "Month and day"
+msgstr "Mês e dia"
+
+msgid "Proximity to current date"
+msgstr "Proximidade da data atual"
+
+msgid "Ignore birthdays with tag"
+msgstr "Ignorar aniversários com tag"
+
+msgid "Only show birthdays with tag"
+msgstr "Mostrar apenas aniversários com tag"
+
+msgid "Processing..."
+msgstr "Processamento..."

--- a/BirthdaysGramplet/po/pt_PT-local.po
+++ b/BirthdaysGramplet/po/pt_PT-local.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gramps51\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-06 08:56-0800\n"
+"POT-Creation-Date: 2026-07-04 00:00-0000\n"
 "PO-Revision-Date: 2025-03-08 07:05+0000\n"
 "Last-Translator: Pedro Albuquerque <pmra@protonmail.com>\n"
 "Language-Team: Portuguese (Portugal) <https://hosted.weblate.org/projects/"
@@ -20,8 +20,23 @@ msgstr "Aniversários"
 msgid "a gramplet that displays the birthdays of the living people"
 msgstr "um gramplet que mostra os aniversários de indivíduos vivos"
 
+msgid "No Family Tree loaded."
+msgstr "Nenhuma árvore genealógica carregada."
+
+msgid "Sort birthdays by"
+msgstr "Classificar aniversários por"
+
+msgid "Month and day"
+msgstr "Mês e dia"
+
+msgid "Proximity to current date"
+msgstr "Proximidade da data atual"
+
 msgid "Ignore birthdays with tag"
 msgstr "Ignorar aniversários com etiqueta"
 
 msgid "Only show birthdays with tag"
 msgstr "Mostrar só aniversários com etiqueta"
+
+msgid "Processing..."
+msgstr "Processamento..."

--- a/BirthdaysGramplet/po/ru-local.po
+++ b/BirthdaysGramplet/po/ru-local.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: gramps50\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-06 08:56-0800\n"
+"POT-Creation-Date: 2026-07-04 00:00-0000\n"
 "PO-Revision-Date: 2018-12-04 16:36+0300\n"
 "Last-Translator: Ivan Komaritsyn <vantu5z@mail.ru>\n"
 "Language-Team: Russian\n"
@@ -16,5 +16,29 @@ msgstr ""
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
 "n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)\n"
 
+msgid "Birthdays"
+msgstr "Дни рождения"
+
 msgid "a gramplet that displays the birthdays of the living people"
 msgstr "Грамплет отображающий дни рождения живых людей"
+
+msgid "No Family Tree loaded."
+msgstr "Семейное древо не загружено."
+
+msgid "Sort birthdays by"
+msgstr "Сортировать дни рождения по"
+
+msgid "Month and day"
+msgstr "Месяц и день"
+
+msgid "Proximity to current date"
+msgstr "Близость к текущей дате"
+
+msgid "Ignore birthdays with tag"
+msgstr "Игнорировать дни рождения с тегом"
+
+msgid "Only show birthdays with tag"
+msgstr "Показывать только дни рождения с тегом"
+
+msgid "Processing..."
+msgstr "Обработка..."

--- a/BirthdaysGramplet/po/sk-local.po
+++ b/BirthdaysGramplet/po/sk-local.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: GRAMPS 3.1.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-06 08:56-0800\n"
+"POT-Creation-Date: 2026-07-04 00:00-0000\n"
 "PO-Revision-Date: 2026-05-11 10:34+0000\n"
 "Last-Translator: Milan <mobrcian@hotmail.com>\n"
 "Language-Team: Slovak <https://hosted.weblate.org/projects/gramps-project/"
@@ -20,8 +20,23 @@ msgstr "Narodeniny"
 msgid "a gramplet that displays the birthdays of the living people"
 msgstr "Gramplet, ktorý zobrazuje narodeniny žijúcich ľudí"
 
+msgid "No Family Tree loaded."
+msgstr "Nebol načítaný žiadny rodokmeň."
+
+msgid "Sort birthdays by"
+msgstr "Zoradiť narodeniny podľa"
+
+msgid "Month and day"
+msgstr "Mesiac a deň"
+
+msgid "Proximity to current date"
+msgstr "Blízkosť k aktuálnemu dátumu"
+
 msgid "Ignore birthdays with tag"
 msgstr "Ignorovať dni narodenia so štítkom"
 
 msgid "Only show birthdays with tag"
 msgstr "Zobraziť iba dni narodenia so štítkom"
+
+msgid "Processing..."
+msgstr "Spracúva sa..."

--- a/BirthdaysGramplet/po/sv-local.po
+++ b/BirthdaysGramplet/po/sv-local.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-06 08:56-0800\n"
+"POT-Creation-Date: 2026-07-04 00:00-0000\n"
 "PO-Revision-Date: 2025-05-26 07:15+0000\n"
 "Last-Translator: Pär Ekholm <github1@m.pekholm.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/gramps-project/"
@@ -20,8 +20,23 @@ msgstr "Födelsedagar"
 msgid "a gramplet that displays the birthdays of the living people"
 msgstr "en Gramplet, som visar födelsedagarna för levande personer"
 
+msgid "No Family Tree loaded."
+msgstr "Inget släktträd laddat."
+
+msgid "Sort birthdays by"
+msgstr "Sortera födelsedagar efter"
+
+msgid "Month and day"
+msgstr "Månad och dag"
+
+msgid "Proximity to current date"
+msgstr "Närhet till aktuellt datum"
+
 msgid "Ignore birthdays with tag"
 msgstr "Ignorera födelsedagar med tagg"
 
 msgid "Only show birthdays with tag"
 msgstr "Visa endast födelsedagar med tagg"
+
+msgid "Processing..."
+msgstr "Bearbetar..."

--- a/BirthdaysGramplet/po/template.pot
+++ b/BirthdaysGramplet/po/template.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-02 12:49-0700\n"
+"POT-Creation-Date: 2026-07-04 00:00-0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,27 +17,29 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: BirthdaysGramplet/BirthdaysGramplet.gpr.py:25
-#: BirthdaysGramplet/BirthdaysGramplet.gpr.py:33
 msgid "Birthdays"
 msgstr ""
 
-#: BirthdaysGramplet/BirthdaysGramplet.gpr.py:26
 msgid "a gramplet that displays the birthdays of the living people"
 msgstr ""
 
-#: BirthdaysGramplet/BirthdaysGramplet.py:38
 msgid "No Family Tree loaded."
 msgstr ""
 
-#: BirthdaysGramplet/BirthdaysGramplet.py:45
+msgid "Sort birthdays by"
+msgstr ""
+
+msgid "Month and day"
+msgstr ""
+
+msgid "Proximity to current date"
+msgstr ""
+
 msgid "Ignore birthdays with tag"
 msgstr ""
 
-#: BirthdaysGramplet/BirthdaysGramplet.py:46
 msgid "Only show birthdays with tag"
 msgstr ""
 
-#: BirthdaysGramplet/BirthdaysGramplet.py:90
 msgid "Processing..."
 msgstr ""

--- a/BirthdaysGramplet/po/tr-local.po
+++ b/BirthdaysGramplet/po/tr-local.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 4.1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-02 12:49-0700\n"
+"POT-Creation-Date: 2026-07-04 00:00-0000\n"
 "PO-Revision-Date: 2026-05-30 20:01+0000\n"
 "Last-Translator: Osman Öz <osmanoz05@hotmail.com>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/gramps-project/"
@@ -23,8 +23,23 @@ msgstr "Doğum günleri"
 msgid "a gramplet that displays the birthdays of the living people"
 msgstr "Yaşayan kişilerin doğum günlerini gösteren bir gramplet"
 
+msgid "No Family Tree loaded."
+msgstr "Soy Ağacı yüklenmedi."
+
+msgid "Sort birthdays by"
+msgstr "Doğum günlerini şuna göre sırala:"
+
+msgid "Month and day"
+msgstr "Ay ve gün"
+
+msgid "Proximity to current date"
+msgstr "Güncel tarihe yakınlık"
+
 msgid "Ignore birthdays with tag"
 msgstr "Etiketli doğum günlerini yok say"
 
 msgid "Only show birthdays with tag"
 msgstr "Sadece etiketli doğum günlerini göster"
+
+msgid "Processing..."
+msgstr "İşleme..."

--- a/BirthdaysGramplet/po/uk-local.po
+++ b/BirthdaysGramplet/po/uk-local.po
@@ -2,7 +2,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-06 08:56-0800\n"
+"POT-Creation-Date: 2026-07-04 00:00-0000\n"
 "PO-Revision-Date: 2025-03-06 13:57+0000\n"
 "Last-Translator: Yurii Liubymyi <jurchello@gmail.com>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/gramps-project/"
@@ -21,8 +21,23 @@ msgstr "Дні народження"
 msgid "a gramplet that displays the birthdays of the living people"
 msgstr "грамплет, що відображає дні народження живих людей"
 
+msgid "No Family Tree loaded."
+msgstr "Сімейне дерево не завантажено."
+
+msgid "Sort birthdays by"
+msgstr "Сортувати дні народження за"
+
+msgid "Month and day"
+msgstr "Місяць і день"
+
+msgid "Proximity to current date"
+msgstr "Близькість до поточної дати"
+
 msgid "Ignore birthdays with tag"
 msgstr "Ігнорувати дні народження з тегом"
 
 msgid "Only show birthdays with tag"
 msgstr "Показувати лише дні народження з тегом"
+
+msgid "Processing..."
+msgstr "Обробка..."


### PR DESCRIPTION
Here's a PR comment for the changes:

BirthdaysGramplet: add sort mode option, set default to proximity
- Added a "Sort birthdays by" dropdown option in build_options() with two modes:
  - Month and day — sort by calendar date (Jan 1 → Dec 31)
  - Proximity to current date — sort by how soon the next birthday is (upcoming first)
- Default mode set to proximity
- Filled all empty msgstr entries across all 22 locale files via Google Translate API — every translation file is now 100% translated