### PR TITLE
GrampyScript: fix AttributeError when committing edited records

### DIFF
--- a/GrampyScript/GrampyScript.py
+++ b/GrampyScript/GrampyScript.py
@@ -854,7 +854,7 @@ for person in people():
         if action == "set":
             if "_class" in data:
                 if self.db._get_table_func(data["_class"]):
-                    method = self.db._table(data["_class"], "commit_func")
+                    method = self.db._get_table_func(data["_class"], "commit_func")
                     method(data._object, self.TRANSACTION)
                 else:
                     raise Exception("%r class is not a PrimaryObject" % data["_class"])


### PR DESCRIPTION
## Summary
- `callback()` in `GrampyScript.py` called the non-existent `db._table(class, "commit_func")` instead of `db._get_table_func(class, "commit_func")`
- Any script that edits data (e.g. sets a field after calling `begin_changes()`) crashed with:
  ```
  AttributeError: 'SQLite' object has no attribute '_table'
  ```
- Fixes the typo so edits actually commit to the database

## Test plan
- [x] Ran a GrampyScript script that clears `attribute_list` on all citations after `begin_changes()`; previously crashed with the AttributeError, now commits successfully