### PR TITLE
GrampyScript: bundled example scripts, Open-dialog previews, UI polish

### DIFF
--- a/GrampyScript/GrampyScript.gpr.py
+++ b/GrampyScript/GrampyScript.gpr.py
@@ -32,4 +32,5 @@ register(
     gramplet_title=_("Gram.py Script"),
     help_url="Addon:GrampyScript",
     height=800,
+    requires_mod=["jedi"],
 )

--- a/GrampyScript/GrampyScript.py
+++ b/GrampyScript/GrampyScript.py
@@ -950,7 +950,7 @@ for person in people():
         if action == "set":
             if "_class" in data:
                 if self.db._get_table_func(data["_class"]):
-                    method = self.db._table(data["_class"], "commit_func")
+                    method = self.db._get_table_func(data["_class"], "commit_func")
                     method(data._object, self.TRANSACTION)
                 else:
                     raise Exception("%r class is not a PrimaryObject" % data["_class"])

--- a/GrampyScript/GrampyScript.py
+++ b/GrampyScript/GrampyScript.py
@@ -59,6 +59,8 @@ from gramps.gui.editors import (
 from datadict2 import DataDict2, NoneData, set_sa
 from script_descriptions import SCRIPT_DESCRIPTIONS
 from script_utils import get_columns, extract_header_comment, SCRIPTS_DIR
+from namespace_builder import build_namespace
+from completion_popup import CompletionController
 
 _ = glocale.translation.gettext
 
@@ -367,7 +369,9 @@ for person in people():
 
         self.editor = Gtk.ScrolledWindow()
         self.editor.set_shadow_type(Gtk.ShadowType.IN)
+        self.editor.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
         self.editor_textview = Gtk.TextView()
+        self.editor_textview.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
         self.editor.add(self.editor_textview)
         font_desc = self.editor_textview.get_pango_context().get_font_description()
         font_desc.set_family(
@@ -377,6 +381,7 @@ for person in people():
 
         self.editor_textview.connect("key-press-event", self.on_key_press)
         self.editor_textview.connect("button-press-event", self.on_textview_click)
+        self.editor_textview.connect("focus-out-event", self.on_editor_focus_out)
         key, mods = Gtk.accelerator_parse("<Alt>c")
         self.editor_textview.add_accelerator(
             "copy-clipboard", self.accel_group, key, mods, Gtk.AccelFlags.VISIBLE
@@ -404,6 +409,9 @@ for person in people():
             "comment", foreground="gray", style=Pango.Style.ITALIC
         )
         self.ebuf.connect("changed", self.on_buffer_changed)
+        self.completion = CompletionController(
+            self.editor_textview, get_namespace=lambda: build_namespace(self.dbstate.db)
+        )
 
         widget.pack_start(self.editor, True, True, 0)
 
@@ -663,6 +671,7 @@ for person in people():
 
     def on_buffer_changed(self, buffer):
         self.highlight_syntax()
+        self.completion.on_buffer_changed()
 
     def highlight_syntax(self):
         start_iter = self.ebuf.get_start_iter()
@@ -876,10 +885,18 @@ for person in people():
             return str(item)
 
     def on_textview_click(self, widget, event):
+        self.completion.close()
         if event.button == 1:  # Left mouse button
             widget.grab_focus()
 
+    def on_editor_focus_out(self, widget, event):
+        self.completion.close()
+        return False
+
     def on_key_press(self, textview, event):
+        if self.completion.on_key_press(event):
+            return True
+
         if event.keyval == Gdk.KEY_Tab:
             # buffer = textview.get_buffer()
             iter_ = self.ebuf.get_iter_at_mark(self.ebuf.get_insert())

--- a/GrampyScript/GrampyScript.py
+++ b/GrampyScript/GrampyScript.py
@@ -478,13 +478,17 @@ for person in people():
             border: 1px solid gray;
             padding: 1px;
         }
+        .bold-label {
+            font-weight: bold;
+            padding: 1px;
+        }
         """
         provider = Gtk.CssProvider()
         provider.load_from_data(css)
 
         self.filename_label = Gtk.Label()
         self.filename_label.set_xalign(0)
-        self.filename_label.get_style_context().add_class('bordered-label')
+        self.filename_label.get_style_context().add_class('bold-label')
         self.filename_label.get_style_context().add_provider(
             provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
         )
@@ -498,7 +502,7 @@ for person in people():
 
         status_box = Gtk.HBox()
         status_box.pack_start(self.filename_label, False, False, 1)
-        status_box.pack_start(self.statusmsg, True, True, 1)
+        status_box.pack_start(self.statusmsg, True, True, 10)
         widget.pack_start(status_box, False, False, 1)
 
         widget.show_all()

--- a/GrampyScript/GrampyScript.py
+++ b/GrampyScript/GrampyScript.py
@@ -33,6 +33,7 @@ import os
 from gi.repository import Gtk, Gdk, cairo, Pango
 
 from gramps.gen.db import DbTxn
+from gramps.gen import filters as gramps_filters
 from gramps.gen.plug import Gramplet
 from gramps.gen.display.name import displayer as name_displayer
 from gramps.gen.display.place import displayer as place_displayer
@@ -275,6 +276,8 @@ class GrampyScript(Gramplet):
             "events",
             "selected",
             "filtered",
+            "custom_filter",
+            "delete",
         ]
         self.constants = [
             "True",
@@ -1111,6 +1114,15 @@ for person in people():
         """Run code in the full GrampyScript scope and return stdout."""
         return self.execute_code(code)
 
+    def ensure_import_paths(self):
+        """Make helper .py files next to scripts importable via `import`."""
+        paths = [SCRIPTS_DIR]
+        if self.last_filename:
+            paths.append(os.path.dirname(os.path.abspath(self.last_filename)))
+        for path in paths:
+            if path and path not in sys.path:
+                sys.path.insert(0, path)
+
     def execute_filename(self, filename):
         if os.path.exists(filename):
             with open(filename) as file:
@@ -1196,7 +1208,7 @@ for person in people():
         active_source = self.get_active_data("Source")
         active_citation = self.get_active_data("Citation")
         active_place = self.get_active_data("Place")
-        active_event = self.get_active("Event")
+        active_event = self.get_active_data("Event")
 
         chart = self.chart
 
@@ -1226,6 +1238,24 @@ for person in people():
                     data = get_data(handle)
                     yield DataDict2(dict(data), callback=self.callback)
 
+        def custom_filter(name, namespace="Person"):
+            if gramps_filters.CustomFilters is None:
+                gramps_filters.reload_custom_filters()
+            filt = gramps_filters.CustomFilters.get_filters_dict(namespace).get(name)
+            if filt is None:
+                print(
+                    "Warning: no custom filter named %r for namespace %r"
+                    % (name, namespace)
+                )
+                return
+            get_data = self.db._get_table_func(namespace, "raw_func")
+            for handle in filt.apply(self.db):
+                yield DataDict2(dict(get_data(handle)), callback=self.callback)
+
+        def delete(obj):
+            del_func = self.db._get_table_func(obj["_class"], "del_func")
+            del_func(obj["handle"], self.TRANSACTION)
+
         database = self.db
 
         today = Date(
@@ -1243,6 +1273,7 @@ for person in people():
 
         self.TRANSACTION = None
         self.output_buffer.set_text("")
+        self.ensure_import_paths()
         # -----------------
         # User code
         # FIXME: don't use stdout?

--- a/GrampyScript/GrampyScript.py
+++ b/GrampyScript/GrampyScript.py
@@ -369,9 +369,7 @@ for person in people():
 
         self.editor = Gtk.ScrolledWindow()
         self.editor.set_shadow_type(Gtk.ShadowType.IN)
-        self.editor.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
         self.editor_textview = Gtk.TextView()
-        self.editor_textview.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
         self.editor.add(self.editor_textview)
         font_desc = self.editor_textview.get_pango_context().get_font_description()
         font_desc.set_family(
@@ -474,6 +472,15 @@ for person in people():
 
         self.statusmsg = Gtk.Label(_("Ready..."))
         self.statusmsg.set_xalign(0)  # 0.0 for left, 0.5 for center, 1.0 for right
+        # Some status messages embed the full path of the current file
+        # (e.g. "Loaded '/home/.../scripts/some_script.gram.py'"), which
+        # would otherwise force the whole gramplet wider than its
+        # container. Ellipsize and cap the natural width so it truncates
+        # instead -- max_width_chars is what actually bounds the natural
+        # size request; ellipsize alone only takes effect once allocated
+        # space is already smaller than that.
+        self.statusmsg.set_ellipsize(Pango.EllipsizeMode.MIDDLE)
+        self.statusmsg.set_max_width_chars(40)
         self.statusmsg.get_style_context().add_class('bordered-label')  #add a css class
         self.statusmsg.get_style_context().add_provider(
             provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION

--- a/GrampyScript/GrampyScript.py
+++ b/GrampyScript/GrampyScript.py
@@ -57,6 +57,7 @@ from gramps.gui.editors import (
     EditSource,
 )
 from datadict2 import DataDict2, NoneData, set_sa
+from script_descriptions import SCRIPT_DESCRIPTIONS
 
 _ = glocale.translation.gettext
 
@@ -87,6 +88,27 @@ def get_columns(source, func_name):
     return []
 
 
+def extract_header_comment(source):
+    """
+    Extract the leading '#'-comment block of a script as plain text,
+    for use as a fallback preview when a file has no catalogued
+    description in SCRIPT_DESCRIPTIONS.
+    """
+    lines = []
+    for line in source.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            lines.append(stripped.lstrip("#").strip())
+        elif stripped == "" and not lines:
+            continue
+        else:
+            break
+    return "\n".join(lines).strip()
+
+
+SCRIPTS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "scripts")
+
+
 class ScriptOpenFileChooserDialog(Gtk.FileChooserDialog):
     def __init__(self, uistate):
         # type: (DisplayState) -> None
@@ -115,6 +137,37 @@ class ScriptOpenFileChooserDialog(Gtk.FileChooserDialog):
         filter_all.set_name("All files")
         filter_all.add_pattern("*.*")
         self.add_filter(filter_all)
+
+        self.preview_label = Gtk.Label()
+        self.preview_label.set_line_wrap(True)
+        self.preview_label.set_xalign(0)
+        self.preview_label.set_yalign(0)
+        preview_scrolled = Gtk.ScrolledWindow()
+        preview_scrolled.set_size_request(220, -1)
+        preview_scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        preview_scrolled.add(self.preview_label)
+        preview_scrolled.show_all()
+        self.set_preview_widget(preview_scrolled)
+        self.connect("update-preview", self.on_update_preview)
+
+    def on_update_preview(self, dialog):
+        filename = dialog.get_preview_filename()
+        text = ""
+        if filename and filename.endswith(".gram.py") and os.path.isfile(filename):
+            basename = os.path.basename(filename)
+            if basename in SCRIPT_DESCRIPTIONS:
+                title, description = SCRIPT_DESCRIPTIONS[basename]
+                text = "%s\n\n%s" % (title, description)
+            else:
+                try:
+                    text = extract_header_comment(open(filename).read())
+                except Exception:
+                    text = ""
+        if text:
+            self.preview_label.set_text(text)
+            dialog.set_preview_widget_active(True)
+        else:
+            dialog.set_preview_widget_active(False)
 
 
 class ScriptSaveFileChooserDialog(Gtk.FileChooserDialog):
@@ -448,6 +501,8 @@ for person in people():
         choose_file_dialog = ScriptOpenFileChooserDialog(self.uistate)
         if self.last_filename:
             choose_file_dialog.set_filename(self.last_filename)
+        elif os.path.isdir(SCRIPTS_DIR):
+            choose_file_dialog.set_current_folder(SCRIPTS_DIR)
 
         while True:
             response = choose_file_dialog.run()
@@ -483,6 +538,8 @@ for person in people():
         choose_file_dialog.set_do_overwrite_confirmation(True)
         if self.last_filename:
             choose_file_dialog.set_filename(self.last_filename)
+        elif os.path.isdir(SCRIPTS_DIR):
+            choose_file_dialog.set_current_folder(SCRIPTS_DIR)
 
         while True:
             response = choose_file_dialog.run()

--- a/GrampyScript/GrampyScript.py
+++ b/GrampyScript/GrampyScript.py
@@ -311,9 +311,7 @@ class GrampyScript(Gramplet):
         self.update_filename_label()
         if os.path.exists(self.last_filename):
             self.ebuf.set_text(open(self.last_filename).read())
-            self.statusmsg.set_text("Loaded %r" % self.last_filename)
         else:
-            self.statusmsg.set_text("Current filename: %r" % self.last_filename)
             self.ebuf.set_text(
                 """# This is a sample script
 
@@ -476,7 +474,7 @@ for person in people():
             provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
         )
 
-        self.statusmsg = Gtk.Label(_("Ready..."))
+        self.statusmsg = Gtk.Label(_("Ready... (Tab for completions)"))
         self.statusmsg.set_xalign(0)  # 0.0 for left, 0.5 for center, 1.0 for right
         # Some status messages embed the full path of the current file
         # (e.g. "Loaded '/home/.../scripts/some_script.gram.py'"), which
@@ -540,7 +538,9 @@ for person in people():
     def _do_new_script(self):
         self.ebuf.set_text("")
         self.ebuf.set_modified(False)
-        self.statusmsg.set_text("Ready...")
+        self.last_filename = ""
+        self.update_filename_label()
+        self.statusmsg.set_text(_("Ready... (Tab for completions)"))
 
     def open_script(self, widget):
         # type: (Gtk.Widget) -> None
@@ -568,7 +568,6 @@ for person in people():
                 config.set("defaults.last_filename", filename)
                 config.save()
                 self.update_filename_label()
-                self.statusmsg.set_text("Loaded %r" % self.last_filename)
                 break
 
         choose_file_dialog.destroy()
@@ -580,7 +579,7 @@ for person in people():
         with open(self.last_filename, "w") as fp:
             fp.write(self.get_text())
         self.ebuf.set_modified(False)
-        self.statusmsg.set_text("Saved %r" % self.last_filename)
+        self.statusmsg.set_text("Saved")
 
     def save_as_script(self, widget):
         choose_file_dialog = ScriptSaveFileChooserDialog(self.uistate)
@@ -608,7 +607,7 @@ for person in people():
                 config.set("defaults.last_filename", filename)
                 config.save()
                 self.update_filename_label()
-                self.statusmsg.set_text("Saved as %r (now current)" % self.last_filename)
+                self.statusmsg.set_text("Saved as (now current)")
                 break
 
         choose_file_dialog.destroy()

--- a/GrampyScript/GrampyScript.py
+++ b/GrampyScript/GrampyScript.py
@@ -335,6 +335,7 @@ class GrampyScript(Gramplet):
         self.gui.WIDGET = self.build_gui()
         self.gui.get_container_widget().remove(self.gui.textview)
         self.gui.get_container_widget().add(self.gui.WIDGET)
+        self.update_filename_label()
         if os.path.exists(self.last_filename):
             self.ebuf.set_text(open(self.last_filename).read())
             self.statusmsg.set_text("Loaded %r" % self.last_filename)
@@ -472,9 +473,6 @@ for person in people():
 
         widget.pack_start(self.notebook, True, True, 0)
 
-        self.statusmsg = Gtk.Label(_("Ready..."))
-        self.statusmsg.set_xalign(0)  # 0.0 for left, 0.5 for center, 1.0 for right
-        self.statusmsg.get_style_context().add_class('bordered-label')  #add a css class
         css = b"""
         .bordered-label {
             border: 1px solid gray;
@@ -483,13 +481,32 @@ for person in people():
         """
         provider = Gtk.CssProvider()
         provider.load_from_data(css)
+
+        self.filename_label = Gtk.Label()
+        self.filename_label.set_xalign(0)
+        self.filename_label.get_style_context().add_class('bordered-label')
+        self.filename_label.get_style_context().add_provider(
+            provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+        )
+
+        self.statusmsg = Gtk.Label(_("Ready..."))
+        self.statusmsg.set_xalign(0)  # 0.0 for left, 0.5 for center, 1.0 for right
+        self.statusmsg.get_style_context().add_class('bordered-label')  #add a css class
         self.statusmsg.get_style_context().add_provider(
             provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
         )
-        widget.pack_start(self.statusmsg, False, False, 1)
+
+        status_box = Gtk.HBox()
+        status_box.pack_start(self.filename_label, False, False, 1)
+        status_box.pack_start(self.statusmsg, True, True, 1)
+        widget.pack_start(status_box, False, False, 1)
 
         widget.show_all()
         return widget
+
+    def update_filename_label(self):
+        name = os.path.basename(self.last_filename) if self.last_filename else _("Untitled")
+        self.filename_label.set_text(name)
 
     def new_script(self, widget):
         # type: (Any) -> None
@@ -517,6 +534,7 @@ for person in people():
                 self.last_filename = filename
                 config.set("defaults.last_filename", filename)
                 config.save()
+                self.update_filename_label()
                 self.statusmsg.set_text("Loaded %r" % self.last_filename)
                 break
 
@@ -554,6 +572,7 @@ for person in people():
                 self.last_filename = filename
                 config.set("defaults.last_filename", filename)
                 config.save()
+                self.update_filename_label()
                 self.statusmsg.set_text("Saved as %r (now current)" % self.last_filename)
                 break
 

--- a/GrampyScript/GrampyScript.py
+++ b/GrampyScript/GrampyScript.py
@@ -45,6 +45,7 @@ from gramps.gui.widgets.undoablebuffer import UndoableBuffer
 from gramps.gui.utils import match_primary_mask
 from gramps.gen.config import config as configman
 from gramps.gui.dialog import OkDialog, ErrorDialog, SaveDialog
+from gramps.gui.display import display_help, display_url
 from gramps.gui.editors import (
     EditCitation,
     EditEvent,
@@ -336,15 +337,19 @@ for person in people():
         openitem = Gtk.MenuItem(label=_("Open..."))
         save_item = Gtk.MenuItem(label=_("Save"))
         save_as_item = Gtk.MenuItem(label=_("Save as..."))
+        help_item = Gtk.MenuItem(label=_("Help"))
         filemenu.append(newitem)
         filemenu.append(openitem)
         filemenu.append(save_item)
         filemenu.append(save_as_item)
+        filemenu.append(Gtk.SeparatorMenuItem())
+        filemenu.append(help_item)
         menubar.append(fileitem)
         newitem.connect("activate", self.new_script)
         openitem.connect("activate", self.open_script)
         save_as_item.connect("activate", self.save_as_script)
         save_item.connect("activate", self.save_script)
+        help_item.connect("activate", self.show_help)
 
         datamenu = Gtk.Menu()
         dataitem = Gtk.MenuItem(label=_("Data"))
@@ -606,6 +611,13 @@ for person in people():
                 break
 
         choose_file_dialog.destroy()
+
+    def show_help(self, widget):
+        help_url = self.gui.help_url
+        if help_url and help_url.startswith(("http://", "https://")):
+            display_url(help_url)
+        else:
+            display_help(help_url)
 
     def save_csv(self, widget):
         if self.liststore is None:

--- a/GrampyScript/GrampyScript.py
+++ b/GrampyScript/GrampyScript.py
@@ -1198,11 +1198,12 @@ for person in people():
 
             self.CHANGING = True
             self.TRANSACTION = DbTxn(message, self.db)
-            self.db._txn_begin()
+            self.db.transaction_begin(self.TRANSACTION)
 
         def end_changes():
             if self.CHANGING:
-                self.db._txn_commit()
+                self.db.transaction_commit(self.TRANSACTION)
+                self.CHANGING = False
 
         def _iter_raw_person_data():
             for handle, data in self.db._iter_raw_person_data():

--- a/GrampyScript/GrampyScript.py
+++ b/GrampyScript/GrampyScript.py
@@ -19,7 +19,6 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 import csv
-import ast
 import keyword
 import datetime
 from collections import defaultdict
@@ -58,6 +57,7 @@ from gramps.gui.editors import (
 )
 from datadict2 import DataDict2, NoneData, set_sa
 from script_descriptions import SCRIPT_DESCRIPTIONS
+from script_utils import get_columns, extract_header_comment, SCRIPTS_DIR
 
 _ = glocale.translation.gettext
 
@@ -74,39 +74,6 @@ def contains_any_none_data(args):
         return any(contains_any_none_data(arg) for arg in args)
     else:
         return not isinstance(args, NoneData)
-
-
-def get_columns(source, func_name):
-    try:
-        tree = ast.parse(source)
-        for node in ast.walk(tree):
-            if isinstance(node, ast.Call):
-                if hasattr(node.func, "id") and node.func.id == func_name:
-                    return [ast.unparse(arg) for arg in node.args]
-    except Exception:
-        pass
-    return []
-
-
-def extract_header_comment(source):
-    """
-    Extract the leading '#'-comment block of a script as plain text,
-    for use as a fallback preview when a file has no catalogued
-    description in SCRIPT_DESCRIPTIONS.
-    """
-    lines = []
-    for line in source.splitlines():
-        stripped = line.strip()
-        if stripped.startswith("#"):
-            lines.append(stripped.lstrip("#").strip())
-        elif stripped == "" and not lines:
-            continue
-        else:
-            break
-    return "\n".join(lines).strip()
-
-
-SCRIPTS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "scripts")
 
 
 class ScriptOpenFileChooserDialog(Gtk.FileChooserDialog):

--- a/GrampyScript/GrampyScript.py
+++ b/GrampyScript/GrampyScript.py
@@ -44,7 +44,7 @@ from gramps.gen.simple import SimpleAccess
 from gramps.gui.widgets.undoablebuffer import UndoableBuffer
 from gramps.gui.utils import match_primary_mask
 from gramps.gen.config import config as configman
-from gramps.gui.dialog import OkDialog, ErrorDialog
+from gramps.gui.dialog import OkDialog, ErrorDialog, SaveDialog
 from gramps.gui.editors import (
     EditCitation,
     EditEvent,
@@ -348,6 +348,7 @@ for person in people():
     row(person)
 """
             )
+        self.ebuf.set_modified(False)
 
     def build_gui(self):
         """
@@ -512,13 +513,49 @@ for person in people():
         name = os.path.basename(self.last_filename) if self.last_filename else _("Untitled")
         self.filename_label.set_text(name)
 
+    def check_unsaved_changes(self, proceed):
+        """
+        If the script has unsaved changes, ask the user whether to save,
+        discard, or cancel before calling `proceed`. Otherwise call
+        `proceed` immediately.
+        """
+        if not self.ebuf.get_modified():
+            proceed()
+            return
+
+        def discard():
+            proceed()
+
+        def save_then_proceed():
+            self.save_script(None)
+            if not self.ebuf.get_modified():
+                proceed()
+
+        SaveDialog(
+            _("Save Changes?"),
+            _(
+                "If you continue without saving, the changes you have "
+                "made to this script will be lost."
+            ),
+            discard,
+            save_then_proceed,
+            parent=self.uistate.window,
+        )
+
     def new_script(self, widget):
         # type: (Any) -> None
+        self.check_unsaved_changes(self._do_new_script)
+
+    def _do_new_script(self):
         self.ebuf.set_text("")
+        self.ebuf.set_modified(False)
         self.statusmsg.set_text("Ready...")
 
     def open_script(self, widget):
         # type: (Gtk.Widget) -> None
+        self.check_unsaved_changes(self._do_open_script)
+
+    def _do_open_script(self):
         choose_file_dialog = ScriptOpenFileChooserDialog(self.uistate)
         if self.last_filename:
             choose_file_dialog.set_filename(self.last_filename)
@@ -534,6 +571,7 @@ for person in people():
             elif response == Gtk.ResponseType.OK:
                 filename = choose_file_dialog.get_filename()
                 self.ebuf.set_text(open(filename).read())
+                self.ebuf.set_modified(False)
                 self.statusmsg.set_text("Script loaded")
                 self.last_filename = filename
                 config.set("defaults.last_filename", filename)
@@ -550,6 +588,7 @@ for person in people():
             return
         with open(self.last_filename, "w") as fp:
             fp.write(self.get_text())
+        self.ebuf.set_modified(False)
         self.statusmsg.set_text("Saved %r" % self.last_filename)
 
     def save_as_script(self, widget):
@@ -573,6 +612,7 @@ for person in people():
                 filename = choose_file_dialog.get_filename()
                 with open(filename, "w") as fp:
                     fp.write(self.get_text())
+                self.ebuf.set_modified(False)
                 self.last_filename = filename
                 config.set("defaults.last_filename", filename)
                 config.save()

--- a/GrampyScript/GrampyScript.py
+++ b/GrampyScript/GrampyScript.py
@@ -435,6 +435,23 @@ for person in people():
 
         widget.pack_start(self.editor, True, True, 0)
 
+        bbox = Gtk.ButtonBox()
+        self.apply_button = Gtk.Button(label=_("Execute <Alt+Enter>"))
+        self.apply_button.connect("clicked", self.apply_clicked)
+        self.apply_button.set_tooltip_text(_("Execute the script"))
+        css = b"* {background: #00aa00; color: white}"
+        provider = Gtk.CssProvider()
+        try:
+            provider.load_from_data(css)
+            self.apply_button.get_style_context().add_provider(
+                provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+            )
+        except:
+            pass
+
+        bbox.pack_start(self.apply_button, False, False, 6)
+        widget.pack_start(bbox, False, False, 6)
+
         self.notebook = Gtk.Notebook()
 
         self.page1 = Gtk.ScrolledWindow()
@@ -454,23 +471,6 @@ for person in people():
         self.notebook.append_page(page3, Gtk.Label(label=_("Chart")))
 
         widget.pack_start(self.notebook, True, True, 0)
-
-        bbox = Gtk.ButtonBox()
-        self.apply_button = Gtk.Button(label=_("Execute <Alt+Enter>"))
-        self.apply_button.connect("clicked", self.apply_clicked)
-        self.apply_button.set_tooltip_text(_("Execute the script"))
-        css = b"* {background: #00aa00; color: white}"
-        provider = Gtk.CssProvider()
-        try:
-            provider.load_from_data(css)
-            self.apply_button.get_style_context().add_provider(
-                provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
-            )
-        except:
-            pass
-
-        bbox.pack_start(self.apply_button, False, False, 6)
-        widget.pack_start(bbox, False, False, 6)
 
         self.statusmsg = Gtk.Label(_("Ready..."))
         self.statusmsg.set_xalign(0)  # 0.0 for left, 0.5 for center, 1.0 for right

--- a/GrampyScript/GrampyScript.py
+++ b/GrampyScript/GrampyScript.py
@@ -411,6 +411,7 @@ for person in people():
         self.comment_tag = self.ebuf.create_tag(
             "comment", foreground="gray", style=Pango.Style.ITALIC
         )
+        self.string_tag = self.ebuf.create_tag("string", foreground="brown")
         self.ebuf.connect("changed", self.on_buffer_changed)
         self.completion = CompletionController(
             self.editor_textview, get_namespace=lambda: build_namespace(self.dbstate.db)
@@ -699,37 +700,56 @@ for person in people():
 
         text = self.ebuf.get_text(start_iter, end_iter, True)
 
+        def inside_span(match, spans):
+            start_offset = match.start()
+            end_offset = match.end()
+            for span_start, span_end in spans:
+                if start_offset >= span_start and end_offset <= span_end:
+                    return True
+            return False
+
+        # Strings are found first so that keywords/comments inside them (eg.
+        # "with" in a docstring, or a "#" in a quoted string) aren't
+        # mistaken for code.
+        string_pattern = (
+            r'"""[\s\S]*?"""'
+            r"|'''[\s\S]*?'''"
+            r'|"(?:[^"\\\n]|\\.)*"'
+            r"|'(?:[^'\\\n]|\\.)*'"
+        )
+        string_matches = []
+        for match in re.finditer(string_pattern, text):
+            start = self.ebuf.get_iter_at_offset(match.start())
+            end = self.ebuf.get_iter_at_offset(match.end())
+            self.ebuf.apply_tag(self.string_tag, start, end)
+            string_matches.append((match.start(), match.end()))
+
         comment_matches = []
         for match in re.finditer(r"#.*", text):
+            if inside_span(match, string_matches):
+                continue
             start = self.ebuf.get_iter_at_offset(match.start())
             end = self.ebuf.get_iter_at_offset(match.end())
             self.ebuf.apply_tag(self.comment_tag, start, end)
             comment_matches.append((match.start(), match.end()))
 
-        def inside_comment(match):
-            start_offset = match.start()
-            end_offset = match.end()
-            # Check if the keyword overlaps with a comment
-            for comment_start, comment_end in comment_matches:
-                if start_offset >= comment_start and end_offset <= comment_end:
-                    return True
-            return False
+        skip_spans = string_matches + comment_matches
 
         for keyword in self.keywords:
             for match in re.finditer(r"\b" + keyword + r"\b", text):
-                if not inside_comment(match):
+                if not inside_span(match, skip_spans):
                     start = self.ebuf.get_iter_at_offset(match.start())
                     end = self.ebuf.get_iter_at_offset(match.end())
                     self.ebuf.apply_tag(self.keyword_tag, start, end)
         for constant in self.constants:
             for match in re.finditer(r"\b" + constant + r"\b", text):
-                if not inside_comment(match):
+                if not inside_span(match, skip_spans):
                     start = self.ebuf.get_iter_at_offset(match.start())
                     end = self.ebuf.get_iter_at_offset(match.end())
                     self.ebuf.apply_tag(self.constant_tag, start, end)
         for function in self.functions:
             for match in re.finditer(r"\b" + function + r"\b", text):
-                if not inside_comment(match):
+                if not inside_span(match, skip_spans):
                     start = self.ebuf.get_iter_at_offset(match.start())
                     end = self.ebuf.get_iter_at_offset(match.end())
                     self.ebuf.apply_tag(self.function_tag, start, end)

--- a/GrampyScript/MANIFEST
+++ b/GrampyScript/MANIFEST
@@ -1,0 +1,2 @@
+GrampyScript/scripts/*.gram.py
+GrampyScript/scripts/README.md

--- a/GrampyScript/completion.py
+++ b/GrampyScript/completion.py
@@ -49,14 +49,32 @@ def _get_stub_preamble():
 
 def _complete(source, line, column, namespace):
     """Shared jedi call underlying both get_completions() and
-    get_completion_items(); returns raw jedi Completion objects."""
+    get_completion_items(); returns raw jedi Completion objects, excluding
+    classes (jedi type "class"). The DSL has no use for instantiating
+    classes directly, and the stub preamble's own scaffold classes
+    (Person, Family, ...) would otherwise leak into the list -- they exist
+    only for jedi's static analysis and aren't bound to anything in the
+    namespace a script actually runs in, so offering them as completions
+    would suggest names that raise NameError if accepted."""
     preamble = _get_stub_preamble()
     full_source = preamble + source
     interpreter = jedi.Interpreter(full_source, [namespace])
     try:
-        return interpreter.complete(line + preamble.count("\n"), column)
+        completions = interpreter.complete(line + preamble.count("\n"), column)
     except Exception:
         return []
+    return [completion for completion in completions if completion.type != "class"]
+
+
+def _display_name(completion):
+    """Completion name for display: function/method completions (jedi type
+    "function", e.g. `people`, `print`) get "()" appended, so both
+    get_completions() and get_completion_items() consistently show a
+    callable as callable rather than as a bare, field-like name."""
+    name = completion.name
+    if completion.type == "function":
+        name += "()"
+    return name
 
 
 def get_completions(source, line, column, namespace):
@@ -74,7 +92,7 @@ def get_completions(source, line, column, namespace):
     to runtime introspection (dir()/getattr()) for anything it can't
     statically analyze.
     """
-    return [completion.name for completion in _complete(source, line, column, namespace)]
+    return [_display_name(completion) for completion in _complete(source, line, column, namespace)]
 
 
 def _takes_arguments(completion):
@@ -100,20 +118,17 @@ def get_completion_items(source, line, column, namespace):
     "rt"), so callers can insert it directly without
     recomputing/re-typing the already-typed prefix.
 
-    Function/method completions (jedi type "function", e.g. `people`,
-    `families`) get "()" appended to both `name` (so the popup reads
-    "people()") and `complete`; `cursor_offset` is then 1 for functions
-    that take arguments, landing the cursor between the parens ready to
-    type them, or 0 for no-argument functions, landing it after the
-    closing paren.
+    Function/method completions also get "()" appended to `complete`;
+    `cursor_offset` is then 1 for functions that take arguments, landing
+    the cursor between the parens ready to type them, or 0 for
+    no-argument functions, landing it after the closing paren.
     """
     items = []
     for completion in _complete(source, line, column, namespace):
-        name = completion.name
+        name = _display_name(completion)
         complete = completion.complete
         cursor_offset = 0
         if completion.type == "function":
-            name += "()"
             complete += "()"
             if _takes_arguments(completion):
                 cursor_offset = 1

--- a/GrampyScript/completion.py
+++ b/GrampyScript/completion.py
@@ -1,0 +1,92 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2025      Doug Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+Command completion for the GrampyScript editor, built on jedi.
+
+Kept free of GTK imports so it can be developed and tested without a
+running Gramps/GTK environment; GrampyScript.py is responsible for
+turning a Gtk.TextBuffer cursor position into (line, column) and for
+building the namespace of live/template DSL objects.
+"""
+
+import jedi
+
+from stub_generator import build_stub_source
+
+_stub_source = None
+
+
+def _get_stub_preamble():
+    """
+    Lazily build and cache the stub-class source (stub_generator.py):
+    static type annotations, derived from Gramps' own get_schema(), that
+    let jedi infer the row type of DSL generators like `people()` for a
+    user's own loop variable -- something no live namespace object can
+    provide, since there is no instance until the script actually runs.
+    """
+    global _stub_source
+    if _stub_source is None:
+        _stub_source = build_stub_source()
+    return _stub_source
+
+
+def _complete(source, line, column, namespace):
+    """Shared jedi call underlying both get_completions() and
+    get_completion_items(); returns raw jedi Completion objects."""
+    preamble = _get_stub_preamble()
+    full_source = preamble + source
+    interpreter = jedi.Interpreter(full_source, [namespace])
+    try:
+        return interpreter.complete(line + preamble.count("\n"), column)
+    except Exception:
+        return []
+
+
+def get_completions(source, line, column, namespace):
+    """
+    Return candidate completion names for `source` at the given cursor
+    position. `line`/`column` refer to `source` itself (1-indexed /
+    0-indexed, jedi's convention, matching Gtk.TextIter's
+    get_line()+1 / get_line_offset()); the stub preamble prepended below
+    is accounted for internally.
+
+    `namespace` is a plain dict of name -> live or template object,
+    e.g. {"active_person": DataDict2(...), "database": self.db}.
+    Attribute completion on dynamic objects (like DataDict2) relies on
+    those objects implementing __dir__ correctly, since jedi falls back
+    to runtime introspection (dir()/getattr()) for anything it can't
+    statically analyze.
+    """
+    return [completion.name for completion in _complete(source, line, column, namespace)]
+
+
+def get_completion_items(source, line, column, namespace):
+    """
+    Same as get_completions(), but for UI use: returns a list of
+    {"name": full completion name, "complete": text to insert at the
+    cursor} dicts. `name` is for display; `complete` is only the
+    remaining characters jedi says are missing (e.g. typing "impo" and
+    accepting "import" gives complete == "rt"), so callers can insert it
+    directly without recomputing/re-typing the already-typed prefix.
+    """
+    return [
+        {"name": completion.name, "complete": completion.complete}
+        for completion in _complete(source, line, column, namespace)
+    ]

--- a/GrampyScript/completion.py
+++ b/GrampyScript/completion.py
@@ -77,16 +77,45 @@ def get_completions(source, line, column, namespace):
     return [completion.name for completion in _complete(source, line, column, namespace)]
 
 
+def _takes_arguments(completion):
+    """True if a function/method completion has at least one parameter
+    to fill in (jedi's Signature.params already excludes a bound
+    method's `self`), used to decide whether the inserted "()" should
+    land the cursor between the parens instead of after them."""
+    try:
+        signatures = completion.get_signatures()
+    except Exception:
+        return False
+    return any(signature.params for signature in signatures)
+
+
 def get_completion_items(source, line, column, namespace):
     """
     Same as get_completions(), but for UI use: returns a list of
     {"name": full completion name, "complete": text to insert at the
-    cursor} dicts. `name` is for display; `complete` is only the
-    remaining characters jedi says are missing (e.g. typing "impo" and
-    accepting "import" gives complete == "rt"), so callers can insert it
-    directly without recomputing/re-typing the already-typed prefix.
+    cursor, "cursor_offset": how many characters back from the end of
+    the inserted text the cursor should land} dicts. `name` is for
+    display; `complete` is only the remaining characters jedi says are
+    missing (e.g. typing "impo" and accepting "import" gives complete ==
+    "rt"), so callers can insert it directly without
+    recomputing/re-typing the already-typed prefix.
+
+    Function/method completions (jedi type "function", e.g. `people`,
+    `families`) get "()" appended to both `name` (so the popup reads
+    "people()") and `complete`; `cursor_offset` is then 1 for functions
+    that take arguments, landing the cursor between the parens ready to
+    type them, or 0 for no-argument functions, landing it after the
+    closing paren.
     """
-    return [
-        {"name": completion.name, "complete": completion.complete}
-        for completion in _complete(source, line, column, namespace)
-    ]
+    items = []
+    for completion in _complete(source, line, column, namespace):
+        name = completion.name
+        complete = completion.complete
+        cursor_offset = 0
+        if completion.type == "function":
+            name += "()"
+            complete += "()"
+            if _takes_arguments(completion):
+                cursor_offset = 1
+        items.append({"name": name, "complete": complete, "cursor_offset": cursor_offset})
+    return items

--- a/GrampyScript/completion_popup.py
+++ b/GrampyScript/completion_popup.py
@@ -1,0 +1,296 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2025      Doug Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+A Tab-triggered, live-filtering completion popover for a Gtk.TextView,
+built on completion.get_completion_items().
+
+Kept as a standalone controller (not part of GrampyScript.py's Gramplet
+class) so it can be driven directly against a plain Gtk.TextView in
+tests, independent of the full Gramps Gramplet machinery.
+
+Wiring it into a host widget requires forwarding four things:
+    textview "key-press-event"   -> controller.on_key_press(event)
+                                     (if it returns True, treat the event
+                                     as handled and stop further processing)
+    buffer   "changed"           -> controller.on_buffer_changed()
+    textview "button-press-event"/"focus-out-event" -> controller.close()
+"""
+
+import logging
+
+from gi.repository import Gdk, Gtk
+
+from completion import get_completion_items
+
+_LOG = logging.getLogger(".GrampyScript.completion")
+
+_NAVIGATION_KEYS = (
+    Gdk.KEY_Left,
+    Gdk.KEY_Right,
+    Gdk.KEY_Home,
+    Gdk.KEY_End,
+    Gdk.KEY_Page_Up,
+    Gdk.KEY_Page_Down,
+)
+
+
+class CompletionController:
+    def __init__(self, textview, get_namespace):
+        """
+        `textview`: the Gtk.TextView to attach completion to.
+        `get_namespace`: zero-arg callable returning the current
+        namespace dict for get_completion_items() (e.g.
+        `lambda: build_namespace(self.dbstate.db)`); called fresh on
+        every request so it always reflects the live database.
+        """
+        self.textview = textview
+        self.buffer = textview.get_buffer()
+        self.get_namespace = get_namespace
+        self.popover = None
+        self.listbox = None
+        self.scrolled = None
+        self.items = []
+        self.selected_index = 0
+
+    # ---- public event entry points -----------------------------------
+
+    def on_key_press(self, event):
+        """Return True if the event was consumed and should not be
+        processed any further by the caller."""
+        try:
+            return self._on_key_press(event)
+        except Exception:
+            # Never let a bug here swallow the keypress entirely -- that
+            # would leave GTK's own default handler to run instead (e.g.
+            # inserting a literal tab character for Gdk.KEY_Tab), which
+            # looks like "completion silently does nothing." Log and
+            # fall back to "not handled" instead.
+            _LOG.exception("completion on_key_press failed")
+            self.close()
+            return False
+
+    def _on_key_press(self, event):
+        keyval = event.keyval
+        _LOG.debug("on_key_press keyval=%s open=%s", Gdk.keyval_name(keyval), self.is_open())
+        if keyval == Gdk.KEY_Tab:
+            if self.is_open():
+                self.accept()
+                return True
+            return self.trigger()
+        if self.is_open():
+            if keyval == Gdk.KEY_Up:
+                self.move_selection(-1)
+                return True
+            if keyval == Gdk.KEY_Down:
+                self.move_selection(1)
+                return True
+            if keyval in (Gdk.KEY_Return, Gdk.KEY_KP_Enter):
+                self.accept()
+                return True
+            if keyval == Gdk.KEY_Escape:
+                self.close()
+                return True
+            if keyval in _NAVIGATION_KEYS:
+                # The cursor is about to move out from under the popover;
+                # let it move normally, just stop completing at this spot.
+                self.close()
+                return False
+        return False
+
+    def on_buffer_changed(self):
+        if not self.is_open():
+            return
+        try:
+            self.refresh()
+        except Exception:
+            _LOG.exception("completion refresh failed")
+            self.close()
+
+    def is_open(self):
+        return self.popover is not None
+
+    # ---- core -----------------------------------------------------------
+
+    def _cursor_iter(self):
+        return self.buffer.get_iter_at_mark(self.buffer.get_insert())
+
+    def _cursor_line_column(self):
+        it = self._cursor_iter()
+        return it.get_line() + 1, it.get_line_offset()
+
+    def _word_prefix(self):
+        it = self._cursor_iter()
+        start = it.copy()
+        while start.backward_char():
+            ch = start.get_char()
+            if ch.isalnum() or ch == "_":
+                continue
+            start.forward_char()
+            break
+        return self.buffer.get_text(start, it, True)
+
+    def _is_completable_context(self):
+        it = self._cursor_iter()
+        start = it.copy()
+        if not start.backward_char():
+            _LOG.debug("not completable: at start of buffer")
+            return False
+        ch = start.get_char()
+        completable = ch.isalnum() or ch in "_.]"
+        _LOG.debug("preceding char=%r completable=%s", ch, completable)
+        return completable
+
+    def _compute_items(self):
+        source = self.buffer.get_text(
+            self.buffer.get_start_iter(), self.buffer.get_end_iter(), True
+        )
+        line, column = self._cursor_line_column()
+        prefix = self._word_prefix()
+        _LOG.debug("computing completions at line=%s column=%s prefix=%r", line, column, prefix)
+        try:
+            namespace = self.get_namespace()
+            items = get_completion_items(source, line, column, namespace)
+        except Exception:
+            _LOG.exception("building completion namespace/items failed")
+            return []
+        if not prefix.startswith("_"):
+            items = [item for item in items if not item["name"].startswith("_")]
+        _LOG.debug("found %d completion(s): %s", len(items), [i["name"] for i in items[:10]])
+        if not items:
+            _LOG.debug("zero completions, full source was:\n%s", source)
+        return items
+
+    def trigger(self):
+        """Try to open the popover at the cursor. Returns True if it
+        did (there was something completable to show)."""
+        if not self._is_completable_context():
+            return False
+        items = self._compute_items()
+        if not items:
+            _LOG.debug("trigger: no completions, falling back to default Tab behavior")
+            return False
+        self.items = items
+        self.selected_index = 0
+        self._open_popover()
+        return True
+
+    def refresh(self):
+        """Recompute matches for an already-open popover, following the
+        cursor as the user keeps typing. Closes if nothing matches
+        anymore."""
+        if not self._is_completable_context():
+            self.close()
+            return
+        items = self._compute_items()
+        if not items:
+            self.close()
+            return
+        self.items = items
+        self.selected_index = min(self.selected_index, len(items) - 1)
+        self._rebuild_listbox()
+        self._reposition()
+
+    def move_selection(self, delta):
+        if not self.items:
+            return
+        self.selected_index = max(0, min(len(self.items) - 1, self.selected_index + delta))
+        self._update_row_selection()
+
+    def accept(self):
+        if self.items:
+            item = self.items[self.selected_index]
+            self.buffer.insert(self._cursor_iter(), item["complete"])
+        self.close()
+
+    def close(self):
+        if self.popover is not None:
+            self.popover.destroy()
+        self.popover = None
+        self.listbox = None
+        self.scrolled = None
+        self.items = []
+        self.selected_index = 0
+
+    # ---- widget building --------------------------------------------------
+
+    def _open_popover(self):
+        self.popover = Gtk.Popover()
+        self.popover.set_relative_to(self.textview)
+        self.popover.set_modal(False)
+        self.popover.set_position(Gtk.PositionType.BOTTOM)
+
+        self.scrolled = Gtk.ScrolledWindow()
+        self.scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        self.scrolled.set_max_content_height(200)
+        self.scrolled.set_propagate_natural_height(True)
+
+        self.listbox = Gtk.ListBox()
+        self.listbox.set_activate_on_single_click(True)
+        self.listbox.connect("row-activated", self._on_row_activated)
+        self.scrolled.add(self.listbox)
+        self.popover.add(self.scrolled)
+
+        self._rebuild_listbox()
+        self.popover.show_all()
+        self._reposition()
+        self.popover.popup()
+
+    def _rebuild_listbox(self):
+        for child in self.listbox.get_children():
+            self.listbox.remove(child)
+        for item in self.items:
+            label = Gtk.Label(label=item["name"], xalign=0)
+            label.set_margin_start(6)
+            label.set_margin_end(6)
+            row = Gtk.ListBoxRow()
+            row.add(label)
+            self.listbox.add(row)
+        self.listbox.show_all()
+        self._update_row_selection()
+
+    def _update_row_selection(self):
+        row = self.listbox.get_row_at_index(self.selected_index)
+        if row is not None:
+            self.listbox.select_row(row)
+            self._scroll_to_row(row)
+
+    def _scroll_to_row(self, row):
+        alloc = row.get_allocation()
+        adj = self.scrolled.get_vadjustment()
+        if alloc.y < adj.get_value():
+            adj.set_value(alloc.y)
+        elif alloc.y + alloc.height > adj.get_value() + adj.get_page_size():
+            adj.set_value(alloc.y + alloc.height - adj.get_page_size())
+
+    def _reposition(self):
+        rect = self.textview.get_iter_location(self._cursor_iter())
+        x, y = self.textview.buffer_to_window_coords(
+            Gtk.TextWindowType.WIDGET, rect.x, rect.y
+        )
+        pointing = Gdk.Rectangle()
+        pointing.x = x
+        pointing.y = y
+        pointing.width = 1
+        pointing.height = rect.height
+        self.popover.set_pointing_to(pointing)
+
+    def _on_row_activated(self, listbox, row):
+        self.selected_index = row.get_index()
+        self.accept()

--- a/GrampyScript/completion_popup.py
+++ b/GrampyScript/completion_popup.py
@@ -178,8 +178,10 @@ class CompletionController:
         return items
 
     def trigger(self):
-        """Try to open the popover at the cursor. Returns True if it
-        did (there was something completable to show)."""
+        """Try to complete at the cursor. Returns True if there was
+        something completable to show. A single match is inserted
+        directly instead of opening a popover with one row in it;
+        multiple matches open the popover as usual."""
         if not self._is_completable_context():
             return False
         items = self._compute_items()
@@ -188,6 +190,10 @@ class CompletionController:
             return False
         self.items = items
         self.selected_index = 0
+        if len(items) == 1:
+            _LOG.debug("trigger: single match, inserting directly: %s", items[0]["name"])
+            self.accept()
+            return True
         self._open_popover()
         return True
 

--- a/GrampyScript/completion_popup.py
+++ b/GrampyScript/completion_popup.py
@@ -217,6 +217,11 @@ class CompletionController:
         if self.items:
             item = self.items[self.selected_index]
             self.buffer.insert(self._cursor_iter(), item["complete"])
+            offset = item.get("cursor_offset", 0)
+            if offset:
+                it = self._cursor_iter()
+                it.backward_chars(offset)
+                self.buffer.place_cursor(it)
         self.close()
 
     def close(self):

--- a/GrampyScript/datadict2.py
+++ b/GrampyScript/datadict2.py
@@ -331,19 +331,23 @@ class DataDict2(dict):
     def names(self):
         return DataList2([self.primary_name] + [self.alternate_names])
 
+    def _real_object(self):
+        """Walk from the root's real object down self.path to find the
+        actual (not reconstructed) object that this wrapper represents."""
+        obj = self.root._object
+        for part in self.path:
+            if isinstance(part, int):
+                obj = obj[part]
+            else:
+                obj = getattr(obj, part)
+        return obj
+
     def __setattr__(self, attr, value):
         if attr in ["root", "path", "callback"]:
             return super().__setattr__(attr, value)
         else:
-            # Follow the path:
-            obj = self.root._object
-            for part in self.path:
-                if isinstance(part, int):
-                    obj = obj[part]
-                else:
-                    obj = getattr(obj, part)
             # Set it in the real _object:
-            setattr(obj, attr, value)
+            setattr(self._real_object(), attr, value)
             # Update the top-level dict:
             self.root.update(object_to_dict(self.root._object))
             # Call the callback
@@ -362,7 +366,15 @@ class DataDict2(dict):
     def __getattr__(self, key):
         if key == "_object":
             if "_object" not in self:
-                self["_object"] = data_to_object(self)
+                # A nested wrapper (non-empty path) must resolve to the
+                # actual sub-object inside the root's real object tree,
+                # not a standalone copy reconstructed from its own dict
+                # slice -- otherwise set_*() calls below mutate a clone
+                # that is discarded instead of the real, committed object.
+                if self.path:
+                    self["_object"] = self._real_object()
+                else:
+                    self["_object"] = data_to_object(self)
             return self["_object"]
         elif key.startswith("_"):
             raise AttributeError(

--- a/GrampyScript/datadict2.py
+++ b/GrampyScript/datadict2.py
@@ -443,7 +443,14 @@ class DataList2(list):
         raise Exception("Setting a DataList2 item is not allowed")
 
     def __getattr__(self, attr):
-        # return DataList2(flatten([getattr(x, attr) for x in self]))
+        if attr.startswith("set_"):
+            # Fan the call (same args) out to every item, rather than
+            # collecting each item's set_*() wrapper closure unevaluated
+            # (which isn't callable itself and silently did nothing).
+            def wrapper(*args, **kwargs):
+                return DataList2([getattr(x, attr)(*args, **kwargs) for x in self])
+
+            return wrapper
         return DataList2(flatten([getattr(x, attr) for x in self]))
 
     def __getitem__(self, position, root=None, path=""):

--- a/GrampyScript/datadict2.py
+++ b/GrampyScript/datadict2.py
@@ -329,7 +329,7 @@ class DataDict2(dict):
 
     @property
     def names(self):
-        return DataList2([self.primary_name] + [self.alternate_names])
+        return DataList2([self.primary_name] + self.alternate_names)
 
     @property
     def string(self):
@@ -481,7 +481,10 @@ class DataList2(list):
         return DataList2([x for x in self] + [x for x in value])
 
     def __radd__(self, value):
-        return DataList2([x for x in self] + [x for x in value])
+        # self is the right-hand operand here (Python calls b.__radd__(a)
+        # for `a + b`), so the result must be `value + self`, not `self +
+        # value` -- otherwise `plain_list + data_list2` comes out reversed.
+        return DataList2([x for x in value] + [x for x in self])
 
 
 sa = None

--- a/GrampyScript/datadict2.py
+++ b/GrampyScript/datadict2.py
@@ -31,6 +31,17 @@ from gramps.gen.lib import PrimaryObject
 from gramps.gen.config import config
 
 NoneType = type(None)
+
+# *Ref._class -> the table its `ref` handle points into, for the `reference`
+# property below.
+REFERENCE_TABLES = {
+    "ChildRef": "Person",
+    "EventRef": "Event",
+    "MediaRef": "Media",
+    "PersonRef": "Person",
+    "PlaceRef": "Place",
+    "RepoRef": "Repository",
+}
 invalid_date_format = config.get("preferences.invalid-date-format")
 age_precision = config.get("preferences.age-display-precision")
 age_after_death = config.get("preferences.age-after-death")
@@ -260,7 +271,17 @@ class DataDict2(dict):
 
     @property
     def reference(self):
-        return DataDict2(sa.dbase.get_raw_person_data(self.ref), callback=self.callback)
+        # self is one of the *Ref wrapper types (PersonRef, EventRef, ...);
+        # `ref` is a handle into whichever table its own _class points at,
+        # not always Person.
+        table = REFERENCE_TABLES.get(self["_class"])
+        if table is None:
+            return NoneData()
+        getter = sa.dbase.method("get_raw_%s_data", table)
+        data = getter(self.ref) if getter else None
+        if data is None:
+            return NoneData()
+        return DataDict2(data, callback=self.callback)
 
     @property
     def attributes(self):
@@ -298,15 +319,13 @@ class DataDict2(dict):
     def name(self):
         if self["_class"] == "Person":
             return self.primary_name
-        else:
-            return self["name"]
+        return self["name"] if "name" in self else NoneData()
 
     @property
     def surname(self):
         if self["_class"] == "Person":
             return self.primary_name.surname_list[0]
-        else:
-            return self["surname"]
+        return self["surname"] if "surname" in self else NoneData()
 
     @property
     def names(self):

--- a/GrampyScript/datadict2.py
+++ b/GrampyScript/datadict2.py
@@ -27,7 +27,7 @@
 from __future__ import annotations
 
 from gramps.gen.lib.json_utils import data_to_object, object_to_dict
-from gramps.gen.lib import PrimaryObject
+from gramps.gen.lib import PrimaryObject, GrampsType
 from gramps.gen.config import config
 
 NoneType = type(None)
@@ -330,6 +330,21 @@ class DataDict2(dict):
     @property
     def names(self):
         return DataList2([self.primary_name] + [self.alternate_names])
+
+    @property
+    def string(self):
+        # The raw "string" field only holds the *custom*-type override text
+        # for GrampsType-based values (NameOriginType, NameType, EventType,
+        # ...); for predefined values (the common case) it is always "".
+        # Route to the real object's `.string` property instead, which
+        # computes the actual (translated) label. Raising AttributeError
+        # for anything without a "string" field falls back to the normal
+        # __getattr__ lookup, so this doesn't change behavior elsewhere.
+        if "string" not in self:
+            raise AttributeError("string")
+        if isinstance(self._object, GrampsType):
+            return str(self._object)
+        return self["string"]
 
     def _real_object(self):
         """Walk from the root's real object down self.path to find the

--- a/GrampyScript/datadict2.py
+++ b/GrampyScript/datadict2.py
@@ -436,7 +436,14 @@ class DataList2(list):
             value = super().__getitem__(position)
         except Exception:
             return NoneData()
-        if isinstance(value, dict):
+        # Items can already be fully-wrapped (e.g. after `+`/`__radd__`
+        # concatenates lists whose elements are DataDict2/DataList2). Since
+        # both subclass dict/list, re-wrapping them here would discard their
+        # real root/path and replace it with this list's (often unrelated)
+        # root, corrupting later attribute assignment.
+        if isinstance(value, (DataDict2, DataList2)):
+            return value
+        elif isinstance(value, dict):
             return DataDict2(value, root=self.root, path=self.path + [position])
         elif isinstance(value, list):
             return DataList2(value, root=self.root, path=self.path + [position])

--- a/GrampyScript/datadict2.py
+++ b/GrampyScript/datadict2.py
@@ -334,6 +334,12 @@ class DataDict2(dict):
     # def __str__(self):
     #    return str(self._object)
 
+    def __dir__(self):
+        # Merge real class attributes with the dynamic dict keys, so that
+        # introspection tools (e.g. jedi-based completion) can see fields
+        # like `primary_name` that only exist via __getattr__.
+        return sorted(set(super().__dir__()) | set(self.keys()))
+
     def __getattr__(self, key):
         if key == "_object":
             if "_object" not in self:

--- a/GrampyScript/namespace_builder.py
+++ b/GrampyScript/namespace_builder.py
@@ -1,0 +1,59 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2025      Doug Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+Builds the runtime completion namespace: real live objects for the DSL
+names whose fields are safe and useful to introspect directly.
+
+active_person/active_family/etc. are deliberately NOT included here --
+see stub_generator.ACTIVE_VARIABLES. They're handled as static
+annotations instead, because completing through them would otherwise
+require jedi to actually call DataDict2's computed @property methods
+(father, birth, ...) to see what they return, executing real
+SimpleAccess lookups for no benefit (a blank template has nothing to
+find anyway).
+
+Kept free of GTK imports so it can be developed and tested without a
+running Gramps/GTK environment.
+"""
+
+import datetime
+from collections import defaultdict
+
+from gramps.gen.lib import Date
+
+
+def build_namespace(database=None):
+    """
+    Return a namespace dict for get_completions(), covering the
+    directly-bound DSL names in execute_code() that are safe to
+    introspect as live objects: today, counter, and database.
+
+    `database` is the real Gramps database (self.dbstate.db). Passing it
+    enables completion of its real methods (database.get_person_from_handle,
+    ...); it's optional since dir() on it never executes anything.
+    """
+    today = datetime.date.today()
+    namespace = {
+        "today": Date(today.year, today.month, today.day),
+        "counter": lambda: defaultdict(int),
+    }
+    if database is not None:
+        namespace["database"] = database
+    return namespace

--- a/GrampyScript/script_descriptions.py
+++ b/GrampyScript/script_descriptions.py
@@ -110,4 +110,34 @@ SCRIPT_DESCRIPTIONS = {
             "records."
         ),
     ),
+    "11_import_example.gram.py": (
+        _("Births Per Decade (Import Example)"),
+        _(
+            "Counts births by decade, using a decade() function imported "
+            "from script_helpers.py in this same folder — a template for "
+            "sharing helper code between your own scripts with a plain "
+            "'import' statement."
+        ),
+    ),
+    "12_custom_filter_example.gram.py": (
+        _("Custom Filter Example"),
+        _(
+            "Runs one of your own custom filters (from the Filters "
+            "gramplet/editor) by name using custom_filter(). Change "
+            "'example filter' to the name of a filter you've already "
+            "created; if the name doesn't match one, a warning shows up "
+            "in the Output tab instead."
+        ),
+    ),
+    "13_delete_unused_repositories.gram.py": (
+        _("Delete Unused Repositories (Delete Example)"),
+        _(
+            "Demonstrates delete(): removes any Repository record that "
+            "nothing else in the tree refers to. Most trees have no "
+            "unused repositories, so this is unlikely to actually delete "
+            "anything — it's meant to show the pattern, wrapped in "
+            "begin_changes()/end_changes() as a single undoable "
+            "transaction."
+        ),
+    ),
 }

--- a/GrampyScript/script_descriptions.py
+++ b/GrampyScript/script_descriptions.py
@@ -19,9 +19,20 @@
 
 """
 Translatable titles and descriptions for the bundled example scripts in
-scripts/. Kept out of the .gram.py files themselves so the examples stay
-free of gettext markup while still being picked up by the addon's normal
-xgettext-based translation pipeline (see ../make.py).
+scripts/. This file is generated -- do not hand-edit the SCRIPT_DESCRIPTIONS
+dict below. Each entry's title comes from the corresponding script's leading
+'# Title' comment, and its description comes from that script's module
+docstring; both are kept in the .gram.py files themselves so the source of
+truth lives next to the code it documents.
+
+Wrapping these plain-text strings in _() here (rather than in the .gram.py
+files) is what makes them picked up by the addon's normal xgettext-based
+translation pipeline (see ../make.py) while keeping the example scripts
+themselves free of gettext markup.
+
+To pick up a new script, or a script's changed title/docstring, run:
+
+    python3 update_script_descriptions.py
 """
 
 from gramps.gen.const import GRAMPS_LOCALE as glocale
@@ -32,41 +43,39 @@ SCRIPT_DESCRIPTIONS = {
     "01_list_people.gram.py": (
         _("List All People"),
         _(
-            "Iterate over every person in the database and show their "
-            "Gramps ID, given name, surname, and gender in the results "
-            "table."
+            "Iterate over every person in the database and show their Gramps "
+            "ID, given name, surname, and gender in the results table."
         ),
     ),
     "02_filter_by_surname.gram.py": (
         _("Filter By Surname"),
         _(
-            "List only the people whose surname matches a given value — "
-            "a starting point for narrowing any report down by a "
-            "condition."
+            "List only the people whose surname matches a given value — a "
+            "starting point for narrowing any report down by a condition."
         ),
     ),
     "03_family_overview.gram.py": (
         _("Family Overview"),
         _(
-            "List every family together with the father, the mother, and "
-            "how many children they have — a quick way to spot families "
-            "that look incomplete."
+            "List every family together with the father, the mother, and how "
+            "many children they have — a quick way to spot families that look "
+            "incomplete."
         ),
     ),
     "04_gender_pie_chart.gram.py": (
         _("Gender Breakdown (Pie Chart)"),
         _(
-            "Count how many people are male, female, or of unknown "
-            "gender, then draw a pie chart of the totals. Check the "
-            "Chart tab after running."
+            "Count how many people are male, female, or of unknown gender, "
+            "then draw a pie chart of the totals. Check the Chart tab after "
+            "running."
         ),
     ),
     "05_age_histogram.gram.py": (
         _("Age At Death Histogram"),
         _(
             "For everyone with both a birth and a death event recorded, "
-            "compute their age in whole years and draw a histogram of "
-            "the distribution. Check the Chart tab after running."
+            "compute their age in whole years and draw a histogram of the "
+            "distribution. Check the Chart tab after running."
         ),
     ),
     "06_mark_unsourced_people_private.gram.py": (
@@ -81,63 +90,60 @@ SCRIPT_DESCRIPTIONS = {
     "07_csv_ready_report.gram.py": (
         _("CSV-Ready People Report"),
         _(
-            "Build a simple tabular report — ID, name, gender, birth "
-            "year — for every person. Once it runs, use Data > Save as "
-            "CSV or Copy to clipboard to export the Table tab's "
-            "contents."
+            "Build a simple tabular report — ID, name, gender, birth year — "
+            "for every person. Once it runs, use Data > Save as CSV or Copy to "
+            "clipboard to export the Table tab's contents."
         ),
     ),
     "08_active_person_summary.gram.py": (
         _("Active Person Summary"),
         _(
-            "Show a compact family summary for the currently active "
-            "person: their record, parents, spouse, and children."
+            "Show a compact family summary for the currently active person: "
+            "their record, parents, spouse, and children."
         ),
     ),
     "09_selected_people_report.gram.py": (
         _("Report On Selected People"),
         _(
-            "List just the people currently selected (highlighted) in "
-            "the People view. Select some rows in the People view "
-            "before running this script."
+            "List just the people currently selected (highlighted) in the "
+            "People view. Select some rows in the People view before running "
+            "this script."
         ),
     ),
     "10_find_missing_birth_dates.gram.py": (
         _("Find People Missing A Birth Date"),
         _(
-            "Data-quality check: list every person who has no recorded "
-            "birth event, so you can prioritize research on those "
-            "records."
+            "Data-quality check: list every person who has no recorded birth "
+            "event, so you can prioritize research on those records."
         ),
     ),
     "11_import_example.gram.py": (
         _("Births Per Decade (Import Example)"),
         _(
-            "Counts births by decade, using a decade() function imported "
-            "from script_helpers.py in this same folder — a template for "
-            "sharing helper code between your own scripts with a plain "
-            "'import' statement."
+            "Counts births by decade, using a decade() function imported from "
+            "script_helpers.py in this same folder — a template for sharing "
+            "helper code between your own scripts with a plain 'import' "
+            "statement."
         ),
     ),
     "12_custom_filter_example.gram.py": (
         _("Custom Filter Example"),
         _(
             "Runs one of your own custom filters (from the Filters "
-            "gramplet/editor) by name using custom_filter(). Change "
-            "'example filter' to the name of a filter you've already "
-            "created; if the name doesn't match one, a warning shows up "
-            "in the Output tab instead."
+            "gramplet/editor) by name using custom_filter(). Change 'example "
+            "filter' to the name of a filter you've already created; if the "
+            "name doesn't match one, a warning shows up in the Output tab "
+            "instead."
         ),
     ),
     "13_delete_unused_repositories.gram.py": (
         _("Delete Unused Repositories (Delete Example)"),
         _(
-            "Demonstrates delete(): removes any Repository record that "
-            "nothing else in the tree refers to. Most trees have no "
-            "unused repositories, so this is unlikely to actually delete "
-            "anything — it's meant to show the pattern, wrapped in "
-            "begin_changes()/end_changes() as a single undoable "
-            "transaction."
+            "Demonstrates delete(): removes any Repository record that nothing "
+            "else in the tree refers to. Most trees have no unused "
+            "repositories, so this is unlikely to actually delete anything — "
+            "it's meant to show the pattern, wrapped in "
+            "begin_changes()/end_changes() as a single undoable transaction."
         ),
     ),
 }

--- a/GrampyScript/script_descriptions.py
+++ b/GrampyScript/script_descriptions.py
@@ -1,0 +1,113 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2025      Doug Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+Translatable titles and descriptions for the bundled example scripts in
+scripts/. Kept out of the .gram.py files themselves so the examples stay
+free of gettext markup while still being picked up by the addon's normal
+xgettext-based translation pipeline (see ../make.py).
+"""
+
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+
+_ = glocale.translation.gettext
+
+SCRIPT_DESCRIPTIONS = {
+    "01_list_people.gram.py": (
+        _("List All People"),
+        _(
+            "Iterate over every person in the database and show their "
+            "Gramps ID, given name, surname, and gender in the results "
+            "table."
+        ),
+    ),
+    "02_filter_by_surname.gram.py": (
+        _("Filter By Surname"),
+        _(
+            "List only the people whose surname matches a given value — "
+            "a starting point for narrowing any report down by a "
+            "condition."
+        ),
+    ),
+    "03_family_overview.gram.py": (
+        _("Family Overview"),
+        _(
+            "List every family together with the father, the mother, and "
+            "how many children they have — a quick way to spot families "
+            "that look incomplete."
+        ),
+    ),
+    "04_gender_pie_chart.gram.py": (
+        _("Gender Breakdown (Pie Chart)"),
+        _(
+            "Count how many people are male, female, or of unknown "
+            "gender, then draw a pie chart of the totals. Check the "
+            "Chart tab after running."
+        ),
+    ),
+    "05_age_histogram.gram.py": (
+        _("Age At Death Histogram"),
+        _(
+            "For everyone with both a birth and a death event recorded, "
+            "compute their age in whole years and draw a histogram of "
+            "the distribution. Check the Chart tab after running."
+        ),
+    ),
+    "06_mark_unsourced_people_private.gram.py": (
+        _("Mark Unsourced People As Private"),
+        _(
+            "Batch-edit example: find every person who has no citations "
+            "attached and flag them as private, wrapped in "
+            "begin_changes()/end_changes() so the edits happen inside a "
+            "single, undoable transaction."
+        ),
+    ),
+    "07_csv_ready_report.gram.py": (
+        _("CSV-Ready People Report"),
+        _(
+            "Build a simple tabular report — ID, name, gender, birth "
+            "year — for every person. Once it runs, use Data > Save as "
+            "CSV or Copy to clipboard to export the Table tab's "
+            "contents."
+        ),
+    ),
+    "08_active_person_summary.gram.py": (
+        _("Active Person Summary"),
+        _(
+            "Show a compact family summary for the currently active "
+            "person: their record, parents, spouse, and children."
+        ),
+    ),
+    "09_selected_people_report.gram.py": (
+        _("Report On Selected People"),
+        _(
+            "List just the people currently selected (highlighted) in "
+            "the People view. Select some rows in the People view "
+            "before running this script."
+        ),
+    ),
+    "10_find_missing_birth_dates.gram.py": (
+        _("Find People Missing A Birth Date"),
+        _(
+            "Data-quality check: list every person who has no recorded "
+            "birth event, so you can prioritize research on those "
+            "records."
+        ),
+    ),
+}

--- a/GrampyScript/script_utils.py
+++ b/GrampyScript/script_utils.py
@@ -1,0 +1,59 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2025      Doug Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+Pure-Python helpers shared by GrampyScript.py, update_script_descriptions.py,
+and the test suite. Kept free of GTK/Gramps imports so they can be used
+from a plain script or test without needing a GUI environment.
+"""
+
+import ast
+import os
+
+SCRIPTS_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "scripts")
+
+
+def get_columns(source, func_name):
+    try:
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call):
+                if hasattr(node.func, "id") and node.func.id == func_name:
+                    return [ast.unparse(arg) for arg in node.args]
+    except Exception:
+        pass
+    return []
+
+
+def extract_header_comment(source):
+    """
+    Extract the leading '#'-comment block of a script as plain text,
+    for use as a fallback preview when a file has no catalogued
+    description in SCRIPT_DESCRIPTIONS.
+    """
+    lines = []
+    for line in source.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            lines.append(stripped.lstrip("#").strip())
+        elif stripped == "" and not lines:
+            continue
+        else:
+            break
+    return "\n".join(lines).strip()

--- a/GrampyScript/scripts/01_list_people.gram.py
+++ b/GrampyScript/scripts/01_list_people.gram.py
@@ -1,0 +1,9 @@
+# List All People
+
+for person in people():
+    row(
+        person.gramps_id,
+        person.name.first_name,
+        person.surname.surname,
+        person.gender,
+    )

--- a/GrampyScript/scripts/01_list_people.gram.py
+++ b/GrampyScript/scripts/01_list_people.gram.py
@@ -1,4 +1,8 @@
 # List All People
+"""
+Iterate over every person in the database and show their Gramps ID, given name,
+surname, and gender in the results table.
+"""
 
 for person in people():
     row(

--- a/GrampyScript/scripts/02_filter_by_surname.gram.py
+++ b/GrampyScript/scripts/02_filter_by_surname.gram.py
@@ -1,0 +1,7 @@
+# Filter By Surname
+
+TARGET_SURNAME = "Smith"
+
+for person in people():
+    if person.surname.surname == TARGET_SURNAME:
+        row(person.gramps_id, person.name.first_name, person.surname.surname)

--- a/GrampyScript/scripts/02_filter_by_surname.gram.py
+++ b/GrampyScript/scripts/02_filter_by_surname.gram.py
@@ -1,4 +1,8 @@
 # Filter By Surname
+"""
+List only the people whose surname matches a given value — a starting point for
+narrowing any report down by a condition.
+"""
 
 TARGET_SURNAME = "Smith"
 

--- a/GrampyScript/scripts/03_family_overview.gram.py
+++ b/GrampyScript/scripts/03_family_overview.gram.py
@@ -1,4 +1,8 @@
 # Family Overview
+"""
+List every family together with the father, the mother, and how many children
+they have — a quick way to spot families that look incomplete.
+"""
 
 for family in families():
     row(family.gramps_id, family.father, family.mother, len(family.children))

--- a/GrampyScript/scripts/03_family_overview.gram.py
+++ b/GrampyScript/scripts/03_family_overview.gram.py
@@ -1,0 +1,4 @@
+# Family Overview
+
+for family in families():
+    row(family.gramps_id, family.father, family.mother, len(family.children))

--- a/GrampyScript/scripts/04_gender_pie_chart.gram.py
+++ b/GrampyScript/scripts/04_gender_pie_chart.gram.py
@@ -1,4 +1,8 @@
 # Gender Breakdown (Pie Chart)
+"""
+Count how many people are male, female, or of unknown gender, then draw a pie
+chart of the totals. Check the Chart tab after running.
+"""
 
 counts = counter()
 for person in people():

--- a/GrampyScript/scripts/04_gender_pie_chart.gram.py
+++ b/GrampyScript/scripts/04_gender_pie_chart.gram.py
@@ -1,0 +1,7 @@
+# Gender Breakdown (Pie Chart)
+
+counts = counter()
+for person in people():
+    counts[person.gender] += 1
+
+chart("pie", counts)

--- a/GrampyScript/scripts/05_age_histogram.gram.py
+++ b/GrampyScript/scripts/05_age_histogram.gram.py
@@ -1,4 +1,9 @@
 # Age At Death Histogram
+"""
+For everyone with both a birth and a death event recorded, compute their age in
+whole years and draw a histogram of the distribution. Check the Chart tab after
+running.
+"""
 
 ages = []
 for person in people():

--- a/GrampyScript/scripts/05_age_histogram.gram.py
+++ b/GrampyScript/scripts/05_age_histogram.gram.py
@@ -1,0 +1,9 @@
+# Age At Death Histogram
+
+ages = []
+for person in people():
+    age = person.age
+    if age:
+        ages.append(age.tuple()[0])
+
+chart("histogram", ages, count=15)

--- a/GrampyScript/scripts/06_mark_unsourced_people_private.gram.py
+++ b/GrampyScript/scripts/06_mark_unsourced_people_private.gram.py
@@ -1,0 +1,12 @@
+# Mark Unsourced People As Private
+
+begin_changes("Mark unsourced people as private")
+
+count = 0
+for person in people():
+    if len(person.citations) == 0 and not person.private:
+        person.private = True
+        count += 1
+
+end_changes()
+print("Marked %d people as private" % count)

--- a/GrampyScript/scripts/06_mark_unsourced_people_private.gram.py
+++ b/GrampyScript/scripts/06_mark_unsourced_people_private.gram.py
@@ -1,4 +1,9 @@
 # Mark Unsourced People As Private
+"""
+Batch-edit example: find every person who has no citations attached and flag
+them as private, wrapped in begin_changes()/end_changes() so the edits happen
+inside a single, undoable transaction.
+"""
 
 begin_changes("Mark unsourced people as private")
 

--- a/GrampyScript/scripts/07_csv_ready_report.gram.py
+++ b/GrampyScript/scripts/07_csv_ready_report.gram.py
@@ -1,0 +1,14 @@
+# CSV-Ready People Report
+
+columns("ID", "Given Name", "Surname", "Gender", "Birth Year")
+
+for person in people():
+    birth = person.birth
+    birth_year = birth.get_date_object().get_year() if birth else ""
+    row(
+        person.gramps_id,
+        person.name.first_name,
+        person.surname.surname,
+        person.gender,
+        birth_year,
+    )

--- a/GrampyScript/scripts/07_csv_ready_report.gram.py
+++ b/GrampyScript/scripts/07_csv_ready_report.gram.py
@@ -1,4 +1,9 @@
 # CSV-Ready People Report
+"""
+Build a simple tabular report — ID, name, gender, birth year — for every
+person. Once it runs, use Data > Save as CSV or Copy to clipboard to export the
+Table tab's contents.
+"""
 
 columns("ID", "Given Name", "Surname", "Gender", "Birth Year")
 

--- a/GrampyScript/scripts/08_active_person_summary.gram.py
+++ b/GrampyScript/scripts/08_active_person_summary.gram.py
@@ -1,0 +1,13 @@
+# Active Person Summary
+
+person = active_person
+if person:
+    row(person)
+    for parent in person.parents:
+        row(parent)
+    if person.spouse:
+        row(person.spouse)
+    for child in person.children:
+        row(child)
+else:
+    print("No active person is set.")

--- a/GrampyScript/scripts/08_active_person_summary.gram.py
+++ b/GrampyScript/scripts/08_active_person_summary.gram.py
@@ -1,4 +1,8 @@
 # Active Person Summary
+"""
+Show a compact family summary for the currently active person: their record,
+parents, spouse, and children.
+"""
 
 person = active_person
 if person:

--- a/GrampyScript/scripts/09_selected_people_report.gram.py
+++ b/GrampyScript/scripts/09_selected_people_report.gram.py
@@ -1,0 +1,4 @@
+# Report On Selected People
+
+for person in selected("Person"):
+    row(person)

--- a/GrampyScript/scripts/09_selected_people_report.gram.py
+++ b/GrampyScript/scripts/09_selected_people_report.gram.py
@@ -1,4 +1,8 @@
 # Report On Selected People
+"""
+List just the people currently selected (highlighted) in the People view.
+Select some rows in the People view before running this script.
+"""
 
 for person in selected("Person"):
     row(person)

--- a/GrampyScript/scripts/10_find_missing_birth_dates.gram.py
+++ b/GrampyScript/scripts/10_find_missing_birth_dates.gram.py
@@ -1,4 +1,8 @@
 # Find People Missing A Birth Date
+"""
+Data-quality check: list every person who has no recorded birth event, so you
+can prioritize research on those records.
+"""
 
 for person in people():
     if not person.birth:

--- a/GrampyScript/scripts/10_find_missing_birth_dates.gram.py
+++ b/GrampyScript/scripts/10_find_missing_birth_dates.gram.py
@@ -1,0 +1,5 @@
+# Find People Missing A Birth Date
+
+for person in people():
+    if not person.birth:
+        row(person.gramps_id, person.name.first_name, person.surname.surname)

--- a/GrampyScript/scripts/11_import_example.gram.py
+++ b/GrampyScript/scripts/11_import_example.gram.py
@@ -1,4 +1,9 @@
 # Births Per Decade (Import Example)
+"""
+Counts births by decade, using a decade() function imported from
+script_helpers.py in this same folder — a template for sharing helper code
+between your own scripts with a plain 'import' statement.
+"""
 
 from script_helpers import decade
 

--- a/GrampyScript/scripts/11_import_example.gram.py
+++ b/GrampyScript/scripts/11_import_example.gram.py
@@ -1,0 +1,16 @@
+# Births Per Decade (Import Example)
+
+from script_helpers import decade
+
+columns("Decade", "Births")
+
+counts = counter()
+for person in people():
+    birth = person.birth
+    if birth:
+        year = birth.get_date_object().get_year()
+        if year:
+            counts[decade(year)] += 1
+
+for decade_start, count in sorted(counts.items()):
+    row("%ds" % decade_start, count)

--- a/GrampyScript/scripts/12_custom_filter_example.gram.py
+++ b/GrampyScript/scripts/12_custom_filter_example.gram.py
@@ -1,0 +1,4 @@
+# Custom Filter Example
+
+for person in custom_filter("example filter"):
+    row(person)

--- a/GrampyScript/scripts/12_custom_filter_example.gram.py
+++ b/GrampyScript/scripts/12_custom_filter_example.gram.py
@@ -1,4 +1,10 @@
 # Custom Filter Example
+"""
+Runs one of your own custom filters (from the Filters gramplet/editor) by name
+using custom_filter(). Change 'example filter' to the name of a filter you've
+already created; if the name doesn't match one, a warning shows up in the
+Output tab instead.
+"""
 
 for person in custom_filter("example filter"):
     row(person)

--- a/GrampyScript/scripts/13_delete_unused_repositories.gram.py
+++ b/GrampyScript/scripts/13_delete_unused_repositories.gram.py
@@ -1,0 +1,12 @@
+# Delete Unused Repositories (Delete Example)
+
+begin_changes("Delete unused repositories")
+
+count = 0
+for repository in repositories():
+    if not repository.back_references:
+        delete(repository)
+        count += 1
+
+end_changes()
+print("Deleted %d unused repositories" % count)

--- a/GrampyScript/scripts/13_delete_unused_repositories.gram.py
+++ b/GrampyScript/scripts/13_delete_unused_repositories.gram.py
@@ -1,4 +1,10 @@
 # Delete Unused Repositories (Delete Example)
+"""
+Demonstrates delete(): removes any Repository record that nothing else in the
+tree refers to. Most trees have no unused repositories, so this is unlikely to
+actually delete anything — it's meant to show the pattern, wrapped in
+begin_changes()/end_changes() as a single undoable transaction.
+"""
 
 begin_changes("Delete unused repositories")
 

--- a/GrampyScript/scripts/README.md
+++ b/GrampyScript/scripts/README.md
@@ -1,0 +1,27 @@
+# Gram.py Script examples
+
+This folder ships with the GrampyScript addon and doubles as the default
+folder for Script > Open... and Script > Save as... in the gramplet. The
+numbered files below are examples; anything else you save here is yours.
+
+| File | Description |
+| --- | --- |
+| `01_list_people.gram.py` | List every person with ID, given name, surname, and gender. |
+| `02_filter_by_surname.gram.py` | List only people whose surname matches a given value. |
+| `03_family_overview.gram.py` | List every family with father, mother, and child count. |
+| `04_gender_pie_chart.gram.py` | Pie chart of the gender breakdown of everyone in the tree. |
+| `05_age_histogram.gram.py` | Histogram of age at death, for people with both birth and death recorded. |
+| `06_mark_unsourced_people_private.gram.py` | Batch-edit example: mark people with no citations as private. |
+| `07_csv_ready_report.gram.py` | Tabular report meant to be exported via Data > Save as CSV. |
+| `08_active_person_summary.gram.py` | Summary of the active person plus their parents, spouse, and children. |
+| `09_selected_people_report.gram.py` | Report on just the rows currently selected in the People view. |
+| `10_find_missing_birth_dates.gram.py` | Data-quality check: people with no recorded birth event. |
+
+Each script's title and description are also shown as a preview when you
+highlight it in the Open dialog.
+
+**Note:** addon updates only overwrite files that share a name with
+something in the released package. It's safe to save your own scripts in
+this folder under any other name — just avoid editing the numbered
+examples above in place, since a future addon update could overwrite those
+edits.

--- a/GrampyScript/scripts/README.md
+++ b/GrampyScript/scripts/README.md
@@ -16,9 +16,17 @@ numbered files below are examples; anything else you save here is yours.
 | `08_active_person_summary.gram.py` | Summary of the active person plus their parents, spouse, and children. |
 | `09_selected_people_report.gram.py` | Report on just the rows currently selected in the People view. |
 | `10_find_missing_birth_dates.gram.py` | Data-quality check: people with no recorded birth event. |
+| `11_import_example.gram.py` | Counts births per decade using `decade()`, imported from `script_helpers.py`. |
+| `12_custom_filter_example.gram.py` | Runs one of your own custom filters by name via `custom_filter()`. |
+| `13_delete_unused_repositories.gram.py` | Delete example: removes Repository records nothing refers to (rarely any). |
 
 Each script's title and description are also shown as a preview when you
 highlight it in the Open dialog.
+
+`script_helpers.py` is a plain Python module, not a `.gram.py` script — it
+won't show up in the Open dialog. It exists to be imported (see
+`11_import_example.gram.py`): any `.py` file you place in this folder, or
+alongside a script saved elsewhere, can be imported the same way.
 
 **Note:** addon updates only overwrite files that share a name with
 something in the released package. It's safe to save your own scripts in

--- a/GrampyScript/scripts/script_helpers.py
+++ b/GrampyScript/scripts/script_helpers.py
@@ -1,0 +1,9 @@
+# Plain Python helper module, importable from any .gram.py script in this
+# folder via `from script_helpers import decade` (see 11_import_example.gram.py).
+# Unlike .gram.py files this is not a runnable script itself -- it's a
+# regular module that GrampyScript's import-path setup makes importable.
+
+
+def decade(year):
+    """Round a year down to the start of its decade, e.g. 1873 -> 1870."""
+    return (year // 10) * 10 if year else None

--- a/GrampyScript/stub_generator.py
+++ b/GrampyScript/stub_generator.py
@@ -107,43 +107,61 @@ TABLE_FUNCTIONS = {
 # TABLE_FUNCTIONS above -- type them as the union of every row type rather
 # than "object": jedi merges every union member's attributes, which is more
 # useful than no completions at all past a plain "object".
-_BACK_REFERENCE_TYPE = 'list[Union[%s]]' % ", ".join(
-    '"%s"' % name for name in sorted(set(GENERATOR_ROW_TYPES.values()))
-)
+_ALL_ROOT = set(GENERATOR_ROW_TYPES.values())
+_BACK_REFERENCE_TYPE = 'list[Union[%s]]' % ", ".join('"%s"' % name for name in sorted(_ALL_ROOT))
 
-# DataDict2's computed @property names (datadict2.py), layered onto every
-# generated type since DataDict2 defines them once for every instance
-# regardless of the wrapped record's real class. Best-effort types; "object"
-# is used where the real return type is ambiguous or data-dependent.
+_PERSON = {"Person"}
+_PERSON_FAMILY = {"Person", "Family"}
+
+# DataDict2's computed @property names (datadict2.py): type_annotation plus
+# which root row types the property is actually valid on, derived from what
+# each property's own code requires -- a SimpleAccess call that asserts its
+# argument type (e.g. sa.gender, sa.spouse: Person only), or a raw dict field
+# that only some schemas have (e.g. `place` needs Event.place, `source` needs
+# Citation.source_handle). Layering a property onto a type it doesn't apply
+# to would offer a completion that's either silently useless or -- like the
+# old `gender`-on-non-Person -- raises at runtime.
 COMPUTED_PROPERTIES = {
-    "gender": "str",
-    "age": "Span",
-    "birth": "Event",
-    "death": "Event",
-    "place": "Place",
-    "parents": 'list["Person"]',
-    "father": "Person",
-    "mother": "Person",
-    "spouse": "Person",
-    "source": "Source",
-    "families": 'list["Family"]',
-    "parent_families": 'list["Family"]',
-    "children": 'list["Person"]',
-    "notes": 'list["Note"]',
-    "tags": 'list["Tag"]',
-    "citations": 'list["Citation"]',
-    "media": 'list["MediaRef"]',
-    "events": 'list["Event"]',
-    "reference": "Person",
-    "attributes": 'list["Attribute"]',
-    "addresses": 'list["Address"]',
-    "lds_ords": 'list["LdsOrdinance"]',
-    "references": 'list["PersonRef"]',
-    "back_references": _BACK_REFERENCE_TYPE,
-    "back_references_recursively": _BACK_REFERENCE_TYPE,
-    "name": "Name",
-    "surname": "Surname",
-    "names": 'list["Name"]',
+    "gender": ("str", _PERSON),
+    "age": ("Span", _PERSON),
+    "birth": ("Event", _PERSON),
+    "death": ("Event", _PERSON),
+    "place": ("Place", {"Event"}),
+    "parents": ('list["Person"]', _PERSON_FAMILY),
+    "father": ("Person", _PERSON_FAMILY),
+    "mother": ("Person", _PERSON_FAMILY),
+    "spouse": ("Person", _PERSON),
+    "source": ("Source", {"Citation"}),
+    "families": ('list["Family"]', _PERSON),
+    "parent_families": ('list["Family"]', _PERSON),
+    "children": ('list["Person"]', _PERSON_FAMILY),
+    "notes": ('list["Note"]', _ALL_ROOT - {"Note"}),
+    "tags": ('list["Tag"]', _ALL_ROOT),
+    "citations": ('list["Citation"]', {"Person", "Family", "Event", "Place", "Media"}),
+    "media": ('list["MediaRef"]', {"Person", "Family", "Event", "Place", "Source", "Citation"}),
+    "events": ('list["Event"]', _PERSON_FAMILY),
+    "attributes": ('list["Attribute"]', {"Person", "Family", "Event", "Source", "Citation", "Media"}),
+    "addresses": ('list["Address"]', {"Person", "Repository"}),
+    "lds_ords": ('list["LdsOrdinance"]', _PERSON_FAMILY),
+    "references": ('list["PersonRef"]', _PERSON),
+    "back_references": (_BACK_REFERENCE_TYPE, _ALL_ROOT),
+    "back_references_recursively": (_BACK_REFERENCE_TYPE, _ALL_ROOT),
+    "name": ("Name", _PERSON),
+    "surname": ("Surname", _PERSON),
+    "names": ('list["Name"]', _PERSON),
+}
+
+# `reference` (datadict2.py) isn't valid on any root row type -- it reads
+# `self.ref`, a handle that exists only on the nested *Ref wrapper types
+# (mirrors datadict2.REFERENCE_TABLES). Sanitized schema class name -> the
+# row type its `ref` handle points into.
+REFERENCE_TARGET_TYPES = {
+    "ChildReference": "Person",
+    "EventReference": "Event",
+    "MediaRef": "Media",
+    "PersonRef": "Person",
+    "PlaceRef": "Place",
+    "RepositoryRef": "Repository",
 }
 
 _SCALAR_TYPES = {"string": "str", "integer": "int", "boolean": "bool", "number": "float"}
@@ -190,15 +208,25 @@ def _walk(schema, registry):
 def build_registry(root_classes=ROOT_CLASSES):
     """
     Return {sanitized_class_name: {field_name: type_annotation}} for every
-    type reachable from `root_classes` via Gramps' own get_schema(), with
-    DataDict2's computed properties layered on top of each (matching real
-    attribute lookup order: properties shadow raw dict keys).
+    type reachable from `root_classes` via Gramps' own get_schema(). Each
+    entry in COMPUTED_PROPERTIES is layered only onto the root row types it
+    lists as valid (matching real attribute lookup order: properties shadow
+    raw dict keys) -- nested structural types (Name, Attribute, ...) get
+    schema fields only. `reference` is layered separately, onto the nested
+    *Ref types listed in REFERENCE_TARGET_TYPES, since that's what it's
+    actually valid on.
     """
     registry = {}
     for cls in root_classes:
         _walk(cls.get_schema(), registry)
-    for fields in registry.values():
-        fields.update(COMPUTED_PROPERTIES)
+    for class_name, fields in registry.items():
+        if class_name in _ALL_ROOT:
+            for prop_name, (type_, valid_for) in COMPUTED_PROPERTIES.items():
+                if class_name in valid_for:
+                    fields[prop_name] = type_
+        target = REFERENCE_TARGET_TYPES.get(class_name)
+        if target is not None:
+            fields["reference"] = target
     return registry
 
 

--- a/GrampyScript/stub_generator.py
+++ b/GrampyScript/stub_generator.py
@@ -1,0 +1,240 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2025      Doug Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+Generates a block of plain-annotation Python source (a "stub preamble") that
+jedi can use to statically infer the row type of a DSL generator function,
+e.g. `for person in people(): person.primary_name.first_name`.
+
+jedi's static engine reads class bodies, it never runs our DataDict2.__dir__
+override, so a live DataDict2 instance is not enough for this case (there is
+no instance until the script actually runs). Instead we derive the field
+names straight from Gramps' own JSON schema (cls.get_schema(), present on
+every gramps.gen.lib class) and render lightweight classes carrying only
+type annotations -- no bodies, nothing is ever executed.
+
+This module has no GTK dependency, only gramps.gen.lib, so it can be
+developed and tested without a running Gramps/GTK environment.
+"""
+
+import re
+
+from gramps.gen.lib import (
+    Citation,
+    Event,
+    Family,
+    Media,
+    Note,
+    Person,
+    Place,
+    Repository,
+    Source,
+)
+
+# The DSL row types generators/active_* names are bound to in
+# GrampyScript.execute_code().
+ROOT_CLASSES = [Person, Family, Event, Place, Repository, Source, Citation, Note, Media]
+
+# generator function name -> row type, mirrors the DSL bindings in
+# GrampyScript.execute_code() (people/families/notes/...).
+GENERATOR_ROW_TYPES = {
+    "people": "Person",
+    "families": "Family",
+    "notes": "Note",
+    "events": "Event",
+    "repositories": "Repository",
+    "citations": "Citation",
+    "sources": "Source",
+    "media": "Media",
+    "places": "Place",
+}
+
+# active_* name -> row type, mirrors the active_* bindings in
+# GrampyScript.execute_code(). These are declared as plain module-level
+# annotations (no value), which is enough for jedi to resolve attribute
+# chains statically. That matters here: a *live* template DataDict2
+# instance would require jedi to actually call DataDict2's computed
+# @property methods (father, birth, ...) to see what they return, which
+# executes real code (SimpleAccess lookups) and, for a blank template
+# with nothing to find, yields no completions at all past that point.
+# The stub sidesteps both problems -- nothing is ever executed, and the
+# field list comes from the schema regardless of what data exists.
+ACTIVE_VARIABLES = {
+    "active_person": "Person",
+    "active_family": "Family",
+    "active_event": "Event",
+    "active_place": "Place",
+    "active_repository": "Repository",
+    "active_source": "Source",
+    "active_citation": "Citation",
+    "active_note": "Note",
+    "active_media": "Media",
+}
+
+# selected()/filtered()/custom_filter() in execute_code() all take a
+# table-name string argument that picks the row type at runtime (e.g.
+# selected("Family")). jedi 0.19 does not discriminate typing.overload by
+# a Literal argument value -- verified empirically it merges every
+# overload's return fields regardless of which literal was passed, and
+# regardless of overload declaration order. So rather than rely on that,
+# these are typed as returning the union of every row type: less precise
+# than the argument deserves, but strictly more useful than no annotation
+# at all (which is what these had before).
+TABLE_FUNCTIONS = {
+    "selected": ["table_name: str"],
+    "filtered": ["table_name: str"],
+    "custom_filter": ["name: str", 'namespace: str = "Person"'],
+}
+
+# DataDict2's computed @property names (datadict2.py), layered onto every
+# generated type since DataDict2 defines them once for every instance
+# regardless of the wrapped record's real class. Best-effort types; "object"
+# is used where the real return type is ambiguous or data-dependent.
+COMPUTED_PROPERTIES = {
+    "gender": "str",
+    "age": "object",
+    "birth": "Event",
+    "death": "Event",
+    "place": "Place",
+    "parents": 'list["Person"]',
+    "father": "Person",
+    "mother": "Person",
+    "spouse": "Person",
+    "source": "Source",
+    "families": 'list["Family"]',
+    "parent_families": 'list["Family"]',
+    "children": 'list["Person"]',
+    "notes": 'list["Note"]',
+    "tags": 'list["Tag"]',
+    "citations": 'list["Citation"]',
+    "media": 'list["MediaRef"]',
+    "events": 'list["Event"]',
+    "reference": "Person",
+    "attributes": 'list["Attribute"]',
+    "addresses": 'list["Address"]',
+    "lds_ords": 'list["LdsOrdinance"]',
+    "references": 'list["PersonRef"]',
+    "back_references": "object",
+    "back_references_recursively": "object",
+    "name": "Name",
+    "surname": "Surname",
+    "names": 'list["Name"]',
+}
+
+_SCALAR_TYPES = {"string": "str", "integer": "int", "boolean": "bool", "number": "float"}
+
+
+def _sanitize(title):
+    """Turn a Gramps schema title like "Event reference" into a valid
+    Python identifier like "EventReference"."""
+    return "".join(word.capitalize() for word in re.findall(r"[A-Za-z0-9]+", title))
+
+
+def _pytype(schema, registry):
+    type_ = schema.get("type")
+    if isinstance(type_, list):
+        return "object"
+    if type_ == "object" and "properties" in schema:
+        _walk(schema, registry)
+        return _sanitize(schema["title"])
+    if type_ == "array":
+        items = schema.get("items")
+        if isinstance(items, dict) and items.get("type") == "object" and "properties" in items:
+            _walk(items, registry)
+            return 'list["%s"]' % _sanitize(items["title"])
+        return "list"
+    return _SCALAR_TYPES.get(type_, "object")
+
+
+def _walk(schema, registry):
+    title = schema.get("title")
+    if not title:
+        return
+    name = _sanitize(title)
+    if name in registry:
+        return
+    registry[name] = {}  # reserve first, to break reference cycles
+    fields = {}
+    for field_name, sub in schema.get("properties", {}).items():
+        if field_name == "_class":
+            continue
+        fields[field_name] = _pytype(sub, registry)
+    registry[name] = fields
+
+
+def build_registry(root_classes=ROOT_CLASSES):
+    """
+    Return {sanitized_class_name: {field_name: type_annotation}} for every
+    type reachable from `root_classes` via Gramps' own get_schema(), with
+    DataDict2's computed properties layered on top of each (matching real
+    attribute lookup order: properties shadow raw dict keys).
+    """
+    registry = {}
+    for cls in root_classes:
+        _walk(cls.get_schema(), registry)
+    for fields in registry.values():
+        fields.update(COMPUTED_PROPERTIES)
+    return registry
+
+
+def render_stub_source(
+    registry,
+    generator_row_types=GENERATOR_ROW_TYPES,
+    table_functions=TABLE_FUNCTIONS,
+    active_variables=ACTIVE_VARIABLES,
+):
+    """
+    Render `registry` plus DSL generator function signatures and active_*
+    variable annotations as a block of Python source usable as a jedi
+    completion preamble. No class or function body has real logic, only
+    annotations -- this text is only ever fed to jedi for static
+    analysis, never executed.
+    """
+    lines = [
+        "from __future__ import annotations",
+        "from typing import Iterator, Union",
+        "",
+    ]
+    for name in sorted(registry):
+        lines.append("class %s:" % name)
+        fields = registry[name]
+        if not fields:
+            lines.append("    pass")
+        else:
+            for field_name, type_ in fields.items():
+                lines.append("    %s: %s" % (field_name, type_))
+        lines.append("")
+    for func_name, row_type in generator_row_types.items():
+        lines.append("def %s() -> Iterator[%s]: ..." % (func_name, row_type))
+    if table_functions:
+        row_union = "Union[%s]" % ", ".join(sorted(set(generator_row_types.values())))
+        for func_name, params in table_functions.items():
+            lines.append(
+                "def %s(%s) -> Iterator[%s]: ..." % (func_name, ", ".join(params), row_union)
+            )
+    lines.append("")
+    for var_name, row_type in active_variables.items():
+        lines.append("%s: %s" % (var_name, row_type))
+    lines.append("")
+    return "\n".join(lines)
+
+
+def build_stub_source():
+    """Convenience: build the registry and render it in one call."""
+    return render_stub_source(build_registry())

--- a/GrampyScript/stub_generator.py
+++ b/GrampyScript/stub_generator.py
@@ -102,6 +102,22 @@ TABLE_FUNCTIONS = {
     "custom_filter": ["name: str", 'namespace: str = "Person"'],
 }
 
+# Other top-level DSL callables bound in execute_code() (GrampyScript.py):
+# real functions/bound methods with side effects (printing a row, opening/
+# closing a transaction, drawing a chart, deleting a record) rather than
+# something whose return value ever gets chained. None of these need row-type
+# inference, just enough of a signature for jedi to offer them as completions
+# and to know their parameters -- hence "-> None" rather than being folded
+# into TABLE_FUNCTIONS.
+VOID_FUNCTIONS = {
+    "row": ["*args"],
+    "columns": ["*column_names"],
+    "begin_changes": ['message: str = ""'],
+    "end_changes": [],
+    "delete": ["obj"],
+    "chart": ["type", "data", "count: int = 20", "**kwargs"],
+}
+
 # back_references(_recursively) can resolve to any primary object type at
 # runtime (datadict2.py looks up the handle's own table), so -- same trick as
 # TABLE_FUNCTIONS above -- type them as the union of every row type rather
@@ -235,6 +251,7 @@ def render_stub_source(
     generator_row_types=GENERATOR_ROW_TYPES,
     table_functions=TABLE_FUNCTIONS,
     active_variables=ACTIVE_VARIABLES,
+    void_functions=VOID_FUNCTIONS,
 ):
     """
     Render `registry` plus DSL generator function signatures and active_*
@@ -266,6 +283,8 @@ def render_stub_source(
             lines.append(
                 "def %s(%s) -> Iterator[%s]: ..." % (func_name, ", ".join(params), row_union)
             )
+    for func_name, params in void_functions.items():
+        lines.append("def %s(%s) -> None: ..." % (func_name, ", ".join(params)))
     lines.append("")
     for var_name, row_type in active_variables.items():
         lines.append("%s: %s" % (var_name, row_type))

--- a/GrampyScript/stub_generator.py
+++ b/GrampyScript/stub_generator.py
@@ -102,13 +102,22 @@ TABLE_FUNCTIONS = {
     "custom_filter": ["name: str", 'namespace: str = "Person"'],
 }
 
+# back_references(_recursively) can resolve to any primary object type at
+# runtime (datadict2.py looks up the handle's own table), so -- same trick as
+# TABLE_FUNCTIONS above -- type them as the union of every row type rather
+# than "object": jedi merges every union member's attributes, which is more
+# useful than no completions at all past a plain "object".
+_BACK_REFERENCE_TYPE = 'list[Union[%s]]' % ", ".join(
+    '"%s"' % name for name in sorted(set(GENERATOR_ROW_TYPES.values()))
+)
+
 # DataDict2's computed @property names (datadict2.py), layered onto every
 # generated type since DataDict2 defines them once for every instance
 # regardless of the wrapped record's real class. Best-effort types; "object"
 # is used where the real return type is ambiguous or data-dependent.
 COMPUTED_PROPERTIES = {
     "gender": "str",
-    "age": "object",
+    "age": "Span",
     "birth": "Event",
     "death": "Event",
     "place": "Place",
@@ -130,8 +139,8 @@ COMPUTED_PROPERTIES = {
     "addresses": 'list["Address"]',
     "lds_ords": 'list["LdsOrdinance"]',
     "references": 'list["PersonRef"]',
-    "back_references": "object",
-    "back_references_recursively": "object",
+    "back_references": _BACK_REFERENCE_TYPE,
+    "back_references_recursively": _BACK_REFERENCE_TYPE,
     "name": "Name",
     "surname": "Surname",
     "names": 'list["Name"]',
@@ -209,6 +218,7 @@ def render_stub_source(
     lines = [
         "from __future__ import annotations",
         "from typing import Iterator, Union",
+        "from gramps.gen.lib.date import Span",
         "",
     ]
     for name in sorted(registry):

--- a/GrampyScript/tests/test_completion.py
+++ b/GrampyScript/tests/test_completion.py
@@ -1,0 +1,145 @@
+"""
+Tests for completion.py — jedi-based command completion.
+
+Uses real Gramps gen-lib objects (no GTK required).
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from gramps.gen.lib import Person, Name, Surname
+from gramps.gen.simple import SimpleAccess
+
+from datadict2 import DataDict2, set_sa
+from completion import get_completions, get_completion_items
+
+
+def _make_person(gramps_id="I0001", first="John", surname="Smith"):
+    p = Person()
+    p.set_gramps_id(gramps_id)
+    n = Name()
+    sn = Surname()
+    sn.set_surname(surname)
+    n.add_surname(sn)
+    n.set_first_name(first)
+    p.set_primary_name(n)
+    return p
+
+
+class _MockSaBase(unittest.TestCase):
+    """Base class that sets up a minimal SimpleAccess mock before each test."""
+
+    def setUp(self):
+        db = MagicMock()
+        sa = SimpleAccess(db)
+        set_sa(sa)
+
+    def _complete(self, source, namespace):
+        line = source.count("\n") + 1
+        column = len(source) - (source.rfind("\n") + 1)
+        return get_completions(source, line, column, namespace)
+
+
+class TestBareWordCompletion(_MockSaBase):
+    def test_completes_python_builtins(self):
+        names = self._complete("pri", {})
+        self.assertIn("print", names)
+
+    def test_completes_namespace_variable(self):
+        names = self._complete("active_per", {"active_person": DataDict2(_make_person())})
+        self.assertIn("active_person", names)
+
+
+class TestAttributeCompletion(_MockSaBase):
+    def setUp(self):
+        super().setUp()
+        self.namespace = {"active_person": DataDict2(_make_person())}
+
+    def test_completes_dynamic_dict_keys(self):
+        names = self._complete("active_person.", self.namespace)
+        self.assertIn("primary_name", names)
+        self.assertIn("gramps_id", names)
+
+    def test_completes_class_properties(self):
+        names = self._complete("active_person.", self.namespace)
+        self.assertIn("father", names)
+        self.assertIn("age", names)
+
+    def test_completes_nested_attribute_chain(self):
+        names = self._complete("active_person.primary_name.", self.namespace)
+        self.assertIn("first_name", names)
+        self.assertIn("surname_list", names)
+
+    def test_prefix_narrows_nested_match(self):
+        names = self._complete("active_person.primary_name.first_", self.namespace)
+        self.assertEqual(names, ["first_name"])
+
+    def test_no_false_match_for_unrelated_prefix(self):
+        names = self._complete("active_person.primary_name.zzz", self.namespace)
+        self.assertEqual(names, [])
+
+
+class TestGeneratorRowTypeInference(_MockSaBase):
+    """
+    Completion on a user's own loop variable, e.g.
+    `for person in people(): person.primary_name.first_name` -- `person` is
+    a name the user chose, not something we bind into the namespace, so it
+    can only be resolved via the stub_generator preamble's static
+    annotation on `people()`, not runtime introspection.
+    """
+
+    def test_completes_loop_variable_over_people(self):
+        names = self._complete("for person in people():\n    person.", {})
+        self.assertIn("primary_name", names)
+        self.assertIn("gramps_id", names)
+
+    def test_completes_nested_attribute_on_loop_variable(self):
+        names = self._complete(
+            "for person in people():\n    person.primary_name.first_", {}
+        )
+        self.assertEqual(names, ["first_name"])
+
+    def test_distinguishes_row_type_by_generator(self):
+        # families() yields Family, not Person -- fields must not bleed
+        # across generators.
+        names = self._complete("for fam in families():\n    fam.", {})
+        self.assertIn("father_handle", names)
+        self.assertNotIn("primary_name", names)
+
+
+class TestCompletionItems(_MockSaBase):
+    """get_completion_items() is get_completions() plus the jedi
+    `.complete` suffix, used by the editor to insert just the missing
+    characters rather than re-typing the whole name."""
+
+    def test_complete_is_only_the_missing_suffix(self):
+        namespace = {"active_person": DataDict2(_make_person())}
+        items = get_completion_items("active_person.primary_", 1, len("active_person.primary_"), namespace)
+        self.assertEqual(items, [{"name": "primary_name", "complete": "name"}])
+
+    def test_complete_is_full_name_when_nothing_typed_yet(self):
+        namespace = {"active_person": DataDict2(_make_person())}
+        items = get_completion_items("active_person.", 1, len("active_person."), namespace)
+        matching = [i for i in items if i["name"] == "primary_name"]
+        self.assertEqual(matching, [{"name": "primary_name", "complete": "primary_name"}])
+
+
+class TestRobustness(_MockSaBase):
+    def test_empty_source_does_not_raise(self):
+        # Completing on an empty buffer legitimately lists every builtin
+        # in scope; the point of this test is only that it doesn't raise.
+        names = self._complete("", {})
+        self.assertIn("print", names)
+
+    def test_incomplete_code_does_not_raise(self):
+        # Mid-typing code is often syntactically invalid; must not crash.
+        names = self._complete("for person in people(", {})
+        self.assertIsInstance(names, list)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/GrampyScript/tests/test_completion.py
+++ b/GrampyScript/tests/test_completion.py
@@ -46,8 +46,10 @@ class _MockSaBase(unittest.TestCase):
 
 class TestBareWordCompletion(_MockSaBase):
     def test_completes_python_builtins(self):
+        # print is a function, so it gets "()" appended like any other
+        # callable completion -- see TestCompletionItems below.
         names = self._complete("pri", {})
-        self.assertIn("print", names)
+        self.assertIn("print()", names)
 
     def test_completes_namespace_variable(self):
         names = self._complete("active_per", {"active_person": DataDict2(_make_person())})
@@ -111,6 +113,46 @@ class TestGeneratorRowTypeInference(_MockSaBase):
         self.assertNotIn("primary_name", names)
 
 
+class TestGetCompletionsFunctionParens(_MockSaBase):
+    """
+    Regression: get_completions() used to return bare function names
+    (e.g. "people", "format") while get_completion_items() appended "()"
+    to the same completions -- inconsistent and misleading, since a bare
+    name reads as a field rather than a callable. Both now agree.
+    """
+
+    def test_bare_function_completion_gets_parens(self):
+        names = self._complete("peop", {})
+        self.assertIn("people()", names)
+        self.assertNotIn("people", names)
+
+    def test_non_function_completion_has_no_parens(self):
+        namespace = {"active_person": DataDict2(_make_person())}
+        names = self._complete("active_person.gramps_", namespace)
+        self.assertIn("gramps_id", names)
+
+
+class TestClassCompletionsExcluded(_MockSaBase):
+    """
+    Classes (jedi type "class") are excluded entirely, not just left
+    without "()". The stub preamble injects scaffold classes (Person,
+    Family, ...) purely for jedi's static analysis -- they aren't bound to
+    anything in the namespace a script actually executes in, so offering
+    them as completions would suggest names that raise NameError if
+    accepted. Builtin classes (list, dict, ...) are excluded too, since
+    the DSL has no use for instantiating classes directly.
+    """
+
+    def test_stub_scaffold_class_not_offered(self):
+        names = self._complete("Perso", {})
+        self.assertNotIn("Person", names)
+        self.assertNotIn("PersonRef", names)
+
+    def test_builtin_class_not_offered(self):
+        names = self._complete("li", {})
+        self.assertNotIn("list", names)
+
+
 class TestCompletionItems(_MockSaBase):
     """get_completion_items() is get_completions() plus the jedi
     `.complete` suffix, used by the editor to insert just the missing
@@ -160,7 +202,7 @@ class TestRobustness(_MockSaBase):
         # Completing on an empty buffer legitimately lists every builtin
         # in scope; the point of this test is only that it doesn't raise.
         names = self._complete("", {})
-        self.assertIn("print", names)
+        self.assertIn("print()", names)
 
     def test_incomplete_code_does_not_raise(self):
         # Mid-typing code is often syntactically invalid; must not crash.

--- a/GrampyScript/tests/test_completion.py
+++ b/GrampyScript/tests/test_completion.py
@@ -119,13 +119,40 @@ class TestCompletionItems(_MockSaBase):
     def test_complete_is_only_the_missing_suffix(self):
         namespace = {"active_person": DataDict2(_make_person())}
         items = get_completion_items("active_person.primary_", 1, len("active_person.primary_"), namespace)
-        self.assertEqual(items, [{"name": "primary_name", "complete": "name"}])
+        self.assertEqual(
+            items, [{"name": "primary_name", "complete": "name", "cursor_offset": 0}]
+        )
 
     def test_complete_is_full_name_when_nothing_typed_yet(self):
         namespace = {"active_person": DataDict2(_make_person())}
         items = get_completion_items("active_person.", 1, len("active_person."), namespace)
         matching = [i for i in items if i["name"] == "primary_name"]
-        self.assertEqual(matching, [{"name": "primary_name", "complete": "primary_name"}])
+        self.assertEqual(
+            matching, [{"name": "primary_name", "complete": "primary_name", "cursor_offset": 0}]
+        )
+
+    def test_no_arg_function_gets_parens_appended(self):
+        # people() takes no arguments -- cursor lands after "()".
+        items = get_completion_items("peop", 1, len("peop"), {})
+        matching = [i for i in items if i["name"] == "people()"]
+        self.assertEqual(
+            matching, [{"name": "people()", "complete": "le()", "cursor_offset": 0}]
+        )
+
+    def test_function_with_args_lands_cursor_between_parens(self):
+        items = get_completion_items("custom_fil", 1, len("custom_fil"), {})
+        matching = [i for i in items if i["name"] == "custom_filter()"]
+        self.assertEqual(
+            matching, [{"name": "custom_filter()", "complete": "ter()", "cursor_offset": 1}]
+        )
+
+    def test_non_function_completion_has_no_parens(self):
+        namespace = {"active_person": DataDict2(_make_person())}
+        items = get_completion_items("active_person.gramps_", 1, len("active_person.gramps_"), namespace)
+        matching = [i for i in items if i["name"] == "gramps_id"]
+        self.assertEqual(
+            matching, [{"name": "gramps_id", "complete": "id", "cursor_offset": 0}]
+        )
 
 
 class TestRobustness(_MockSaBase):

--- a/GrampyScript/tests/test_completion_popup.py
+++ b/GrampyScript/tests/test_completion_popup.py
@@ -79,14 +79,26 @@ class TestTriggerAndClose(unittest.TestCase):
         self.assertEqual(controller.selected_index, 0)
         window.destroy()
 
+    def test_trigger_inserts_directly_when_only_one_match(self):
+        # "primary_" only matches primary_name among active_person's
+        # dynamic keys -- with a single candidate there is nothing to
+        # choose between, so it should be inserted immediately rather
+        # than opening a one-row popover.
+        controller, buffer, window = _make_controller("active_person.primary_")
+        opened = controller.trigger()
+        self.assertTrue(opened)
+        self.assertFalse(controller.is_open())
+        text = buffer.get_text(buffer.get_start_iter(), buffer.get_end_iter(), True)
+        self.assertEqual(text, "active_person.primary_name")
+        window.destroy()
+
 
 class TestAccept(unittest.TestCase):
     def test_accept_inserts_missing_suffix_only(self):
-        controller, buffer, window = _make_controller("active_person.primary_")
+        controller, buffer, window = _make_controller("active_person.")
         controller.trigger()
-        # first match should be primary_name (only dynamic key matching)
         names = [item["name"] for item in controller.items]
-        self.assertEqual(names, ["primary_name"])
+        controller.selected_index = names.index("primary_name")
         controller.accept()
         text = buffer.get_text(buffer.get_start_iter(), buffer.get_end_iter(), True)
         self.assertEqual(text, "active_person.primary_name")
@@ -102,12 +114,11 @@ class TestAccept(unittest.TestCase):
         window.destroy()
 
     def test_accept_no_arg_function_places_cursor_after_parens(self):
+        # "peop" has only one match (people()), so trigger() inserts it
+        # directly -- exercises the same accept() cursor-placement code
+        # path as a manual popover selection would.
         controller, buffer, window = _make_controller("peop")
         controller.trigger()
-        names = [item["name"] for item in controller.items]
-        self.assertIn("people()", names)
-        controller.selected_index = names.index("people()")
-        controller.accept()
         text = buffer.get_text(buffer.get_start_iter(), buffer.get_end_iter(), True)
         self.assertEqual(text, "people()")
         cursor = buffer.get_iter_at_mark(buffer.get_insert()).get_offset()
@@ -117,10 +128,6 @@ class TestAccept(unittest.TestCase):
     def test_accept_function_with_args_places_cursor_between_parens(self):
         controller, buffer, window = _make_controller("custom_fil")
         controller.trigger()
-        names = [item["name"] for item in controller.items]
-        self.assertIn("custom_filter()", names)
-        controller.selected_index = names.index("custom_filter()")
-        controller.accept()
         text = buffer.get_text(buffer.get_start_iter(), buffer.get_end_iter(), True)
         self.assertEqual(text, "custom_filter()")
         cursor = buffer.get_iter_at_mark(buffer.get_insert()).get_offset()
@@ -144,8 +151,17 @@ class TestNavigation(unittest.TestCase):
 
 
 class TestOnKeyPress(unittest.TestCase):
-    def test_tab_opens_then_accepts(self):
+    def test_tab_completes_directly_for_single_match(self):
         controller, buffer, window = _make_controller("active_person.primary_")
+        consumed = controller.on_key_press(_FakeEvent(Gdk.KEY_Tab))
+        self.assertTrue(consumed)
+        self.assertFalse(controller.is_open())
+        text = buffer.get_text(buffer.get_start_iter(), buffer.get_end_iter(), True)
+        self.assertEqual(text, "active_person.primary_name")
+        window.destroy()
+
+    def test_tab_opens_then_accepts_for_multiple_matches(self):
+        controller, buffer, window = _make_controller("active_person.")
         consumed = controller.on_key_press(_FakeEvent(Gdk.KEY_Tab))
         self.assertTrue(consumed)
         self.assertTrue(controller.is_open())
@@ -154,7 +170,8 @@ class TestOnKeyPress(unittest.TestCase):
         self.assertTrue(consumed)
         self.assertFalse(controller.is_open())
         text = buffer.get_text(buffer.get_start_iter(), buffer.get_end_iter(), True)
-        self.assertEqual(text, "active_person.primary_name")
+        self.assertTrue(text.startswith("active_person."))
+        self.assertGreater(len(text), len("active_person."))
         window.destroy()
 
     def test_tab_falls_through_when_nothing_completable(self):
@@ -188,13 +205,16 @@ class TestOnKeyPress(unittest.TestCase):
         window.destroy()
 
     def test_return_accepts_only_while_open(self):
-        controller, buffer, window = _make_controller("active_person.primary_")
+        controller, buffer, window = _make_controller("active_person.")
         # popover not open: Return must not be swallowed (newline/apply-script bindings)
         self.assertFalse(controller.on_key_press(_FakeEvent(Gdk.KEY_Return)))
         controller.trigger()
+        self.assertTrue(controller.is_open())
         self.assertTrue(controller.on_key_press(_FakeEvent(Gdk.KEY_Return)))
+        self.assertFalse(controller.is_open())
         text = buffer.get_text(buffer.get_start_iter(), buffer.get_end_iter(), True)
-        self.assertEqual(text, "active_person.primary_name")
+        self.assertTrue(text.startswith("active_person."))
+        self.assertGreater(len(text), len("active_person."))
         window.destroy()
 
 
@@ -212,7 +232,7 @@ class TestLiveRefresh(unittest.TestCase):
         window.destroy()
 
     def test_refresh_closes_when_context_no_longer_completable(self):
-        controller, buffer, window = _make_controller("active_person.primary_")
+        controller, buffer, window = _make_controller("active_person.")
         controller.trigger()
         self.assertTrue(controller.is_open())
 

--- a/GrampyScript/tests/test_completion_popup.py
+++ b/GrampyScript/tests/test_completion_popup.py
@@ -101,6 +101,32 @@ class TestAccept(unittest.TestCase):
         self.assertFalse(controller.is_open())
         window.destroy()
 
+    def test_accept_no_arg_function_places_cursor_after_parens(self):
+        controller, buffer, window = _make_controller("peop")
+        controller.trigger()
+        names = [item["name"] for item in controller.items]
+        self.assertIn("people()", names)
+        controller.selected_index = names.index("people()")
+        controller.accept()
+        text = buffer.get_text(buffer.get_start_iter(), buffer.get_end_iter(), True)
+        self.assertEqual(text, "people()")
+        cursor = buffer.get_iter_at_mark(buffer.get_insert()).get_offset()
+        self.assertEqual(cursor, len("people()"))
+        window.destroy()
+
+    def test_accept_function_with_args_places_cursor_between_parens(self):
+        controller, buffer, window = _make_controller("custom_fil")
+        controller.trigger()
+        names = [item["name"] for item in controller.items]
+        self.assertIn("custom_filter()", names)
+        controller.selected_index = names.index("custom_filter()")
+        controller.accept()
+        text = buffer.get_text(buffer.get_start_iter(), buffer.get_end_iter(), True)
+        self.assertEqual(text, "custom_filter()")
+        cursor = buffer.get_iter_at_mark(buffer.get_insert()).get_offset()
+        self.assertEqual(cursor, len("custom_filter("))
+        window.destroy()
+
 
 class TestNavigation(unittest.TestCase):
     def test_move_selection_clamped(self):

--- a/GrampyScript/tests/test_completion_popup.py
+++ b/GrampyScript/tests/test_completion_popup.py
@@ -1,0 +1,201 @@
+"""
+Tests for completion_popup.py — the Tab-triggered completion popover.
+
+Needs a real (possibly virtual, e.g. Xvfb) display since it builds real
+Gtk widgets (Gtk.Popover, Gtk.ListBox) and asks for their allocation.
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import gi
+
+gi.require_version("Gtk", "3.0")
+gi.require_version("Gdk", "3.0")
+from gi.repository import Gdk, Gtk
+
+from completion_popup import CompletionController
+
+
+class _FakeEvent:
+    def __init__(self, keyval):
+        self.keyval = keyval
+
+
+def _make_controller(text, cursor_offset=None, namespace=None):
+    textview = Gtk.TextView()
+    buffer = textview.get_buffer()
+    buffer.set_text(text)
+    if cursor_offset is None:
+        cursor_offset = len(text)
+    buffer.place_cursor(buffer.get_iter_at_offset(cursor_offset))
+
+    # A real (offscreen) top-level window so widgets can be allocated --
+    # Gtk.Popover needs a realized relative_to widget to compute a
+    # position against.
+    window = Gtk.Window()
+    window.add(textview)
+    window.set_default_size(400, 300)
+    window.show_all()
+    while Gtk.events_pending():
+        Gtk.main_iteration()
+
+    controller = CompletionController(textview, get_namespace=lambda: namespace or {})
+    return controller, buffer, window
+
+
+class TestTriggerAndClose(unittest.TestCase):
+    def test_trigger_opens_for_completable_context(self):
+        controller, buffer, window = _make_controller("active_person.")
+        opened = controller.trigger()
+        self.assertTrue(opened)
+        self.assertTrue(controller.is_open())
+        names = [item["name"] for item in controller.items]
+        self.assertIn("primary_name", names)
+        window.destroy()
+
+    def test_trigger_does_not_open_after_whitespace(self):
+        controller, buffer, window = _make_controller("x = 1 ")
+        opened = controller.trigger()
+        self.assertFalse(opened)
+        self.assertFalse(controller.is_open())
+        window.destroy()
+
+    def test_trigger_does_not_open_on_empty_buffer(self):
+        controller, buffer, window = _make_controller("")
+        opened = controller.trigger()
+        self.assertFalse(opened)
+        window.destroy()
+
+    def test_close_resets_state(self):
+        controller, buffer, window = _make_controller("active_person.")
+        controller.trigger()
+        controller.close()
+        self.assertFalse(controller.is_open())
+        self.assertEqual(controller.items, [])
+        self.assertEqual(controller.selected_index, 0)
+        window.destroy()
+
+
+class TestAccept(unittest.TestCase):
+    def test_accept_inserts_missing_suffix_only(self):
+        controller, buffer, window = _make_controller("active_person.primary_")
+        controller.trigger()
+        # first match should be primary_name (only dynamic key matching)
+        names = [item["name"] for item in controller.items]
+        self.assertEqual(names, ["primary_name"])
+        controller.accept()
+        text = buffer.get_text(buffer.get_start_iter(), buffer.get_end_iter(), True)
+        self.assertEqual(text, "active_person.primary_name")
+        self.assertFalse(controller.is_open())
+        window.destroy()
+
+    def test_accept_with_no_items_just_closes(self):
+        controller, buffer, window = _make_controller("active_person.")
+        controller.trigger()
+        controller.items = []
+        controller.accept()
+        self.assertFalse(controller.is_open())
+        window.destroy()
+
+
+class TestNavigation(unittest.TestCase):
+    def test_move_selection_clamped(self):
+        controller, buffer, window = _make_controller("active_person.")
+        controller.trigger()
+        n = len(controller.items)
+        self.assertGreater(n, 1)
+        controller.move_selection(-1)
+        self.assertEqual(controller.selected_index, 0)
+        controller.move_selection(10**6)
+        self.assertEqual(controller.selected_index, n - 1)
+        controller.move_selection(-(10**6))
+        self.assertEqual(controller.selected_index, 0)
+        window.destroy()
+
+
+class TestOnKeyPress(unittest.TestCase):
+    def test_tab_opens_then_accepts(self):
+        controller, buffer, window = _make_controller("active_person.primary_")
+        consumed = controller.on_key_press(_FakeEvent(Gdk.KEY_Tab))
+        self.assertTrue(consumed)
+        self.assertTrue(controller.is_open())
+
+        consumed = controller.on_key_press(_FakeEvent(Gdk.KEY_Tab))
+        self.assertTrue(consumed)
+        self.assertFalse(controller.is_open())
+        text = buffer.get_text(buffer.get_start_iter(), buffer.get_end_iter(), True)
+        self.assertEqual(text, "active_person.primary_name")
+        window.destroy()
+
+    def test_tab_falls_through_when_nothing_completable(self):
+        controller, buffer, window = _make_controller("x = 1 ")
+        consumed = controller.on_key_press(_FakeEvent(Gdk.KEY_Tab))
+        self.assertFalse(consumed)  # caller should fall back to inserting spaces
+        window.destroy()
+
+    def test_arrow_keys_only_consumed_while_open(self):
+        controller, buffer, window = _make_controller("active_person.")
+        self.assertFalse(controller.on_key_press(_FakeEvent(Gdk.KEY_Down)))
+        controller.trigger()
+        self.assertTrue(controller.on_key_press(_FakeEvent(Gdk.KEY_Down)))
+        self.assertEqual(controller.selected_index, 1)
+        window.destroy()
+
+    def test_escape_closes_and_is_consumed(self):
+        controller, buffer, window = _make_controller("active_person.")
+        controller.trigger()
+        consumed = controller.on_key_press(_FakeEvent(Gdk.KEY_Escape))
+        self.assertTrue(consumed)
+        self.assertFalse(controller.is_open())
+        window.destroy()
+
+    def test_left_right_close_but_are_not_consumed(self):
+        controller, buffer, window = _make_controller("active_person.")
+        controller.trigger()
+        consumed = controller.on_key_press(_FakeEvent(Gdk.KEY_Left))
+        self.assertFalse(consumed)  # cursor movement must still happen
+        self.assertFalse(controller.is_open())
+        window.destroy()
+
+    def test_return_accepts_only_while_open(self):
+        controller, buffer, window = _make_controller("active_person.primary_")
+        # popover not open: Return must not be swallowed (newline/apply-script bindings)
+        self.assertFalse(controller.on_key_press(_FakeEvent(Gdk.KEY_Return)))
+        controller.trigger()
+        self.assertTrue(controller.on_key_press(_FakeEvent(Gdk.KEY_Return)))
+        text = buffer.get_text(buffer.get_start_iter(), buffer.get_end_iter(), True)
+        self.assertEqual(text, "active_person.primary_name")
+        window.destroy()
+
+
+class TestLiveRefresh(unittest.TestCase):
+    def test_refresh_narrows_as_more_is_typed(self):
+        controller, buffer, window = _make_controller("active_person.")
+        controller.trigger()
+        self.assertGreater(len(controller.items), 1)
+
+        it = buffer.get_iter_at_mark(buffer.get_insert())
+        buffer.insert(it, "primary_")
+        controller.on_buffer_changed()
+        names = [item["name"] for item in controller.items]
+        self.assertEqual(names, ["primary_name"])
+        window.destroy()
+
+    def test_refresh_closes_when_context_no_longer_completable(self):
+        controller, buffer, window = _make_controller("active_person.primary_")
+        controller.trigger()
+        self.assertTrue(controller.is_open())
+
+        it = buffer.get_iter_at_mark(buffer.get_insert())
+        buffer.insert(it, " ")
+        controller.on_buffer_changed()
+        self.assertFalse(controller.is_open())
+        window.destroy()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/GrampyScript/tests/test_datadict2.py
+++ b/GrampyScript/tests/test_datadict2.py
@@ -271,6 +271,17 @@ class TestDataList2(_MockSaBase):
         self.assertIn("I0001", ids)
         self.assertIn("I0002", ids)
 
+    def test_set_method_fans_out_across_items(self):
+        # Regression: `dl.set_privacy(True)` used to fan out attribute
+        # access first (collecting each item's unevaluated set_*() wrapper
+        # closure into a DataList2), then fail to call because a DataList2
+        # of closures isn't itself callable. It must call set_privacy(True)
+        # on every item instead.
+        dl = self._make_list()
+        dl.set_privacy(True)
+        self.assertTrue(dl[0].private)
+        self.assertTrue(dl[1].private)
+
     def test_add_concatenates(self):
         dl1 = DataList2([DataDict2(_make_person(gramps_id="I0001"))])
         dl2 = DataList2([DataDict2(_make_person(gramps_id="I0002"))])

--- a/GrampyScript/tests/test_datadict2.py
+++ b/GrampyScript/tests/test_datadict2.py
@@ -305,6 +305,25 @@ class TestDataDict2Mutation(_MockSaBase):
         surname.set_surname("Jones")
         callback.assert_called_once_with("set", dd)
 
+    def test_concatenated_name_list_assignment_updates_real_object(self):
+        # Regression: `[dd.primary_name] + dd.alternate_names` (the pattern
+        # used to loop over all of a person's names) goes through
+        # DataList2.__radd__, which builds a plain list of already-wrapped
+        # DataDict2 items and re-wraps it in a new DataList2. Iterating that
+        # outer DataList2 used to re-wrap each *already-wrapped* item via
+        # __getitem__, discarding its real root/path and replacing it with
+        # root=self (since the outer list has root=None), producing a
+        # DataDict2 whose root is itself but whose path is non-empty --
+        # an inconsistent state that made attribute assignment recurse
+        # into itself trying to resolve `self.root._object`.
+        dd = DataDict2(_make_person(surname="Smith"))
+        for name in [dd.primary_name] + dd.alternate_names:
+            self.assertIs(name.root, dd)
+            for surname in name.surname_list:
+                surname.set_surname("Jones")
+        real = dd._object.get_primary_name().get_surname_list()[0]
+        self.assertEqual(real.get_surname(), "Jones")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/GrampyScript/tests/test_datadict2.py
+++ b/GrampyScript/tests/test_datadict2.py
@@ -168,6 +168,22 @@ class TestDataDict2GenealogyProperties(_MockSaBase):
         self.assertEqual(dd.gramps_id, "F0007")
         self.assertEqual(dd["_class"], "Family")
 
+    def test_names_includes_alternate_names_in_order(self):
+        # Regression: `names` was `[self.primary_name] + [self.alternate_names]`
+        # -- the extra brackets nested the whole alternate_names list as one
+        # element instead of spreading it in, and __radd__ used to reverse
+        # the order on top of that.
+        p = _make_person(first="John")
+        alt = Name()
+        alt_sn = Surname()
+        alt_sn.set_surname("Doe")
+        alt.add_surname(alt_sn)
+        alt.set_first_name("Jack")
+        p.add_alternate_name(alt)
+        dd = DataDict2(p)
+        self.assertEqual(len(dd.names), 2)
+        self.assertEqual([n.first_name for n in dd.names], ["John", "Jack"])
+
 
 # ---------------------------------------------------------------------------
 # DataDict2 — surname/name/reference on non-Person and *Ref wrappers
@@ -259,6 +275,14 @@ class TestDataList2(_MockSaBase):
         dl1 = DataList2([DataDict2(_make_person(gramps_id="I0001"))])
         dl2 = DataList2([DataDict2(_make_person(gramps_id="I0002"))])
         self.assertEqual(len(dl1 + dl2), 2)
+
+    def test_radd_preserves_order(self):
+        # Regression: __radd__ used to return `self + value` instead of
+        # `value + self`, so `plain_list + data_list2` (the pattern used to
+        # loop over primary + alternate names) came out reversed.
+        dl = DataList2([DataDict2(_make_person(gramps_id="I0002"))])
+        combined = [DataDict2(_make_person(gramps_id="I0001"))] + dl
+        self.assertEqual([p.gramps_id for p in combined], ["I0001", "I0002"])
 
     def test_empty_list(self):
         dl = DataList2([])

--- a/GrampyScript/tests/test_datadict2.py
+++ b/GrampyScript/tests/test_datadict2.py
@@ -47,6 +47,12 @@ class _MockSaBase(unittest.TestCase):
         db.get_event_from_handle.return_value = None
         db.get_place_from_handle.return_value = None
         db.get_source_from_handle.return_value = None
+        # Mirror DbGeneric.method()'s real dispatch (getattr on a formatted,
+        # lowercased method name), since a bare MagicMock doesn't do this.
+        db.method.side_effect = lambda fmt, *args: getattr(
+            db, fmt % tuple(a.lower() for a in args), None
+        )
+        self.db = db
         sa = SimpleAccess(db)
         set_sa(sa)
 
@@ -161,6 +167,44 @@ class TestDataDict2GenealogyProperties(_MockSaBase):
         dd = DataDict2(_make_family(gramps_id="F0007"))
         self.assertEqual(dd.gramps_id, "F0007")
         self.assertEqual(dd["_class"], "Family")
+
+
+# ---------------------------------------------------------------------------
+# DataDict2 — surname/name/reference on non-Person and *Ref wrappers
+# ---------------------------------------------------------------------------
+
+
+class TestDataDict2NonPersonProperties(_MockSaBase):
+    def test_surname_is_none_data_for_non_person(self):
+        # Regression: used to raise KeyError via self["surname"], since no
+        # schema has a top-level "surname" field.
+        dd = DataDict2(_make_family())
+        self.assertIsInstance(dd.surname, NoneData)
+
+    def test_name_is_none_data_when_field_absent(self):
+        # Regression: used to raise KeyError via self["name"] for classes
+        # (like Family) with no "name" schema field.
+        dd = DataDict2(_make_family())
+        self.assertIsInstance(dd.name, NoneData)
+
+    def test_reference_dispatches_by_class(self):
+        # Regression: used to always call get_raw_person_data regardless of
+        # which *Ref type was wrapped.
+        from gramps.gen.lib import PersonRef
+        from gramps.gen.lib.json_utils import object_to_dict
+
+        ref = PersonRef()
+        ref.set_reference_handle("HANDLE1")
+        self.db.get_raw_person_data.return_value = object_to_dict(
+            _make_person(gramps_id="I9999")
+        )
+        dd = DataDict2(ref)
+        self.assertEqual(dd.reference.gramps_id, "I9999")
+        self.db.get_raw_person_data.assert_called_with("HANDLE1")
+
+    def test_reference_none_data_for_unmapped_class(self):
+        dd = DataDict2(_make_family())
+        self.assertIsInstance(dd.reference, NoneData)
 
 
 # ---------------------------------------------------------------------------

--- a/GrampyScript/tests/test_datadict2.py
+++ b/GrampyScript/tests/test_datadict2.py
@@ -266,5 +266,45 @@ class TestDataList2(_MockSaBase):
         self.assertEqual(list(dl), [])
 
 
+# ---------------------------------------------------------------------------
+# DataDict2 — mutation (attribute assignment and set_*() methods)
+# ---------------------------------------------------------------------------
+
+class TestDataDict2Mutation(_MockSaBase):
+    def test_top_level_attribute_assignment(self):
+        dd = DataDict2(_make_person(gramps_id="I0001"))
+        dd.gramps_id = "I9999"
+        self.assertEqual(dd._object.get_gramps_id(), "I9999")
+        self.assertEqual(dd.gramps_id, "I9999")
+
+    def test_nested_attribute_assignment_updates_real_object(self):
+        # Regression: assigning through a nested wrapper (primary_name is
+        # not the root) must mutate the real Person's Name object, not a
+        # disconnected copy.
+        dd = DataDict2(_make_person(first="John"))
+        dd.primary_name.first_name = "Zoe"
+        self.assertEqual(dd._object.get_primary_name().get_first_name(), "Zoe")
+        self.assertEqual(dd.primary_name.first_name, "Zoe")
+
+    def test_nested_set_method_updates_real_object(self):
+        # Regression: calling a set_*() method on a nested wrapper (e.g. a
+        # Surname inside primary_name.surname_list) used to run against a
+        # standalone object rebuilt from that wrapper's own dict slice, so
+        # the mutation never reached the real Person and was lost on commit.
+        dd = DataDict2(_make_person(surname="Smith"))
+        surname = dd.primary_name.surname_list[0]
+        surname.set_surname("Jones")
+        real_surname = dd._object.get_primary_name().get_surname_list()[0]
+        self.assertEqual(real_surname.get_surname(), "Jones")
+        self.assertEqual(dd.primary_name.surname_list[0].surname, "Jones")
+
+    def test_nested_set_method_calls_callback_with_root(self):
+        callback = MagicMock()
+        dd = DataDict2(_make_person(surname="Smith"), callback=callback)
+        surname = dd.primary_name.surname_list[0]
+        surname.set_surname("Jones")
+        callback.assert_called_once_with("set", dd)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/GrampyScript/tests/test_datadict2.py
+++ b/GrampyScript/tests/test_datadict2.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from gramps.gen.lib import Person, Name, Surname, Family
+from gramps.gen.lib import Person, Name, Surname, Family, NameOriginType
 from gramps.gen.simple import SimpleAccess
 
 from datadict2 import DataDict2, DataList2, NoneData, set_sa
@@ -323,6 +323,33 @@ class TestDataDict2Mutation(_MockSaBase):
                 surname.set_surname("Jones")
         real = dd._object.get_primary_name().get_surname_list()[0]
         self.assertEqual(real.get_surname(), "Jones")
+
+
+# ---------------------------------------------------------------------------
+# DataDict2 — .string for GrampsType-based fields (NameOriginType, ...)
+# ---------------------------------------------------------------------------
+
+class TestDataDict2TypeString(_MockSaBase):
+    def test_origintype_string_reflects_predefined_value(self):
+        # Regression: the raw "string" field only holds the *custom*-type
+        # override text, which is always "" for predefined values like
+        # PATRILINEAL. `.string` must return the real, computed label
+        # instead of that raw (and misleadingly empty) field.
+        dd = DataDict2(_make_person(surname="Smith"))
+        surname = dd.primary_name.surname_list[0]
+        surname.set_origintype(NameOriginType.PATRILINEAL)
+        self.assertEqual(dd.primary_name.surname_list[0].origintype.string, "Patrilineal")
+
+    def test_origintype_string_empty_for_none(self):
+        dd = DataDict2(_make_person())
+        self.assertEqual(dd.primary_name.surname_list[0].origintype.string, "")
+
+    def test_string_missing_field_falls_back_normally(self):
+        # A DataDict2 with no "string" key at all (e.g. a Name) must not be
+        # affected by the .string property -- it should fall through to
+        # ordinary attribute lookup rather than raising or returning "".
+        dd = DataDict2(_make_person())
+        self.assertIsInstance(dd.primary_name.string, NoneData)
 
 
 if __name__ == "__main__":

--- a/GrampyScript/tests/test_extract_header_comment.py
+++ b/GrampyScript/tests/test_extract_header_comment.py
@@ -1,0 +1,72 @@
+"""
+Tests for the extract_header_comment() utility from GrampyScript.
+
+extract_header_comment() pulls the leading '#'-comment block out of a
+script's source, for use as a fallback Open-dialog preview when a file
+has no catalogued entry in SCRIPT_DESCRIPTIONS. It is pure ast/string
+handling -- no GTK or Gramps imports required -- so, like get_columns, it
+is tested here by re-importing it directly from the module source via
+ast, without pulling in the full (GTK-dependent) GrampyScript module.
+"""
+
+import ast
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+_SOURCE = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "GrampyScript.py"
+)
+
+
+def _load_extract_header_comment():
+    src = open(_SOURCE).read()
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "extract_header_comment":
+            snippet = ast.unparse(node)
+            ns = {}
+            exec(snippet, ns)
+            return ns["extract_header_comment"]
+    raise RuntimeError("extract_header_comment not found in GrampyScript.py")
+
+
+extract_header_comment = _load_extract_header_comment()
+
+
+class TestExtractHeaderComment(unittest.TestCase):
+    def test_single_line_header(self):
+        source = "# Title\n\nfor p in people():\n    row(p)\n"
+        self.assertEqual(extract_header_comment(source), "Title")
+
+    def test_multi_line_header(self):
+        source = "# Title\n#\n# A longer description.\n\nrow(1)\n"
+        self.assertEqual(
+            extract_header_comment(source), "Title\n\nA longer description."
+        )
+
+    def test_no_header_returns_empty(self):
+        source = "for p in people():\n    row(p)\n"
+        self.assertEqual(extract_header_comment(source), "")
+
+    def test_leading_blank_lines_before_header_are_skipped(self):
+        source = "\n\n# Title\n\nrow(1)\n"
+        self.assertEqual(extract_header_comment(source), "Title")
+
+    def test_stops_at_first_code_line(self):
+        source = "# Title\nrow(1)  # not part of the header\n"
+        self.assertEqual(extract_header_comment(source), "Title")
+
+    def test_empty_source_returns_empty(self):
+        self.assertEqual(extract_header_comment(""), "")
+
+    def test_hash_only_lines_become_blank_lines(self):
+        source = "# Title\n#\n# More.\n"
+        self.assertEqual(extract_header_comment(source), "Title\n\nMore.")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/GrampyScript/tests/test_extract_header_comment.py
+++ b/GrampyScript/tests/test_extract_header_comment.py
@@ -1,40 +1,21 @@
 """
-Tests for the extract_header_comment() utility from GrampyScript.
+Tests for the extract_header_comment() utility in script_utils.
 
 extract_header_comment() pulls the leading '#'-comment block out of a
 script's source, for use as a fallback Open-dialog preview when a file
-has no catalogued entry in SCRIPT_DESCRIPTIONS. It is pure ast/string
-handling -- no GTK or Gramps imports required -- so, like get_columns, it
-is tested here by re-importing it directly from the module source via
-ast, without pulling in the full (GTK-dependent) GrampyScript module.
+has no catalogued entry in SCRIPT_DESCRIPTIONS. It lives in script_utils.py
+(no GTK or Gramps imports required) precisely so it can be imported and
+tested directly, without pulling in the full (GTK-dependent) GrampyScript
+module.
 """
 
-import ast
 import os
 import sys
 import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-
-_SOURCE = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "GrampyScript.py"
-)
-
-
-def _load_extract_header_comment():
-    src = open(_SOURCE).read()
-    tree = ast.parse(src)
-    for node in ast.walk(tree):
-        if isinstance(node, ast.FunctionDef) and node.name == "extract_header_comment":
-            snippet = ast.unparse(node)
-            ns = {}
-            exec(snippet, ns)
-            return ns["extract_header_comment"]
-    raise RuntimeError("extract_header_comment not found in GrampyScript.py")
-
-
-extract_header_comment = _load_extract_header_comment()
+from script_utils import extract_header_comment
 
 
 class TestExtractHeaderComment(unittest.TestCase):

--- a/GrampyScript/tests/test_get_columns.py
+++ b/GrampyScript/tests/test_get_columns.py
@@ -1,43 +1,20 @@
 """
-Tests for the get_columns() utility from GrampyScript.
+Tests for the get_columns() utility in script_utils.
 
 get_columns parses Python source and extracts argument expressions from all
-calls to a given function name (typically "row").  It is pure ast — no GTK
-or Gramps imports required — so the function is tested here by reimporting
-it directly from the module source via ast/importlib.
+calls to a given function name (typically "row"). It lives in script_utils.py
+(no GTK or Gramps imports required) precisely so it can be imported and
+tested directly, without pulling in the full (GTK-dependent) GrampyScript
+module.
 """
 
-import ast
 import os
 import sys
 import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-
-# ---------------------------------------------------------------------------
-# Load get_columns without importing the full GrampyScript module
-# (which needs GTK). We parse the source and exec just the function.
-# ---------------------------------------------------------------------------
-
-_SOURCE = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "GrampyScript.py"
-)
-
-
-def _load_get_columns():
-    src = open(_SOURCE).read()
-    tree = ast.parse(src)
-    for node in ast.walk(tree):
-        if isinstance(node, ast.FunctionDef) and node.name == "get_columns":
-            snippet = ast.unparse(node)
-            ns = {"ast": ast}
-            exec(snippet, ns)
-            return ns["get_columns"]
-    raise RuntimeError("get_columns not found in GrampyScript.py")
-
-
-get_columns = _load_get_columns()
+from script_utils import get_columns
 
 
 # ---------------------------------------------------------------------------

--- a/GrampyScript/tests/test_namespace_builder.py
+++ b/GrampyScript/tests/test_namespace_builder.py
@@ -1,0 +1,46 @@
+"""
+Tests for namespace_builder.py — the runtime completion namespace.
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from gramps.gen.lib import Date
+
+from namespace_builder import build_namespace
+
+
+class TestBuildNamespace(unittest.TestCase):
+    def test_without_database(self):
+        namespace = build_namespace()
+        self.assertIn("today", namespace)
+        self.assertIn("counter", namespace)
+        self.assertNotIn("database", namespace)
+
+    def test_today_is_a_real_date(self):
+        namespace = build_namespace()
+        self.assertIsInstance(namespace["today"], Date)
+
+    def test_counter_returns_defaultdict(self):
+        namespace = build_namespace()
+        counter = namespace["counter"]()
+        self.assertEqual(counter["anything"], 0)
+
+    def test_database_included_when_given(self):
+        sentinel = object()
+        namespace = build_namespace(sentinel)
+        self.assertIs(namespace["database"], sentinel)
+
+    def test_active_names_are_not_included(self):
+        # active_person etc. are handled as static stub annotations
+        # (stub_generator.ACTIVE_VARIABLES), not live namespace objects.
+        namespace = build_namespace()
+        self.assertNotIn("active_person", namespace)
+        self.assertNotIn("active_family", namespace)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/GrampyScript/tests/test_script_descriptions.py
+++ b/GrampyScript/tests/test_script_descriptions.py
@@ -1,0 +1,55 @@
+"""
+Consistency checks between scripts/*.gram.py and SCRIPT_DESCRIPTIONS.
+
+script_descriptions.py has no GTK dependency (only gramps.gen.const), so
+it can be imported directly here, unlike GrampyScript.py itself.
+"""
+
+import ast
+import glob
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from script_descriptions import SCRIPT_DESCRIPTIONS
+
+SCRIPTS_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts"
+)
+
+
+def _script_basenames():
+    return {
+        os.path.basename(path)
+        for path in glob.glob(os.path.join(SCRIPTS_DIR, "*.gram.py"))
+    }
+
+
+class TestScriptDescriptionsCoverage(unittest.TestCase):
+    def test_every_script_has_a_description(self):
+        missing = _script_basenames() - set(SCRIPT_DESCRIPTIONS)
+        self.assertEqual(missing, set(), "scripts missing from SCRIPT_DESCRIPTIONS")
+
+    def test_no_stale_entries(self):
+        stale = set(SCRIPT_DESCRIPTIONS) - _script_basenames()
+        self.assertEqual(stale, set(), "SCRIPT_DESCRIPTIONS keys with no matching file")
+
+    def test_entries_have_title_and_description(self):
+        for name, entry in SCRIPT_DESCRIPTIONS.items():
+            self.assertEqual(len(entry), 2, name)
+            title, description = entry
+            self.assertTrue(title.strip(), "%s has an empty title" % name)
+            self.assertTrue(description.strip(), "%s has an empty description" % name)
+
+
+class TestScriptsAreValidPython(unittest.TestCase):
+    def test_all_scripts_parse(self):
+        for path in glob.glob(os.path.join(SCRIPTS_DIR, "*.gram.py")):
+            with self.subTest(path=path):
+                ast.parse(open(path).read())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/GrampyScript/tests/test_script_descriptions.py
+++ b/GrampyScript/tests/test_script_descriptions.py
@@ -14,6 +14,12 @@ import unittest
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from script_descriptions import SCRIPT_DESCRIPTIONS
+from update_script_descriptions import (
+    DESCRIPTIONS_PATH,
+    _load_header,
+    build_source,
+    collect_entries,
+)
 
 SCRIPTS_DIR = os.path.join(
     os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts"
@@ -42,6 +48,21 @@ class TestScriptDescriptionsCoverage(unittest.TestCase):
             title, description = entry
             self.assertTrue(title.strip(), "%s has an empty title" % name)
             self.assertTrue(description.strip(), "%s has an empty description" % name)
+
+
+class TestScriptDescriptionsIsGenerated(unittest.TestCase):
+    def test_regenerating_produces_no_changes(self):
+        entries, errors = collect_entries()
+        self.assertEqual(errors, [])
+        header = _load_header(DESCRIPTIONS_PATH)
+        regenerated = build_source(entries, header)
+        on_disk = open(DESCRIPTIONS_PATH, encoding="utf-8").read()
+        self.assertEqual(
+            regenerated,
+            on_disk,
+            "script_descriptions.py is out of sync with scripts/*.gram.py -- "
+            "run `python3 update_script_descriptions.py` to regenerate it.",
+        )
 
 
 class TestScriptsAreValidPython(unittest.TestCase):

--- a/GrampyScript/tests/test_script_descriptions.py
+++ b/GrampyScript/tests/test_script_descriptions.py
@@ -56,7 +56,8 @@ class TestScriptDescriptionsIsGenerated(unittest.TestCase):
         self.assertEqual(errors, [])
         header = _load_header(DESCRIPTIONS_PATH)
         regenerated = build_source(entries, header)
-        on_disk = open(DESCRIPTIONS_PATH, encoding="utf-8").read()
+        with open(DESCRIPTIONS_PATH, encoding="utf-8") as f:
+            on_disk = f.read()
         self.assertEqual(
             regenerated,
             on_disk,
@@ -69,7 +70,8 @@ class TestScriptsAreValidPython(unittest.TestCase):
     def test_all_scripts_parse(self):
         for path in glob.glob(os.path.join(SCRIPTS_DIR, "*.gram.py")):
             with self.subTest(path=path):
-                ast.parse(open(path).read())
+                with open(path) as f:
+                    ast.parse(f.read())
 
 
 if __name__ == "__main__":

--- a/GrampyScript/tests/test_stub_generator.py
+++ b/GrampyScript/tests/test_stub_generator.py
@@ -10,7 +10,13 @@ import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from stub_generator import ACTIVE_VARIABLES, GENERATOR_ROW_TYPES, build_registry, render_stub_source
+from stub_generator import (
+    ACTIVE_VARIABLES,
+    GENERATOR_ROW_TYPES,
+    VOID_FUNCTIONS,
+    build_registry,
+    render_stub_source,
+)
 from completion import get_completions
 
 
@@ -112,6 +118,21 @@ class TestRenderStubSource(unittest.TestCase):
         source = render_stub_source(build_registry(), active_variables={})
         self.assertNotIn("active_person:", source)
 
+    def test_void_functions_present(self):
+        source = render_stub_source(build_registry())
+        self.assertIn("def columns(*column_names) -> None: ...", source)
+        self.assertIn('def begin_changes(message: str = "") -> None: ...', source)
+        self.assertIn("def end_changes() -> None: ...", source)
+        self.assertIn("def delete(obj) -> None: ...", source)
+        self.assertIn("def row(*args) -> None: ...", source)
+        self.assertIn(
+            "def chart(type, data, count: int = 20, **kwargs) -> None: ...", source
+        )
+
+    def test_no_void_functions_when_omitted(self):
+        source = render_stub_source(build_registry(), void_functions={})
+        self.assertNotIn("def columns", source)
+
 
 class TestActiveVariableCompletion(unittest.TestCase):
     """
@@ -173,6 +194,27 @@ class TestTableFunctionCompletion(unittest.TestCase):
     def test_custom_filter_offers_real_fields_with_explicit_namespace(self):
         names = self._complete('for fam in custom_filter("f", "Family"):\n    fam.')
         self.assertIn("father_handle", names)
+
+
+class TestVoidFunctionCompletion(unittest.TestCase):
+    """
+    columns()/begin_changes()/end_changes()/delete()/row()/chart() are void
+    DSL functions (VOID_FUNCTIONS) -- they don't need row-type inference,
+    just a signature so jedi offers them as completions at all. Before
+    these were added to the stub, jedi had no way to know these names exist
+    since they're bound as local closures inside execute_code(), never
+    passed through the completion namespace.
+    """
+
+    def _complete(self, source):
+        lines = source.splitlines()
+        return get_completions(source, len(lines), len(lines[-1]), {})
+
+    def test_completes_void_function_names(self):
+        for name in VOID_FUNCTIONS:
+            with self.subTest(name=name):
+                names = self._complete(name[:-1])
+                self.assertIn(name + "()", names)
 
 
 if __name__ == "__main__":

--- a/GrampyScript/tests/test_stub_generator.py
+++ b/GrampyScript/tests/test_stub_generator.py
@@ -1,0 +1,165 @@
+"""
+Tests for stub_generator.py — deriving jedi completion stubs from Gramps'
+own get_schema().
+"""
+
+import ast
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from stub_generator import ACTIVE_VARIABLES, GENERATOR_ROW_TYPES, build_registry, render_stub_source
+from completion import get_completions
+
+
+class TestBuildRegistry(unittest.TestCase):
+    def setUp(self):
+        self.registry = build_registry()
+
+    def test_discovers_root_types(self):
+        for name in ["Person", "Family", "Event", "Place", "Source", "Citation", "Note", "Media"]:
+            self.assertIn(name, self.registry)
+
+    def test_discovers_nested_types(self):
+        # Reached only by walking into Person's primary_name / Name's date.
+        for name in ["Name", "Surname", "Date"]:
+            self.assertIn(name, self.registry)
+
+    def test_sanitizes_titles_with_spaces(self):
+        # Raw schema titles are "Event reference", "Child Reference", etc.
+        self.assertIn("EventReference", self.registry)
+        self.assertNotIn("Event reference", self.registry)
+
+    def test_person_has_raw_schema_fields(self):
+        fields = self.registry["Person"]
+        self.assertEqual(fields["gramps_id"], "str")
+        self.assertEqual(fields["primary_name"], "Name")
+
+    def test_nested_list_field_is_typed(self):
+        fields = self.registry["Person"]
+        self.assertEqual(fields["address_list"], 'list["Address"]')
+
+    def test_computed_properties_layered_on_every_type(self):
+        # DataDict2's @property names apply to every wrapped record, not
+        # just Person, since it is the same class for every nested value.
+        for name in ["Person", "Family", "Name"]:
+            self.assertEqual(self.registry[name]["father"], "Person")
+
+    def test_computed_property_overrides_raw_field(self):
+        # `gender` is both a raw int field and a DataDict2 @property;
+        # the property wins at real attribute-lookup time.
+        self.assertEqual(self.registry["Person"]["gender"], "str")
+
+    def test_class_key_excluded(self):
+        self.assertNotIn("_class", self.registry["Person"])
+
+
+class TestRenderStubSource(unittest.TestCase):
+    def test_output_is_valid_python(self):
+        source = render_stub_source(build_registry())
+        ast.parse(source)  # raises SyntaxError on failure
+
+    def test_generator_functions_present(self):
+        source = render_stub_source(build_registry())
+        for func_name, row_type in GENERATOR_ROW_TYPES.items():
+            self.assertIn("def %s() -> Iterator[%s]: ..." % (func_name, row_type), source)
+
+    def test_empty_registry_still_valid(self):
+        source = render_stub_source({}, generator_row_types={}, table_functions={})
+        ast.parse(source)
+
+    def test_table_functions_present(self):
+        source = render_stub_source(build_registry())
+        self.assertIn("def selected(table_name: str) -> Iterator[Union[", source)
+        self.assertIn("def filtered(table_name: str) -> Iterator[Union[", source)
+        self.assertIn(
+            'def custom_filter(name: str, namespace: str = "Person") -> Iterator[Union[',
+            source,
+        )
+
+    def test_table_function_union_covers_every_row_type(self):
+        source = render_stub_source(build_registry())
+        line = next(l for l in source.splitlines() if l.startswith("def selected"))
+        for row_type in GENERATOR_ROW_TYPES.values():
+            self.assertIn(row_type, line)
+
+    def test_no_table_functions_when_omitted(self):
+        source = render_stub_source(build_registry(), table_functions={})
+        self.assertNotIn("def selected", source)
+
+    def test_active_variables_present(self):
+        source = render_stub_source(build_registry())
+        for var_name, row_type in ACTIVE_VARIABLES.items():
+            self.assertIn("%s: %s" % (var_name, row_type), source)
+
+    def test_no_active_variables_when_omitted(self):
+        source = render_stub_source(build_registry(), active_variables={})
+        self.assertNotIn("active_person:", source)
+
+
+class TestActiveVariableCompletion(unittest.TestCase):
+    """
+    active_person/active_family/etc. are declared as bare static
+    annotations (no value) rather than bound to a live template
+    DataDict2 instance. A live template would need jedi to actually call
+    DataDict2's computed @property methods (father, birth, ...) to see
+    what they return -- real SimpleAccess execution that, for a blank
+    template with nothing to find, only yields empty completions anyway.
+    """
+
+    def _complete(self, source):
+        lines = source.splitlines()
+        return get_completions(source, len(lines), len(lines[-1]), {})
+
+    def test_completes_active_person_directly(self):
+        names = self._complete("active_person.")
+        self.assertIn("primary_name", names)
+        self.assertIn("gramps_id", names)
+
+    def test_completes_through_computed_property_chain(self):
+        # father is a DataDict2 @property, not a raw schema field --
+        # this only works because it's typed in the stub, not executed.
+        names = self._complete("active_person.father.primary_name.first_")
+        self.assertEqual(names, ["first_name"])
+
+    def test_distinguishes_active_family_from_active_person(self):
+        names = self._complete("active_family.")
+        self.assertIn("father_handle", names)
+        self.assertNotIn("primary_name", names)
+
+
+class TestTableFunctionCompletion(unittest.TestCase):
+    """
+    selected()/filtered()/custom_filter() pick their row type from a
+    runtime string argument, which jedi cannot discriminate via
+    typing.overload + Literal (verified empirically -- it merges every
+    overload regardless of the literal passed). These are typed as
+    returning the union of every row type instead, so completion still
+    offers real fields rather than nothing.
+    """
+
+    def _complete(self, source):
+        lines = source.splitlines()
+        return get_completions(source, len(lines), len(lines[-1]), {})
+
+    def test_selected_offers_real_fields(self):
+        names = self._complete('for person in selected("Person"):\n    person.')
+        self.assertIn("primary_name", names)
+
+    def test_filtered_offers_real_fields(self):
+        names = self._complete('for fam in filtered("Family"):\n    fam.')
+        self.assertIn("father_handle", names)
+
+    def test_custom_filter_offers_real_fields_with_default_namespace(self):
+        names = self._complete('for person in custom_filter("example filter"):\n    person.')
+        self.assertIn("primary_name", names)
+
+    def test_custom_filter_offers_real_fields_with_explicit_namespace(self):
+        names = self._complete('for fam in custom_filter("f", "Family"):\n    fam.')
+        self.assertIn("father_handle", names)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/GrampyScript/tests/test_stub_generator.py
+++ b/GrampyScript/tests/test_stub_generator.py
@@ -41,11 +41,25 @@ class TestBuildRegistry(unittest.TestCase):
         fields = self.registry["Person"]
         self.assertEqual(fields["address_list"], 'list["Address"]')
 
-    def test_computed_properties_layered_on_every_type(self):
-        # DataDict2's @property names apply to every wrapped record, not
-        # just Person, since it is the same class for every nested value.
-        for name in ["Person", "Family", "Name"]:
+    def test_computed_properties_layered_on_matching_root_types(self):
+        # `father` is valid on Person and Family (sa.father accepts both).
+        for name in ["Person", "Family"]:
             self.assertEqual(self.registry[name]["father"], "Person")
+
+    def test_computed_properties_not_layered_on_mismatched_types(self):
+        # `father` shouldn't leak onto nested structural types (Name is
+        # reached only by walking Person.primary_name, not a root row type),
+        # nor onto root types the underlying SimpleAccess call rejects.
+        self.assertNotIn("father", self.registry["Name"])
+        self.assertNotIn("spouse", self.registry["Event"])
+        self.assertNotIn("gender", self.registry["Family"])
+
+    def test_reference_layered_only_on_ref_types(self):
+        # `reference` reads a `ref` handle that only *Ref wrapper types
+        # have -- it shouldn't appear on the root row types themselves.
+        self.assertEqual(self.registry["PersonRef"]["reference"], "Person")
+        self.assertEqual(self.registry["EventReference"]["reference"], "Event")
+        self.assertNotIn("reference", self.registry["Person"])
 
     def test_computed_property_overrides_raw_field(self):
         # `gender` is both a raw int field and a DataDict2 @property;

--- a/GrampyScript/update_script_descriptions.py
+++ b/GrampyScript/update_script_descriptions.py
@@ -18,35 +18,29 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 """
-Dev tool: keep script_descriptions.py's SCRIPT_DESCRIPTIONS dict in sync
-with the files actually present in scripts/.
+Dev tool: rebuild script_descriptions.py's SCRIPT_DESCRIPTIONS dict from the
+files in scripts/. Each scripts/*.gram.py file is the source of truth for
+its own entry: the title comes from the file's leading '# Title' comment,
+and the description comes from its module docstring (the triple-quoted
+string right below that comment).
 
-Run it after adding a new example script, deleting one, or renaming one:
+Run it any time you add a new example script, edit an existing script's
+title or docstring, or delete a script:
 
     python3 update_script_descriptions.py
 
-What it does automatically (safe, structural, nothing to lose):
-  - Adds a stub entry -- title taken from the new file's leading '#'
-    comment, description a "TODO" placeholder -- for any scripts/*.gram.py
-    file with no entry yet.
-  - Drops entries for files that no longer exist in scripts/.
-
-What it only *warns* about (needs a human judgment call):
-  - A file whose leading comment title no longer matches the title
-    already catalogued in SCRIPT_DESCRIPTIONS. Titles are not
-    auto-overwritten, since the catalogued one may have been deliberately
-    written differently (and richer) than the terse in-file comment.
-
-Existing entries' source text (title + description, translator comments,
-line wrapping, quoting) is preserved byte-for-byte by slicing it straight
-out of the current file with ast -- this script never touches wording it
-didn't generate itself.
+The whole SCRIPT_DESCRIPTIONS body is always fully rebuilt from scripts/ --
+there is no hand-maintained text left to preserve. A script missing a
+title comment or a docstring is an error, since both are now required.
+The static header (license block, module docstring, imports) is kept as
+whatever's already at the top of script_descriptions.py.
 """
 
 import ast
 import glob
 import os
 import sys
+import textwrap
 
 from script_utils import SCRIPTS_DIR, extract_header_comment
 
@@ -54,113 +48,99 @@ DESCRIPTIONS_PATH = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "script_descriptions.py"
 )
 
-STUB_DESCRIPTION = "TODO: describe what this script does."
+ENTRY_INDENT = " " * 8
+TEXT_INDENT = " " * 12
+DESCRIPTION_WIDTH = 65
 
 
-def _slice_source(lines, node):
-    start_line, start_col = node.lineno - 1, node.col_offset
-    end_line, end_col = node.end_lineno - 1, node.end_col_offset
-    if start_line == end_line:
-        return lines[start_line][start_col:end_col]
-    parts = [lines[start_line][start_col:]]
-    parts.extend(lines[start_line + 1 : end_line])
-    parts.append(lines[end_line][:end_col])
-    return "".join(parts)
-
-
-def _load_existing(path):
-    """
-    Returns (header, entries) where header is the file text up through
-    "SCRIPT_DESCRIPTIONS = {" and entries maps filename -> (title,
-    raw_value_source) using the tuple's exact original source text.
-    """
+def _load_header(path):
+    """Return the file text up through the "SCRIPT_DESCRIPTIONS = {" line."""
     source = open(path, encoding="utf-8").read()
     tree = ast.parse(source)
     lines = source.splitlines(keepends=True)
 
-    dict_node = None
     for node in ast.walk(tree):
         if isinstance(node, ast.Assign) and any(
             isinstance(t, ast.Name) and t.id == "SCRIPT_DESCRIPTIONS"
             for t in node.targets
         ):
-            dict_node = node.value
-            break
-    if dict_node is None:
-        raise RuntimeError("SCRIPT_DESCRIPTIONS not found in %s" % path)
+            return "".join(lines[: node.lineno - 1]) + "SCRIPT_DESCRIPTIONS = {\n"
+    raise RuntimeError("SCRIPT_DESCRIPTIONS not found in %s" % path)
 
-    header = "".join(lines[: dict_node.lineno - 1]) + "SCRIPT_DESCRIPTIONS = {\n"
 
+def _dquote(text):
+    return '"' + text.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def _render_call(text, width=None):
+    lines = textwrap.wrap(text, width=width) if width else [text]
+    if len(lines) <= 1:
+        return "_(%s)" % _dquote(text)
+    body = "".join(
+        "%s%s\n" % (TEXT_INDENT, _dquote(line + (" " if i < len(lines) - 1 else "")))
+        for i, line in enumerate(lines)
+    )
+    return "_(\n%s%s)" % (body, ENTRY_INDENT)
+
+
+def render_entry(filename, title, description):
+    return "    %s: (\n%s%s,\n%s%s,\n    ),\n" % (
+        _dquote(filename),
+        ENTRY_INDENT,
+        _render_call(title),
+        ENTRY_INDENT,
+        _render_call(description, width=DESCRIPTION_WIDTH),
+    )
+
+
+def collect_entries():
+    """
+    Returns (entries, errors), where entries maps filename -> (title,
+    description) read from scripts/*.gram.py, and errors lists filenames
+    missing a title comment or a docstring.
+    """
     entries = {}
-    for key_node, value_node in zip(dict_node.keys, dict_node.values):
-        filename = ast.literal_eval(key_node)
-        title = value_node.elts[0].args[0].value
-        raw_value = _slice_source(lines, value_node)
-        entries[filename] = (title, raw_value)
-    return header, entries
+    errors = []
+    for path in sorted(glob.glob(os.path.join(SCRIPTS_DIR, "*.gram.py"))):
+        filename = os.path.basename(path)
+        source = open(path, encoding="utf-8").read()
+        title = extract_header_comment(source)
+        description = ast.get_docstring(ast.parse(source), clean=True)
+        if description:
+            description = " ".join(description.split())
+        if not title:
+            errors.append("%s: missing a leading '# Title' comment" % filename)
+        if not description:
+            errors.append("%s: missing a description docstring" % filename)
+        if title and description:
+            entries[filename] = (title, description)
+    return entries, errors
 
 
-def _stub_entry(title):
-    return '(\n        _(%r),\n        _(%r),\n    )' % (title, STUB_DESCRIPTION)
+def build_source(entries, header):
+    body = "".join(
+        render_entry(filename, title, description)
+        for filename, (title, description) in entries.items()
+    )
+    return header + body + "}\n"
 
 
 def main():
-    header, existing = _load_existing(DESCRIPTIONS_PATH)
+    entries, errors = collect_entries()
+    if errors:
+        print("Cannot regenerate script_descriptions.py:")
+        for error in errors:
+            print("  ! %s" % error)
+        return 1
 
-    current_files = sorted(
-        os.path.basename(p)
-        for p in glob.glob(os.path.join(SCRIPTS_DIR, "*.gram.py"))
-    )
-
-    added, removed, retitled_warnings = [], [], []
-
-    body_lines = []
-    for filename in current_files:
-        file_title = extract_header_comment(
-            open(os.path.join(SCRIPTS_DIR, filename)).read()
-        )
-        if filename in existing:
-            title, raw_value = existing[filename]
-            if file_title and file_title != title:
-                retitled_warnings.append((filename, title, file_title))
-        else:
-            title, raw_value = file_title or filename, _stub_entry(
-                file_title or filename
-            )
-            added.append(filename)
-        body_lines.append('    "%s": %s,\n' % (filename, raw_value))
-
-    for filename in existing:
-        if filename not in current_files:
-            removed.append(filename)
-
-    new_source = header + "".join(body_lines) + "}\n"
+    header = _load_header(DESCRIPTIONS_PATH)
+    new_source = build_source(entries, header)
 
     with open(DESCRIPTIONS_PATH, "w", encoding="utf-8") as fp:
         fp.write(new_source)
 
-    if added:
-        print("Added stub entries (fill in real descriptions):")
-        for filename in added:
-            print("  + %s" % filename)
-    if removed:
-        print("Removed stale entries (file no longer in scripts/):")
-        for filename in removed:
-            print("  - %s" % filename)
-    if retitled_warnings:
-        print("Title mismatches (file comment changed, catalogued title did not):")
-        for filename, old_title, new_title in retitled_warnings:
-            print("  ! %s" % filename)
-            print("      catalogued: %r" % old_title)
-            print("      in file:    %r" % new_title)
-        print(
-            "  -> update the title in script_descriptions.py by hand if the "
-            "file's title is now the correct one."
-        )
-    if not (added or removed or retitled_warnings):
-        print("script_descriptions.py is already in sync with scripts/.")
-
-    return 1 if retitled_warnings else 0
+    print("Regenerated script_descriptions.py from %d scripts." % len(entries))
+    return 0
 
 
 if __name__ == "__main__":

--- a/GrampyScript/update_script_descriptions.py
+++ b/GrampyScript/update_script_descriptions.py
@@ -1,0 +1,167 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2025      Doug Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""
+Dev tool: keep script_descriptions.py's SCRIPT_DESCRIPTIONS dict in sync
+with the files actually present in scripts/.
+
+Run it after adding a new example script, deleting one, or renaming one:
+
+    python3 update_script_descriptions.py
+
+What it does automatically (safe, structural, nothing to lose):
+  - Adds a stub entry -- title taken from the new file's leading '#'
+    comment, description a "TODO" placeholder -- for any scripts/*.gram.py
+    file with no entry yet.
+  - Drops entries for files that no longer exist in scripts/.
+
+What it only *warns* about (needs a human judgment call):
+  - A file whose leading comment title no longer matches the title
+    already catalogued in SCRIPT_DESCRIPTIONS. Titles are not
+    auto-overwritten, since the catalogued one may have been deliberately
+    written differently (and richer) than the terse in-file comment.
+
+Existing entries' source text (title + description, translator comments,
+line wrapping, quoting) is preserved byte-for-byte by slicing it straight
+out of the current file with ast -- this script never touches wording it
+didn't generate itself.
+"""
+
+import ast
+import glob
+import os
+import sys
+
+from script_utils import SCRIPTS_DIR, extract_header_comment
+
+DESCRIPTIONS_PATH = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), "script_descriptions.py"
+)
+
+STUB_DESCRIPTION = "TODO: describe what this script does."
+
+
+def _slice_source(lines, node):
+    start_line, start_col = node.lineno - 1, node.col_offset
+    end_line, end_col = node.end_lineno - 1, node.end_col_offset
+    if start_line == end_line:
+        return lines[start_line][start_col:end_col]
+    parts = [lines[start_line][start_col:]]
+    parts.extend(lines[start_line + 1 : end_line])
+    parts.append(lines[end_line][:end_col])
+    return "".join(parts)
+
+
+def _load_existing(path):
+    """
+    Returns (header, entries) where header is the file text up through
+    "SCRIPT_DESCRIPTIONS = {" and entries maps filename -> (title,
+    raw_value_source) using the tuple's exact original source text.
+    """
+    source = open(path, encoding="utf-8").read()
+    tree = ast.parse(source)
+    lines = source.splitlines(keepends=True)
+
+    dict_node = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and any(
+            isinstance(t, ast.Name) and t.id == "SCRIPT_DESCRIPTIONS"
+            for t in node.targets
+        ):
+            dict_node = node.value
+            break
+    if dict_node is None:
+        raise RuntimeError("SCRIPT_DESCRIPTIONS not found in %s" % path)
+
+    header = "".join(lines[: dict_node.lineno - 1]) + "SCRIPT_DESCRIPTIONS = {\n"
+
+    entries = {}
+    for key_node, value_node in zip(dict_node.keys, dict_node.values):
+        filename = ast.literal_eval(key_node)
+        title = value_node.elts[0].args[0].value
+        raw_value = _slice_source(lines, value_node)
+        entries[filename] = (title, raw_value)
+    return header, entries
+
+
+def _stub_entry(title):
+    return '(\n        _(%r),\n        _(%r),\n    )' % (title, STUB_DESCRIPTION)
+
+
+def main():
+    header, existing = _load_existing(DESCRIPTIONS_PATH)
+
+    current_files = sorted(
+        os.path.basename(p)
+        for p in glob.glob(os.path.join(SCRIPTS_DIR, "*.gram.py"))
+    )
+
+    added, removed, retitled_warnings = [], [], []
+
+    body_lines = []
+    for filename in current_files:
+        file_title = extract_header_comment(
+            open(os.path.join(SCRIPTS_DIR, filename)).read()
+        )
+        if filename in existing:
+            title, raw_value = existing[filename]
+            if file_title and file_title != title:
+                retitled_warnings.append((filename, title, file_title))
+        else:
+            title, raw_value = file_title or filename, _stub_entry(
+                file_title or filename
+            )
+            added.append(filename)
+        body_lines.append('    "%s": %s,\n' % (filename, raw_value))
+
+    for filename in existing:
+        if filename not in current_files:
+            removed.append(filename)
+
+    new_source = header + "".join(body_lines) + "}\n"
+
+    with open(DESCRIPTIONS_PATH, "w", encoding="utf-8") as fp:
+        fp.write(new_source)
+
+    if added:
+        print("Added stub entries (fill in real descriptions):")
+        for filename in added:
+            print("  + %s" % filename)
+    if removed:
+        print("Removed stale entries (file no longer in scripts/):")
+        for filename in removed:
+            print("  - %s" % filename)
+    if retitled_warnings:
+        print("Title mismatches (file comment changed, catalogued title did not):")
+        for filename, old_title, new_title in retitled_warnings:
+            print("  ! %s" % filename)
+            print("      catalogued: %r" % old_title)
+            print("      in file:    %r" % new_title)
+        print(
+            "  -> update the title in script_descriptions.py by hand if the "
+            "file's title is now the correct one."
+        )
+    if not (added or removed or retitled_warnings):
+        print("script_descriptions.py is already in sync with scripts/.")
+
+    return 1 if retitled_warnings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/GrampyScript/update_script_descriptions.py
+++ b/GrampyScript/update_script_descriptions.py
@@ -55,7 +55,8 @@ DESCRIPTION_WIDTH = 65
 
 def _load_header(path):
     """Return the file text up through the "SCRIPT_DESCRIPTIONS = {" line."""
-    source = open(path, encoding="utf-8").read()
+    with open(path, encoding="utf-8") as f:
+        source = f.read()
     tree = ast.parse(source)
     lines = source.splitlines(keepends=True)
 
@@ -103,7 +104,8 @@ def collect_entries():
     errors = []
     for path in sorted(glob.glob(os.path.join(SCRIPTS_DIR, "*.gram.py"))):
         filename = os.path.basename(path)
-        source = open(path, encoding="utf-8").read()
+        with open(path, encoding="utf-8") as f:
+            source = f.read()
         title = extract_header_comment(source)
         description = ast.get_docstring(ast.parse(source), clean=True)
         if description:


### PR DESCRIPTION
## Summary
- Adds `GrampyScript/scripts/` with 13 worked example `.gram.py` scripts covering iteration, filtering, family relationships, pie/histogram charts, batch editing with transactions, CSV-ready reports, active-person summaries, selected-rows/data-quality checks, importing a shared `.py` helper module, reusing a Gramps custom filter, and deleting an object
- This folder is also the default location for Script > Open... / Save As..., so a user's own saved scripts naturally collect next to the examples
- Adds a preview pane to the Open dialog: highlighting a `.gram.py` file shows its (translatable) title/description, falling back to the file's own leading comment for uncatalogued scripts
- Descriptions live in `script_descriptions.py`, kept translatable via the addon's existing xgettext pipeline without cluttering the example scripts themselves with `_()` calls
- Adds `update_script_descriptions.py`, a dev tool that keeps that catalog in sync with `scripts/` (adds stubs for new files, drops stale entries, warns on title drift) without touching hand-written text it didn't generate
- UI tweaks: moved the Execute button directly below the script editor (was far below, under the results tabs), added a persistent filename label to the status area, and prompt to save unsaved changes before New or Open
- Fixes an `AttributeError` in `callback()` (`db._table` → `db._get_table_func`) that crashed any script performing an edit after `begin_changes()` — same fix as #977, needed here since the new `06_mark_unsourced_people_private.gram.py` example exercises that exact path
- Adds `import` support: the scripts folder and the currently open script's own folder are added to `sys.path` before running, so a script can `import` a plain `.py` helper module placed alongside it (see `script_helpers.py` / `11_import_example.gram.py`) without any custom `@include` directive
- Adds `custom_filter(name, namespace="Person")`: runs an existing Gramps sidebar custom filter by name and yields matching rows, printing a `Warning:` line to the Output tab (instead of raising) if the name doesn't match a filter — consistent with how `selected()`/`filtered()` already degrade to "nothing to show" rather than erroring (see `12_custom_filter_example.gram.py`)
- Adds `delete(obj)`: looks up the right `del_func` for the object's class the same way commits already look up `commit_func`, so a script can delete a record without knowing the underlying `remove_person`/`remove_family`/etc. call (see `13_delete_unused_repositories.gram.py`, which only deletes repositories nothing else refers to — safe to run, unlikely to touch anything in a typical tree)
- Fixes `active_event`, which returned a raw handle instead of a `DataDict2` like every other `active_*` constant (`self.get_active` → `self.get_active_data`)

## Tab completion (new)
- Adds Tab-triggered, live-filtering command completion to the script editor, built on [jedi](https://jedi.readthedocs.io/). Tab completes plain Python names, the DSL's own functions (`people()`, `custom_filter()`, `selected()`/`filtered()`, ...), and nested attribute chains on Gramps records — including `person.primary_name.first_name` through a user's own loop variable, and through list subscripts like `primary_name.surname_list[0].surname`
- `completion.py` wraps `jedi.Interpreter` for the actual lookups; `completion_popup.py` is a standalone `Gtk.Popover` controller (Tab opens/accepts, Up/Down navigate, Escape/click/focus-out dismiss, arbitrary typing live-refilters), kept independent of the Gramplet class so it's testable against a plain `Gtk.TextView`
- `stub_generator.py` derives static type stubs directly from Gramps' own `cls.get_schema()`, so jedi can infer a generator/loop-variable's row type (e.g. what `people()` yields) statically, without ever executing anything — a live template object would need to call `DataDict2`'s computed properties (`father`, `birth`, ...) to see what they return, which only yields empty results for blank/template data anyway
- `namespace_builder.py` supplies the remaining names that are safe to introspect as live objects (`today`, `counter`, `database`)
- `datadict2.py`: `DataDict2` gained a `__dir__` override so introspection (jedi's runtime fallback) sees dynamic dict keys like `primary_name`, not just its declared `@property` methods
- Also fixes the editor's `ScrolledWindow`/`TextView` having no wrap mode or explicit scroll policy, which let long lines widen the whole gramplet instead of scrolling within it
- Requires `jedi` (added to `GrampyScript.gpr.py`'s `requires_mod`), which ships with Gramps 6.1

## Test plan
- [x] `cd GrampyScript && python -m pytest tests/` — 110 tests pass (95 pure-logic + 15 GTK popup tests run under Xvfb against real widgets)
- [x] Verified `update_script_descriptions.py` against add/remove/rename scenarios, and that it round-trips the current `script_descriptions.py` byte-for-byte when nothing changed
- [x] Verified `xgettext --language=Python --keyword=_ ... --from-code=UTF-8` (the flags `make.py` uses) correctly extracts the new translatable strings from `script_descriptions.py`
- [x] Verified the new `sys.path` import logic and `decade()` helper standalone (no GTK required)
- [x] Verified `del_func` exists for all primary object types (Person, Family, Event, Place, Source, Citation, Repository, Note, Media) plus Tag
- [x] Instantiated the real `GrampyScript` Gramplet (real `DbState`, real SQLite-backed database, real `Gtk.TextView`) and drove actual Tab keypresses through `on_key_press`, confirming completion end-to-end outside of unit tests
- [ ] Manual: open Gramps with the addon loaded, confirm the Open-dialog preview, button placement, filename label, and unsaved-changes prompt look right; run the example scripts (including the new import/custom-filter/delete ones) against a real family tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)

