### PR TITLE
GrampsAssistant: document custom_filter() and delete() DSL functions; added help url

### DIFF
--- a/GrampsAssistant/grampsassistant.gpr.py
+++ b/GrampsAssistant/grampsassistant.gpr.py
@@ -36,4 +36,5 @@ register(
     optionclass="GrampsAssistantOptions",
     tool_modes=[TOOL_MODE_GUI],
     depends_on=["Grampy Script"],
+    help_url="Addon:GrampsAssistant",
 )

--- a/GrampsAssistant/grampsassistant.py
+++ b/GrampsAssistant/grampsassistant.py
@@ -29,6 +29,7 @@ import uuid
 from gi.repository import GLib, Gdk, Gtk, Pango
 
 from gramps.gen.config import config as global_config
+from gramps.gui.display import display_url
 
 try:
     from gramps.gui.sidepanel import BaseSidePanel
@@ -43,6 +44,8 @@ from gramps.gen.const import GRAMPS_LOCALE as glocale
 
 _ = glocale.translation.gettext
 _LOG = logging.getLogger("gramps-assistant")
+
+WIKI_PAGE = "https://gramps-project.org/wiki/index.php?title=Addon:GrampsAssistant"
 
 # ---------------------------------------------------------------------------
 # Plugin-local configuration
@@ -213,6 +216,10 @@ class GrampsAssistant(BaseSidePanel):
         clear_btn.set_tooltip_text(_("Clear conversation and context"))
         clear_btn.connect("clicked", self._on_clear_clicked)
 
+        help_btn = Gtk.Button(label=_("Help"))
+        help_btn.set_tooltip_text(_("Open the Gramps Assistant wiki page"))
+        help_btn.connect("clicked", self._on_help_clicked)
+
         self._send_btn = Gtk.Button(label=_("Send"))
         self._send_btn.connect("clicked", self._on_send_clicked)
 
@@ -221,6 +228,7 @@ class GrampsAssistant(BaseSidePanel):
 
         btn_row.pack_start(settings_btn, False, False, 0)
         btn_row.pack_start(clear_btn, False, False, 0)
+        btn_row.pack_start(help_btn, False, False, 0)
         btn_row.pack_start(self._context_label, True, True, 4)
         btn_row.pack_end(self._send_btn, False, False, 0)
 
@@ -706,6 +714,9 @@ class GrampsAssistant(BaseSidePanel):
         self._chat_buffer.set_text("")
         self._show_welcome()
         self._update_context_label()
+
+    def _on_help_clicked(self, button):
+        display_url(WIKI_PAGE)
 
     # ------------------------------------------------------------------
     # Message submission

--- a/GrampsAssistant/tools.py
+++ b/GrampsAssistant/tools.py
@@ -1268,7 +1268,7 @@ def register_gramps_tools(dbstate, uistate):
         The same scope as execute_script is available:
           database, people(), families(), events(), places(), sources(),
           citations(), media(), notes(), repositories(), selected(), filtered(),
-          active_person, active_family, ..., today, counter()
+          custom_filter(), active_person, active_family, ..., today, counter()
 
         In addition, any Gramps lib class can be imported normally:
           from gramps.gen.lib import Person, Event, Date
@@ -1313,6 +1313,9 @@ def register_gramps_tools(dbstate, uistate):
           media(), notes(), repositories()   -- all records of that type
           selected("Person")   -- currently selected rows in the active view
           filtered("Person")   -- currently filtered rows in the active view
+          custom_filter(name, namespace="Person")  -- rows matching an existing
+              Gramps sidebar custom filter; prints a Warning and yields
+              nothing if no filter with that name exists for the namespace
           ("Person","Family","Event","Place","Source","Citation",
            "Media","Note","Repository" are valid table names)
 
@@ -1332,6 +1335,8 @@ def register_gramps_tools(dbstate, uistate):
           counter()          -- defaultdict(int) for tallying
           begin_changes()    -- open a DB transaction for edits
           end_changes()      -- commit the transaction
+          delete(obj)        -- delete a record (person, family, event, ...);
+              must be called between begin_changes() and end_changes()
 
         ## Person properties
           person.gramps_id                          -- "I0001"
@@ -1387,6 +1392,12 @@ def register_gramps_tools(dbstate, uistate):
           for person in people():
               if condition:
                   person.private = True   # triggers auto-commit via callback
+          end_changes()
+
+          begin_changes()
+          for repo in repositories():
+              if not repo.back_references:
+                  delete(repo)   # deletes the record itself
           end_changes()
 
         Example -- people born before 1800:


### PR DESCRIPTION
## Summary
- PR #978 added `custom_filter(name, namespace="Person")` and `delete(obj)` to GrampyScript's script execution scope.
- GrampsAssistant's `execute_script`/`evaluate_expression` tool docstrings in `tools.py` describe that same scope to the model, so they needed updating to mention these two functions, their semantics, and an example (deleting unreferenced repositories inside a `begin_changes()`/`end_changes()` transaction).
- Added help URL, and included help in the addon

## Test plan
- [x] Verified the documented behavior against the actual `custom_filter`/`delete` implementation added in gramps-project/addons-source@bfc9166b7
- [ ] Manual: ask GrampsAssistant to use `custom_filter()` and `delete()` in a generated script and confirm it produces correct GrampyScript code

🤖 Generated with [Claude Code](https://claude.com/claude-code)