### PR TITLE
fix: resolve issue with non-Gregorian calendar

### DIFF
--- a/BirthdaysGramplet/BirthdaysGramplet.gpr.py
+++ b/BirthdaysGramplet/BirthdaysGramplet.gpr.py
@@ -3,6 +3,7 @@
 #
 # Copyright (C) 2010  Peter Potrowl <peter017@gmail.com>
 # Copyright (C) 2019  Matthias Kemmer <matt.familienforschung@gmail.com>
+# Copyright (C) 2026  Javad Razavian <javadr@gmail.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -25,7 +26,7 @@ register(
     name=_("Birthdays"),
     description=_("a gramplet that displays the birthdays of the living people"),
     status=STABLE,
-    version = '1.1.16',
+    version = '1.1.20',
     fname="BirthdaysGramplet.py",
     height=200,
     gramplet="BirthdaysGramplet",

--- a/BirthdaysGramplet/BirthdaysGramplet.gpr.py
+++ b/BirthdaysGramplet/BirthdaysGramplet.gpr.py
@@ -28,9 +28,11 @@ register(
     status=STABLE,
     version = '1.1.20',
     fname="BirthdaysGramplet.py",
+    authors = ["Peter Potrowl", "Matthias Kemmer", "Javad Razavian" ],
+    authors_email = ["peter017@gmail.com", "matt.familienforschung@gmail.com", "javadr@gmail.com" ],
     height=200,
     gramplet="BirthdaysGramplet",
     gramps_target_version="6.0",
     gramplet_title=_("Birthdays"),
-    help_url="BirthdaysGramplet",
+    help_url="Addon:BirthdaysGramplet",
 )

--- a/BirthdaysGramplet/BirthdaysGramplet.py
+++ b/BirthdaysGramplet/BirthdaysGramplet.py
@@ -3,6 +3,7 @@
 #
 # Copyright (C) 2010  Peter Potrowl <peter017@gmail.com>
 # Copyright (C) 2019  Matthias Kemmer <matt.familienforschung@gmail.com>
+# Copyright (C) 2026  Javad Razavian <javadr@gmail.com>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -22,7 +23,7 @@
 from gramps.gen.plug import Gramplet
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 from gramps.gen.display.name import displayer as name_displayer
-from gramps.gen.lib.date import Today, Date
+from gramps.gen.lib.date import Today, Date, gregorian
 import gramps.gen.datehandler
 from gramps.gen.config import config
 from gramps.gen.plug.menu import EnumeratedListOption
@@ -37,10 +38,17 @@ class BirthdaysGramplet(Gramplet):
     def init(self):
         self.set_text(_("No Family Tree loaded."))
         self.max_age = config.get('behavior.max-age-prob-alive')
+        self.sort_mode = 'proximity'
 
     def build_options(self):
         """Build the configuration options"""
         db = self.dbstate.db
+
+        name_sort = _("Sort birthdays by")
+        self.opt_sort = EnumeratedListOption(name_sort, self.sort_mode)
+        self.opt_sort.add_item("proximity", _("Proximity to current date"))
+        self.opt_sort.add_item("month_day", _("Month and day"))
+
 
         name_ignore = _("Ignore birthdays with tag")
         name_only = _("Only show birthdays with tag")
@@ -56,26 +64,30 @@ class BirthdaysGramplet(Gramplet):
                 self.opt_ignore.add_item(tag_name, tag_name)
                 self.opt_only.add_item(tag_name, tag_name)
 
+        self.add_option(self.opt_sort)
         self.add_option(self.opt_ignore)
         self.add_option(self.opt_only)
 
     def save_options(self):
         """Save gramplet configuration data"""
+        self.sort_mode = self.opt_sort.get_value()
         self.ignore_tag = self.opt_ignore.get_value()
         self.only_tag = self.opt_only.get_value()
 
     def save_update_options(self, obj):
         """Save a gramplet's options to file"""
         self.save_options()
-        self.gui.data = [self.ignore_tag, self.only_tag]
+        self.gui.data = [self.sort_mode, self.ignore_tag, self.only_tag]
         self.update()
 
     def on_load(self):
         """Load stored configuration data"""
-        if len(self.gui.data) == 2:
-            self.ignore_tag = self.gui.data[0]
-            self.only_tag = self.gui.data[1]
+        if len(self.gui.data) == 3:
+            self.sort_mode = self.gui.data[0]
+            self.ignore_tag = self.gui.data[1]
+            self.only_tag = self.gui.data[2]
         else:
+            self.sort_mode = 'proximity'
             self.ignore_tag = ''
             self.only_tag = ''
 
@@ -114,8 +126,13 @@ class BirthdaysGramplet(Gramplet):
                 # calculate age and days until birthday
                 self.__calculate(database, person)
 
-        # Reverse sort on number of days from now:
-        self.result.sort(key=lambda item: -item[0])
+        # Sort based on user preference:
+        sort_by = self.opt_sort.get_value()
+        if sort_by == "proximity":
+            self.result.sort(key=lambda item: -item[0])
+        else:
+            self.result.sort(key=lambda item: (item[2].get_month(),
+                                               item[2].get_day()))
         self.clear_text()
 
         # handle text shown in gramplet
@@ -137,9 +154,10 @@ class BirthdaysGramplet(Gramplet):
             birth = database.get_event_from_handle(birth_ref.ref)
             birth_date = birth.get_date_object()
             if birth_date.is_regular():
+                birth_greg = gregorian(birth_date)
                 birthday_this_year = Date(today.get_year(),
-                                          birth_date.get_month(),
-                                          birth_date.get_day())
+                                          birth_greg.get_month(),
+                                          birth_greg.get_day())
                 next_age = birthday_this_year - birth_date
                 # (0 year, months, days) between now and birthday of this
                 # year (positive if passed):


### PR DESCRIPTION
This PR fixes birthday sorting for non-Gregorian calendars and adds a configurable birthday sorting mode.

# Fix: Correct proximity sorting for non-Gregorian birth dates

The proximity sorting logic assumed that extracting the month and day directly from `birth_date` would produce values compatible with the Gregorian calendar. However, `Date(year, month, day)` always creates a Gregorian date.

As a result, birthdays stored in calendars such as the Persian calendar were interpreted incorrectly. For example, 1 Farvardin (approximately March 21 in the Gregorian calendar) was treated as January 1, producing incorrect proximity calculations and an incorrect sort order.

The fix converts `birth_date` to the Gregorian calendar using `gregorian()` before constructing `birthday_this_year`. This ensures that the month and day correspond to the same calendar used for today's date, resulting in correct proximity calculations.

It resolves what appears to be a 16-year-old bug.

# Feature: Configurable birthday sorting

This PR also introduces a new "Sort birthdays by" option in `build_options()` with two sorting modes:

**Month and day** – Sort birthdays in calendar order (January 1 → December 31).
**Proximity** to the current date – Sort birthdays by how soon they occur, with upcoming birthdays listed first.

The default sorting mode is Proximity to the current date.