### PR TITLE
PDFForms: added help URL

### DIFF
--- a/PDFForms/PDFForms.gpr.py
+++ b/PDFForms/PDFForms.gpr.py
@@ -38,6 +38,7 @@ register(
     tool_modes=[TOOL_MODE_GUI],
     requires_mod=["reportlab"],
     depends_on=["Form Gramplet"],
+    help_url="Addon:PDFForms",
 )
 
 register(
@@ -56,4 +57,5 @@ register(
     extension="pdf",
     requires_mod=["pypdf"],
     depends_on=["Form Gramplet"],
+    help_url="Addon:PDFForms",
 )


### PR DESCRIPTION
## Summary
- Adds `help_url="Addon:PDFForms"` to both plugin registrations (the `Generate PDF Forms` tool and the `Import Fillable PDF Forms` importer) in `PDFForms.gpr.py`, matching the convention used by GrampyScript and GrampsAssistant.
- The corresponding wiki page [Addon:PDFForms](https://gramps-project.org/wiki/index.php/Addon:PDFForms) was be created on the Gramps wiki.

## Test plan
- [x] Verified `help_url` follows the same `Addon:<Name>` convention as other recently-updated addons (GrampyScript, GrampsAssistant).