### PR TITLE
MediaVerify auto update media object names #12610

### DIFF
--- a/MediaVerify/MediaVerify.py
+++ b/MediaVerify/MediaVerify.py
@@ -390,6 +390,17 @@ class MediaVerify(tool.Tool, ManagedWindow):
 
             for handle, new_path in self.moved_files:
                 media = self.db.get_media_from_handle(handle)
+
+                old_title = media.get_description()
+                old_path = media.get_path()
+                old_filename = os.path.splitext(os.path.basename(old_path))[0]
+
+                # If the old media title matches the old filename then update the
+                # media title to match the new filename.
+                if old_title == old_filename:
+                    new_title = os.path.splitext(os.path.basename(new_path))[0]
+                    media.set_description(new_title)
+
                 media.set_path(new_path)
                 self.db.commit_media(media, trans)
 


### PR DESCRIPTION
Resolves [12610](https://gramps-project.org/bugs/view.php?id=12610)

Updated the MediaVerify plugin so that it sets the media title after the `Fix` media button is pressed.

### Changes
By default media objects inherit the title of the media path filename (without extension). The current behavior of the `fix_media()` method changes media path filename but not the media title resulting in a mismatch.

This update fixes that by automatically setting the media title to the new path filename but only if the old title matches the old path filename. This ensures that user-modified media titles are never changed accidentally by the MediaVerify tool.

### Examples
Repro steps:
- create a dummy file named `photoA.jpg`
- create 2 media objects and assign `photoA.jpg` to both of them
- rename 1 of the media objects to `Photo A example`
- rename `photoA.jpg` to `photoA_renamed.jpg` on your filesystem
- use the MediaVerify tool to fix the file path of the media objects

Old titles:
- photoA
- Photo A example

New titles:
- photoA_renamed
- Photo A example

