### PR TITLE
Refactor & test Gramps Web Sync Addon

### DIFF
--- a/GrampsWebSync/adapters.py
+++ b/GrampsWebSync/adapters.py
@@ -1,0 +1,156 @@
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2021-2026       David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""Production implementations of the :mod:`session` ports."""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from collections.abc import Callable
+from typing import Any
+
+from gi.repository import GLib
+from gramps.gen.config import config as configman
+from gramps.gen.utils.file import media_path_full
+
+LOG = logging.getLogger("grampswebsync")
+
+
+def get_password(service: str, username: str) -> str | None:
+    """Return the stored password for ``username``, if a keyring is available.
+
+    :param service: Keyring service name; the server URL is used.
+    :param username: The account whose password is wanted.
+    :returns: The password, or ``None`` if unavailable.
+    """
+    LOG.debug("Retrieving password for user %s", username)
+    try:
+        import keyring
+    except ImportError:
+        LOG.warning("Keyring is not installed, cannot retrieve password.")
+        return None
+    return keyring.get_password(service, username)
+
+
+def set_password(service: str, username: str, password: str) -> None:
+    """Store ``password`` in the keyring, if one is available."""
+    try:
+        import keyring
+    except ImportError:
+        return
+    LOG.debug("Storing password for user %s", username)
+    keyring.set_password(service, username, password)
+
+
+class ConfigCredentialStore:
+    """Credentials in the Gramps config file, password in the system keyring."""
+
+    def __init__(self) -> None:
+        self.config = configman.register_manager("webapisync")
+        self.config.register("credentials.url", "")
+        self.config.register("credentials.username", "")
+        self.config.register("credentials.timestamp", 0)
+        self.config.load()
+
+    def get_url(self) -> str:
+        return self.config.get("credentials.url")
+
+    def get_username(self) -> str:
+        return self.config.get("credentials.username")
+
+    def get_password(self) -> str | None:
+        url = self.get_url()
+        username = self.get_username()
+        if not url or not username:
+            return None
+        return get_password(url, username)
+
+    def get_timestamp(self) -> float:
+        return self.config.get("credentials.timestamp")
+
+    def set_timestamp(self, timestamp: float) -> None:
+        LOG.debug("Recording last successful sync at %s", timestamp)
+        self.config.set("credentials.timestamp", timestamp)
+        self.config.save()
+
+    def save_credentials(self, url: str, username: str, password: str) -> None:
+        """Persist the credentials, resetting the sync time if the URL changed."""
+        if url != self.get_url():
+            self.config.set("credentials.timestamp", 0)
+        self.config.set("credentials.url", url)
+        self.config.set("credentials.username", username)
+        set_password(url, username, password)
+        self.config.save()
+
+
+class GrampsMediaStore:
+    """Resolves media paths against the open Gramps database's media path.
+
+    :param db: The local database whose media base path applies.
+    """
+
+    def __init__(self, db) -> None:
+        self.db = db
+
+    def full_path(self, media: Any) -> str:
+        """Return the absolute path of ``media``'s file."""
+        return media_path_full(self.db, media.get_path())
+
+    def exists(self, media: Any) -> bool:
+        """Whether ``media``'s file is present on disk."""
+        return os.path.exists(self.full_path(media))
+
+
+class GLibTaskRunner:
+    """Defers a task to the GTK main loop.
+
+    The task must not run on a worker thread: it drives Gramps progress
+    through the GUI :class:`gramps.gui.user.User`, which touches widgets, and
+    GTK is not thread-safe -- doing so segfaults inside ``diff_dbs``.
+    :func:`GLib.idle_add` keeps the work on the main loop while still letting
+    the caller return so the assistant can paint the progress page first.
+    """
+
+    def run(
+        self,
+        func: Callable[[], Any],
+        on_success: Callable[[Any], None],
+        on_error: Callable[[BaseException], None],
+    ) -> None:
+        """Schedule ``func`` on the main loop and dispatch the outcome there."""
+
+        def once() -> bool:
+            try:
+                result = func()
+            except BaseException as exc:  # noqa: BLE001 -- reported, not swallowed
+                on_error(exc)
+            else:
+                on_success(result)
+            return False  # run once
+
+        GLib.idle_add(once)
+
+
+class SystemClock:
+    """The wall clock."""
+
+    def now(self) -> float:
+        """Return the current POSIX timestamp."""
+        return time.time()

--- a/GrampsWebSync/grampswebsync.py
+++ b/GrampsWebSync/grampswebsync.py
@@ -30,7 +30,7 @@ The synchronization itself lives in :mod:`session`.
 from __future__ import annotations
 
 import logging
-from urllib.parse import urlparse
+from urllib.parse import urlparse, urlunparse
 
 from adapters import (
     ConfigCredentialStore,
@@ -377,6 +377,7 @@ class GrampsWebSyncTool(BatchTool, ManagedWindow):
         :param url: The URL as typed by the user.
         :returns: The URL to actually use.
         """
+        url = url.strip()
         parsed_url = urlparse(url)
         if parsed_url.scheme == "":
             # if no httpX given, prepend https!
@@ -395,7 +396,7 @@ class GrampsWebSyncTool(BatchTool, ManagedWindow):
                 parent=self.window,
             )
             if not question.run():
-                return url.replace("http", "https")
+                return urlunparse(parsed_url._replace(scheme="https"))
         return url
 
 

--- a/GrampsWebSync/grampswebsync.py
+++ b/GrampsWebSync/grampswebsync.py
@@ -1,6 +1,6 @@
 # Gramps - a GTK+/GNOME based genealogy program
 #
-# Copyright (C) 2021-2024       David Straub
+# Copyright (C) 2021-2026       David Straub
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,19 +17,27 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 
-"""Gramps addon to synchronize with a Gramps Web server."""
+"""Gramps addon to synchronize with a Gramps Web server.
+
+Provides :class:`GrampsWebSyncTool`, a :class:`Gtk.Assistant` presenting a
+:class:`session.SyncSession`. :data:`PAGE_FOR_STATE` maps each
+:class:`session.State` to an assistant page and :func:`error_message`
+localizes a :class:`session.ErrorKind`.
+
+The synchronization itself lives in :mod:`session`.
+"""
 
 from __future__ import annotations
 
 import logging
-import os
-import threading
-from collections.abc import Callable
-from datetime import datetime
-from typing import Any
-from urllib.error import HTTPError, URLError
 from urllib.parse import urlparse
 
+from adapters import (
+    ConfigCredentialStore,
+    GLibTaskRunner,
+    GrampsMediaStore,
+    SystemClock,
+)
 from const import (
     C_ADD_LOC,
     C_ADD_REM,
@@ -44,24 +52,23 @@ from const import (
     MODE_RESET_TO_REMOTE,
     Actions,
 )
-from diffhandler import (
-    WebApiSyncDiffHandler,
-    changes_to_actions,
-    has_local_actions,
-    has_remote_actions,
-)
-from gi.repository import GLib, Gtk
-from gramps.gen.config import config as configman
+from diffhandler import changes_to_actions, has_local_actions, has_remote_actions
+from gi.repository import Gtk
 from gramps.gen.const import GRAMPS_LOCALE as glocale
-from gramps.gen.db import DbTxn
-from gramps.gen.db.utils import import_as_dict
-from gramps.gen.errors import HandleError
 from gramps.gen.lib import Tag
-from gramps.gen.utils.file import media_path_full
 from gramps.gui.dialog import QuestionDialog2
 from gramps.gui.managedwindow import ManagedWindow
 from gramps.gui.plug.tool import BatchTool, ToolOptions
-from webapihandler import WebApiHandler, transaction_to_json
+from session import (
+    STATUS_COMPARING,
+    STATUS_FETCHING,
+    STATUS_LOCAL_APPLIED,
+    ErrorKind,
+    State,
+    SyncSession,
+    next_state,
+)
+from webapihandler import WebApiHandler
 
 assert glocale is not None  # for type checker
 try:
@@ -75,65 +82,115 @@ ngettext = _trans.ngettext
 LOG = logging.getLogger("grampswebsync")
 
 
-def get_password(service: str, username: str) -> str | None:
-    """If keyring is installed, return the user's password or None."""
-    LOG.debug("Retrieving password for user %s", username)
-    try:
-        import keyring
-    except ImportError:
-        LOG.warning("Keyring is not installed, cannot retrieve password.")
-        return None
-    return keyring.get_password(service, username)
+#: Assistant page indices, in the order the pages are appended.
+PAGE_INTRO = 0
+PAGE_LOGIN = 1
+PAGE_COMPARING = 2
+PAGE_REVIEW_CHANGES = 3
+PAGE_APPLYING = 4
+PAGE_REVIEW_FILES = 5
+PAGE_TRANSFERRING = 6
+PAGE_CONCLUSION = 7
+
+#: The one place that knows how flow states correspond to assistant pages.
+#: Both terminal states share the conclusion page, which renders either the
+#: summary or the error.
+PAGE_FOR_STATE: dict[State, int] = {
+    State.INTRO: PAGE_INTRO,
+    State.LOGIN: PAGE_LOGIN,
+    State.COMPARING: PAGE_COMPARING,
+    State.REVIEW_CHANGES: PAGE_REVIEW_CHANGES,
+    State.APPLYING: PAGE_APPLYING,
+    State.REVIEW_FILES: PAGE_REVIEW_FILES,
+    State.TRANSFERRING: PAGE_TRANSFERRING,
+    State.DONE: PAGE_CONCLUSION,
+    State.FAILED: PAGE_CONCLUSION,
+}
 
 
-def set_password(service: str, username: str, password: str) -> None:
-    """If keyring is installed, store the user's password."""
-    try:
-        import keyring
-    except ImportError:
-        return None
-    LOG.debug("Storing password for user %s", username)
-    keyring.set_password(service, username, password)
+def error_message(kind: ErrorKind, detail: str = "") -> str:
+    """Return the localized message for an error kind.
+
+    Translation lives here rather than in :mod:`session` so the flow logic can
+    be asserted on stable enum values instead of translated prose.
+
+    :param kind: The classification recorded by the session.
+    :param detail: Optional extra context, e.g. an HTTP status.
+    :returns: A message suitable for display.
+    """
+    messages = {
+        ErrorKind.AUTH_FAILED: _(
+            "Authentication failed. Please check your username and password."
+        ),
+        ErrorKind.FORBIDDEN: _(
+            "Access forbidden. Please check username and password."
+        ),
+        ErrorKind.NOT_FOUND: _("GrampsWeb service not found. Please check the URL."),
+        ErrorKind.RATE_LIMITED: _(
+            "Too many requests, please try again in a few seconds."
+        ),
+        ErrorKind.TREE_DISABLED: _("GrampsWeb tree is disabled."),
+        ErrorKind.CONNECTION_FAILED: _(
+            "Connection failed. Please check the URL and your internet connection."
+        ),
+        ErrorKind.INVALID_RESPONSE: _(
+            "Invalid server response. Please check the URL."
+        ),
+        ErrorKind.INSUFFICIENT_PERMISSIONS: _(
+            "Your user does not have sufficient server permissions to use sync."
+        ),
+        ErrorKind.XML_IMPORT_FAILED: _("Failed importing downloaded XML file."),
+        ErrorKind.CONFLICT: _(
+            "Unable to synchronize changes to server: objects have been modified."
+        ),
+        ErrorKind.APPLY_FAILED: _("Unexpected error while applying changes."),
+    }
+    if kind is ErrorKind.SERVER_ERROR:
+        return _("Server error %s. Please check your connection.") % detail
+    if kind is ErrorKind.UNEXPECTED:
+        return _("Unexpected error: %s") % detail
+    return messages.get(kind, _("Unexpected error: %s") % detail)
 
 
 class GrampsWebSyncTool(BatchTool, ManagedWindow):
-    """Main class for the Gramps Web Sync tool."""
+    """Assistant presenting a :class:`session.SyncSession` to the user."""
 
     def __init__(self, dbstate, user, options_class, name, *args, **kwargs) -> None:
-        """Initialize GUI."""
+        """Build the assistant and the session behind it."""
         LOG.debug("Initializing Gramps Web Sync addon.")
         BatchTool.__init__(self, dbstate, user, options_class, name)
         ManagedWindow.__init__(self, user.uistate, [], self.__class__)
 
         self.dbstate = dbstate
-        self.callback = self.uistate.pulse_progressbar
 
-        self.config = configman.register_manager("webapisync")
-        self.config.register("credentials.url", "")
-        self.config.register("credentials.username", "")
-        self.config.register("credentials.timestamp", 0)
-        self.config.load()
+        self.credentials = ConfigCredentialStore()
+        self.session = SyncSession(
+            db=dbstate.db,
+            user=self._user,
+            backend_factory=self._make_backend,
+            credentials=self.credentials,
+            media=GrampsMediaStore(dbstate.db),
+            runner=GLibTaskRunner(),
+            clock=SystemClock(),
+            listener=self,
+        )
 
         self.assistant = Gtk.Assistant()
         self.set_window(self.assistant, None, _("Gramps Web Sync"))
         self.setup_configs("interface.webapisync", 780, 600)
 
-        self.assistant.connect("close", self.do_close)
-        self.assistant.connect("cancel", self.do_close)
-        self.assistant.connect("apply", self.apply)
+        self.assistant.connect("close", self.do_close, "close")
+        self.assistant.connect("cancel", self.do_close, "cancel")
         self.assistant.connect("prepare", self.prepare)
 
         self.intro = IntroductionPage(self.assistant)
         self.add_page(self.intro, Gtk.AssistantPageType.INTRO, _("Introduction"))
 
-        self.url = self.config.get("credentials.url")
-        self.username = self.config.get("credentials.username")
-        self.password = self.get_password()
         self.loginpage = LoginPage(
             self.assistant,
-            url=self.url,
-            username=self.username,
-            password=self.password,
+            url=self.credentials.get_url(),
+            username=self.credentials.get_username(),
+            password=self.credentials.get_password(),
         )
         self.add_page(self.loginpage, Gtk.AssistantPageType.CONTENT, _("Login"))
 
@@ -151,16 +208,12 @@ class GrampsWebSyncTool(BatchTool, ManagedWindow):
 
         self.sync_progress_page = SyncProgressPage(self.assistant)
         self.add_page(
-            self.sync_progress_page,
-            Gtk.AssistantPageType.PROGRESS,
-            _("Summary"),
+            self.sync_progress_page, Gtk.AssistantPageType.PROGRESS, _("Summary")
         )
 
         self.file_confirmation = FileConfirmationPage(self.assistant)
         self.add_page(
-            self.file_confirmation,
-            Gtk.AssistantPageType.CONFIRM,
-            _("Media Files"),
+            self.file_confirmation, Gtk.AssistantPageType.CONFIRM, _("Media Files")
         )
 
         self.file_progress_page = FileProgressPage(self.assistant)
@@ -176,447 +229,154 @@ class GrampsWebSyncTool(BatchTool, ManagedWindow):
         self.show()
         self.assistant.set_forward_page_func(self.forward_page, None)
 
-        self._api: WebApiHandler | None = None
-
-        self.db1 = dbstate.db
-        self.db2 = None
-        self._closing = False
-        self._download_timestamp = 0
-        self._changes: Actions | None = None
-        self._sync: WebApiSyncDiffHandler | None = None
-        self.files_missing_local: list[tuple[str, str]] = []
-        self.files_missing_remote: list[tuple[str, str]] = []
-        self.uploaded: dict[str, bool] = {}
-        self.downloaded: dict[str, bool] = {}
-
-    @property
-    def api(self) -> WebApiHandler:
-        if self._api is None:
-            raise ValueError("No WebApiHandler found")  # shouldn't happen!
-        return self._api
-
-    @property
-    def sync(self) -> WebApiSyncDiffHandler:
-        if self._sync is None:
-            raise ValueError("No WebApiSyncDiffHandler found")  # shouldn't happen!
-        return self._sync
-
-    @property
-    def changes(self) -> Actions:
-        if self._changes is None:
-            raise ValueError("No change actions found")  # shouldn't happen!
-        return self._changes
-
+    # --------------------------------------------------------
+    # Window management
+    # --------------------------------------------------------
     def build_menu_names(self, obj):  # type: ignore
         """Override :class:`.ManagedWindow` method."""
         return (_("Gramps Web Sync"), None)
 
-    def do_close(self, assistant):
-        """Close the assistant."""
-        LOG.debug("Closing Gramps Web Sync addon.")
-        self._closing = True
-        if self.db2 is not None:
-            LOG.debug("Closing in-memory remote database.")
-            self.db2.close()
-            self.db2 = None
-        # Clear the diff handler which holds references to both db1 and db2
-        self._sync = None
-        self._changes = None
-        position = self.window.get_position()  # crock
-        self.assistant.hide()
-        self.window.move(position[0], position[1])
-        self.close()
-
-    def forward_page(self, page, data):
-        """Specify the next page to be displayed."""
-        LOG.debug(f"Moving to next page from page {page}.")
-        if self.conclusion.error:
-            LOG.debug("Skipping to last page due to error.")
-            return 7
-        if page == 2 and self._changes is not None and len(self.changes) == 0:
-            LOG.debug("Skipping to media sync as databases are in sync.")
-            return 4
-        if page == 5 and self.conclusion.unchanged:
-            LOG.debug("Skipping to last page as media files are in sync.")
-            return 7
-        return page + 1
-
     def add_page(self, page, page_type, title=""):
-        """Add a page to the assistant."""
+        """Append a page to the assistant."""
         page.show_all()
         self.assistant.append_page(page)
         self.assistant.set_page_title(page, title)
         self.assistant.set_page_type(page, page_type)
 
-    def handle_done_syncing_dbs(self):
-        """Handle the completion of syncing the databases."""
-        self.save_timestamp()
-        self.sync_progress_page.handle_done_syncing_dbs()
-        self.files_missing_local = self.get_missing_files_local()
-        self.assistant.next_page()
+    def do_close(self, assistant, signal_name="?"):
+        """Close the assistant and release the session's resources.
 
-    def prepare(self, assistant, page):
-        """Run page preparation code."""
-        page.update_complete()
-        if page == self.diff_progress_page:
-            # Clear any previous login error when starting fresh
-            self.loginpage.clear_error()
-
-            # Try to connect and authenticate
-            self.save_credentials()
-            url, username, password = self.get_credentials()
-            if not self.test_connection(url, username, password):
-                # Connection failed, go back to login page
-                self.assistant.set_current_page(1)  # Login page index
-                return None
-
-            if "ViewPrivate" not in self.api.get_permissions():
-                self.loginpage.show_error(
-                    _(
-                        "Your user does not have sufficient server permissions to use sync."
-                    )
-                )
-                self.assistant.set_current_page(1)  # Go back to login page
-                return None
-
-            self.diff_progress_page.label.set_text(_("Fetching remote data..."))
-            t = threading.Thread(target=self.async_compare_dbs)
-            t.start()
-        elif page == self.confirmation:
-            self.confirmation.prepare(self.changes)
-        elif page == self.sync_progress_page:
-            self.assistant.commit()  # just erases the visited page history
-            actions = changes_to_actions(self.changes, self.confirmation.sync_mode)
-            self.sync_progress_page.prepare(actions)
-            if len(actions) == 0:
-                self.handle_done_syncing_dbs()
-            else:
-                try:
-                    self.commit_all_actions(actions)
-                except Exception as e:
-                    self.handle_error(
-                        _("Unexpected error while applying changes.") + f" {e}"
-                    )
-
-            # now, get missing media files
-        elif page == self.file_confirmation:
-            if self.files_missing_local:
-                LOG.debug(
-                    "The following media files are missing on the local side: %s",
-                    ", ".join([gramps_id for gramps_id, _ in self.files_missing_local]),
-                )
-            else:
-                LOG.debug("No files missing locally.")
-            self.files_missing_remote = self.get_missing_files_remote()
-            if self.files_missing_remote:
-                LOG.debug(
-                    "The following media files are missing on the remote side: %s",
-                    ", ".join(
-                        [gramps_id for gramps_id, _ in self.files_missing_remote]
-                    ),
-                )
-            else:
-                LOG.debug("No files missing remotely.")
-            if not self.files_missing_local and not self.files_missing_remote:
-                self.handle_files_unchanged()
-            else:
-                self.file_confirmation.prepare(
-                    self.files_missing_local, self.files_missing_remote
-                )
-        elif page == self.file_progress_page:
-            self.file_progress_page.prepare(
-                self.files_missing_local, self.files_missing_remote
-            )
-            t = threading.Thread(target=self.async_transfer_media)
-            t.start()
-        elif page == self.conclusion:
-            if self.conclusion.error:
-                pass
-            elif self.conclusion.unchanged:
-                text = _("Media files are in sync.")
-                self.conclusion.label.set_text(text)
-                LOG.info("Media files are in sync.")
-            else:
-                text = ""
-                if self.downloaded:
-                    ok = sum([b for gid, b in self.downloaded.items()])
-                    nok = sum([not b for gid, b in self.downloaded.items()])
-                    if ok:
-                        text += _("Successfully downloaded %s media files.") % ok
-                        text += " "
-                    if nok:
-                        text += _("Encountered %s errors during download.") % nok
-                        text += " "
-                if self.uploaded:
-                    ok = sum([b for gid, b in self.uploaded.items()])
-                    nok = sum([not b for gid, b in self.uploaded.items()])
-                    if ok:
-                        text += _("Successfully uploaded %s media files.") % ok
-                        text += " "
-                    if nok:
-                        text += _("Encountered %s errors during upload.") % nok
-                self.conclusion.label.set_text(text)
-
-            self.conclusion.set_complete()
-
-    def test_connection(self, url: str, username: str, password: str) -> bool:
-        """Test the connection and authentication. Return True if successful."""
-        try:
-            # Try to create API handler
-            self._api = WebApiHandler(url, username, password, None)
-
-            # Test the connection by making a simple API call
-            self.api.get_permissions()
-            return True
-
-        except HTTPError as exc:
-            if exc.code == 401:
-                self.loginpage.show_error(
-                    _("Authentication failed. Please check your username and password.")
-                )
-            elif exc.code == 403:
-                self.loginpage.show_error(
-                    _("Access forbidden. Please check username and password.")
-                )
-            elif exc.code == 404:
-                self.loginpage.show_error(
-                    _("GrampsWeb service not found. Please check the URL.")
-                )
-            elif exc.code == 429:
-                self.loginpage.show_error(
-                    _("Too many requests, please try again in a few seconds.")
-                )
-            elif exc.code == 503:
-                self.loginpage.show_error(_("GrampsWeb tree is disabled."))
-            else:
-                self.loginpage.show_error(
-                    _("Server error %s. Please check your connection.") % exc.code
-                )
-            return False
-        except URLError:
-            self.loginpage.show_error(
-                _(
-                    "Connection failed. Please check the URL and your internet connection."
-                )
-            )
-            return False
-        except ValueError:
-            self.loginpage.show_error(
-                _("Invalid server response. Please check the URL.")
-            )
-            return False
-        except Exception as e:
-            self.loginpage.show_error(_("Unexpected error: %s") % str(e))
-            return False
-
-    def handle_files_unchanged(self):
-        self.conclusion.unchanged = True
-        self.assistant.next_page()
-
-    def apply(self, assistant):
-        """Apply the changes."""
-        page_number = assistant.get_current_page()
-        page = assistant.get_nth_page(page_number)
-        if page == self.confirmation:
-            pass
-        elif page == self.file_confirmation:
-            pass
-
-    def download_files(self):
-        """Download media files missing locally."""
-        if not self.files_missing_local:
-            return
-        res = {}
-        for gramps_id, handle in self.files_missing_local:
-            LOG.debug("Downloading file %s", gramps_id)
-            self.downloaded[gramps_id] = self._download_file(handle)
-            self._update_file_progress()
-        return res
-
-    def _update_file_progress(self):
-        """Update the file progress bars."""
-        self.file_progress_page.update_progress(
-            self.files_missing_local,
-            self.files_missing_remote,
-            self.downloaded,
-            self.uploaded,
+        :param assistant: The assistant emitting the signal.
+        :param signal_name: Which signal fired, ``close`` or ``cancel``.
+        """
+        LOG.debug(
+            "Closing Gramps Web Sync addon (signal=%s, page=%s, state=%s).",
+            signal_name,
+            assistant.get_current_page(),
+            self.session.state.name,
         )
-        # force updating progress bar
+        self.session.cancel()
+        position = self.window.get_position()  # crock
+        self.assistant.hide()
+        self.window.move(position[0], position[1])
+        self.close()
+
+    def _make_backend(self, url: str, username: str, password: str) -> WebApiHandler:
+        """Build the real Web API handler. Injected into the session."""
+        return WebApiHandler(url, username, password, None)
+
+    # --------------------------------------------------------
+    # SessionListener
+    # --------------------------------------------------------
+    def on_state_changed(self, state: State) -> None:
+        """Follow the session to the page representing ``state``."""
+        target = PAGE_FOR_STATE[state]
+        if self.assistant.get_current_page() != target:
+            self.assistant.set_current_page(target)
+
+    def on_progress(self, kind: str, fraction: float) -> None:
+        """Render a progress update from the session."""
+        if kind == "api":
+            self.sync_progress_page.update_api_progress(fraction)
+        else:
+            self.file_progress_page.update_progress(kind, fraction)
+        self._pump()
+
+    def on_status(self, stage: str) -> None:
+        """Render a status update from the session."""
+        self._render_status(stage)
+        self._pump()
+
+    @staticmethod
+    def _pump() -> None:
+        """Redraw now.
+
+        The session's steps run on the main loop, so without this the label
+        and bar would not repaint until the whole step finished.
+        """
         while Gtk.events_pending():
             Gtk.main_iteration()
 
-    def _download_file(self, handle):
-        """Download a single media file."""
-        try:
-            obj = self.db1.get_media_from_handle(handle)
-        except HandleError:
-            self.handle_error(_("Error accessing media object."))
-            return False
-        path = media_path_full(self.db1, obj.get_path())
-        try:
-            return self.api.download_media_file(handle=handle, path=path)
-        except Exception as e:
-            LOG.warning(f"Failed to download media file {obj.gramps_id}: {e}")
-            return False
-
-    def upload_files(self):
-        """Upload media files missing remotely."""
-        if not self.files_missing_remote:
-            return
-        res = {}
-        for gramps_id, handle in self.files_missing_remote:
-            LOG.debug("Uploading file %s", gramps_id)
-            self.uploaded[gramps_id] = self._upload_file(handle)
-            self._update_file_progress()
-        return res
-
-    def _upload_file(self, handle):
-        """Upload a single media file."""
-        try:
-            obj = self.db1.get_media_from_handle(handle)
-        except HandleError:
-            self.handle_error(_("Error accessing media object."))
-            return
-        path = media_path_full(self.db1, obj.get_path())
-        return self.api.upload_media_file(handle=handle, path=path)
-
-    def get_password(self):
-        """Get a stored password."""
-        url = self.config.get("credentials.url")
-        username = self.config.get("credentials.username")
-        if not url or not username:
-            return None
-        return get_password(url, username)
-
-    def handle_error(self, message):
-        """Handle an error message during sync."""
-        LOG.warning(message)
-        self.conclusion.error = True
-        self.assistant.next_page()
-        self.conclusion.label.set_text(message)
-        self.conclusion.set_complete()
-
-    def handle_unchanged(self):
-        """Return a message if nothing has changed."""
-        self.save_timestamp()
-        self.assistant.next_page()
-
-    def async_compare_dbs(self):
-        """Download the remote data and import it to an in-memory database."""
-        # store timestamp just before downloading the XML
-        self._download_timestamp = datetime.now().timestamp()
-        GLib.idle_add(self.get_diff_actions)
-
-    def get_diff_actions(self) -> None:
-        """Download the remote data, import it and compare it to local."""
-        if self._closing:
-            return
-        LOG.info("Downloading Gramps XML file.")
-        path = self.handle_server_errors(self.api.download_xml)
-        if path is None:
-            return
-        LOG.debug(f"The file name of the downloaded file is: {path}")
-        LOG.debug("Importing Gramps XML file.")
-        db2 = import_as_dict(str(path), self._user)
-        if db2 is None:
-            self.handle_error(_("Failed importing downloaded XML file."))
-            return
-        LOG.debug("Successfully imported Gramps XML file.")
-        path.unlink()  # delete temporary file
-        self.db2 = db2
-        self.diff_progress_page.label.set_text(_("Comparing local and remote data..."))
-        LOG.info("Comparing local and remote data...")
-        timestamp = self.config.get("credentials.timestamp") or None
-        from datetime import datetime
-
-        LOG.debug(
-            "Loading last sync timestamp from config: %s (%s)",
-            timestamp,
-            (
-                datetime.fromtimestamp(timestamp).strftime("%Y-%m-%d %H:%M:%S %Z")
-                if timestamp
-                else "None"
-            ),
-        )
-        self._sync = WebApiSyncDiffHandler(
-            self.db1, self.db2, user=self._user, last_synced=timestamp
-        )
-        self._changes = self.sync.get_changes()
-        self.diff_progress_page.label.set_text("")
-        self.diff_progress_page.set_complete()
-        if len(self.changes) == 0:
-            LOG.info("Databases are in sync.")
-            self.handle_unchanged()
-        else:
-            self.assistant.next_page()
-
-    def async_transfer_media(self):
-        """Upload/download media files."""
-        GLib.idle_add(self._async_transfer_media)
-
-    def _async_transfer_media(self):
-        """Upload/download media files."""
-        if self._closing:
-            return
-        self.handle_server_errors(self.download_files)
-        if self.conclusion.error:
-            return
-        self.handle_server_errors(self.upload_files)
-        if self.conclusion.error:
-            return
-        self.file_progress_page.set_complete()
-        self.assistant.next_page()
-
-    def handle_server_errors(self, callback: Callable, *args) -> None:
-        """Handle server errors while executing a function."""
-        try:
-            return callback(*args)
-        except HTTPError as exc:
-            if exc.code == 401:
-                self.handle_error(_("Server authorization error."))
-            elif exc.code == 403:
-                self.handle_error(
-                    _("Server authorization error: insufficient permissions.")
-                )
-            elif exc.code == 404:
-                self.handle_error(_("Error: URL not found."))
-            elif exc.code == 409:
-                self.handle_error(
-                    _(
-                        "Unable to synchronize changes to server: objects have been modified."
-                    )
-                )
-            else:
-                self.handle_error(_("Error %s while connecting to server.") % exc.code)
-            return None
-        except URLError:
-            self.handle_error(_("URL error while connecting to server."))
-            return None
-        except ValueError as exc:
-            self.handle_error(
-                f"{_('Unable to synchronize changes to server.')} ({exc})"
+    def _render_status(self, stage: str) -> None:
+        """Show the message for ``stage``."""
+        if stage == STATUS_FETCHING:
+            self.diff_progress_page.label.set_text(_("Fetching remote data..."))
+        elif stage == STATUS_COMPARING:
+            self.diff_progress_page.label.set_text(
+                _("Comparing local and remote data...")
             )
-            return None
+        elif stage == STATUS_LOCAL_APPLIED:
+            self.sync_progress_page.label.set_text(
+                _("Successfully applied changes to local database.")
+            )
 
-    def save_credentials(self) -> None:
-        """Save the login credentials."""
-        url = self.loginpage.url.get_text()
-        url = self.sanitize_url(url)
-        if url is None:
-            self.handle_error("No URL provided")
-            return
-        username = self.loginpage.username.get_text()
-        password = self.loginpage.password.get_text()
-        if url != self.config.get("credentials.url"):
-            # if URL changed, clear last sync timestamp
-            self.config.set("credentials.timestamp", 0)
-        self.config.set("credentials.url", url)
-        self.config.set("credentials.username", username)
-        set_password(url, username, password)
-        self.config.save()
+    # --------------------------------------------------------
+    # Navigation
+    # --------------------------------------------------------
+    def forward_page(self, page, data):
+        """Return the page index the session's flow says comes next."""
+        return PAGE_FOR_STATE[next_state(self.session.state, self.session)]
 
-    def sanitize_url(self, url: str) -> str | None:
-        """Warn if http and prepend https if missing."""
+    def prepare(self, assistant, page):
+        """Render a page as it is shown, and fire any intent it triggers.
+
+        Every intent is guarded on the session's current state, so a page
+        being prepared more than once -- which happens whenever the session
+        navigates to the page it is already on -- cannot start the same work
+        twice.
+        """
+        page.update_complete()
+
+        if page is self.loginpage:
+            if self.session.state is State.INTRO:
+                self.session.begin()
+            if self.session.login_error is not None:
+                error = self.session.login_error
+                self.loginpage.show_error(error_message(error.kind, error.detail))
+            else:
+                self.loginpage.clear_error()
+
+        elif page is self.diff_progress_page:
+            if self.session.state is State.LOGIN:
+                self.loginpage.clear_error()
+                url = self.sanitize_url(self.loginpage.url.get_text())
+                self.session.submit_credentials(
+                    url,
+                    self.loginpage.username.get_text(),
+                    self.loginpage.password.get_text(),
+                )
+
+        elif page is self.confirmation:
+            self.confirmation.prepare(self.session.changes)
+
+        elif page is self.sync_progress_page:
+            if self.session.state is State.REVIEW_CHANGES:
+                self.assistant.commit()  # erases the visited page history
+                mode = self.confirmation.sync_mode
+                self.sync_progress_page.prepare(self.session, mode)
+                self.session.confirm_changes(mode)
+
+        elif page is self.file_confirmation:
+            self.file_confirmation.prepare(
+                self.session.missing_local, self.session.missing_remote
+            )
+
+        elif page is self.file_progress_page:
+            if self.session.state is State.REVIEW_FILES:
+                self.file_progress_page.prepare(
+                    self.session.missing_local, self.session.missing_remote
+                )
+                self.session.confirm_files()
+
+        elif page is self.conclusion:
+            self.conclusion.prepare(self.session)
+
+    def sanitize_url(self, url: str) -> str:
+        """Prepend https if no scheme is given, and warn about plain http.
+
+        :param url: The URL as typed by the user.
+        :returns: The URL to actually use.
+        """
         parsed_url = urlparse(url)
         if parsed_url.scheme == "":
             # if no httpX given, prepend https!
@@ -637,84 +397,6 @@ class GrampsWebSyncTool(BatchTool, ManagedWindow):
             if not question.run():
                 return url.replace("http", "https")
         return url
-
-    def get_credentials(self):
-        """Get a tuple of URL, username, and password."""
-        return (
-            self.config.get("credentials.url"),
-            self.config.get("credentials.username"),
-            self.loginpage.password.get_text(),
-        )
-
-    def commit_all_actions(self, actions: Actions) -> None:
-        """Commit all changes to the databases."""
-        LOG.info("Committing all changes to the databases.")
-        msg = "Apply Gramps Web Sync changes"
-        with DbTxn(msg, self.sync.db1) as trans1:
-            with DbTxn(msg, self.sync.db2) as trans2:
-                if has_local_actions(actions):
-                    LOG.debug("Committing changes to local database.")
-                else:
-                    LOG.debug("No changes to apply to local database.")
-                self.sync.commit_actions(actions, trans1, trans2)
-                self.sync_progress_page.handle_local_sync_complete(actions)
-                # force the sync for all modes: the server-side "object has changed"
-                # check compares against the XML-round-tripped object, which often
-                # differs from the live server object due to serialization artifacts,
-                # causing false-positive 409 conflicts even when no real concurrent
-                # edit has occurred.
-                force = True
-                lang = self.api.get_lang()
-                payload = transaction_to_json(trans2, lang)
-        GLib.idle_add(self.async_commit_actions_to_remote, payload, force)
-
-    def async_commit_actions_to_remote(
-        self, payload: dict[str, "Any"], force: bool
-    ) -> None:
-        """Commit all changes to the remote database."""
-        GLib.idle_add(self._async_commit_actions_to_remote, payload, force)
-
-    def _async_commit_actions_to_remote(
-        self, payload: dict[str, "Any"], force: bool
-    ) -> None:
-        """Upload/download media files."""
-        if self._closing:
-            return
-        LOG.debug("Committing changes to remote database.")
-        self.handle_server_errors(
-            self.api.commit,
-            payload,
-            force,
-            self.sync_progress_page.update_api_progress,
-        )
-        if self.conclusion.error:
-            return
-        self.handle_done_syncing_dbs()
-
-    def save_timestamp(self):
-        """Save last sync timestamp."""
-        # self.config.set("credentials.timestamp", self._download_timestamp)
-        timestamp = datetime.now().timestamp()
-        LOG.debug(
-            "Saving current time stamp (%s) as last successful sync time (%s).",
-            timestamp,
-            datetime.fromtimestamp(timestamp).strftime("%Y-%m-%d %H:%M:%S %Z"),
-        )
-        self.config.set("credentials.timestamp", timestamp)
-        self.config.save()
-
-    def get_missing_files_local(self) -> list[tuple[str, str]]:
-        """Get a list of media files missing locally."""
-        return [
-            (media.gramps_id, media.handle)
-            for media in self.db1.iter_media()
-            if not os.path.exists(media_path_full(self.db1, media.get_path()))
-        ]
-
-    def get_missing_files_remote(self):
-        """Get a list of media files missing remotely."""
-        missing_files = self.handle_server_errors(self.api.get_missing_files) or []
-        return [(media["gramps_id"], media["handle"]) for media in missing_files]
 
 
 class Page(Gtk.Box):
@@ -944,6 +626,7 @@ class ConfirmationPage(Page):
 
     def prepare(self, changes: Actions):
         """Convert the changes list to a tree store."""
+        self.store.clear()  # this page may be prepared more than once
         change_labels = {
             _("Local changes"): {
                 _("Added"): C_ADD_LOC,
@@ -1026,11 +709,17 @@ class SyncProgressPage(Page):
             self.progressbar_api.set_fraction(progress)
         else:
             self.progressbar_api.pulse()
-        # force updating progress bar
-        while Gtk.events_pending():
-            Gtk.main_iteration()
 
-    def prepare(self, actions: Actions):
+    def prepare(self, session: SyncSession, sync_mode: int):
+        """Describe the work about to be done.
+
+        Called before the session applies anything, so the actions are derived
+        here from the mode the user just chose.
+
+        :param session: The session holding the pending changes.
+        :param sync_mode: The mode selected on the confirmation page.
+        """
+        actions = changes_to_actions(session.changes, sync_mode)
         if len(actions) == 0:
             self.label.set_text(_("Both trees are the same."))
             self.label_progressbar_api.hide()
@@ -1052,16 +741,6 @@ class SyncProgressPage(Page):
                 _("No changes to apply to remote database.")
             )
             self.progressbar_api.hide()
-
-    def handle_local_sync_complete(self, actions: Actions) -> None:
-        """Handle completion of local sync."""
-        if not has_local_actions(actions):
-            return
-        self.label.set_text(_("Successfully applied changes to local database."))
-
-    def handle_done_syncing_dbs(self) -> None:
-        """Handle completion of syncing the databases."""
-        self.media_label.show()
 
 
 class FileConfirmationPage(Page):
@@ -1086,6 +765,8 @@ class FileConfirmationPage(Page):
         self.pack_start(scrolled_window, True, True, 0)
 
     def prepare(self, missing_local, missing_remote):
+        """List the files that would be transferred."""
+        self.store.clear()  # this page may be prepared more than once
         iter_local = self.store.append(None, [_("Missing locally")])
         for gramps_id, handle in missing_local:
             self.store.append(iter_local, [gramps_id])
@@ -1127,7 +808,14 @@ class FileProgressPage(Page):
         else:
             self.label1.show()
             self.progressbar1.show()
-            self.label1.set_text(_("Downloading %s media file(s)") % n_down)
+            self.label1.set_text(
+                ngettext(
+                    "Downloading %s media file",
+                    "Downloading %s media files",
+                    n_down,
+                )
+                % n_down
+            )
         n_up = len(files_missing_remote)
         if not n_up:
             self.label2.hide()
@@ -1135,35 +823,99 @@ class FileProgressPage(Page):
         else:
             self.label2.show()
             self.progressbar2.show()
-            self.label2.set_text(_("Uploading %s media file(s)") % n_up)
+            self.label2.set_text(
+                ngettext(
+                    "Uploading %s media file",
+                    "Uploading %s media files",
+                    n_up,
+                )
+                % n_up
+            )
 
-    def update_progress(
-        self, files_missing_local, files_missing_remote, downloaded, uploaded
-    ):
-        """Update the progress bar."""
-        n_down = len(files_missing_local)
-        n_up = len(files_missing_remote)
-        i_down = len(downloaded)
-        i_up = len(uploaded)
-        if n_down:
-            self.progressbar1.set_fraction(i_down / n_down)
-        if n_up:
-            self.progressbar2.set_fraction(i_up / n_up)
+    def update_progress(self, kind: str, fraction: float):
+        """Update the download or upload progress bar.
+
+        :param kind: Either ``"download"`` or ``"upload"``.
+        :param fraction: Completed share of that transfer, in ``[0, 1]``.
+        """
+        if kind == "download":
+            self.progressbar1.set_fraction(fraction)
+        elif kind == "upload":
+            self.progressbar2.set_fraction(fraction)
 
 
 class ConclusionPage(Page):
-    """The conclusion page."""
+    """The conclusion page, reporting either the outcome or the error."""
 
     def __init__(self, assistant):
         super().__init__(assistant)
-        self.error = False
-        self.unchanged = False
         label = Gtk.Label(label="")
         label.set_line_wrap(True)
         label.set_use_markup(True)
         label.set_max_width_chars(60)
         self.label = label
         self.pack_start(self.label, False, False, 0)
+
+    def prepare(self, session: SyncSession) -> None:
+        """Render the final message for ``session``."""
+        if session.error is not None:
+            self.label.set_text(
+                error_message(session.error.kind, session.error.detail)
+            )
+        elif not session.downloaded and not session.uploaded:
+            self.label.set_text(_("Media files are in sync."))
+            LOG.info("Media files are in sync.")
+        else:
+            self.label.set_text(self._transfer_summary(session))
+        self.set_complete()
+
+    @staticmethod
+    def _transfer_summary(session: SyncSession) -> str:
+        """Summarize how many media files moved, and how many failed."""
+        text = ""
+        if session.downloaded:
+            ok = sum(session.downloaded.values())
+            nok = sum(not v for v in session.downloaded.values())
+            if ok:
+                text += (
+                    ngettext(
+                        "Successfully downloaded %s media file.",
+                        "Successfully downloaded %s media files.",
+                        ok,
+                    )
+                    % ok
+                    + " "
+                )
+            if nok:
+                text += (
+                    ngettext(
+                        "Encountered %s error during download.",
+                        "Encountered %s errors during download.",
+                        nok,
+                    )
+                    % nok
+                    + " "
+                )
+        if session.uploaded:
+            ok = sum(session.uploaded.values())
+            nok = sum(not v for v in session.uploaded.values())
+            if ok:
+                text += (
+                    ngettext(
+                        "Successfully uploaded %s media file.",
+                        "Successfully uploaded %s media files.",
+                        ok,
+                    )
+                    % ok
+                    + " "
+                )
+            if nok:
+                text += ngettext(
+                    "Encountered %s error during upload.",
+                    "Encountered %s errors during upload.",
+                    nok,
+                ) % nok
+        return text
 
 
 class GrampsWebSyncOptions(ToolOptions):

--- a/GrampsWebSync/po/template.pot
+++ b/GrampsWebSync/po/template.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-11 21:37+0200\n"
+"POT-Creation-Date: 2026-07-27 09:45+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,9 +16,10 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: GrampsWebSync/grampswebsync.gpr.py:29 GrampsWebSync/grampswebsync.py:116
-#: GrampsWebSync/grampswebsync.py:209
+#: GrampsWebSync/grampswebsync.gpr.py:29 GrampsWebSync/grampswebsync.py:179
+#: GrampsWebSync/grampswebsync.py:237
 msgid "Gramps Web Sync"
 msgstr ""
 
@@ -26,172 +27,115 @@ msgstr ""
 msgid "Synchronizes a local database with a Gramps Web instance."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:125
-msgid "Introduction"
-msgstr ""
-
-#: GrampsWebSync/grampswebsync.py:136
-msgid "Login"
-msgstr ""
-
-#: GrampsWebSync/grampswebsync.py:142 GrampsWebSync/grampswebsync.py:168
-msgid "Progress Information"
-msgstr ""
-
-#: GrampsWebSync/grampswebsync.py:147
-msgid "Final confirmation"
-msgstr ""
-
-#: GrampsWebSync/grampswebsync.py:154 GrampsWebSync/grampswebsync.py:172
-msgid "Summary"
-msgstr ""
-
-#: GrampsWebSync/grampswebsync.py:161
-msgid "Media Files"
-msgstr ""
-
-#: GrampsWebSync/grampswebsync.py:264
-msgid "Your user does not have sufficient server permissions to use sync."
-msgstr ""
-
-#: GrampsWebSync/grampswebsync.py:269
-msgid "Fetching remote data..."
-msgstr ""
-
-#: GrampsWebSync/grampswebsync.py:285
-msgid "Unexpected error while applying changes."
-msgstr ""
-
-#: GrampsWebSync/grampswebsync.py:323
-msgid "Media files are in sync."
-msgstr ""
-
-#: GrampsWebSync/grampswebsync.py:332
-#, python-format
-msgid "Successfully downloaded %s media file."
-msgid_plural "Successfully downloaded %s media files."
-msgstr[0] ""
-msgstr[1] ""
-
-#: GrampsWebSync/grampswebsync.py:335
-#, python-format
-msgid "Encountered %s error during download."
-msgid_plural "Encountered %s errors during download."
-msgstr[0] ""
-msgstr[1] ""
-
-#: GrampsWebSync/grampswebsync.py:341
-#, python-format
-msgid "Successfully uploaded %s media file."
-msgid_plural "Successfully uploaded %s media files."
-msgstr[0] ""
-msgstr[1] ""
-
-#: GrampsWebSync/grampswebsync.py:344
-#, python-format
-msgid "Encountered %s error during upload."
-msgid_plural "Encountered %s errors during upload."
-msgstr[0] ""
-msgstr[1] ""
-
-#: GrampsWebSync/grampswebsync.py:362
+#: GrampsWebSync/grampswebsync.py:123
 msgid "Authentication failed. Please check your username and password."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:366
+#: GrampsWebSync/grampswebsync.py:126
 msgid "Access forbidden. Please check username and password."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:370
+#: GrampsWebSync/grampswebsync.py:128
 msgid "GrampsWeb service not found. Please check the URL."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:374
+#: GrampsWebSync/grampswebsync.py:130
 msgid "Too many requests, please try again in a few seconds."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:378
+#: GrampsWebSync/grampswebsync.py:132
 msgid "GrampsWeb tree is disabled."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:382
+#: GrampsWebSync/grampswebsync.py:134
+msgid "Connection failed. Please check the URL and your internet connection."
+msgstr ""
+
+#: GrampsWebSync/grampswebsync.py:137
+msgid "Invalid server response. Please check the URL."
+msgstr ""
+
+#: GrampsWebSync/grampswebsync.py:140
+msgid "Your user does not have sufficient server permissions to use sync."
+msgstr ""
+
+#: GrampsWebSync/grampswebsync.py:142
+msgid "Failed importing downloaded XML file."
+msgstr ""
+
+#: GrampsWebSync/grampswebsync.py:144
+msgid "Unable to synchronize changes to server: objects have been modified."
+msgstr ""
+
+#: GrampsWebSync/grampswebsync.py:146
+msgid "Unexpected error while applying changes."
+msgstr ""
+
+#: GrampsWebSync/grampswebsync.py:149
 #, python-format
 msgid "Server error %s. Please check your connection."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:387
-msgid "Connection failed. Please check the URL and your internet connection."
-msgstr ""
-
-#: GrampsWebSync/grampswebsync.py:391
-msgid "Invalid server response. Please check the URL."
-msgstr ""
-
-#: GrampsWebSync/grampswebsync.py:394
+#: GrampsWebSync/grampswebsync.py:151 GrampsWebSync/grampswebsync.py:152
 #, python-format
 msgid "Unexpected error: %s"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:438 GrampsWebSync/grampswebsync.py:459
-msgid "Error accessing media object."
+#: GrampsWebSync/grampswebsync.py:187
+msgid "Introduction"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:500
-msgid "Failed importing downloaded XML file."
+#: GrampsWebSync/grampswebsync.py:195
+msgid "Login"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:505
+#: GrampsWebSync/grampswebsync.py:201 GrampsWebSync/grampswebsync.py:223
+msgid "Progress Information"
+msgstr ""
+
+#: GrampsWebSync/grampswebsync.py:206
+msgid "Final confirmation"
+msgstr ""
+
+#: GrampsWebSync/grampswebsync.py:211 GrampsWebSync/grampswebsync.py:227
+msgid "Summary"
+msgstr ""
+
+#: GrampsWebSync/grampswebsync.py:216
+msgid "Media Files"
+msgstr ""
+
+#: GrampsWebSync/grampswebsync.py:289
+msgid "Fetching remote data..."
+msgstr ""
+
+#: GrampsWebSync/grampswebsync.py:292
 msgid "Comparing local and remote data..."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:537
-msgid "Server authorization error."
+#: GrampsWebSync/grampswebsync.py:296
+msgid "Successfully applied changes to local database."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:540
-msgid "Server authorization error: insufficient permissions."
-msgstr ""
-
-#: GrampsWebSync/grampswebsync.py:543
-msgid "Error: URL not found."
-msgstr ""
-
-#: GrampsWebSync/grampswebsync.py:547
-msgid "Unable to synchronize changes to server: objects have been modified."
-msgstr ""
-
-#: GrampsWebSync/grampswebsync.py:551
-#, python-format
-msgid "Error %s while connecting to server."
-msgstr ""
-
-#: GrampsWebSync/grampswebsync.py:554
-msgid "URL error while connecting to server."
-msgstr ""
-
-#: GrampsWebSync/grampswebsync.py:557
-msgid "Unable to synchronize changes to server."
-msgstr ""
-
-#: GrampsWebSync/grampswebsync.py:585
+#: GrampsWebSync/grampswebsync.py:377
 msgid "Continue without transport encryption?"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:587
+#: GrampsWebSync/grampswebsync.py:379
 msgid ""
 "You have specified a URL with http scheme. If you continue, your password "
 "will be sent in clear text over the network. Use only for local testing!"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:592
+#: GrampsWebSync/grampswebsync.py:384
 msgid "Continue with HTTP"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:593
+#: GrampsWebSync/grampswebsync.py:385
 msgid "Use HTTPS"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:711
+#: GrampsWebSync/grampswebsync.py:435
 msgid ""
 "This tool allows to synchronize the currently opened family tree with a "
 "remote family tree served by Gramps Web.\n"
@@ -207,105 +151,133 @@ msgid ""
 "option to make manual modifications, use the Import Merge Tool instead."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:738
+#: GrampsWebSync/grampswebsync.py:462
 msgid "Server URL: "
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:747
+#: GrampsWebSync/grampswebsync.py:471
 msgid "Username: "
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:755
+#: GrampsWebSync/grampswebsync.py:479
 msgid "Password: "
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:847
+#: GrampsWebSync/grampswebsync.py:571
 msgid "Bidirectional Synchronization"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:856
+#: GrampsWebSync/grampswebsync.py:580
 msgid "Reset remote to local"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:864
+#: GrampsWebSync/grampswebsync.py:588
 msgid "Reset local to remote"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:872
+#: GrampsWebSync/grampswebsync.py:596
 msgid "Merge"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:897
+#: GrampsWebSync/grampswebsync.py:622
 msgid "Local changes"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:898 GrampsWebSync/grampswebsync.py:903
+#: GrampsWebSync/grampswebsync.py:623 GrampsWebSync/grampswebsync.py:628
 msgid "Added"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:899 GrampsWebSync/grampswebsync.py:904
+#: GrampsWebSync/grampswebsync.py:624 GrampsWebSync/grampswebsync.py:629
 msgid "Deleted"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:900 GrampsWebSync/grampswebsync.py:905
-#: GrampsWebSync/grampswebsync.py:907
+#: GrampsWebSync/grampswebsync.py:625 GrampsWebSync/grampswebsync.py:630
+#: GrampsWebSync/grampswebsync.py:632
 msgid "Modified"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:902
+#: GrampsWebSync/grampswebsync.py:627
 msgid "Remote changes"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:907
+#: GrampsWebSync/grampswebsync.py:632
 msgid "Simultaneous changes"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:964
+#: GrampsWebSync/grampswebsync.py:689
 msgid "Fetching information about media files..."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:985
+#: GrampsWebSync/grampswebsync.py:715
 msgid "Both trees are the same."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:991
+#: GrampsWebSync/grampswebsync.py:721
 msgid "Applying changes to local database ..."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:993
+#: GrampsWebSync/grampswebsync.py:723
 msgid "No changes to apply to local database."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:996
+#: GrampsWebSync/grampswebsync.py:727
 msgid "Applying changes to remote database ..."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:999
+#: GrampsWebSync/grampswebsync.py:732
 msgid "No changes to apply to remote database."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:1006
-msgid "Successfully applied changes to local database."
-msgstr ""
-
-#: GrampsWebSync/grampswebsync.py:1035
+#: GrampsWebSync/grampswebsync.py:761
 msgid "Missing locally"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:1038
+#: GrampsWebSync/grampswebsync.py:764
 msgid "Missing remotely"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:1076
+#: GrampsWebSync/grampswebsync.py:804
 #, python-format
 msgid "Downloading %s media file"
 msgid_plural "Downloading %s media files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: GrampsWebSync/grampswebsync.py:1084
+#: GrampsWebSync/grampswebsync.py:819
 #, python-format
 msgid "Uploading %s media file"
 msgid_plural "Uploading %s media files"
+msgstr[0] ""
+msgstr[1] ""
+
+#: GrampsWebSync/grampswebsync.py:857
+msgid "Media files are in sync."
+msgstr ""
+
+#: GrampsWebSync/grampswebsync.py:873
+#, python-format
+msgid "Successfully downloaded %s media file."
+msgid_plural "Successfully downloaded %s media files."
+msgstr[0] ""
+msgstr[1] ""
+
+#: GrampsWebSync/grampswebsync.py:883
+#, python-format
+msgid "Encountered %s error during download."
+msgid_plural "Encountered %s errors during download."
+msgstr[0] ""
+msgstr[1] ""
+
+#: GrampsWebSync/grampswebsync.py:896
+#, python-format
+msgid "Successfully uploaded %s media file."
+msgid_plural "Successfully uploaded %s media files."
+msgstr[0] ""
+msgstr[1] ""
+
+#: GrampsWebSync/grampswebsync.py:905
+#, python-format
+msgid "Encountered %s error during upload."
+msgid_plural "Encountered %s errors during upload."
 msgstr[0] ""
 msgstr[1] ""

--- a/GrampsWebSync/session.py
+++ b/GrampsWebSync/session.py
@@ -1,0 +1,625 @@
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2021-2026       David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""Headless sync session for the Gramps Web Sync addon.
+
+:class:`SyncSession` runs a synchronization against a Gramps Web server,
+progressing through the stages in :class:`State`. Callers drive it with
+:meth:`~SyncSession.begin`, :meth:`~SyncSession.submit_credentials`,
+:meth:`~SyncSession.confirm_changes` and :meth:`~SyncSession.confirm_files`,
+and observe it through a :class:`SessionListener`.
+
+Collaborators are supplied as ports: :class:`Backend`,
+:class:`CredentialStore`, :class:`MediaStore`, :class:`TaskRunner` and
+:class:`Clock`. Failures are recorded as a :class:`SyncError` carrying an
+:class:`ErrorKind`; callers are responsible for localizing them.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import Enum, auto
+from pathlib import Path
+from typing import Any, Protocol
+from urllib.error import HTTPError, URLError
+
+from const import MODE_BIDIRECTIONAL, Actions
+from diffhandler import (
+    WebApiSyncDiffHandler,
+    changes_to_actions,
+    has_local_actions,
+    has_remote_actions,
+)
+from gramps.gen.db import DbTxn
+from gramps.gen.db.utils import import_as_dict
+from gramps.gen.errors import HandleError
+from webapihandler import transaction_to_json
+
+LOG = logging.getLogger("grampswebsync")
+
+#: Transaction description recorded in both databases' undo history.
+TXN_MSG = "Apply Gramps Web Sync changes"
+
+#: Server permission required to run a sync at all.
+REQUIRED_PERMISSION = "ViewPrivate"
+
+#: Stages reported through :meth:`SessionListener.on_status`.
+STATUS_FETCHING = "fetching"
+STATUS_COMPARING = "comparing"
+STATUS_LOCAL_APPLIED = "local_applied"
+
+
+# ------------------------------------------------------------
+#
+# States and errors
+#
+# ------------------------------------------------------------
+class State(Enum):
+    """The stages of a sync run."""
+
+    INTRO = auto()
+    LOGIN = auto()
+    COMPARING = auto()
+    REVIEW_CHANGES = auto()
+    APPLYING = auto()
+    REVIEW_FILES = auto()
+    TRANSFERRING = auto()
+    DONE = auto()
+    FAILED = auto()
+
+
+class ErrorKind(Enum):
+    """Classification of a failure, independent of its localized wording."""
+
+    AUTH_FAILED = auto()  # HTTP 401
+    FORBIDDEN = auto()  # HTTP 403
+    NOT_FOUND = auto()  # HTTP 404
+    RATE_LIMITED = auto()  # HTTP 429
+    TREE_DISABLED = auto()  # HTTP 503
+    CONFLICT = auto()  # HTTP 409
+    SERVER_ERROR = auto()
+    CONNECTION_FAILED = auto()
+    INVALID_RESPONSE = auto()
+    INSUFFICIENT_PERMISSIONS = auto()
+    XML_IMPORT_FAILED = auto()
+    APPLY_FAILED = auto()
+    UNEXPECTED = auto()
+
+
+@dataclass(frozen=True)
+class SyncError:
+    """A failure recorded by the session.
+
+    :param kind: The classification.
+    :param detail: Untranslated detail, e.g. an HTTP status or exception text.
+    """
+
+    kind: ErrorKind
+    detail: str = ""
+
+
+class XmlImportFailed(Exception):
+    """The downloaded Gramps XML could not be imported."""
+
+
+class ApplyFailed(Exception):
+    """Applying the confirmed actions to the databases raised."""
+
+
+# Login and mid-sync failures read a few status codes differently.
+_LOGIN_HTTP_ERRORS: dict[int, ErrorKind] = {
+    401: ErrorKind.AUTH_FAILED,
+    403: ErrorKind.FORBIDDEN,
+    404: ErrorKind.NOT_FOUND,
+    429: ErrorKind.RATE_LIMITED,
+    503: ErrorKind.TREE_DISABLED,
+}
+
+_SYNC_HTTP_ERRORS: dict[int, ErrorKind] = {
+    401: ErrorKind.AUTH_FAILED,
+    403: ErrorKind.FORBIDDEN,
+    404: ErrorKind.NOT_FOUND,
+    409: ErrorKind.CONFLICT,
+}
+
+
+def classify_http_error(exc: HTTPError, *, login: bool) -> SyncError:
+    """Classify an :class:`HTTPError` into a :class:`SyncError`.
+
+    :param exc: The raised error.
+    :param login: Whether this happened while establishing the connection.
+    :returns: The corresponding :class:`SyncError`.
+    """
+    table = _LOGIN_HTTP_ERRORS if login else _SYNC_HTTP_ERRORS
+    kind = table.get(exc.code, ErrorKind.SERVER_ERROR)
+    return SyncError(kind, str(exc.code))
+
+
+# ------------------------------------------------------------
+#
+# Ports
+#
+# ------------------------------------------------------------
+class Backend(Protocol):
+    """What the session needs from a Gramps Web server.
+
+    Implemented by :class:`webapihandler.WebApiHandler`.
+    """
+
+    def get_permissions(self) -> set[str]: ...
+
+    def get_lang(self) -> str | None: ...
+
+    def download_xml(self) -> Path: ...
+
+    def commit(
+        self,
+        payload: list[dict[str, Any]],
+        force: bool = True,
+        progress_callback: Callable | None = None,
+    ) -> None: ...
+
+    def get_missing_files(self) -> list[dict[str, Any]]: ...
+
+    def download_media_file(self, handle: str, path: str) -> bool: ...
+
+    def upload_media_file(self, handle: str, path: str) -> bool: ...
+
+
+class CredentialStore(Protocol):
+    """Persistence for server credentials and the last-sync timestamp."""
+
+    def get_url(self) -> str: ...
+
+    def get_username(self) -> str: ...
+
+    def get_password(self) -> str | None: ...
+
+    def get_timestamp(self) -> float: ...
+
+    def set_timestamp(self, timestamp: float) -> None: ...
+
+    def save_credentials(self, url: str, username: str, password: str) -> None: ...
+
+
+class MediaStore(Protocol):
+    """Access to local media files belonging to the local database."""
+
+    def full_path(self, media: Any) -> str: ...
+
+    def exists(self, media: Any) -> bool: ...
+
+
+class TaskRunner(Protocol):
+    """Runs a potentially slow callable and reports the outcome back."""
+
+    def run(
+        self,
+        func: Callable[[], Any],
+        on_success: Callable[[Any], None],
+        on_error: Callable[[BaseException], None],
+    ) -> None: ...
+
+
+class Clock(Protocol):
+    """Source of the current time."""
+
+    def now(self) -> float: ...
+
+
+class SessionListener(Protocol):
+    """Receives session state changes, status and progress updates."""
+
+    def on_state_changed(self, state: State) -> None: ...
+
+    def on_progress(self, kind: str, fraction: float) -> None: ...
+
+    def on_status(self, stage: str) -> None: ...
+
+
+# ------------------------------------------------------------
+#
+# Transition table
+#
+# ------------------------------------------------------------
+def next_state(state: State, session: SyncSession) -> State:
+    """Return the state that follows ``state``.
+
+    :param state: The state being left.
+    :param session: The session, consulted for the branch conditions.
+    :returns: The next state.
+    """
+    if session.error is not None:
+        return State.FAILED
+    if state is State.INTRO:
+        return State.LOGIN
+    if state is State.LOGIN:
+        return State.COMPARING
+    if state is State.COMPARING:
+        if session.changes:
+            return State.REVIEW_CHANGES
+        return State.REVIEW_FILES if session.has_missing_files else State.DONE
+    if state is State.REVIEW_CHANGES:
+        return State.APPLYING
+    if state is State.APPLYING:
+        # Skipped entirely rather than shown empty: there is nothing to
+        # confirm when no file is missing on either side.
+        return State.REVIEW_FILES if session.has_missing_files else State.DONE
+    if state is State.REVIEW_FILES:
+        return State.TRANSFERRING if session.has_missing_files else State.DONE
+    if state is State.TRANSFERRING:
+        return State.DONE
+    return state
+
+
+# ------------------------------------------------------------
+#
+# SyncSession
+#
+# ------------------------------------------------------------
+class SyncSession:
+    """Drives one synchronization run against a Gramps Web server."""
+
+    def __init__(
+        self,
+        db,
+        user,
+        backend_factory: Callable[[str, str, str], Backend],
+        credentials: CredentialStore,
+        media: MediaStore,
+        runner: TaskRunner,
+        clock: Clock,
+        listener: SessionListener | None = None,
+    ) -> None:
+        """Initialize the session.
+
+        :param db: The local (currently open) Gramps database.
+        :param user: A :class:`gramps.gen.user.User` for import/diff progress.
+        :param backend_factory: Builds a :class:`Backend` from url, username
+            and password.
+        :param credentials: Where credentials and the last-sync time live.
+        :param media: Access to local media files.
+        :param runner: Executes the slow steps.
+        :param clock: Supplies the time recorded as the last successful sync.
+        :param listener: Optional observer of state and progress.
+        """
+        self.db1 = db
+        self.db2 = None
+        self._user = user
+        self._backend_factory = backend_factory
+        self.credentials = credentials
+        self.media = media
+        self.runner = runner
+        self.clock = clock
+        self.listener = listener
+
+        self.state: State = State.INTRO
+        self.error: SyncError | None = None
+        #: Set when login fails. Recoverable, unlike :attr:`error`.
+        self.login_error: SyncError | None = None
+
+        self.backend: Backend | None = None
+        self.sync: WebApiSyncDiffHandler | None = None
+        self.changes: Actions = []
+        self.actions: Actions = []
+        self.sync_mode: int = MODE_BIDIRECTIONAL
+
+        self.missing_local: list[tuple[str, str]] = []
+        self.missing_remote: list[tuple[str, str]] = []
+        self.downloaded: dict[str, bool] = {}
+        self.uploaded: dict[str, bool] = {}
+
+        self._closing = False
+
+    # --------------------------------------------------------
+    # Observable state
+    # --------------------------------------------------------
+    @property
+    def has_missing_files(self) -> bool:
+        """Whether any media file is missing on either side."""
+        return bool(self.missing_local or self.missing_remote)
+
+    @property
+    def has_local_actions(self) -> bool:
+        """Whether the pending actions touch the local database."""
+        return has_local_actions(self.actions)
+
+    @property
+    def has_remote_actions(self) -> bool:
+        """Whether the pending actions touch the remote database."""
+        return has_remote_actions(self.actions)
+
+    # --------------------------------------------------------
+    # Internals
+    # --------------------------------------------------------
+    def _goto(self, state: State) -> None:
+        """Enter ``state`` and notify the listener."""
+        LOG.debug("Sync session: %s -> %s", self.state.name, state.name)
+        self.state = state
+        if self.listener is not None:
+            self.listener.on_state_changed(state)
+
+    def _advance(self) -> None:
+        """Move to whatever :func:`next_state` says comes next."""
+        self._goto(next_state(self.state, self))
+
+    def _fail(self, error: SyncError) -> None:
+        """Record a terminal failure and move to :attr:`State.FAILED`."""
+        LOG.warning("Sync failed: %s (%s)", error.kind.name, error.detail)
+        self.error = error
+        self._goto(State.FAILED)
+
+    def _progress(self, kind: str, fraction: float) -> None:
+        """Forward a progress update to the listener, if any."""
+        if self.listener is not None:
+            self.listener.on_progress(kind, fraction)
+
+    def _status(self, stage: str) -> None:
+        """Forward a status update to the listener, if any."""
+        if self.listener is not None:
+            self.listener.on_status(stage)
+
+    def _classify(self, exc: BaseException, *, login: bool = False) -> SyncError:
+        """Turn an exception raised by a port into a :class:`SyncError`."""
+        if isinstance(exc, XmlImportFailed):
+            return SyncError(ErrorKind.XML_IMPORT_FAILED)
+        if isinstance(exc, ApplyFailed):
+            return SyncError(ErrorKind.APPLY_FAILED, str(exc))
+        if isinstance(exc, HTTPError):
+            return classify_http_error(exc, login=login)
+        if isinstance(exc, URLError):
+            return SyncError(ErrorKind.CONNECTION_FAILED, str(exc.reason))
+        if isinstance(exc, ValueError):
+            kind = ErrorKind.INVALID_RESPONSE if login else ErrorKind.SERVER_ERROR
+            return SyncError(kind, str(exc))
+        return SyncError(ErrorKind.UNEXPECTED, str(exc))
+
+    # --------------------------------------------------------
+    # Intents
+    # --------------------------------------------------------
+    def begin(self) -> None:
+        """Leave the introduction page."""
+        self._advance()
+
+    def submit_credentials(self, url: str, username: str, password: str) -> None:
+        """Connect, authenticate, then download and diff the remote tree.
+
+        On an authentication or permission problem the session stays on
+        :attr:`State.LOGIN` with :attr:`login_error` set.
+
+        :param url: Server URL, already sanitized by the caller.
+        :param username: Login name.
+        :param password: Password.
+        """
+        self.login_error = None
+        self.credentials.save_credentials(url, username, password)
+
+        try:
+            self.backend = self._backend_factory(url, username, password)
+            permissions = self.backend.get_permissions()
+        except Exception as exc:  # noqa: BLE001 -- classified below
+            self.backend = None
+            self.login_error = self._classify(exc, login=True)
+            self._goto(State.LOGIN)
+            return
+
+        if REQUIRED_PERMISSION not in permissions:
+            self.login_error = SyncError(ErrorKind.INSUFFICIENT_PERMISSIONS)
+            self._goto(State.LOGIN)
+            return
+
+        self._goto(State.COMPARING)
+        self.runner.run(self._compare, self._on_compared, self._on_step_error)
+
+    def confirm_changes(self, sync_mode: int) -> None:
+        """Accept the reviewed changes and apply them.
+
+        :param sync_mode: One of the ``MODE_*`` constants from :mod:`const`.
+        """
+        self.sync_mode = sync_mode
+        self._goto(State.APPLYING)
+        self.runner.run(self._apply, self._on_applied, self._on_step_error)
+
+    def confirm_files(self) -> None:
+        """Accept the media file transfer and carry it out.
+
+        Goes straight to :attr:`State.DONE` if nothing is missing.
+        """
+        if not self.has_missing_files:
+            self._advance()
+            return
+        self._goto(State.TRANSFERRING)
+        self.runner.run(self._transfer, self._on_transferred, self._on_step_error)
+
+    def cancel(self) -> None:
+        """Abandon the run and release the in-memory remote database."""
+        self._closing = True
+        if self.db2 is not None:
+            self.db2.close()
+            self.db2 = None
+        self.sync = None  # holds references to both databases
+
+    # --------------------------------------------------------
+    # Steps
+    # --------------------------------------------------------
+    def _on_step_error(self, exc: BaseException) -> None:
+        """Handle an exception escaping one of the background steps."""
+        self._fail(self._classify(exc))
+
+    def _compare(self) -> None:
+        """Download the remote tree and diff it against the local one."""
+        if self._closing:
+            return
+        assert self.backend is not None
+        LOG.info("Downloading Gramps XML file.")
+        self._status(STATUS_FETCHING)
+        path = self.backend.download_xml()
+        LOG.debug("Downloaded XML to %s", path)
+
+        db2 = import_as_dict(str(path), self._user)
+        path.unlink()
+        if db2 is None:
+            raise XmlImportFailed()
+        self.db2 = db2
+
+        LOG.info("Comparing local and remote data.")
+        self._status(STATUS_COMPARING)
+        last_synced = self.credentials.get_timestamp() or None
+        self.sync = WebApiSyncDiffHandler(
+            self.db1, self.db2, user=self._user, last_synced=last_synced
+        )
+        self.changes = self.sync.get_changes()
+
+    def _on_compared(self, _result: Any) -> None:
+        """Move on once the diff is available."""
+        if self._closing:
+            return
+        if not self.changes:
+            LOG.info("Databases are in sync.")
+            self.credentials.set_timestamp(self.clock.now())
+            self.missing_local = self._find_missing_local()
+            self.missing_remote = self._find_missing_remote()
+        self._advance()
+
+    def _apply(self) -> None:
+        """Apply the confirmed actions locally, then push them to the server."""
+        if self._closing:
+            return
+        assert self.backend is not None and self.sync is not None
+        self.actions = changes_to_actions(self.changes, self.sync_mode)
+        if not self.actions:
+            return
+
+        LOG.info("Committing %s actions.", len(self.actions))
+        try:
+            with DbTxn(TXN_MSG, self.sync.db1) as trans1:
+                with DbTxn(TXN_MSG, self.sync.db2) as trans2:
+                    self.sync.commit_actions(self.actions, trans1, trans2)
+                    lang = self.backend.get_lang()
+                    payload = transaction_to_json(trans2, lang)
+        except Exception as exc:
+            raise ApplyFailed(str(exc)) from exc
+
+        if self.has_local_actions:
+            self._status(STATUS_LOCAL_APPLIED)
+
+        # Always force: the server compares against the XML-round-tripped
+        # object, which differs from the live one through serialization
+        # artifacts alone, yielding spurious 409s.
+        self.backend.commit(
+            payload, True, lambda fraction: self._progress("api", fraction)
+        )
+
+    def _on_applied(self, _result: Any) -> None:
+        """Record the sync time and collect media state."""
+        if self._closing:
+            return
+        self.credentials.set_timestamp(self.clock.now())
+        self.missing_local = self._find_missing_local()
+        self.missing_remote = self._find_missing_remote()
+        self._advance()
+
+    def _transfer(self) -> None:
+        """Download media missing locally, then upload media missing remotely.
+
+        Progress reporting lets the view pump the event loop, so the user can
+        cancel mid-transfer; both loops check for that between files.
+        """
+        if self._closing:
+            return
+        assert self.backend is not None
+        for gramps_id, handle in self.missing_local:
+            if self._closing:
+                return
+            LOG.debug("Downloading file %s", gramps_id)
+            self.downloaded[gramps_id] = self._download_one(handle)
+            self._progress("download", len(self.downloaded) / len(self.missing_local))
+        for gramps_id, handle in self.missing_remote:
+            if self._closing:
+                return
+            LOG.debug("Uploading file %s", gramps_id)
+            self.uploaded[gramps_id] = self._upload_one(handle)
+            self._progress("upload", len(self.uploaded) / len(self.missing_remote))
+
+    def _on_transferred(self, _result: Any) -> None:
+        """Finish the run."""
+        if self._closing:
+            return
+        self._advance()
+
+    # --------------------------------------------------------
+    # Media helpers
+    # --------------------------------------------------------
+    def _find_missing_local(self) -> list[tuple[str, str]]:
+        """Return ``(gramps_id, handle)`` for media whose file is absent locally."""
+        return [
+            (media.gramps_id, media.handle)
+            for media in self.db1.iter_media()
+            if not self.media.exists(media)
+        ]
+
+    def _find_missing_remote(self) -> list[tuple[str, str]]:
+        """Return ``(gramps_id, handle)`` for media whose file is absent remotely."""
+        assert self.backend is not None
+        return [
+            (media["gramps_id"], media["handle"])
+            for media in self.backend.get_missing_files() or []
+        ]
+
+    def _download_one(self, handle: str) -> bool:
+        """Download one media file, reporting failure rather than raising."""
+        assert self.backend is not None
+        try:
+            obj = self.db1.get_media_from_handle(handle)
+        except HandleError:
+            LOG.warning("Cannot access media object %s", handle)
+            return False
+        try:
+            return self.backend.download_media_file(handle, self.media.full_path(obj))
+        except Exception as exc:  # noqa: BLE001 -- one bad file must not abort
+            LOG.warning("Failed to download media file %s: %s", obj.gramps_id, exc)
+            return False
+
+    def _upload_one(self, handle: str) -> bool:
+        """Upload one media file.
+
+        A file absent on both sides appears in both missing lists: the
+        download cannot supply it and there is nothing local to send, so it is
+        recorded as a failure instead of raising.
+
+        :param handle: Handle of the media object to upload.
+        :returns: Whether the file was uploaded.
+        """
+        assert self.backend is not None
+        try:
+            obj = self.db1.get_media_from_handle(handle)
+        except HandleError:
+            LOG.warning("Cannot access media object %s", handle)
+            return False
+        if not self.media.exists(obj):
+            LOG.warning(
+                "Cannot upload media file %s: missing locally as well (%s)",
+                obj.gramps_id,
+                self.media.full_path(obj),
+            )
+            return False
+        return self.backend.upload_media_file(handle, self.media.full_path(obj))
+
+

--- a/GrampsWebSync/session.py
+++ b/GrampsWebSync/session.py
@@ -473,8 +473,10 @@ class SyncSession:
         path = self.backend.download_xml()
         LOG.debug("Downloaded XML to %s", path)
 
-        db2 = import_as_dict(str(path), self._user)
-        path.unlink()
+        try:
+            db2 = import_as_dict(str(path), self._user)
+        finally:
+            path.unlink()
         if db2 is None:
             raise XmlImportFailed()
         self.db2 = db2

--- a/GrampsWebSync/tests/__init__.py
+++ b/GrampsWebSync/tests/__init__.py
@@ -18,22 +18,16 @@
 
 """Test package for the Gramps Web Sync addon.
 
-Importing this package pins GTK to 3.0, adds :data:`ADDON_DIR` and
-:data:`ADDONS_ROOT` to ``sys.path`` and sets ``GRAMPS_RESOURCES`` if unset, so
-test modules can import ``gramps`` and the addon's flat modules directly.
+Importing this package adds :data:`ADDON_DIR` and :data:`ADDONS_ROOT` to
+``sys.path`` and sets ``GRAMPS_RESOURCES`` if unset, so test modules can
+import ``gramps`` and the addon's flat modules directly. GTK/Gdk version
+pinning is handled repo-wide by the root ``tests/__init__.py`` (PR #950).
 """
 
 from __future__ import annotations
 
 import os
 import sys
-
-import gi
-
-# Must precede any gramps import, or PyGObject may load GTK 4 and the
-# gramps.gui chain dies on the GTK 3-only Gtk.IconSize.MENU.
-gi.require_version("Gtk", "3.0")
-gi.require_version("Gdk", "3.0")
 
 #: The ``GrampsWebSync`` addon directory, i.e. the parent of this package.
 ADDON_DIR: str = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/GrampsWebSync/tests/__init__.py
+++ b/GrampsWebSync/tests/__init__.py
@@ -1,0 +1,51 @@
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""Test package for the Gramps Web Sync addon.
+
+Importing this package pins GTK to 3.0, adds :data:`ADDON_DIR` and
+:data:`ADDONS_ROOT` to ``sys.path`` and sets ``GRAMPS_RESOURCES`` if unset, so
+test modules can import ``gramps`` and the addon's flat modules directly.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import gi
+
+# Must precede any gramps import, or PyGObject may load GTK 4 and the
+# gramps.gui chain dies on the GTK 3-only Gtk.IconSize.MENU.
+gi.require_version("Gtk", "3.0")
+gi.require_version("Gdk", "3.0")
+
+#: The ``GrampsWebSync`` addon directory, i.e. the parent of this package.
+ADDON_DIR: str = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ADDON_DIR not in sys.path:
+    sys.path.insert(0, ADDON_DIR)
+
+#: The ``addons-source`` checkout root.
+ADDONS_ROOT: str = os.path.dirname(ADDON_DIR)
+if ADDONS_ROOT not in sys.path:
+    sys.path.insert(0, ADDONS_ROOT)
+
+if "GRAMPS_RESOURCES" not in os.environ:
+    import gramps
+
+    os.environ["GRAMPS_RESOURCES"] = os.path.dirname(os.path.dirname(gramps.__file__))

--- a/GrampsWebSync/tests/fakes.py
+++ b/GrampsWebSync/tests/fakes.py
@@ -1,0 +1,359 @@
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""In-process test doubles for the :mod:`session` ports.
+
+:class:`FakeGrampsWebServer` implements :class:`session.Backend` over a real
+Gramps database, exporting Gramps XML and applying transaction payloads;
+:meth:`~FakeGrampsWebServer.fail_next` and
+:meth:`~FakeGrampsWebServer.fail_always` inject faults.
+
+The remaining classes stand in for the other ports:
+:class:`InlineTaskRunner`, :class:`FrozenClock`,
+:class:`MemoryCredentialStore`, :class:`DirectoryMediaStore` and
+:class:`RecordingListener`. None depend on a test framework.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError
+
+from gramps.cli.user import User
+from gramps.gen.db import DbTxn
+from gramps.gen.db.utils import make_database
+from gramps.gen.lib.json_utils import data_to_object
+from gramps.plugins.export.exportxml import export_data
+
+#: Permissions a Gramps Web user needs for a sync to be allowed to proceed.
+DEFAULT_PERMISSIONS = frozenset({"ViewPrivate", "EditObject", "AddObject"})
+
+
+def http_error(code: int, url: str = "https://example.org/api/") -> HTTPError:
+    """Build an :class:`HTTPError` with ``code``, for fault injection.
+
+    :param code: The HTTP status to simulate.
+    :param url: The URL to attribute the error to.
+    :returns: A ready-to-raise :class:`HTTPError`.
+    """
+    return HTTPError(url, code, f"Simulated HTTP {code}", {}, None)  # type: ignore[arg-type]
+
+
+# ------------------------------------------------------------
+#
+# FakeGrampsWebServer
+#
+# ------------------------------------------------------------
+class FakeGrampsWebServer:
+    """A Gramps Web server backed by a real in-memory Gramps database.
+
+    Satisfies the :class:`session.Backend` protocol.
+
+    :param db: The database to serve. A fresh empty one is created if omitted.
+    :param permissions: Permissions to report for the logged-in user.
+    :param lang: Value returned by :meth:`get_lang`.
+    """
+
+    def __init__(
+        self,
+        db=None,
+        permissions: set[str] | frozenset[str] = DEFAULT_PERMISSIONS,
+        lang: str | None = "en",
+    ) -> None:
+        if db is None:
+            db = make_database("sqlite")
+            db.load(":memory:")
+        self.db = db
+        self.permissions = set(permissions)
+        self.lang = lang
+        self.user = User(auto_accept=True, quiet=True)
+
+        #: Handles of media objects whose file the server actually holds.
+        self.media_files: dict[str, bytes] = {}
+        #: Every method call made against this server, in order.
+        self.calls: list[str] = []
+        #: Each payload passed to :meth:`commit`.
+        self.committed: list[list[dict[str, Any]]] = []
+        #: Method name -> exception, raised once then cleared.
+        self._fail_once: dict[str, BaseException] = {}
+        #: Method name -> exception, raised on every call.
+        self._fail_always: dict[str, BaseException] = {}
+        self._tempfiles: list[Path] = []
+
+    # --------------------------------------------------------
+    # Fault injection
+    # --------------------------------------------------------
+    def fail_next(self, method: str, exc: BaseException) -> None:
+        """Make the next call to ``method`` raise ``exc``.
+
+        :param method: Name of the backend method, e.g. ``"download_xml"``.
+        :param exc: The exception to raise.
+        """
+        self._fail_once[method] = exc
+
+    def fail_always(self, method: str, exc: BaseException) -> None:
+        """Make every call to ``method`` raise ``exc``."""
+        self._fail_always[method] = exc
+
+    def _enter(self, method: str) -> None:
+        """Record a call and honour any fault configured for it."""
+        self.calls.append(method)
+        exc = self._fail_once.pop(method, None) or self._fail_always.get(method)
+        if exc is not None:
+            raise exc
+
+    # --------------------------------------------------------
+    # Backend protocol
+    # --------------------------------------------------------
+    def get_permissions(self) -> set[str]:
+        """Return the logged-in user's permissions."""
+        self._enter("get_permissions")
+        return set(self.permissions)
+
+    def get_lang(self) -> str | None:
+        """Return the server's configured language."""
+        self._enter("get_lang")
+        return self.lang
+
+    def download_xml(self) -> Path:
+        """Export the served database to a Gramps XML file.
+
+        The caller owns the file and is expected to unlink it.
+
+        :returns: Path to the exported ``.gramps`` file.
+        """
+        self._enter("download_xml")
+        handle, name = tempfile.mkstemp(suffix=".gramps", prefix="fakeweb_")
+        os.close(handle)
+        path = Path(name)
+        self._tempfiles.append(path)
+        if not export_data(self.db, str(path), self.user):
+            raise ValueError("Fake server failed to export XML")
+        return path
+
+    def commit(
+        self,
+        payload: list[dict[str, Any]],
+        force: bool = True,
+        progress_callback: Callable | None = None,
+    ) -> None:
+        """Apply a transaction payload to the served database.
+
+        :param payload: Items as produced by
+            :func:`webapihandler.transaction_to_json`.
+        :param force: Accepted for protocol compatibility; ignored.
+        :param progress_callback: Called with a fraction in ``[0, 1]``.
+        """
+        self._enter("commit")
+        self.committed.append(payload)
+        if not payload:
+            return
+        with DbTxn("Fake server transaction", self.db, batch=True) as trans:
+            for index, item in enumerate(payload):
+                self._apply_item(item, trans)
+                if progress_callback is not None:
+                    progress_callback((index + 1) / len(payload))
+
+    def _apply_item(self, item: dict[str, Any], trans: DbTxn) -> None:
+        """Apply a single transaction item to the served database."""
+        class_name = item["_class"]
+        if item["type"] == "delete":
+            method = self.db.method("remove_%s", class_name)
+            assert method is not None
+            method(item["handle"], trans)
+            return
+        obj = data_to_object(item["new"])
+        # commit_* upserts, covering both "add" and "update". Passing the
+        # object's own change time keeps timestamps meaningful across a sync.
+        method = self.db.method("commit_%s", class_name)
+        assert method is not None
+        method(obj, trans, obj.change)
+
+    def get_missing_files(self) -> list[dict[str, Any]]:
+        """Return media objects the server knows about but has no file for."""
+        self._enter("get_missing_files")
+        return [
+            {"gramps_id": media.gramps_id, "handle": media.handle}
+            for media in self.db.iter_media()
+            if media.handle not in self.media_files
+        ]
+
+    def download_media_file(self, handle: str, path: str) -> bool:
+        """Write the server's copy of a media file to ``path``."""
+        self._enter("download_media_file")
+        if handle not in self.media_files:
+            raise http_error(404)
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+        Path(path).write_bytes(self.media_files[handle])
+        return True
+
+    def upload_media_file(self, handle: str, path: str) -> bool:
+        """Store a media file uploaded by the client."""
+        self._enter("upload_media_file")
+        self.media_files[handle] = Path(path).read_bytes()
+        return True
+
+    # --------------------------------------------------------
+    # Lifecycle
+    # --------------------------------------------------------
+    def close(self) -> None:
+        """Close the served database and remove leftover export files."""
+        for path in self._tempfiles:
+            path.unlink(missing_ok=True)
+        self._tempfiles.clear()
+        try:
+            self.db.close()
+        except Exception:  # noqa: BLE001 -- teardown must not mask failures
+            pass
+
+
+# ------------------------------------------------------------
+#
+# Simple doubles
+#
+# ------------------------------------------------------------
+class InlineTaskRunner:
+    """Runs each task synchronously on the calling thread.
+
+    By the time ``run`` returns, the step and its completion callback have
+    both finished.
+    """
+
+    def run(
+        self,
+        func: Callable[[], Any],
+        on_success: Callable[[Any], None],
+        on_error: Callable[[BaseException], None],
+    ) -> None:
+        """Execute ``func`` and dispatch to the appropriate callback."""
+        try:
+            result = func()
+        except BaseException as exc:  # noqa: BLE001 -- mirrors the real runner
+            on_error(exc)
+        else:
+            on_success(result)
+
+
+class FrozenClock:
+    """A clock that only moves when :meth:`advance` is called.
+
+    :param start: The initial time, as a POSIX timestamp.
+    """
+
+    def __init__(self, start: float = 1_700_000_000.0) -> None:
+        self.time = start
+
+    def now(self) -> float:
+        """Return the current fake time."""
+        return self.time
+
+    def advance(self, seconds: float) -> None:
+        """Move the clock forward by ``seconds``."""
+        self.time += seconds
+
+
+class MemoryCredentialStore:
+    """In-memory stand-in for the config file and keyring.
+
+    :param url: Initially stored server URL.
+    :param username: Initially stored user name.
+    :param password: Initially stored password.
+    :param timestamp: Initially stored last-sync time.
+    """
+
+    def __init__(
+        self,
+        url: str = "https://example.org/api",
+        username: str = "owner",
+        password: str = "secret",
+        timestamp: float = 0.0,
+    ) -> None:
+        self.url = url
+        self.username = username
+        self.password = password
+        self.timestamp = timestamp
+        #: Every ``(url, username, password)`` passed to
+        #: :meth:`save_credentials`.
+        self.saved: list[tuple[str, str, str]] = []
+
+    def get_url(self) -> str:
+        return self.url
+
+    def get_username(self) -> str:
+        return self.username
+
+    def get_password(self) -> str | None:
+        return self.password
+
+    def get_timestamp(self) -> float:
+        return self.timestamp
+
+    def set_timestamp(self, timestamp: float) -> None:
+        self.timestamp = timestamp
+
+    def save_credentials(self, url: str, username: str, password: str) -> None:
+        # A changed URL invalidates the last-sync time, as in production.
+        if url != self.url:
+            self.timestamp = 0.0
+        self.url = url
+        self.username = username
+        self.password = password
+        self.saved.append((url, username, password))
+
+
+class DirectoryMediaStore:
+    """Media store resolving paths under a directory owned by the test.
+
+    :param base_dir: Directory that plays the role of the Gramps media path.
+    """
+
+    def __init__(self, base_dir: str) -> None:
+        self.base_dir = base_dir
+
+    def full_path(self, media: Any) -> str:
+        """Return the absolute path of ``media``'s file."""
+        return os.path.join(self.base_dir, media.get_path())
+
+    def exists(self, media: Any) -> bool:
+        """Whether ``media``'s file is present on disk."""
+        return os.path.exists(self.full_path(media))
+
+
+class RecordingListener:
+    """Records state, status and progress updates for later assertions."""
+
+    def __init__(self) -> None:
+        #: States entered, in order.
+        self.states: list[Any] = []
+        #: ``(kind, fraction)`` progress updates, in order.
+        self.progress: list[tuple[str, float]] = []
+        #: Status stages reported, in order.
+        self.statuses: list[str] = []
+
+    def on_state_changed(self, state) -> None:
+        self.states.append(state)
+
+    def on_progress(self, kind: str, fraction: float) -> None:
+        self.progress.append((kind, fraction))
+
+    def on_status(self, stage: str) -> None:
+        self.statuses.append(stage)

--- a/GrampsWebSync/tests/scenario.py
+++ b/GrampsWebSync/tests/scenario.py
@@ -1,0 +1,401 @@
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""A small DSL for writing Gramps Web Sync scenarios.
+
+:class:`SyncScenario` holds a local tree and a remote one derived from it.
+Seed the local tree, call :meth:`~SyncScenario.share` to create the remote
+side, edit either through its :class:`TreeEditor`, then
+:meth:`~SyncScenario.run` a full sync and inspect the :class:`RunResult`::
+
+    with SyncScenario() as sc:
+        sc.seed_person("I0001", surname="Doe", changed_at=T0)
+        sc.share()
+        sc.local.edit_person("I0001", surname="Müller", changed_at=T2)
+        sc.remote.edit_person("I0001", surname="Mueller", changed_at=T3)
+        result = sc.run()
+
+:data:`T0` to :data:`T3` are increasing timestamps for the ``changed_at``
+argument every mutator takes.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from dataclasses import dataclass
+from typing import Any
+
+from const import MODE_BIDIRECTIONAL
+from gramps.cli.user import User
+from gramps.gen.db import DbTxn
+from gramps.gen.db.utils import import_as_dict, make_database
+from gramps.gen.lib import Media, Name, Person, Surname, Tag
+from session import State, SyncSession
+
+from .fakes import (
+    DirectoryMediaStore,
+    FakeGrampsWebServer,
+    FrozenClock,
+    InlineTaskRunner,
+    MemoryCredentialStore,
+    RecordingListener,
+)
+
+#: A convenient baseline "already synced" time for scenarios.
+T0 = 1_600_000_000.0
+#: A time after :data:`T0`, for an edit on one side.
+T1 = T0 + 1_000
+#: A time after :data:`T1`, for a later or competing edit.
+T2 = T0 + 2_000
+#: A time after :data:`T2`.
+T3 = T0 + 3_000
+
+
+class TreeEditor:
+    """Mutates one side of a scenario with explicit change timestamps.
+
+    :param db: The database to edit.
+    :param media_dir: Directory holding this side's media files, if any.
+    """
+
+    def __init__(self, db, media_dir: str | None = None) -> None:
+        self.db = db
+        self.media_dir = media_dir
+
+    # --------------------------------------------------------
+    # Lookup
+    # --------------------------------------------------------
+    def person(self, gramps_id: str) -> Person | None:
+        """Return the person with ``gramps_id``, or ``None`` if absent."""
+        return self.db.get_person_from_gramps_id(gramps_id)
+
+    def surname(self, gramps_id: str) -> str | None:
+        """Return the primary surname of ``gramps_id``, or ``None`` if absent."""
+        person = self.person(gramps_id)
+        if person is None:
+            return None
+        return person.get_primary_name().get_surname()
+
+    def tag(self, name: str) -> Tag | None:
+        """Return the tag called ``name``, or ``None`` if absent."""
+        return self.db.get_tag_from_name(name)
+
+    def person_ids(self) -> set[str]:
+        """Return every Gramps ID in this tree."""
+        return {
+            self.db.get_person_from_handle(handle).gramps_id
+            for handle in self.db.get_person_handles()
+        }
+
+    # --------------------------------------------------------
+    # Mutation
+    # --------------------------------------------------------
+    def add_person(
+        self,
+        gramps_id: str,
+        surname: str = "Doe",
+        first_name: str = "John",
+        changed_at: float = T0,
+    ) -> str:
+        """Add a person and return its handle.
+
+        :param gramps_id: The Gramps ID to assign.
+        :param surname: Primary surname.
+        :param first_name: Given name.
+        :param changed_at: Value to record as the object's change time.
+        :returns: The new person's handle.
+        """
+        person = Person()
+        person.set_gramps_id(gramps_id)
+        name = Name()
+        name.set_first_name(first_name)
+        surname_obj = Surname()
+        surname_obj.set_surname(surname)
+        name.add_surname(surname_obj)
+        person.set_primary_name(name)
+        with DbTxn(f"add {gramps_id}", self.db) as trans:
+            handle = self.db.add_person(person, trans)
+            self.db.commit_person(person, trans, changed_at)
+        return handle
+
+    def edit_person(
+        self,
+        gramps_id: str,
+        surname: str | None = None,
+        first_name: str | None = None,
+        changed_at: float = T1,
+    ) -> None:
+        """Modify an existing person.
+
+        :param gramps_id: Which person to edit.
+        :param surname: New primary surname, if given.
+        :param first_name: New given name, if given.
+        :param changed_at: Value to record as the object's change time.
+        :raises LookupError: If no such person exists.
+        """
+        person = self.person(gramps_id)
+        if person is None:
+            raise LookupError(f"No person {gramps_id} in this tree")
+        name = person.get_primary_name()
+        if surname is not None:
+            surname_obj = Surname()
+            surname_obj.set_surname(surname)
+            name.set_surname_list([surname_obj])
+        if first_name is not None:
+            name.set_first_name(first_name)
+        person.set_primary_name(name)
+        with DbTxn(f"edit {gramps_id}", self.db) as trans:
+            self.db.commit_person(person, trans, changed_at)
+
+    def delete_person(self, gramps_id: str) -> None:
+        """Remove a person from this tree.
+
+        :param gramps_id: Which person to remove.
+        :raises LookupError: If no such person exists.
+        """
+        person = self.person(gramps_id)
+        if person is None:
+            raise LookupError(f"No person {gramps_id} in this tree")
+        with DbTxn(f"delete {gramps_id}", self.db) as trans:
+            self.db.remove_person(person.handle, trans)
+
+    def add_media(
+        self,
+        gramps_id: str,
+        filename: str,
+        content: bytes = b"fake image bytes",
+        changed_at: float = T0,
+        on_disk: bool = True,
+    ) -> str:
+        """Add a media object, optionally writing its file.
+
+        :param gramps_id: The Gramps ID to assign.
+        :param filename: Path relative to the media directory.
+        :param content: Bytes to write when ``on_disk`` is true.
+        :param changed_at: Value to record as the object's change time.
+        :param on_disk: Whether to create the file. ``False`` produces a media
+            object whose file is missing.
+        :returns: The new media object's handle.
+        """
+        media = Media()
+        media.set_gramps_id(gramps_id)
+        media.set_path(filename)
+        media.set_description(gramps_id)
+        with DbTxn(f"add media {gramps_id}", self.db) as trans:
+            handle = self.db.add_media(media, trans)
+            self.db.commit_media(media, trans, changed_at)
+        if on_disk and self.media_dir is not None:
+            target = os.path.join(self.media_dir, filename)
+            os.makedirs(os.path.dirname(target), exist_ok=True)
+            with open(target, "wb") as fobj:
+                fobj.write(content)
+        return handle
+
+    def add_tag(self, name: str, changed_at: float = T0) -> str:
+        """Add a tag and return its handle."""
+        tag = Tag()
+        tag.set_name(name)
+        with DbTxn(f"add tag {name}", self.db) as trans:
+            handle = self.db.add_tag(tag, trans)
+            self.db.commit_tag(tag, trans, changed_at)
+        return handle
+
+
+@dataclass
+class RunResult:
+    """The outcome of a :meth:`SyncScenario.run`.
+
+    :param states: Every state the session entered, in order.
+    :param progress: Progress updates as ``(kind, fraction)``.
+    :param statuses: Status stages reported, in order.
+    :param session: The session itself, for further assertions.
+    """
+
+    states: list[State]
+    progress: list[tuple[str, float]]
+    statuses: list[str]
+    session: SyncSession
+
+    @property
+    def final_state(self) -> State:
+        """The state the session ended in."""
+        return self.states[-1] if self.states else State.INTRO
+
+    @property
+    def error(self):
+        """The terminal error, if the run failed."""
+        return self.session.error
+
+    @property
+    def login_error(self):
+        """The recoverable login error, if login was rejected."""
+        return self.session.login_error
+
+    def change_ids(self, change_type: str) -> set[str]:
+        """Return the Gramps IDs reported under a given change type.
+
+        :param change_type: One of the ``C_*`` constants from :mod:`const`.
+        :returns: The set of Gramps IDs (tag *names*, for tags).
+        """
+        ids = set()
+        for kind, _handle, class_name, obj1, obj2 in self.session.changes:
+            if kind != change_type:
+                continue
+            obj = obj1 if obj1 is not None else obj2
+            ids.add(obj.name if class_name == "Tag" else obj.gramps_id)
+        return ids
+
+
+class SyncScenario:
+    """Builds two related trees, then runs a full sync between them.
+
+    Use as a context manager so the databases and temporary directories are
+    cleaned up::
+
+        with SyncScenario() as sc:
+            ...
+    """
+
+    def __init__(self, permissions: set[str] | None = None) -> None:
+        self._tmpdir = tempfile.mkdtemp(prefix="gws_scenario_")
+        self.local_media_dir = os.path.join(self._tmpdir, "local_media")
+        os.makedirs(self.local_media_dir, exist_ok=True)
+
+        self.user = User(auto_accept=True, quiet=True)
+        self.db1 = make_database("sqlite")
+        self.db1.load(":memory:")
+
+        self.local = TreeEditor(self.db1, media_dir=self.local_media_dir)
+        #: Set by :meth:`share`; until then there is no remote tree.
+        self.remote: TreeEditor | None = None
+        self.server: FakeGrampsWebServer | None = None
+        self._permissions = permissions
+
+        self.clock = FrozenClock()
+        self.credentials = MemoryCredentialStore()
+        self.listener = RecordingListener()
+
+    # --------------------------------------------------------
+    # Setup
+    # --------------------------------------------------------
+    def seed_person(self, gramps_id: str, **kwargs: Any) -> str:
+        """Add a person to the local tree before it is shared."""
+        return self.local.add_person(gramps_id, **kwargs)
+
+    def share(self, last_synced: float | None = T0) -> None:
+        """Create the remote tree as a copy of the local one.
+
+        :param last_synced: Value to record as the last successful sync time.
+            Pass ``None`` to simulate a first-ever sync.
+        """
+        export_path = os.path.join(self._tmpdir, "seed.gramps")
+        from gramps.plugins.export.exportxml import export_data
+
+        if not export_data(self.db1, export_path, self.user):
+            raise RuntimeError("Failed to export the seed tree")
+        remote_db = import_as_dict(export_path, self.user)
+        if remote_db is None:
+            raise RuntimeError("Failed to import the seed tree")
+
+        kwargs: dict[str, Any] = {"db": remote_db}
+        if self._permissions is not None:
+            kwargs["permissions"] = self._permissions
+        self.server = FakeGrampsWebServer(**kwargs)
+        self.remote = TreeEditor(remote_db)
+        self.credentials.timestamp = last_synced or 0.0
+
+    def _require_shared(self) -> FakeGrampsWebServer:
+        """Return the server, raising a clear error if :meth:`share` was skipped."""
+        if self.server is None:
+            raise RuntimeError("Call share() before running the scenario")
+        return self.server
+
+    def make_session(self) -> SyncSession:
+        """Build a :class:`SyncSession` wired to this scenario's fakes."""
+        server = self._require_shared()
+        return SyncSession(
+            db=self.db1,
+            user=self.user,
+            backend_factory=lambda url, username, password: server,
+            credentials=self.credentials,
+            media=DirectoryMediaStore(self.local_media_dir),
+            runner=InlineTaskRunner(),
+            clock=self.clock,
+            listener=self.listener,
+        )
+
+    # --------------------------------------------------------
+    # Running
+    # --------------------------------------------------------
+    def run(
+        self,
+        mode: int = MODE_BIDIRECTIONAL,
+        confirm_files: bool = True,
+        url: str = "https://example.org/api",
+        username: str = "owner",
+        password: str = "secret",
+    ) -> RunResult:
+        """Drive a complete sync, answering every confirmation.
+
+        Stops early if the session fails or returns to the login page.
+
+        :param mode: The sync mode to confirm with.
+        :param confirm_files: Whether to accept the media transfer. ``False``
+            leaves the session on :attr:`State.REVIEW_FILES`.
+        :param url: Server URL to submit.
+        :param username: User name to submit.
+        :param password: Password to submit.
+        :returns: A :class:`RunResult` describing the run.
+        """
+        session = self.make_session()
+        session.begin()
+        session.submit_credentials(url, username, password)
+
+        if session.state is State.REVIEW_CHANGES:
+            session.confirm_changes(mode)
+        if session.state is State.REVIEW_FILES and confirm_files:
+            session.confirm_files()
+
+        return RunResult(
+            states=list(self.listener.states),
+            progress=list(self.listener.progress),
+            statuses=list(self.listener.statuses),
+            session=session,
+        )
+
+    # --------------------------------------------------------
+    # Lifecycle
+    # --------------------------------------------------------
+    def close(self) -> None:
+        """Release databases and temporary directories."""
+        if self.server is not None:
+            self.server.close()
+            self.server = None
+        try:
+            self.db1.close()
+        except Exception:  # noqa: BLE001 -- teardown must not mask failures
+            pass
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def __enter__(self) -> SyncScenario:
+        return self
+
+    def __exit__(self, *exc_info: Any) -> None:
+        self.close()

--- a/GrampsWebSync/tests/test_adapters.py
+++ b/GrampsWebSync/tests/test_adapters.py
@@ -1,0 +1,94 @@
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""Tests for the production ports in :mod:`adapters`.
+
+Drives a real :class:`GLib.MainLoop`; no widgets are built, so no display is
+needed.
+"""
+
+from __future__ import annotations
+
+import threading
+import unittest
+
+from adapters import GLibTaskRunner
+from gi.repository import GLib
+
+#: Milliseconds before an unresponsive loop is torn down.
+TIMEOUT_MS = 5000
+
+
+def run_task(func):
+    """Run ``func`` through :class:`GLibTaskRunner` and return the outcome.
+
+    :param func: The task to schedule.
+    :returns: Dict with ``result`` or ``error``, and ``thread``.
+    """
+    outcome: dict = {}
+    loop = GLib.MainLoop()
+
+    def on_success(result):
+        outcome["result"] = result
+        loop.quit()
+
+    def on_error(exc):
+        outcome["error"] = exc
+        loop.quit()
+
+    def wrapped():
+        outcome["thread"] = threading.current_thread()
+        return func()
+
+    GLibTaskRunner().run(wrapped, on_success, on_error)
+    GLib.timeout_add(TIMEOUT_MS, loop.quit)
+    loop.run()
+    return outcome
+
+
+class GLibTaskRunnerTest(unittest.TestCase):
+    """The runner must keep work on the thread that owns GTK."""
+
+    def test_task_runs_on_the_calling_thread(self) -> None:
+        """Steps drive Gramps progress through the GUI ``User``, which touches
+        widgets. Running them on a worker thread segfaults inside ``diff_dbs``,
+        so the runner must not spawn one."""
+        outcome = run_task(lambda: "done")
+        self.assertEqual(outcome.get("result"), "done")
+        self.assertIs(outcome["thread"], threading.current_thread())
+
+    def test_success_callback_receives_the_return_value(self) -> None:
+        self.assertEqual(run_task(lambda: 42).get("result"), 42)
+
+    def test_failure_is_reported_to_the_error_callback(self) -> None:
+        def boom():
+            raise ValueError("boom")
+
+        outcome = run_task(boom)
+        self.assertNotIn("result", outcome)
+        self.assertIsInstance(outcome.get("error"), ValueError)
+
+    def test_task_is_run_exactly_once(self) -> None:
+        """The idle source must remove itself, or it repeats forever."""
+        calls = []
+        run_task(lambda: calls.append(1))
+        self.assertEqual(len(calls), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/GrampsWebSync/tests/test_errors.py
+++ b/GrampsWebSync/tests/test_errors.py
@@ -1,0 +1,263 @@
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""Failure handling, exercised by injecting faults into the fake server."""
+
+from __future__ import annotations
+
+import unittest
+from urllib.error import URLError
+
+from session import ErrorKind, State
+
+from .fakes import http_error
+from .scenario import T0, T2, SyncScenario
+
+
+class LoginFailureTest(unittest.TestCase):
+    """Authentication and reachability problems at connect time."""
+
+    def make_scenario(self, **kwargs) -> SyncScenario:
+        scenario = SyncScenario(**kwargs)
+        self.addCleanup(scenario.close)
+        scenario.seed_person("I0001", surname="Doe", changed_at=T0)
+        scenario.share()
+        return scenario
+
+    def test_http_statuses_map_to_distinct_error_kinds(self) -> None:
+        """Each status the server can return is reported as its own kind."""
+        cases = [
+            (401, ErrorKind.AUTH_FAILED),
+            (403, ErrorKind.FORBIDDEN),
+            (404, ErrorKind.NOT_FOUND),
+            (429, ErrorKind.RATE_LIMITED),
+            (503, ErrorKind.TREE_DISABLED),
+            (500, ErrorKind.SERVER_ERROR),
+        ]
+        for code, expected in cases:
+            with self.subTest(code=code):
+                scenario = self.make_scenario()
+                scenario.server.fail_always("get_permissions", http_error(code))
+                result = scenario.run()
+                self.assertIs(result.final_state, State.LOGIN)
+                self.assertIsNotNone(result.login_error)
+                self.assertIs(result.login_error.kind, expected)
+
+    def test_login_failure_is_recoverable_not_terminal(self) -> None:
+        """A rejected login must not set the terminal error."""
+        scenario = self.make_scenario()
+        scenario.server.fail_always("get_permissions", http_error(401))
+        result = scenario.run()
+        self.assertIsNone(result.error)
+        self.assertIs(result.final_state, State.LOGIN)
+
+    def test_unreachable_server_reports_a_connection_failure(self) -> None:
+        scenario = self.make_scenario()
+        scenario.server.fail_always("get_permissions", URLError("no route to host"))
+        result = scenario.run()
+        self.assertIs(result.login_error.kind, ErrorKind.CONNECTION_FAILED)
+
+    def test_non_api_response_reports_an_invalid_response(self) -> None:
+        """Something answered, but it was not the Gramps Web API."""
+        scenario = self.make_scenario()
+        scenario.server.fail_always("get_permissions", ValueError("not JSON"))
+        result = scenario.run()
+        self.assertIs(result.login_error.kind, ErrorKind.INVALID_RESPONSE)
+
+    def test_user_without_required_permission_is_refused(self) -> None:
+        """Without ViewPrivate the export is partial, so sync must not start."""
+        scenario = self.make_scenario(permissions={"ViewObject"})
+        result = scenario.run()
+        self.assertIs(result.final_state, State.LOGIN)
+        self.assertIs(result.login_error.kind, ErrorKind.INSUFFICIENT_PERMISSIONS)
+
+    def test_failed_login_does_not_touch_either_tree(self) -> None:
+        scenario = self.make_scenario()
+        scenario.local.edit_person("I0001", surname="Müller", changed_at=T2)
+        scenario.server.fail_always("get_permissions", http_error(401))
+
+        scenario.run()
+
+        self.assertEqual(scenario.remote.surname("I0001"), "Doe")
+        self.assertEqual(scenario.server.committed, [])
+
+
+class MidSyncFailureTest(unittest.TestCase):
+    """Failures after the connection is established are terminal."""
+
+    def make_scenario(self) -> SyncScenario:
+        scenario = SyncScenario()
+        self.addCleanup(scenario.close)
+        scenario.seed_person("I0001", surname="Doe", changed_at=T0)
+        scenario.seed_person("I0002", surname="Roe", changed_at=T0)
+        scenario.share()
+        return scenario
+
+    def test_export_download_failure_fails_the_run(self) -> None:
+        scenario = self.make_scenario()
+        scenario.server.fail_always("download_xml", http_error(500))
+        result = scenario.run()
+        self.assertIs(result.final_state, State.FAILED)
+        self.assertIs(result.error.kind, ErrorKind.SERVER_ERROR)
+
+    def test_transaction_conflict_is_reported_as_a_conflict(self) -> None:
+        """HTTP 409 means the server rejected the transaction as stale."""
+        scenario = self.make_scenario()
+        scenario.local.edit_person("I0001", surname="Müller", changed_at=T2)
+        scenario.server.fail_always("commit", http_error(409))
+
+        result = scenario.run()
+
+        self.assertIs(result.final_state, State.FAILED)
+        self.assertIs(result.error.kind, ErrorKind.CONFLICT)
+
+    def test_expired_token_mid_sync_is_reported_as_auth_failure(self) -> None:
+        scenario = self.make_scenario()
+        scenario.local.edit_person("I0001", surname="Müller", changed_at=T2)
+        scenario.server.fail_always("commit", http_error(401))
+        result = scenario.run()
+        self.assertIs(result.error.kind, ErrorKind.AUTH_FAILED)
+
+    def test_failed_run_does_not_record_a_sync_timestamp(self) -> None:
+        """Recording it would move the diff cutoff past the unsynced changes."""
+        scenario = self.make_scenario()
+        scenario.credentials.timestamp = T0
+        scenario.local.edit_person("I0001", surname="Müller", changed_at=T2)
+        scenario.server.fail_always("commit", http_error(409))
+
+        scenario.run()
+
+        self.assertEqual(scenario.credentials.get_timestamp(), T0)
+
+    def test_local_changes_survive_a_failed_remote_commit(self) -> None:
+        """The local transaction commits before the upload is attempted."""
+        scenario = self.make_scenario()
+        scenario.remote.edit_person("I0002", surname="Neu", changed_at=T2)
+        scenario.server.fail_always("commit", http_error(500))
+
+        result = scenario.run()
+
+        self.assertIs(result.final_state, State.FAILED)
+        self.assertEqual(scenario.local.surname("I0002"), "Neu")
+
+
+class CancellationTest(unittest.TestCase):
+    """Cancelling must stop work that has been scheduled but not yet run."""
+
+    def make_scenario(self) -> SyncScenario:
+        scenario = SyncScenario()
+        self.addCleanup(scenario.close)
+        scenario.seed_person("I0001", surname="Doe", changed_at=T0)
+        scenario.share()
+        return scenario
+
+    def test_cancel_before_compare_skips_the_download(self) -> None:
+        scenario = self.make_scenario()
+        session = scenario.make_session()
+        session.begin()
+        session.cancel()
+
+        session._compare()
+
+        self.assertNotIn("download_xml", scenario.server.calls)
+
+    def test_cancel_before_apply_sends_nothing(self) -> None:
+        """``cancel`` releases the diff handler, so applying must not proceed."""
+        scenario = self.make_scenario()
+        scenario.local.edit_person("I0001", surname="Müller", changed_at=T2)
+        session = scenario.make_session()
+        session.begin()
+        session.submit_credentials("https://example.org/api", "owner", "secret")
+        session.cancel()
+
+        session._apply()
+
+        self.assertEqual(scenario.server.committed, [])
+
+    def test_cancel_before_transfer_moves_no_files(self) -> None:
+        scenario = SyncScenario()
+        self.addCleanup(scenario.close)
+        scenario.local.add_media("O0001", "photo.jpg", changed_at=T0)
+        scenario.share()
+        session = scenario.make_session()
+        session.begin()
+        session.submit_credentials("https://example.org/api", "owner", "secret")
+        session.cancel()
+
+        session._transfer()
+
+        self.assertEqual(scenario.server.media_files, {})
+
+
+class MediaFailureTest(unittest.TestCase):
+    """One bad media file must not abort the whole transfer."""
+
+    def make_scenario(self) -> SyncScenario:
+        scenario = SyncScenario()
+        self.addCleanup(scenario.close)
+        return scenario
+
+    def test_failed_download_is_recorded_without_failing_the_run(self) -> None:
+        """A single unreadable file is recorded and the run continues."""
+        scenario = self.make_scenario()
+        first = scenario.local.add_media("O0001", "first.jpg", on_disk=False)
+        second = scenario.local.add_media("O0002", "second.jpg", on_disk=False)
+        scenario.share()
+        # The server holds both files, so nothing needs uploading and this
+        # test isolates the download path.
+        scenario.server.media_files[first] = b"first bytes"
+        scenario.server.media_files[second] = b"second bytes"
+        scenario.server.fail_next("download_media_file", http_error(500))
+
+        result = scenario.run()
+
+        self.assertIs(result.final_state, State.DONE)
+        self.assertEqual(result.session.downloaded, {"O0001": False, "O0002": True})
+
+    def test_file_missing_on_both_sides_is_recorded_not_fatal(self) -> None:
+        """Such an object is in both missing lists; neither side can supply it.
+
+        The download 404s and the upload has nothing to send, so both are
+        recorded as failures and the run still completes.
+        """
+        scenario = self.make_scenario()
+        scenario.local.add_media("O0001", "nowhere.jpg", on_disk=False)
+        scenario.share()
+
+        result = scenario.run()
+
+        self.assertIs(result.final_state, State.DONE)
+        self.assertIsNone(result.error)
+        self.assertEqual(result.session.downloaded, {"O0001": False})
+        self.assertEqual(result.session.uploaded, {"O0001": False})
+
+    def test_upload_still_fails_the_run_on_a_server_error(self) -> None:
+        """The new guard must not swallow genuine transport failures."""
+        scenario = self.make_scenario()
+        scenario.local.add_media("O0002", "present.jpg", changed_at=T0)
+        scenario.share()
+        scenario.server.fail_always("upload_media_file", http_error(500))
+
+        result = scenario.run()
+
+        self.assertIs(result.final_state, State.FAILED)
+        self.assertIs(result.error.kind, ErrorKind.SERVER_ERROR)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/GrampsWebSync/tests/test_sync_flow.py
+++ b/GrampsWebSync/tests/test_sync_flow.py
@@ -1,0 +1,320 @@
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""End-to-end sync runs against an in-process fake Gramps Web server."""
+
+from __future__ import annotations
+
+import os
+import unittest
+
+from const import (
+    C_ADD_LOC,
+    C_ADD_REM,
+    C_DEL_LOC,
+    C_DEL_REM,
+    C_UPD_BOTH,
+    C_UPD_LOC,
+    C_UPD_REM,
+    MODE_BIDIRECTIONAL,
+    MODE_MERGE,
+    MODE_RESET_TO_LOCAL,
+    MODE_RESET_TO_REMOTE,
+)
+from session import (
+    STATUS_COMPARING,
+    STATUS_FETCHING,
+    STATUS_LOCAL_APPLIED,
+    State,
+)
+
+from .scenario import T0, T2, T3, SyncScenario
+
+
+class SyncFlowTestCase(unittest.TestCase):
+    """Base class providing a seeded, shared two-tree scenario."""
+
+    def make_scenario(self, **kwargs) -> SyncScenario:
+        """Return a shared scenario with two people, registered for teardown."""
+        scenario = SyncScenario(**kwargs)
+        self.addCleanup(scenario.close)
+        scenario.seed_person("I0001", surname="Doe", changed_at=T0)
+        scenario.seed_person("I0002", surname="Roe", changed_at=T0)
+        scenario.share()
+        return scenario
+
+
+class InSyncTest(SyncFlowTestCase):
+    """Two identical trees."""
+
+    def test_identical_trees_report_no_changes(self) -> None:
+        """A tree exported and reimported must diff as unchanged."""
+        scenario = self.make_scenario()
+        result = scenario.run()
+        self.assertEqual(result.session.changes, [])
+        self.assertIs(result.final_state, State.DONE)
+
+    def test_confirmation_stage_is_skipped(self) -> None:
+        """With nothing to confirm, the flow bypasses the review page."""
+        scenario = self.make_scenario()
+        result = scenario.run()
+        self.assertNotIn(State.REVIEW_CHANGES, result.states)
+        self.assertNotIn(State.APPLYING, result.states)
+
+    def test_nothing_is_sent_to_the_server(self) -> None:
+        """An in-sync run must not post a transaction."""
+        scenario = self.make_scenario()
+        scenario.run()
+        self.assertEqual(scenario.server.committed, [])
+
+    def test_media_confirmation_is_skipped_when_nothing_is_missing(self) -> None:
+        """No page may be shown with two empty lists and an Apply button."""
+        scenario = self.make_scenario()
+        result = scenario.run()
+        self.assertNotIn(State.REVIEW_FILES, result.states)
+        self.assertEqual(
+            result.states, [State.LOGIN, State.COMPARING, State.DONE]
+        )
+
+
+class BidirectionalSyncTest(SyncFlowTestCase):
+    """Changes made on one side only, propagating to the other."""
+
+    def test_local_edit_reaches_the_server(self) -> None:
+        scenario = self.make_scenario()
+        scenario.local.edit_person("I0001", surname="Müller", changed_at=T2)
+        result = scenario.run()
+        self.assertEqual(result.change_ids(C_UPD_LOC), {"I0001"})
+        self.assertEqual(scenario.remote.surname("I0001"), "Müller")
+
+    def test_remote_edit_reaches_the_local_tree(self) -> None:
+        scenario = self.make_scenario()
+        scenario.remote.edit_person("I0001", surname="Mueller", changed_at=T2)
+        result = scenario.run()
+        self.assertEqual(result.change_ids(C_UPD_REM), {"I0001"})
+        self.assertEqual(scenario.local.surname("I0001"), "Mueller")
+
+    def test_local_addition_reaches_the_server(self) -> None:
+        scenario = self.make_scenario()
+        scenario.local.add_person("I9001", surname="Neu", changed_at=T2)
+        result = scenario.run()
+        self.assertEqual(result.change_ids(C_ADD_LOC), {"I9001"})
+        self.assertIn("I9001", scenario.remote.person_ids())
+
+    def test_remote_addition_reaches_the_local_tree(self) -> None:
+        scenario = self.make_scenario()
+        scenario.remote.add_person("I9002", surname="Neuer", changed_at=T2)
+        result = scenario.run()
+        self.assertEqual(result.change_ids(C_ADD_REM), {"I9002"})
+        self.assertIn("I9002", scenario.local.person_ids())
+
+    def test_local_deletion_reaches_the_server(self) -> None:
+        scenario = self.make_scenario()
+        scenario.local.delete_person("I0002")
+        result = scenario.run()
+        self.assertEqual(result.change_ids(C_DEL_LOC), {"I0002"})
+        self.assertNotIn("I0002", scenario.remote.person_ids())
+
+    def test_remote_deletion_reaches_the_local_tree(self) -> None:
+        scenario = self.make_scenario()
+        scenario.remote.delete_person("I0002")
+        result = scenario.run()
+        self.assertEqual(result.change_ids(C_DEL_REM), {"I0002"})
+        self.assertNotIn("I0002", scenario.local.person_ids())
+
+    def test_edits_on_both_sides_are_flagged_as_simultaneous(self) -> None:
+        """Competing edits to one object are reported as simultaneous."""
+        scenario = self.make_scenario()
+        scenario.local.edit_person("I0001", surname="Müller", changed_at=T2)
+        scenario.remote.edit_person("I0001", surname="Mueller", changed_at=T3)
+        result = scenario.run()
+        self.assertEqual(result.change_ids(C_UPD_BOTH), {"I0001"})
+
+    def test_independent_changes_on_both_sides_both_propagate(self) -> None:
+        """Each side's change lands on the other in a single run."""
+        scenario = self.make_scenario()
+        scenario.local.edit_person("I0001", surname="Müller", changed_at=T2)
+        scenario.remote.add_person("I9003", surname="Neu", changed_at=T2)
+        scenario.run()
+        self.assertEqual(scenario.remote.surname("I0001"), "Müller")
+        self.assertIn("I9003", scenario.local.person_ids())
+
+
+class SyncModeTest(SyncFlowTestCase):
+    """The four sync modes resolve the same divergence differently."""
+
+    def diverged(self) -> SyncScenario:
+        """Return a scenario where each side added a distinct person."""
+        scenario = self.make_scenario()
+        scenario.local.add_person("I9100", surname="LocalOnly", changed_at=T2)
+        scenario.remote.add_person("I9200", surname="RemoteOnly", changed_at=T2)
+        return scenario
+
+    def test_bidirectional_keeps_both_additions(self) -> None:
+        scenario = self.diverged()
+        scenario.run(mode=MODE_BIDIRECTIONAL)
+        for side in (scenario.local, scenario.remote):
+            self.assertIn("I9100", side.person_ids())
+            self.assertIn("I9200", side.person_ids())
+
+    def test_reset_to_local_makes_the_server_match_the_local_tree(self) -> None:
+        scenario = self.diverged()
+        scenario.run(mode=MODE_RESET_TO_LOCAL)
+        self.assertIn("I9100", scenario.remote.person_ids())
+        self.assertNotIn("I9200", scenario.remote.person_ids())
+        self.assertNotIn("I9200", scenario.local.person_ids())
+
+    def test_reset_to_remote_makes_the_local_tree_match_the_server(self) -> None:
+        scenario = self.diverged()
+        scenario.run(mode=MODE_RESET_TO_REMOTE)
+        self.assertIn("I9200", scenario.local.person_ids())
+        self.assertNotIn("I9100", scenario.local.person_ids())
+        self.assertNotIn("I9100", scenario.remote.person_ids())
+
+    def test_merge_restores_a_locally_deleted_object(self) -> None:
+        """Merge mode never deletes; a removal on one side is undone."""
+        scenario = self.make_scenario()
+        scenario.local.delete_person("I0002")
+        scenario.run(mode=MODE_MERGE)
+        self.assertIn("I0002", scenario.local.person_ids())
+        self.assertIn("I0002", scenario.remote.person_ids())
+
+
+class MediaFileTest(SyncFlowTestCase):
+    """Media files, which sync separately from object data."""
+
+    def test_file_missing_locally_is_downloaded(self) -> None:
+        scenario = SyncScenario()
+        self.addCleanup(scenario.close)
+        handle = scenario.local.add_media(
+            "O0001", "photo.jpg", changed_at=T0, on_disk=False
+        )
+        scenario.share()
+        scenario.server.media_files[handle] = b"server image bytes"
+
+        result = scenario.run()
+
+        self.assertIs(result.final_state, State.DONE)
+        self.assertEqual(result.session.downloaded, {"O0001": True})
+        media = scenario.db1.get_media_from_handle(handle)
+        local_path = os.path.join(scenario.local_media_dir, media.get_path())
+        self.assertTrue(os.path.exists(local_path))
+        self.assertEqual(open(local_path, "rb").read(), b"server image bytes")
+
+    def test_file_missing_remotely_is_uploaded(self) -> None:
+        scenario = SyncScenario()
+        self.addCleanup(scenario.close)
+        handle = scenario.local.add_media(
+            "O0002", "portrait.jpg", content=b"local bytes", changed_at=T0
+        )
+        scenario.share()
+        self.assertNotIn(handle, scenario.server.media_files)
+
+        result = scenario.run()
+
+        self.assertEqual(result.session.uploaded, {"O0002": True})
+        self.assertEqual(scenario.server.media_files[handle], b"local bytes")
+
+    def test_transfer_stage_is_skipped_when_all_files_are_present(self) -> None:
+        scenario = SyncScenario()
+        self.addCleanup(scenario.close)
+        handle = scenario.local.add_media("O0003", "ok.jpg", changed_at=T0)
+        scenario.share()
+        scenario.server.media_files[handle] = b"fake image bytes"
+
+        result = scenario.run()
+
+        self.assertNotIn(State.TRANSFERRING, result.states)
+        self.assertIs(result.final_state, State.DONE)
+
+    def test_declining_the_transfer_leaves_the_session_on_review(self) -> None:
+        """Declining the transfer must neither advance nor fail."""
+        scenario = SyncScenario()
+        self.addCleanup(scenario.close)
+        scenario.local.add_media("O0004", "skipped.jpg", changed_at=T0)
+        scenario.share()
+
+        result = scenario.run(confirm_files=False)
+
+        self.assertIs(result.final_state, State.REVIEW_FILES)
+        self.assertEqual(scenario.server.media_files, {})
+
+
+class TimestampTest(SyncFlowTestCase):
+    """The last-sync timestamp, which drives every later diff."""
+
+    def test_successful_run_records_the_sync_time(self) -> None:
+        scenario = self.make_scenario()
+        scenario.local.edit_person("I0001", surname="Müller", changed_at=T2)
+        scenario.clock.time = 1_700_000_500.0
+
+        scenario.run()
+
+        self.assertEqual(scenario.credentials.get_timestamp(), 1_700_000_500.0)
+
+    def test_in_sync_run_also_records_the_sync_time(self) -> None:
+        """Finding no differences still counts as a successful sync."""
+        scenario = self.make_scenario()
+        scenario.clock.time = 1_700_000_900.0
+
+        scenario.run()
+
+        self.assertEqual(scenario.credentials.get_timestamp(), 1_700_000_900.0)
+
+    def test_changing_the_url_clears_the_stored_timestamp(self) -> None:
+        """A timestamp is meaningless against a different tree."""
+        scenario = self.make_scenario()
+        scenario.credentials.timestamp = T3
+        scenario.run(url="https://elsewhere.example/api")
+        self.assertNotEqual(scenario.credentials.get_timestamp(), T3)
+
+
+class ProgressTest(SyncFlowTestCase):
+    """Progress and status reporting reach the listener."""
+
+    def test_applying_changes_reports_api_progress(self) -> None:
+        scenario = self.make_scenario()
+        scenario.local.edit_person("I0001", surname="Müller", changed_at=T2)
+        result = scenario.run()
+        api_progress = [f for kind, f in result.progress if kind == "api"]
+        self.assertTrue(api_progress)
+        self.assertEqual(api_progress[-1], 1.0)
+
+    def test_comparison_reports_fetching_then_comparing(self) -> None:
+        scenario = self.make_scenario()
+        result = scenario.run()
+        self.assertEqual(
+            [s for s in result.statuses if s in (STATUS_FETCHING, STATUS_COMPARING)],
+            [STATUS_FETCHING, STATUS_COMPARING],
+        )
+
+    def test_local_commit_is_reported(self) -> None:
+        scenario = self.make_scenario()
+        scenario.remote.edit_person("I0001", surname="Mueller", changed_at=T2)
+        result = scenario.run()
+        self.assertIn(STATUS_LOCAL_APPLIED, result.statuses)
+
+    def test_remote_only_changes_do_not_report_a_local_commit(self) -> None:
+        scenario = self.make_scenario()
+        scenario.local.edit_person("I0001", surname="Müller", changed_at=T2)
+        result = scenario.run()
+        self.assertNotIn(STATUS_LOCAL_APPLIED, result.statuses)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/GrampsWebSync/tests/test_transitions.py
+++ b/GrampsWebSync/tests/test_transitions.py
@@ -1,0 +1,129 @@
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""Unit tests for :func:`session.next_state`."""
+
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+
+from session import ErrorKind, State, SyncError, next_state
+
+
+def fake_session(
+    error: SyncError | None = None,
+    changes: list | None = None,
+    has_missing_files: bool = False,
+) -> SimpleNamespace:
+    """Build a stand-in exposing the attributes :func:`next_state` reads.
+
+    :param error: A terminal error, if any.
+    :param changes: The pending change list.
+    :param has_missing_files: Whether media files are missing on either side.
+    :returns: The stand-in session.
+    """
+    return SimpleNamespace(
+        error=error,
+        changes=changes if changes is not None else [],
+        has_missing_files=has_missing_files,
+    )
+
+
+class NextStateTest(unittest.TestCase):
+    """The happy-path chain and its two conditional skips."""
+
+    def test_linear_path_with_changes_and_files(self) -> None:
+        """With both changes and missing files, every state is visited."""
+        session = fake_session(changes=["a change"], has_missing_files=True)
+        expected = [
+            (State.INTRO, State.LOGIN),
+            (State.LOGIN, State.COMPARING),
+            (State.COMPARING, State.REVIEW_CHANGES),
+            (State.REVIEW_CHANGES, State.APPLYING),
+            (State.APPLYING, State.REVIEW_FILES),
+            (State.REVIEW_FILES, State.TRANSFERRING),
+            (State.TRANSFERRING, State.DONE),
+        ]
+        for state, following in expected:
+            with self.subTest(state=state.name):
+                self.assertIs(next_state(state, session), following)
+
+    def test_no_changes_but_missing_files_goes_to_the_media_stage(self) -> None:
+        session = fake_session(changes=[], has_missing_files=True)
+        self.assertIs(next_state(State.COMPARING, session), State.REVIEW_FILES)
+
+    def test_nothing_to_do_at_all_ends_the_run(self) -> None:
+        """Fully in sync: no confirmation page of any kind is shown."""
+        session = fake_session(changes=[], has_missing_files=False)
+        self.assertIs(next_state(State.COMPARING, session), State.DONE)
+
+    def test_applying_with_no_missing_files_ends_the_run(self) -> None:
+        """The media page is skipped rather than shown with empty lists."""
+        session = fake_session(changes=["a change"], has_missing_files=False)
+        self.assertIs(next_state(State.APPLYING, session), State.DONE)
+
+    def test_changes_present_requires_confirmation(self) -> None:
+        """Any pending change must be confirmed before it is applied."""
+        session = fake_session(changes=["a change"])
+        self.assertIs(next_state(State.COMPARING, session), State.REVIEW_CHANGES)
+
+    def test_no_missing_files_skips_transfer(self) -> None:
+        """With all media present on both sides, the run ends after review."""
+        session = fake_session(has_missing_files=False)
+        self.assertIs(next_state(State.REVIEW_FILES, session), State.DONE)
+
+    def test_missing_files_requires_transfer(self) -> None:
+        """Missing media on either side means a transfer stage."""
+        session = fake_session(has_missing_files=True)
+        self.assertIs(next_state(State.REVIEW_FILES, session), State.TRANSFERRING)
+
+
+class ErrorShortCircuitTest(unittest.TestCase):
+    """A recorded error overrides the flow from wherever it happened."""
+
+    def test_error_from_any_state_goes_to_failed(self) -> None:
+        """Every non-terminal state jumps to FAILED once an error is set."""
+        session = fake_session(
+            error=SyncError(ErrorKind.CONFLICT), changes=["a change"]
+        )
+        for state in State:
+            if state in (State.DONE, State.FAILED):
+                continue
+            with self.subTest(state=state.name):
+                self.assertIs(next_state(state, session), State.FAILED)
+
+    def test_error_outranks_the_skip_conditions(self) -> None:
+        """The error check runs before any branch that might route elsewhere."""
+        session = fake_session(error=SyncError(ErrorKind.AUTH_FAILED), changes=[])
+        self.assertIs(next_state(State.COMPARING, session), State.FAILED)
+
+
+class TerminalStateTest(unittest.TestCase):
+    """Terminal states do not advance on their own."""
+
+    def test_done_is_terminal(self) -> None:
+        self.assertIs(next_state(State.DONE, fake_session()), State.DONE)
+
+    def test_failed_is_terminal(self) -> None:
+        session = fake_session(error=SyncError(ErrorKind.UNEXPECTED))
+        self.assertIs(next_state(State.FAILED, session), State.FAILED)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/GrampsWebSync/tests/test_view_mapping.py
+++ b/GrampsWebSync/tests/test_view_mapping.py
@@ -1,0 +1,72 @@
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""Checks that the GTK view's lookup tables cover the session's enums.
+
+Constructs no widgets, so no display is needed.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+import grampswebsync
+from grampswebsync import PAGE_FOR_STATE, error_message
+from session import ErrorKind, State
+
+
+class PageMappingTest(unittest.TestCase):
+    """Every flow state must correspond to a page the assistant owns."""
+
+    def test_every_state_maps_to_a_page(self) -> None:
+        self.assertEqual(set(PAGE_FOR_STATE), set(State))
+
+    def test_page_indices_match_the_assistant_page_order(self) -> None:
+        """Indices must be the contiguous range the pages are appended in.
+
+        The assistant addresses pages positionally, so a gap or an off-by-one
+        here sends the user to the wrong page rather than failing loudly.
+        """
+        self.assertEqual(sorted(set(PAGE_FOR_STATE.values())), list(range(8)))
+
+    def test_terminal_states_share_the_conclusion_page(self) -> None:
+        """Success and failure are both reported on the last page."""
+        self.assertEqual(
+            PAGE_FOR_STATE[State.DONE], PAGE_FOR_STATE[State.FAILED]
+        )
+        self.assertEqual(PAGE_FOR_STATE[State.DONE], grampswebsync.PAGE_CONCLUSION)
+
+
+class ErrorMessageTest(unittest.TestCase):
+    """Every error the session can record must render as something readable."""
+
+    def test_every_error_kind_has_a_message(self) -> None:
+        """An unmapped kind would surface to the user as an empty dialog."""
+        for kind in ErrorKind:
+            with self.subTest(kind=kind.name):
+                message = error_message(kind, "42")
+                self.assertTrue(message.strip(), f"{kind.name} rendered empty")
+
+    def test_detail_is_included_where_it_carries_information(self) -> None:
+        """Status codes must reach the user for the otherwise-opaque kinds."""
+        self.assertIn("42", error_message(ErrorKind.SERVER_ERROR, "42"))
+        self.assertIn("boom", error_message(ErrorKind.UNEXPECTED, "boom"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/GrampsWebSync/webapihandler.py
+++ b/GrampsWebSync/webapihandler.py
@@ -204,7 +204,7 @@ class WebApiHandler:
 
     def commit(
         self,
-        payload: dict[str, Any],
+        payload: list[dict[str, Any]],
         force: bool = True,
         progress_callback: Callable | None = None,
     ) -> None:


### PR DESCRIPTION
This PR adds/changes a lot of code, but it's not as terrible as is looks :blush: 

Basically, I am trying to bring the Gramps Web Sync Addon into a *maintainable* state. This PR brings it much closer by

- Refactoring the GUI code into a thin GTK class and a headless sync session class
- Adding extensive unit tests for everything except the GTK part

The sync logic and network stuff was already factored out into a separate module, which is not touched in this PR (except a single fix of an incorrect type hint.)

This PR was prepared with the help of Claude Sonnet 5. I tested the resulting code with Gramps 6.0.7.

The strategy in this PR was to change as little as possible of the user facing part of the addon, so everything still works & looks exactly as it did before. The next step will be to actually start improving it, now that there is a maintainable basis to build upon.