### PR TITLE
Update SharedPostgreSQL to match PostgreSQL addon

### DIFF
--- a/SharedPostgreSQL/shareddbapi.py
+++ b/SharedPostgreSQL/shareddbapi.py
@@ -289,7 +289,9 @@ class SharedDBAPI(DbGeneric):
         self.dbapi.execute(
             "CREATE INDEX citation_gramps_id " "ON citation(treeid,gramps_id)"
         )
-        self.dbapi.execute("CREATE INDEX media_desc " "ON media(treeid,desc)")
+        self.dbapi.execute(
+            f"CREATE INDEX media_desc ON media(treeid,{self._quote_column('desc')})"
+        )
         self.dbapi.execute("CREATE INDEX media_gramps_id " "ON media(treeid,gramps_id)")
         self.dbapi.execute("CREATE INDEX place_title " "ON place(treeid,title)")
         self.dbapi.execute(
@@ -699,7 +701,7 @@ class SharedDBAPI(DbGeneric):
             self.dbapi.execute(
                 "SELECT handle FROM media "
                 "WHERE treeid = ? "
-                "ORDER BY desc "
+                f"ORDER BY {self._quote_column('desc')} "
                 'COLLATE "%s"' % locale.get_collation(),
                 [self.dbapi.treeid],
             )
@@ -882,7 +884,7 @@ class SharedDBAPI(DbGeneric):
         else:
             # Insert the object:
             sql = (
-                f"INSERT INTO %s (treeid, handle, {self.serializer.data_field}) VALUES (?, ?)"
+                f"INSERT INTO %s (treeid, handle, {self.serializer.data_field}) VALUES (?, ?, ?)"
             ) % table
             self.dbapi.execute(
                 sql, [self.dbapi.treeid, handle, self.serializer.data_to_string(data)]
@@ -1306,6 +1308,17 @@ class SharedDBAPI(DbGeneric):
             surname_list.append(row[0])
         return surname_list
 
+    def _quote_column(self, col):
+        """
+        Return a safe column name for the current dialect.
+
+        Override in dialect subclasses to handle reserved keywords, e.g. by
+        quoting or renaming them.
+        """
+        # Mirrors the hook added by gramps PR #2178; drop once that is merged
+        # and shareddbapi is resynced with core dbapi.
+        return col
+
     def _sql_type(self, schema_type, max_length):
         """
         Given a schema type, return the SQL type for
@@ -1346,7 +1359,7 @@ class SharedDBAPI(DbGeneric):
                     sql_type = self._sql_type(schema_type, max_length)
                     self.dbapi.execute(
                         "ALTER TABLE %s ADD COLUMN %s %s"
-                        % (table_name, field, sql_type)
+                        % (table_name, self._quote_column(field), sql_type)
                     )
 
     def _update_secondary_values(self, obj):
@@ -1360,7 +1373,7 @@ class SharedDBAPI(DbGeneric):
         sets = []
         values = []
         for field in fields:
-            sets.append("%s = ?" % field)
+            sets.append("%s = ?" % self._quote_column(field))
             values.append(getattr(obj, field))
 
         # Derived fields

--- a/SharedPostgreSQL/sharedpostgresql.py
+++ b/SharedPostgreSQL/sharedpostgresql.py
@@ -53,6 +53,21 @@ psycopg2.paramstyle = "format"
 #
 # -------------------------------------------------------------------------
 class SharedPostgreSQL(SharedDBAPI):
+    dialect = "postgresql"
+
+    # Column names as they physically exist in shared PostgreSQL databases.
+    # "desc" is reserved in PostgreSQL and was renamed by the old blanket
+    # substring rewrite, which also caught "description" as a side effect.
+    # Both names are kept so existing databases stay readable.
+    _COLUMN_NAMES = {"desc": "desc_", "description": "desc_ription"}
+
+    def _quote_column(self, col):
+        return self._COLUMN_NAMES.get(col, col)
+
+    def _sql_type(self, schema_type, max_length):
+        result = super()._sql_type(schema_type, max_length)
+        return "bytea" if result == "BLOB" else result
+
     def get_summary(self):
         """
         Return a diction of information about this database
@@ -179,18 +194,20 @@ class Connection:
         Checks that a collation exists and if not creates it.
 
         :param locale: Locale to be checked.
-        :param type: A GrampsLocale object.
+        :type locale: A GrampsLocale object.
         """
-        # Duplicating system collations works, but to delete them the schema
-        # must be specified, so get the current schema
         collation = locale.get_collation()
-        self.execute(
-            'CREATE COLLATION IF NOT EXISTS "%s"'
-            "(LOCALE = '%s')" % (collation, locale.collation)
-        )
+        # Use pg_collation to check existence rather than IF NOT EXISTS, which
+        # requires PostgreSQL 12+.
+        self.execute("SELECT 1 FROM pg_collation WHERE collname = %s", [collation])
+        if not self.fetchone():
+            self.execute(
+                "CREATE COLLATION \"%s\" (LOCALE = '%s')"
+                % (collation, locale.collation)
+            )
 
     def execute(self, *args, **kwargs):
-        sql = _hack_query(args[0])
+        sql = _translate_sql(args[0])
         if len(args) > 1:
             args = args[1]
         else:
@@ -279,7 +296,7 @@ class Cursor:
         :param kwargs: arguments to be passed to the sqlite3 execute statement
         :type kwargs: list
         """
-        sql = _hack_query(args[0])
+        sql = _translate_sql(args[0])
         if len(args) > 1:
             args = args[1]
         else:
@@ -297,25 +314,26 @@ class Cursor:
             return None
 
 
-def _hack_query(query):
-    query = query.replace("?", "%s")
-    query = query.replace("REGEXP", "~")
-    query = query.replace("desc", "desc_")
-    query = query.replace("BLOB", "bytea")
-    query = query.replace("INTEGER PRIMARY KEY", "SERIAL PRIMARY KEY")
-    ## LIMIT offset, count
-    ## count can be -1, for all
-    ## LIMIT -1
-    ## LIMIT offset, -1
-    query = query.replace("LIMIT -1", "LIMIT all")  ##
-    match = re.match(".* LIMIT (.*), (.*) ", query)
-    if match and match.groups():
-        offset, count = match.groups()
-        if count == "-1":
-            count = "all"
-        query = re.sub(
-            "(.*) LIMIT (.*), (.*) ",
-            "\\1 LIMIT %s OFFSET %s " % (count, offset),
-            query,
-        )
-    return query
+def _translate_sql(query):
+    """
+    Translate an SQLite-flavoured SQL statement to PostgreSQL.
+
+    :param query: the statement to translate.
+    :type query: str
+    :returns: the translated statement.
+    :rtype: str
+    """
+    sql = query.replace("?", "%s")  # qmark -> format paramstyle
+    sql = sql.replace(" REGEXP ", " ~ ")  # SQLite REGEXP -> PostgreSQL ~
+    sql = sql.replace("INTEGER PRIMARY KEY", "SERIAL PRIMARY KEY")
+    sql = re.sub(r"\bBLOB\b", "BYTEA", sql)  # SQLite BLOB -> PostgreSQL BYTEA
+    # LIMIT offset, count -> LIMIT count OFFSET offset; a count of -1 means all
+    sql = re.sub(
+        r"\bLIMIT\s+(-?\d+)\s*,\s*(-?\d+)",
+        lambda m: f'LIMIT {"ALL" if m.group(2) == "-1" else m.group(2)}'
+        f" OFFSET {m.group(1)}",
+        sql,
+        flags=re.IGNORECASE,
+    )
+    sql = re.sub(r"\bLIMIT\s+-1\b", "LIMIT ALL", sql, flags=re.IGNORECASE)
+    return sql

--- a/SharedPostgreSQL/tests/test_sql_translations.py
+++ b/SharedPostgreSQL/tests/test_sql_translations.py
@@ -1,0 +1,412 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2015-2016 Douglas S. Blank <doug.blank@gmail.com>
+# Copyright (C) 2026 David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Unit tests for the SharedPostgreSQL SQL dialect translations.
+
+These tests cover every rewrite rule applied before a query reaches psycopg2:
+  - qmark -> format paramstyle  (? -> %s)
+  - REGEXP operator             (REGEXP -> ~)
+  - autoincrement primary key   (INTEGER PRIMARY KEY -> SERIAL PRIMARY KEY)
+  - BLOB column type            (BLOB -> BYTEA)
+  - two-arg LIMIT               (LIMIT offset, count -> LIMIT count OFFSET offset)
+  - unlimited LIMIT             (LIMIT -1 -> LIMIT ALL)
+
+and the column naming applied by _quote_column().
+
+psycopg2 is stubbed so no real database is required.  gramps core is
+required for the import chain; the whole module is skipped cleanly if
+it is not present.
+
+Run with::
+
+    python3 -m unittest SharedPostgreSQL.tests.test_sql_translations -v
+"""
+
+# -------------------------------------------------------------------------
+#
+# Standard python modules
+#
+# -------------------------------------------------------------------------
+import os
+import sys
+import unittest
+from unittest import mock
+
+# -------------------------------------------------------------------------
+#
+# Stub psycopg2 before the addon is imported so no real DB driver is needed
+#
+# -------------------------------------------------------------------------
+ADDON_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ADDON_DIR not in sys.path:
+    sys.path.insert(0, ADDON_DIR)
+
+_mock_psycopg2 = mock.MagicMock()
+_mock_psycopg2.paramstyle = "format"
+_mock_psycopg2.OperationalError = Exception
+sys.modules.setdefault("psycopg2", _mock_psycopg2)
+
+# -------------------------------------------------------------------------
+#
+# Gramps modules (required by the addon's import chain)
+#
+# -------------------------------------------------------------------------
+try:
+    import gramps
+except ImportError as _err:
+    raise unittest.SkipTest("gramps package not available: %s" % _err)
+
+if "GRAMPS_RESOURCES" not in os.environ:
+    os.environ["GRAMPS_RESOURCES"] = os.path.dirname(os.path.dirname(gramps.__file__))
+
+try:
+    from SharedPostgreSQL.sharedpostgresql import Connection, Cursor, SharedPostgreSQL
+except Exception as _err:
+    raise unittest.SkipTest("SharedPostgreSQL module unavailable: %s" % _err)
+
+# The addon imports shareddbapi by bare name, the way Gramps loads addons, so
+# reach the base class through the MRO rather than importing it a second time.
+SharedDBAPI = SharedPostgreSQL.__bases__[0]
+
+
+# -------------------------------------------------------------------------
+#
+# Helpers
+#
+# -------------------------------------------------------------------------
+
+
+def _make_connection():
+    """Return a (Connection, mock_cursor) pair without touching psycopg2."""
+    conn = Connection.__new__(Connection)
+    cursor = mock.MagicMock()
+    conn._Connection__cursor = cursor
+    return conn, cursor
+
+
+def _translated(sql):
+    """Return the SQL string that Connection.execute() would pass to psycopg2."""
+    conn, cursor = _make_connection()
+    conn.execute(sql)
+    return cursor.execute.call_args[0][0]
+
+
+# -------------------------------------------------------------------------
+#
+# TestExecuteQmarkParamstyle
+#
+# -------------------------------------------------------------------------
+class TestExecuteQmarkParamstyle(unittest.TestCase):
+    """? -> %s substitution."""
+
+    def test_single_placeholder(self):
+        self.assertEqual(
+            _translated("SELECT * FROM person WHERE gramps_id = ?"),
+            "SELECT * FROM person WHERE gramps_id = %s",
+        )
+
+    def test_multiple_placeholders(self):
+        result = _translated("INSERT INTO t (treeid, a) VALUES (?, ?)")
+        self.assertEqual(result.count("%s"), 2)
+        self.assertNotIn("?", result)
+
+    def test_no_placeholders_unchanged(self):
+        sql = "SELECT * FROM person"
+        self.assertEqual(_translated(sql), sql)
+
+
+# -------------------------------------------------------------------------
+#
+# TestExecuteRegexpOperator
+#
+# -------------------------------------------------------------------------
+class TestExecuteRegexpOperator(unittest.TestCase):
+    """REGEXP -> ~ substitution."""
+
+    def test_regexp_replaced(self):
+        result = _translated("SELECT * FROM person WHERE name REGEXP 'foo'")
+        self.assertIn(" ~ ", result)
+        self.assertNotIn("REGEXP", result)
+
+    def test_no_regexp_unchanged(self):
+        sql = "SELECT * FROM person WHERE name = 'foo'"
+        self.assertEqual(_translated(sql), sql)
+
+
+# -------------------------------------------------------------------------
+#
+# TestExecuteSerialPrimaryKey
+#
+# -------------------------------------------------------------------------
+class TestExecuteSerialPrimaryKey(unittest.TestCase):
+    """INTEGER PRIMARY KEY -> SERIAL PRIMARY KEY.
+
+    The trees table relies on the treeid being assigned automatically when a
+    new tree is inserted, which in PostgreSQL requires SERIAL.
+    """
+
+    def test_trees_table_uses_serial(self):
+        result = _translated(
+            "CREATE TABLE trees (treeid INTEGER PRIMARY KEY, uuid VARCHAR(32))"
+        )
+        self.assertIn("treeid SERIAL PRIMARY KEY", result)
+        self.assertNotIn("INTEGER PRIMARY KEY", result)
+
+    def test_plain_integer_column_unchanged(self):
+        sql = "ALTER TABLE person ADD COLUMN priority INTEGER"
+        self.assertEqual(_translated(sql), sql)
+
+
+# -------------------------------------------------------------------------
+#
+# TestExecuteBlobType
+#
+# -------------------------------------------------------------------------
+class TestExecuteBlobType(unittest.TestCase):
+    """BLOB -> BYTEA substitution."""
+
+    def test_metadata_table_blob_replaced(self):
+        result = _translated(
+            "CREATE TABLE metadata "
+            "(treeid INTEGER, setting VARCHAR(50), json_data TEXT, value BLOB)"
+        )
+        self.assertIn("BYTEA", result)
+        self.assertNotIn("BLOB", result)
+
+    def test_blob_data_column_replaced(self):
+        result = _translated(
+            "CREATE TABLE person "
+            "(treeid INTEGER, handle VARCHAR(50), blob_data BLOB)"
+        )
+        self.assertIn("blob_data BYTEA", result)
+
+    def test_blob_word_boundary_not_in_identifier(self):
+        """BLOB as part of a longer identifier is not replaced."""
+        result = _translated("SELECT blobfield FROM person")
+        self.assertEqual(result, "SELECT blobfield FROM person")
+
+    def test_multiple_blob_columns_all_replaced(self):
+        result = _translated("CREATE TABLE t (a BLOB, b TEXT, c BLOB)")
+        self.assertEqual(result.count("BYTEA"), 2)
+        self.assertNotIn("BLOB", result)
+
+
+# -------------------------------------------------------------------------
+#
+# TestExecuteLimitTranslations
+#
+# -------------------------------------------------------------------------
+class TestExecuteLimitTranslations(unittest.TestCase):
+    """LIMIT dialect translations."""
+
+    def test_limit_minus_one_becomes_all(self):
+        result = _translated("SELECT * FROM person LIMIT -1")
+        self.assertIn("LIMIT ALL", result)
+        self.assertNotIn("-1", result)
+
+    def test_limit_offset_comma_count(self):
+        result = _translated("SELECT * FROM person LIMIT 5, 10")
+        self.assertIn("LIMIT 10 OFFSET 5", result)
+
+    def test_limit_offset_comma_minus_one(self):
+        result = _translated("SELECT * FROM person LIMIT 5, -1")
+        self.assertIn("LIMIT ALL OFFSET 5", result)
+
+    def test_plain_limit_unchanged(self):
+        result = _translated("SELECT * FROM person LIMIT 10")
+        self.assertEqual(result, "SELECT * FROM person LIMIT 10")
+
+    def test_limit_with_offset_clause_unchanged(self):
+        result = _translated("SELECT * FROM person LIMIT 10 OFFSET 5")
+        self.assertEqual(result, "SELECT * FROM person LIMIT 10 OFFSET 5")
+
+
+# -------------------------------------------------------------------------
+#
+# TestExecuteLeavesIdentifiersAlone
+#
+# -------------------------------------------------------------------------
+class TestExecuteLeavesIdentifiersAlone(unittest.TestCase):
+    """Identifiers are no longer rewritten by blind substring replacement.
+
+    The previous implementation replaced every occurrence of "desc", which
+    also corrupted unrelated identifiers.  Column naming is now the job of
+    _quote_column(), so execute() must leave identifiers untouched.
+    """
+
+    def test_desc_column_not_rewritten(self):
+        sql = "SELECT handle FROM media ORDER BY desc_"
+        self.assertEqual(_translated(sql), sql)
+
+    def test_description_not_corrupted(self):
+        sql = "SELECT description FROM event"
+        self.assertEqual(_translated(sql), sql)
+
+    def test_descending_order_not_corrupted(self):
+        sql = "SELECT handle FROM person ORDER BY surname desc"
+        self.assertEqual(_translated(sql), sql)
+
+
+# -------------------------------------------------------------------------
+#
+# TestCursorTranslatesToo
+#
+# -------------------------------------------------------------------------
+class TestCursorTranslatesToo(unittest.TestCase):
+    """Cursor.execute applies the same translations as Connection.execute.
+
+    Unlike core dbapi, shareddbapi passes bound parameters to cursor queries
+    in order to filter by treeid, so the cursor needs translation as well.
+    """
+
+    def test_cursor_translates_placeholders(self):
+        cursor_obj = Cursor.__new__(Cursor)
+        inner = mock.MagicMock()
+        cursor_obj._Cursor__cursor = inner
+        cursor_obj.execute("SELECT handle FROM person WHERE treeid = ?", [1])
+        self.assertEqual(
+            inner.execute.call_args[0][0],
+            "SELECT handle FROM person WHERE treeid = %s",
+        )
+
+
+# -------------------------------------------------------------------------
+#
+# TestSharedPostgreSQLSqlType
+#
+# -------------------------------------------------------------------------
+class TestSharedPostgreSQLSqlType(unittest.TestCase):
+    """SharedPostgreSQL._sql_type maps BLOB -> bytea; other types pass through."""
+
+    def setUp(self):
+        self.pg = SharedPostgreSQL.__new__(SharedPostgreSQL)
+
+    def test_blob_becomes_bytea(self):
+        with mock.patch.object(SharedDBAPI, "_sql_type", return_value="BLOB"):
+            self.assertEqual(self.pg._sql_type("blob_field", 0), "bytea")
+
+    def test_text_unchanged(self):
+        with mock.patch.object(SharedDBAPI, "_sql_type", return_value="TEXT"):
+            self.assertEqual(self.pg._sql_type("text_field", 255), "TEXT")
+
+    def test_integer_unchanged(self):
+        with mock.patch.object(SharedDBAPI, "_sql_type", return_value="INTEGER"):
+            self.assertEqual(self.pg._sql_type("int_field", 0), "INTEGER")
+
+
+# -------------------------------------------------------------------------
+#
+# TestSharedPostgreSQLQuoteColumn
+#
+# -------------------------------------------------------------------------
+class TestSharedPostgreSQLQuoteColumn(unittest.TestCase):
+    """SharedPostgreSQL._quote_column returns the physical column names."""
+
+    def setUp(self):
+        self.pg = SharedPostgreSQL.__new__(SharedPostgreSQL)
+
+    def test_desc_reserved(self):
+        self.assertEqual(self.pg._quote_column("desc"), "desc_")
+
+    def test_description_keeps_legacy_name(self):
+        """Existing databases have desc_ription, created by the old rewrite."""
+        self.assertEqual(self.pg._quote_column("description"), "desc_ription")
+
+    def test_normal_column_unchanged(self):
+        self.assertEqual(self.pg._quote_column("gramps_id"), "gramps_id")
+
+    def test_handle_unchanged(self):
+        self.assertEqual(self.pg._quote_column("handle"), "handle")
+
+    def test_change_unchanged(self):
+        self.assertEqual(self.pg._quote_column("change"), "change")
+
+    def test_base_class_is_identity(self):
+        base = SharedDBAPI.__new__(SharedDBAPI)
+        self.assertEqual(base._quote_column("desc"), "desc")
+
+
+# -------------------------------------------------------------------------
+#
+# TestSecondaryColumnNaming
+#
+# -------------------------------------------------------------------------
+class TestSecondaryColumnNaming(unittest.TestCase):
+    """Every Gramps secondary field maps to the column an existing database has.
+
+    Guards against a rename of the two fields whose physical column names were
+    fixed by the previous substring rewrite.
+    """
+
+    def setUp(self):
+        self.pg = SharedPostgreSQL.__new__(SharedPostgreSQL)
+
+    def test_media_desc_field(self):
+        from gramps.gen.lib import Media
+
+        fields = [field[0] for field in Media.get_secondary_fields()]
+        self.assertIn("desc", fields)
+        self.assertEqual(self.pg._quote_column("desc"), "desc_")
+
+    def test_event_description_field(self):
+        from gramps.gen.lib import Event
+
+        fields = [field[0] for field in Event.get_secondary_fields()]
+        self.assertIn("description", fields)
+        self.assertEqual(self.pg._quote_column("description"), "desc_ription")
+
+    def test_no_other_field_needs_renaming(self):
+        """Only desc and description were affected by the old rewrite."""
+        from gramps.gen.lib import (
+            Citation,
+            Event,
+            Family,
+            Media,
+            Note,
+            Person,
+            Place,
+            Repository,
+            Source,
+            Tag,
+        )
+
+        affected = set()
+        for cls in (
+            Person,
+            Family,
+            Event,
+            Place,
+            Repository,
+            Source,
+            Citation,
+            Media,
+            Note,
+            Tag,
+        ):
+            for field, _type, _length in cls.get_secondary_fields():
+                if "desc" in field:
+                    affected.add(field)
+        self.assertEqual(affected, {"desc", "description"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR backports @dsblank's recent improvements to the PostgreSQL addon (#943) to the SharedPostgreSQL addon (which is used by many Gramps Web deployments).

Claude's summary:

- Replace the blind `_hack_query()` substring rewriting (`"?"→"%s"`, `"desc"→"desc_"`, `"BLOB"→"bytea"`, etc.) with targeted, word-boundary-safe SQL dialect translation and a `_quote_column()` hook for reserved-word columns. The old approach corrupted any identifier containing "desc" as a substring (e.g. `description` silently became `desc_ription` in every query).
- Fix PostgreSQL collation check to work on PostgreSQL < 12 by querying `pg_collation` instead of relying on `CREATE COLLATION IF NOT EXISTS`.
- Fix a parameter-count mismatch in `_commit_raw()`'s INSERT branch (3 columns, only 2 `?` placeholders), which would raise a database error if ever triggered. Only reachable via legacy schema-upgrade code paths (schema version 14–16, roughly Gramps 3.3–4.1 era), so unlikely to have affected real trees in practice.
- Add a `dialect` class attribute and `_sql_type()` BLOB→bytea mapping for forward-compatibility with upstream Gramps dialect support.
- Add unit tests covering the SQL translation rules and column naming, adapted for this addon's schema.

Notes:

- Existing databases already have physical columns named `desc_` and `desc_ription` (artifacts of the old blind substring rewrite). These legacy names are preserved via `_quote_column()` rather than renamed, so no migration is required for existing trees.
