### PR TITLE
Gramps Web Sync refactoring No. 2

### DIFF
--- a/GrampsWebSync/adapters.py
+++ b/GrampsWebSync/adapters.py
@@ -160,15 +160,25 @@ class Keyring:
             return False
         return True
 
-    def delete(self, service: str, username: str) -> None:
-        """Remove a stored password, ignoring one that was never there."""
+    def delete(self, service: str, username: str) -> bool:
+        """Remove a stored password.
+
+        :returns: Whether the password is now gone.
+        """
         keyring = self._module()
         if keyring is None:
-            return
+            return False
         try:
             keyring.delete_password(service, username)
         except Exception as exc:  # noqa: BLE001 -- absent entries raise too
-            LOG.debug("Keyring delete for %s failed: %s", username, exc)
+            # Deleting what was never there raises, and is harmless; a keyring
+            # that is actually broken still has the password afterwards.
+            if self.get(service, username) is None:
+                LOG.debug("Nothing to delete for %s: %s", username, exc)
+                return True
+            self._failed("delete", exc)
+            return False
+        return True
 
 
 # ------------------------------------------------------------

--- a/GrampsWebSync/adapters.py
+++ b/GrampsWebSync/adapters.py
@@ -172,8 +172,10 @@ class Keyring:
             keyring.delete_password(service, username)
         except Exception as exc:  # noqa: BLE001 -- absent entries raise too
             # Deleting what was never there raises, and is harmless; a keyring
-            # that is actually broken still has the password afterwards.
-            if self.get(service, username) is None:
+            # that is actually broken still has the password afterwards. A read
+            # that fails proves nothing either way, so it counts as a failure.
+            before = self.unavailable
+            if self.get(service, username) is None and self.unavailable is before:
                 LOG.debug("Nothing to delete for %s: %s", username, exc)
                 return True
             self._failed("delete", exc)

--- a/GrampsWebSync/adapters.py
+++ b/GrampsWebSync/adapters.py
@@ -16,14 +16,26 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-"""Production implementations of the :mod:`session` ports."""
+"""Production implementations of the :mod:`session` ports.
+
+Two task runners are provided rather than one. :class:`GLibTaskRunner` keeps a
+step on the GTK main loop, which is mandatory for anything touching a Gramps
+database: the sqlite backend binds a connection to its creating thread.
+:class:`IoRunner` moves a step to a worker thread, which is where the network
+calls belong -- they are the only part of a sync that can block indefinitely.
+
+:class:`ConfigCredentialStore` keeps one entry per ``(url, username)`` pair, so
+each server carries its own sync baseline.
+"""
 
 from __future__ import annotations
 
 import logging
 import os
+import threading
 import time
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
 from gi.repository import GLib
@@ -32,74 +44,378 @@ from gramps.gen.utils.file import media_path_full
 
 LOG = logging.getLogger("grampswebsync")
 
+#: Keys the pre-multi-server versions of the addon used. Still written, as a
+#: mirror of the last-used entry, so that downgrading keeps working.
+LEGACY_URL = "credentials.url"
+LEGACY_USERNAME = "credentials.username"
+LEGACY_TIMESTAMP = "credentials.timestamp"
 
-def get_password(service: str, username: str) -> str | None:
-    """Return the stored password for ``username``, if a keyring is available.
+#: snapd interface granting access to ``org.freedesktop.secrets``. Declared by
+#: the Gramps snap but manually connected, so it is off until the user says so.
+SNAP_KEYRING_INTERFACE = "password-manager-service"
 
-    :param service: Keyring service name; the server URL is used.
-    :param username: The account whose password is wanted.
-    :returns: The password, or ``None`` if unavailable.
+
+def normalize_url(url: str) -> str:
+    """Return ``url`` in the form used as a credential-store key.
+
+    Normalizing here rather than in :class:`webapihandler.WebApiHandler` keeps a
+    stray trailing slash from looking like a different server, which would
+    otherwise cost the entry its sync baseline.
+
+    :param url: The URL as typed or stored.
+    :returns: The URL without surrounding whitespace or trailing slashes.
     """
-    LOG.debug("Retrieving password for user %s", username)
-    try:
-        import keyring
-    except ImportError:
-        LOG.warning("Keyring is not installed, cannot retrieve password.")
+    return url.strip().rstrip("/")
+
+
+# ------------------------------------------------------------
+#
+# Keyring
+#
+# ------------------------------------------------------------
+@dataclass(frozen=True)
+class KeyringUnavailable:
+    """A keyring call that failed, for the view to report.
+
+    :param detail: The underlying exception text, for logs and details views.
+    :param snap_command: The ``snap connect`` command that would fix it, when
+        running confined under snap; ``None`` elsewhere.
+    """
+
+    detail: str
+    snap_command: str | None = None
+
+
+def snap_connect_command() -> str | None:
+    """Return the command connecting the keyring interface, under snap only.
+
+    ``SNAP_INSTANCE_NAME`` rather than ``SNAP_NAME`` is what makes the command
+    correct under a parallel install.
+
+    :returns: The command, or ``None`` when not running as a snap.
+    """
+    if not os.environ.get("SNAP"):
         return None
-    return keyring.get_password(service, username)
+    name = (
+        os.environ.get("SNAP_INSTANCE_NAME")
+        or os.environ.get("SNAP_NAME")
+        or "gramps"
+    )
+    return f"snap connect {name}:{SNAP_KEYRING_INTERFACE}"
 
 
-def set_password(service: str, username: str, password: str) -> None:
-    """Store ``password`` in the keyring, if one is available."""
-    try:
-        import keyring
-    except ImportError:
-        return
-    LOG.debug("Storing password for user %s", username)
-    keyring.set_password(service, username, password)
+class Keyring:
+    """The system keyring, degrading to unavailable instead of raising.
 
+    Every call is guarded with a bare ``except Exception``. The failures seen in
+    practice do not derive from ``keyring.errors``: under snap confinement the
+    Secret Service backend raises ``jeepney.wrappers.DBusErrorResponse``, from a
+    transitive dependency, so catching the keyring package's own hierarchy is
+    not enough.
 
-class ConfigCredentialStore:
-    """Credentials in the Gramps config file, password in the system keyring."""
+    After a failure the keyring is marked unavailable and no further calls are
+    attempted for the lifetime of this object.
+    """
 
     def __init__(self) -> None:
-        self.config = configman.register_manager("webapisync")
-        self.config.register("credentials.url", "")
-        self.config.register("credentials.username", "")
-        self.config.register("credentials.timestamp", 0)
-        self.config.load()
+        self.unavailable: KeyringUnavailable | None = None
 
+    def _module(self):
+        """Return the ``keyring`` module, or ``None`` if it cannot be used."""
+        if self.unavailable is not None:
+            return None
+        try:
+            import keyring
+        except Exception as exc:  # noqa: BLE001 -- absence is not an error here
+            LOG.warning("Keyring is not available: %s", exc)
+            self.unavailable = KeyringUnavailable(str(exc), snap_connect_command())
+            return None
+        return keyring
+
+    def _failed(self, action: str, exc: Exception) -> None:
+        """Record that ``action`` failed and stop using the keyring."""
+        LOG.warning("Keyring %s failed: %s", action, exc)
+        self.unavailable = KeyringUnavailable(str(exc), snap_connect_command())
+
+    def get(self, service: str, username: str) -> str | None:
+        """Return the stored password, or ``None`` if it cannot be read."""
+        keyring = self._module()
+        if keyring is None:
+            return None
+        try:
+            return keyring.get_password(service, username)
+        except Exception as exc:  # noqa: BLE001 -- reported through `unavailable`
+            self._failed("read", exc)
+            return None
+
+    def set(self, service: str, username: str, password: str) -> bool:
+        """Store ``password``. Returns whether it was actually stored."""
+        keyring = self._module()
+        if keyring is None:
+            return False
+        try:
+            keyring.set_password(service, username, password)
+        except Exception as exc:  # noqa: BLE001 -- reported through `unavailable`
+            self._failed("write", exc)
+            return False
+        return True
+
+    def delete(self, service: str, username: str) -> None:
+        """Remove a stored password, ignoring one that was never there."""
+        keyring = self._module()
+        if keyring is None:
+            return
+        try:
+            keyring.delete_password(service, username)
+        except Exception as exc:  # noqa: BLE001 -- absent entries raise too
+            LOG.debug("Keyring delete for %s failed: %s", username, exc)
+
+
+# ------------------------------------------------------------
+#
+# Credential store
+#
+# ------------------------------------------------------------
+class ConfigCredentialStore:
+    """Server entries in the Gramps config file, passwords in the keyring.
+
+    Each entry is keyed by ``(url, username)`` -- which identifies a tree, since
+    a Gramps Web account belongs to exactly one -- and carries its own
+    ``timestamp``, the baseline the diff uses. Per-entry baselines are why
+    switching servers no longer discards one.
+    """
+
+    def __init__(self, keyring: Keyring | None = None, config: Any = None) -> None:
+        """Initialize the store.
+
+        :param keyring: Password storage. A real one is built if omitted.
+        :param config: An already-registered config manager. Tests pass one
+            pointed at a temporary directory so a run cannot write to the
+            user's own Gramps configuration.
+        """
+        self.keyring = keyring if keyring is not None else Keyring()
+        self.config = (
+            config if config is not None else configman.register_manager("webapisync")
+        )
+        self.config.register(LEGACY_URL, "")
+        self.config.register(LEGACY_USERNAME, "")
+        self.config.register(LEGACY_TIMESTAMP, 0)
+        self.config.register("credentials.servers", [])
+        self.config.register("credentials.last_used", [])
+        self.config.load()
+        self._reconcile_legacy()
+
+    # --------------------------------------------------------
+    # Raw access
+    # --------------------------------------------------------
+    def _servers(self) -> list[dict[str, Any]]:
+        """Return the stored entries, tolerating a corrupted config value.
+
+        A value the config manager could not parse is stored as ``None`` rather
+        than falling back to the registered default, so the type has to be
+        checked rather than assumed.
+        """
+        servers = self.config.get("credentials.servers")
+        if not isinstance(servers, list):
+            LOG.warning("Ignoring unreadable server list in config.")
+            return []
+        return [entry for entry in servers if isinstance(entry, dict)]
+
+    def _find(
+        self, servers: list[dict[str, Any]], url: str, username: str
+    ) -> dict[str, Any] | None:
+        """Return the entry for ``(url, username)``, or ``None``."""
+        url = normalize_url(url)
+        for entry in servers:
+            if normalize_url(entry.get("url", "")) == url and (
+                entry.get("username", "") == username
+            ):
+                return entry
+        return None
+
+    def _last_used(self) -> tuple[str, str] | None:
+        """Return the ``(url, username)`` last synced, if any."""
+        pair = self.config.get("credentials.last_used")
+        if isinstance(pair, list) and len(pair) == 2:
+            return str(pair[0]), str(pair[1])
+        return None
+
+    def _current(self) -> dict[str, Any] | None:
+        """Return the last-used entry, falling back to the only one stored."""
+        servers = self._servers()
+        pair = self._last_used()
+        if pair is not None:
+            entry = self._find(servers, *pair)
+            if entry is not None:
+                return entry
+        return servers[0] if len(servers) == 1 else None
+
+    def _write(self, servers: list[dict[str, Any]]) -> None:
+        """Persist the entry list and the legacy mirror, then save."""
+        self.config.set("credentials.servers", servers)
+        self._write_legacy_mirror(servers)
+        self.config.save()
+
+    def _write_legacy_mirror(self, servers: list[dict[str, Any]]) -> None:
+        """Mirror the last-used entry into the pre-multi-server keys.
+
+        An older version of the addon reads only those keys. Keeping them
+        current means a downgrade finds its credentials and its baseline where
+        it expects them, instead of resyncing from scratch.
+        """
+        pair = self._last_used()
+        entry = self._find(servers, *pair) if pair is not None else None
+        if entry is None:
+            self.config.set(LEGACY_URL, "")
+            self.config.set(LEGACY_USERNAME, "")
+            self.config.set(LEGACY_TIMESTAMP, 0)
+            return
+        self.config.set(LEGACY_URL, entry.get("url", ""))
+        self.config.set(LEGACY_USERNAME, entry.get("username", ""))
+        self.config.set(LEGACY_TIMESTAMP, int(entry.get("timestamp", 0) or 0))
+
+    def _reconcile_legacy(self) -> None:
+        """Fold the legacy keys into the entry list.
+
+        Covers both cases in one path: on first run after an upgrade there is no
+        matching entry and the legacy triple becomes one, and after a downgrade
+        and back the entry exists but an older version may have synced in the
+        meantime, so the later of the two baselines wins.
+        """
+        legacy_url = normalize_url(self.config.get(LEGACY_URL) or "")
+        if not legacy_url:
+            return
+        legacy_username = self.config.get(LEGACY_USERNAME) or ""
+        legacy_timestamp = float(self.config.get(LEGACY_TIMESTAMP) or 0)
+
+        servers = self._servers()
+        entry = self._find(servers, legacy_url, legacy_username)
+        if entry is None:
+            LOG.info("Migrating stored credentials to the server list.")
+            servers.append(
+                {
+                    "url": legacy_url,
+                    "username": legacy_username,
+                    "timestamp": legacy_timestamp,
+                    "remember_password": True,
+                }
+            )
+            self.config.set("credentials.last_used", [legacy_url, legacy_username])
+        elif legacy_timestamp > float(entry.get("timestamp", 0) or 0):
+            entry["timestamp"] = legacy_timestamp
+        else:
+            return
+        self.config.set("credentials.servers", servers)
+        self.config.save()
+
+    # --------------------------------------------------------
+    # CredentialStore protocol
+    # --------------------------------------------------------
     def get_url(self) -> str:
-        return self.config.get("credentials.url")
+        """Return the last-used server URL, for pre-filling the login page."""
+        entry = self._current()
+        return entry.get("url", "") if entry else ""
 
     def get_username(self) -> str:
-        return self.config.get("credentials.username")
+        """Return the last-used user name."""
+        entry = self._current()
+        return entry.get("username", "") if entry else ""
 
     def get_password(self) -> str | None:
-        url = self.get_url()
-        username = self.get_username()
+        """Return the last-used password, if one was stored and is readable."""
+        entry = self._current()
+        if not entry or not entry.get("remember_password", True):
+            return None
+        url = entry.get("url", "")
+        username = entry.get("username", "")
         if not url or not username:
             return None
-        return get_password(url, username)
+        return self.keyring.get(url, username)
 
-    def get_timestamp(self) -> float:
-        return self.config.get("credentials.timestamp")
+    def get_timestamp(self, url: str, username: str) -> float:
+        """Return the sync baseline for one server.
 
-    def set_timestamp(self, timestamp: float) -> None:
+        :param url: The server URL.
+        :param username: The account on that server.
+        :returns: The last successful sync time, or ``0`` if never synced.
+        """
+        entry = self._find(self._servers(), url, username)
+        return float(entry.get("timestamp", 0) or 0) if entry else 0.0
+
+    def set_timestamp(self, url: str, username: str, timestamp: float) -> None:
+        """Record a successful sync against one server."""
+        servers = self._servers()
+        entry = self._find(servers, url, username)
+        if entry is None:
+            entry = {
+                "url": normalize_url(url),
+                "username": username,
+                "remember_password": True,
+            }
+            servers.append(entry)
+        entry["timestamp"] = timestamp
         LOG.debug("Recording last successful sync at %s", timestamp)
-        self.config.set("credentials.timestamp", timestamp)
-        self.config.save()
+        self.config.set("credentials.last_used", [normalize_url(url), username])
+        self._write(servers)
 
-    def save_credentials(self, url: str, username: str, password: str) -> None:
-        """Persist the credentials, resetting the sync time if the URL changed."""
-        if url != self.get_url():
-            self.config.set("credentials.timestamp", 0)
-        self.config.set("credentials.url", url)
-        self.config.set("credentials.username", username)
-        set_password(url, username, password)
-        self.config.save()
+    def save_credentials(
+        self, url: str, username: str, password: str, remember_password: bool = True
+    ) -> None:
+        """Persist one server entry, and its password if asked to.
+
+        The entry itself is always stored: it carries the sync baseline, which
+        is not a credential, and discarding it would make every later run a cold
+        sync. ``remember_password`` governs the keyring only.
+
+        :param url: The server URL, already sanitized by the caller.
+        :param username: The account name.
+        :param password: The password, stored only if ``remember_password``.
+        :param remember_password: Whether the password may go to the keyring.
+        """
+        url = normalize_url(url)
+        servers = self._servers()
+        entry = self._find(servers, url, username)
+        if entry is None:
+            entry = {"url": url, "username": username, "timestamp": 0.0}
+            servers.append(entry)
+        entry["remember_password"] = remember_password
+
+        if remember_password:
+            self.keyring.set(url, username, password)
+        else:
+            # Turning the setting off has to erase what is already stored, not
+            # merely stop writing, or it appears to do nothing.
+            self.keyring.delete(url, username)
+
+        self.config.set("credentials.last_used", [url, username])
+        self._write(servers)
+
+    def forget(self, url: str, username: str) -> None:
+        """Remove one server entry entirely, keyring item included."""
+        url = normalize_url(url)
+        servers = [
+            entry
+            for entry in self._servers()
+            if not (
+                normalize_url(entry.get("url", "")) == url
+                and entry.get("username", "") == username
+            )
+        ]
+        self.keyring.delete(url, username)
+        if self._last_used() == (url, username):
+            self.config.set("credentials.last_used", [])
+        self._write(servers)
+
+    def keyring_error(self) -> KeyringUnavailable | None:
+        """Return the keyring failure to report, if one has occurred."""
+        return self.keyring.unavailable
 
 
+# ------------------------------------------------------------
+#
+# Media
+#
+# ------------------------------------------------------------
 class GrampsMediaStore:
     """Resolves media paths against the open Gramps database's media path.
 
@@ -118,14 +434,32 @@ class GrampsMediaStore:
         return os.path.exists(self.full_path(media))
 
 
+# ------------------------------------------------------------
+#
+# Task runners
+#
+# ------------------------------------------------------------
+def _post_to_main_loop(func: Callable[[], None]) -> None:
+    """Schedule ``func`` to run once on the GTK main loop."""
+
+    def once() -> bool:
+        func()
+        return False
+
+    GLib.idle_add(once)
+
+
 class GLibTaskRunner:
     """Defers a task to the GTK main loop.
 
-    The task must not run on a worker thread: it drives Gramps progress
-    through the GUI :class:`gramps.gui.user.User`, which touches widgets, and
-    GTK is not thread-safe -- doing so segfaults inside ``diff_dbs``.
-    :func:`GLib.idle_add` keeps the work on the main loop while still letting
-    the caller return so the assistant can paint the progress page first.
+    For steps that touch a Gramps database. Those must not run on a worker
+    thread: the sqlite backend passes no ``check_same_thread=False`` and shares
+    one cursor, so a connection is usable only from the thread that created it.
+    They also drive Gramps progress through the GUI
+    :class:`gramps.gui.user.User`, which touches widgets.
+
+    :func:`GLib.idle_add` keeps the work on the main loop while still letting the
+    caller return, so the view can paint the progress page first.
     """
 
     def run(
@@ -146,6 +480,54 @@ class GLibTaskRunner:
             return False  # run once
 
         GLib.idle_add(once)
+
+    def post(self, func: Callable[[], None]) -> None:
+        """Run ``func`` on the main loop."""
+        _post_to_main_loop(func)
+
+
+class IoRunner:
+    """Runs a task on a worker thread, dispatching the outcome on the main loop.
+
+    For steps that only do network I/O. Those are where a sync spends most of
+    its wall-clock time and the only place it can block indefinitely, so moving
+    them off the main loop is what makes the window stay responsive and Cancel
+    actually work. Callbacks are marshalled back through
+    :func:`GLib.idle_add`, so listeners still run on the thread that owns GTK.
+    """
+
+    def run(
+        self,
+        func: Callable[[], Any],
+        on_success: Callable[[Any], None],
+        on_error: Callable[[BaseException], None],
+    ) -> None:
+        """Run ``func`` on a worker thread; call back on the main loop."""
+
+        def work() -> None:
+            try:
+                result = func()
+            except BaseException as exc:  # noqa: BLE001 -- reported, not swallowed
+                # Handed straight on: `except ... as exc` unbinds the name when
+                # the block exits, and the callback runs later than that.
+                self._dispatch(on_error, exc)
+            else:
+                self._dispatch(on_success, result)
+
+        threading.Thread(target=work, daemon=True, name="grampswebsync-io").start()
+
+    @staticmethod
+    def _dispatch(callback: Callable[[Any], None], value: Any) -> None:
+        """Deliver ``value`` to ``callback`` on the main loop."""
+        _post_to_main_loop(lambda: callback(value))
+
+    def post(self, func: Callable[[], None]) -> None:
+        """Run ``func`` on the main loop.
+
+        Progress raised inside a network step arrives here, so that listeners
+        drawing widgets never run on the worker thread.
+        """
+        _post_to_main_loop(func)
 
 
 class SystemClock:

--- a/GrampsWebSync/const.py
+++ b/GrampsWebSync/const.py
@@ -65,4 +65,8 @@ OBJ_LST = [
 MODE_BIDIRECTIONAL = 0
 MODE_RESET_TO_LOCAL = 1
 MODE_RESET_TO_REMOTE = 2
-MODE_MERGE = 3
+
+#: Modes that delete rather than propagate. The view warns about these instead
+#: of presenting them as equal-weight peers of the default. Display text lives
+#: in the view, which is where translation happens.
+DESTRUCTIVE_MODES = frozenset({MODE_RESET_TO_LOCAL, MODE_RESET_TO_REMOTE})

--- a/GrampsWebSync/diffhandler.py
+++ b/GrampsWebSync/diffhandler.py
@@ -48,7 +48,6 @@ from const import (
     MODE_BIDIRECTIONAL,
     MODE_RESET_TO_LOCAL,
     MODE_RESET_TO_REMOTE,
-    MODE_MERGE,
     OBJ_LST,
     Action,
     Actions,
@@ -342,16 +341,6 @@ def changes_to_actions(changes, sync_mode: int) -> Actions:
             C_DEL_LOC: A_ADD_LOC,
             C_DEL_REM: A_DEL_LOC,
             C_UPD_LOC: A_UPD_LOC,
-            C_UPD_REM: A_UPD_LOC,
-        }
-    elif sync_mode == MODE_MERGE:
-        change_to_action = {
-            C_UPD_BOTH: A_MRG_REM,
-            C_ADD_LOC: A_ADD_REM,
-            C_ADD_REM: A_ADD_LOC,
-            C_DEL_LOC: A_ADD_LOC,
-            C_DEL_REM: A_ADD_REM,
-            C_UPD_LOC: A_UPD_REM,
             C_UPD_REM: A_UPD_LOC,
         }
     else:

--- a/GrampsWebSync/grampswebsync.gpr.py
+++ b/GrampsWebSync/grampswebsync.gpr.py
@@ -28,7 +28,7 @@ register(
     id="gramps_web_sync",
     name=_("Gramps Web Sync"),
     description=_("Synchronizes a local database with a Gramps Web instance."),
-    version = '1.3.12',
+    version = '1.4.0',
     gramps_target_version="6.0",
     status=STABLE,
     fname="grampswebsync.py",

--- a/GrampsWebSync/grampswebsync.gpr.py
+++ b/GrampsWebSync/grampswebsync.gpr.py
@@ -28,7 +28,7 @@ register(
     id="gramps_web_sync",
     name=_("Gramps Web Sync"),
     description=_("Synchronizes a local database with a Gramps Web instance."),
-    version = '1.4.0',
+    version = '1.3.12',
     gramps_target_version="6.0",
     status=STABLE,
     fname="grampswebsync.py",

--- a/GrampsWebSync/grampswebsync.py
+++ b/GrampsWebSync/grampswebsync.py
@@ -113,20 +113,17 @@ PAGE_FOR_STATE: dict[State, int] = {
 def keyring_message(problem: KeyringUnavailable) -> str:
     """Return the localized notice for an unusable keyring.
 
-    Under snap the failure is a confinement setting the user can change, so the
-    message carries the command rather than only apologizing.
-
     :param problem: What the keyring reported.
     :returns: A message suitable for display.
     """
     if problem.snap_command:
         return _(
-            "The password could not be saved to the system keyring. "
-            "Snap confinement blocks access until you run: %s"
+            "The system keyring could not be used. Snap confinement blocks "
+            "access until you run: %s"
         ) % problem.snap_command
     return _(
-        "The password could not be saved to the system keyring. "
-        "You will need to enter it each time."
+        "The system keyring could not be used. "
+        "You will need to enter your password each time."
     )
 
 

--- a/GrampsWebSync/grampswebsync.py
+++ b/GrampsWebSync/grampswebsync.py
@@ -36,6 +36,8 @@ from adapters import (
     ConfigCredentialStore,
     GLibTaskRunner,
     GrampsMediaStore,
+    IoRunner,
+    KeyringUnavailable,
     SystemClock,
 )
 from const import (
@@ -46,14 +48,14 @@ from const import (
     C_UPD_BOTH,
     C_UPD_LOC,
     C_UPD_REM,
+    DESTRUCTIVE_MODES,
     MODE_BIDIRECTIONAL,
-    MODE_MERGE,
     MODE_RESET_TO_LOCAL,
     MODE_RESET_TO_REMOTE,
     Actions,
 )
 from diffhandler import changes_to_actions, has_local_actions, has_remote_actions
-from gi.repository import Gtk
+from gi.repository import GLib, Gtk
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 from gramps.gen.lib import Tag
 from gramps.gui.dialog import QuestionDialog2
@@ -108,6 +110,26 @@ PAGE_FOR_STATE: dict[State, int] = {
 }
 
 
+def keyring_message(problem: KeyringUnavailable) -> str:
+    """Return the localized notice for an unusable keyring.
+
+    Under snap the failure is a confinement setting the user can change, so the
+    message carries the command rather than only apologizing.
+
+    :param problem: What the keyring reported.
+    :returns: A message suitable for display.
+    """
+    if problem.snap_command:
+        return _(
+            "The password could not be saved to the system keyring. "
+            "Snap confinement blocks access until you run: %s"
+        ) % problem.snap_command
+    return _(
+        "The password could not be saved to the system keyring. "
+        "You will need to enter it each time."
+    )
+
+
 def error_message(kind: ErrorKind, detail: str = "") -> str:
     """Return the localized message for an error kind.
 
@@ -144,7 +166,13 @@ def error_message(kind: ErrorKind, detail: str = "") -> str:
             "Unable to synchronize changes to server: objects have been modified."
         ),
         ErrorKind.APPLY_FAILED: _("Unexpected error while applying changes."),
+        ErrorKind.STALE_LOCAL_DATA: _(
+            "The family tree was modified while the changes were being "
+            "reviewed. Nothing has been applied. Please compare again."
+        ),
     }
+    if kind is ErrorKind.SERVER_TASK_FAILED:
+        return _("The server could not apply the changes: %s") % detail
     if kind is ErrorKind.SERVER_ERROR:
         return _("Server error %s. Please check your connection.") % detail
     if kind is ErrorKind.UNEXPECTED:
@@ -159,6 +187,11 @@ class GrampsWebSyncTool(BatchTool, ManagedWindow):
         """Build the assistant and the session behind it."""
         LOG.debug("Initializing Gramps Web Sync addon.")
         BatchTool.__init__(self, dbstate, user, options_class, name)
+        if self.fail:
+            # The user declined the undo-history warning; honour that instead
+            # of opening the assistant anyway.
+            LOG.debug("Undo history warning declined; not opening the tool.")
+            return
         ManagedWindow.__init__(self, user.uistate, [], self.__class__)
 
         self.dbstate = dbstate
@@ -171,6 +204,7 @@ class GrampsWebSyncTool(BatchTool, ManagedWindow):
             credentials=self.credentials,
             media=GrampsMediaStore(dbstate.db),
             runner=GLibTaskRunner(),
+            io_runner=IoRunner(),
             clock=SystemClock(),
             listener=self,
         )
@@ -223,7 +257,7 @@ class GrampsWebSyncTool(BatchTool, ManagedWindow):
             _("Progress Information"),
         )
 
-        self.conclusion = ConclusionPage(self.assistant)
+        self.conclusion = ConclusionPage(self.assistant, on_retry=self.on_retry)
         self.add_page(self.conclusion, Gtk.AssistantPageType.SUMMARY, _("Summary"))
 
         self.show()
@@ -264,6 +298,10 @@ class GrampsWebSyncTool(BatchTool, ManagedWindow):
     def _make_backend(self, url: str, username: str, password: str) -> WebApiHandler:
         """Build the real Web API handler. Injected into the session."""
         return WebApiHandler(url, username, password, None)
+
+    def on_retry(self, _button) -> None:
+        """Resume a failed run from the step that failed."""
+        self.session.retry()
 
     # --------------------------------------------------------
     # SessionListener
@@ -335,6 +373,7 @@ class GrampsWebSyncTool(BatchTool, ManagedWindow):
                 self.loginpage.show_error(error_message(error.kind, error.detail))
             else:
                 self.loginpage.clear_error()
+            self._show_keyring_notice(self.loginpage)
 
         elif page is self.diff_progress_page:
             if self.session.state is State.LOGIN:
@@ -370,6 +409,17 @@ class GrampsWebSyncTool(BatchTool, ManagedWindow):
 
         elif page is self.conclusion:
             self.conclusion.prepare(self.session)
+            self._show_keyring_notice(self.conclusion)
+
+    def _show_keyring_notice(self, page) -> None:
+        """Tell the user if the keyring could not be used.
+
+        Reported rather than swallowed: without this the password field is
+        simply empty every run and nothing explains why.
+        """
+        problem = self.credentials.keyring_error()
+        if problem is not None:
+            page.show_notice(keyring_message(problem))
 
     def sanitize_url(self, url: str) -> str:
         """Prepend https if no scheme is given, and warn about plain http.
@@ -505,14 +555,30 @@ class LoginPage(Page):
         self.error_label.hide()
         grid.attach(self.error_label, 0, 3, 2, 1)
 
+        # Non-fatal notice, e.g. an unusable keyring. Distinct from the error
+        # label because it does not stop the user from continuing.
+        self.notice_label = Gtk.Label()
+        self.notice_label.set_line_wrap(True)
+        self.notice_label.set_max_width_chars(60)
+        self.notice_label.set_no_show_all(True)
+        self.notice_label.hide()
+        grid.attach(self.notice_label, 0, 4, 2, 1)
+
         # Connect entry change events
         self.url.connect("changed", self.on_entry_changed)
         self.username.connect("changed", self.on_entry_changed)
         self.password.connect("changed", self.on_entry_changed)
 
     def show_error(self, message: str):
-        """Display an error message on the login page."""
-        self.error_label.set_markup(f"<b>Error:</b> {message}")
+        """Display an error message on the login page.
+
+        The message is escaped: it can carry server or exception text, and an
+        unescaped ``&`` or ``<`` would break the markup or swallow the message.
+        """
+        label = GLib.markup_escape_text(_("Error:"))
+        self.error_label.set_markup(
+            f"<b>{label}</b> {GLib.markup_escape_text(message)}"
+        )
         self.error_label.show()
         self.update_complete()
 
@@ -520,6 +586,11 @@ class LoginPage(Page):
         """Clear any displayed error message."""
         self.error_label.hide()
         self.update_complete()
+
+    def show_notice(self, message: str):
+        """Display a non-fatal notice, such as an unusable keyring."""
+        self.notice_label.set_markup(f"<i>{GLib.markup_escape_text(message)}</i>")
+        self.notice_label.show()
 
     @property
     def complete(self):
@@ -572,47 +643,54 @@ class ConfirmationPage(Page):
         scrolled_window.add(self.tree_view)
 
         self.sync_label = Gtk.Label()
-        self.sync_label.set_text("Sync mode")
+        self.sync_label.set_text(_("Sync mode"))
 
         # Box for radio buttons
         self.radio_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
 
-        # Radio buttons
-        option_name = _("Bidirectional Synchronization")
-        self.radio_button1 = Gtk.RadioButton.new_with_label_from_widget(
-            None, option_name
-        )
-        self.radio_button1.connect(
-            "toggled", self.on_radio_button_toggled, MODE_BIDIRECTIONAL
-        )
-        self.radio_box.pack_start(self.radio_button1, False, False, 0)
+        #: Mode -> the one-line explanation shown when it is selected. With
+        #: per-object selection out of scope this is the user's only control,
+        #: so each option has to say what it will do.
+        self.mode_descriptions = {
+            MODE_BIDIRECTIONAL: _(
+                "Changes from both sides are combined. Objects edited in both "
+                "places are merged."
+            ),
+            MODE_RESET_TO_LOCAL: _(
+                "The server is made to match this computer. Anything changed "
+                "only on the server is discarded."
+            ),
+            MODE_RESET_TO_REMOTE: _(
+                "This computer is made to match the server. Anything changed "
+                "only here is discarded."
+            ),
+        }
 
-        option_name = _("Reset remote to local")
-        self.radio_button2 = Gtk.RadioButton.new_from_widget(self.radio_button1)
-        self.radio_button2.set_label(option_name)
-        self.radio_button2.connect(
-            "toggled", self.on_radio_button_toggled, MODE_RESET_TO_LOCAL
-        )
-        self.radio_box.pack_start(self.radio_button2, False, False, 0)
+        first = None
+        for mode, label in (
+            (MODE_BIDIRECTIONAL, _("Bidirectional Synchronization")),
+            (MODE_RESET_TO_LOCAL, _("Reset remote to local")),
+            (MODE_RESET_TO_REMOTE, _("Reset local to remote")),
+        ):
+            if first is None:
+                button = Gtk.RadioButton.new_with_label_from_widget(None, label)
+                first = button
+            else:
+                button = Gtk.RadioButton.new_from_widget(first)
+                button.set_label(label)
+            button.connect("toggled", self.on_radio_button_toggled, mode)
+            self.radio_box.pack_start(button, False, False, 0)
 
-        option_name = _("Reset local to remote")
-        self.radio_button3 = Gtk.RadioButton.new_from_widget(self.radio_button1)
-        self.radio_button3.set_label(option_name)
-        self.radio_button3.connect(
-            "toggled", self.on_radio_button_toggled, MODE_RESET_TO_REMOTE
-        )
-        self.radio_box.pack_start(self.radio_button3, False, False, 0)
-
-        option_name = _("Merge")
-        self.radio_button4 = Gtk.RadioButton.new_from_widget(self.radio_button1)
-        self.radio_button4.set_label(option_name)
-        self.radio_button4.connect("toggled", self.on_radio_button_toggled, MODE_MERGE)
-        self.radio_box.pack_start(self.radio_button4, False, False, 0)
+        self.description_label = Gtk.Label()
+        self.description_label.set_line_wrap(True)
+        self.description_label.set_max_width_chars(70)
+        self.description_label.set_xalign(0)
 
         # Box to hold the label and radio buttons
         self.label_radio_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=5)
         self.label_radio_box.pack_start(self.sync_label, False, False, 0)
         self.label_radio_box.pack_start(self.radio_box, False, False, 0)
+        self.label_radio_box.pack_start(self.description_label, False, False, 0)
 
         self.outer_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=10)
         self.outer_box.pack_start(scrolled_window, True, True, 0)
@@ -624,6 +702,18 @@ class ConfirmationPage(Page):
         """Callback for radio buttons setting sync mode."""
         if button.get_active():
             self.sync_mode = int(name)
+            self.update_description()
+
+    def update_description(self):
+        """Describe the selected mode, warning if it deletes."""
+        text = self.mode_descriptions.get(self.sync_mode, "")
+        if self.sync_mode in DESTRUCTIVE_MODES:
+            self.description_label.set_markup(
+                f"<b>{GLib.markup_escape_text(_('Warning:'))}</b> "
+                f"{GLib.markup_escape_text(text)}"
+            )
+        else:
+            self.description_label.set_text(text)
 
     def prepare(self, changes: Actions):
         """Convert the changes list to a tree store."""
@@ -674,6 +764,7 @@ class ConfirmationPage(Page):
         for i, row in enumerate(self.store):
             self.tree_view.expand_row(Gtk.TreePath(i), False)
 
+        self.update_description()
         self.set_complete()
 
 
@@ -846,9 +937,13 @@ class FileProgressPage(Page):
 
 
 class ConclusionPage(Page):
-    """The conclusion page, reporting either the outcome or the error."""
+    """The conclusion page, reporting either the outcome or the error.
 
-    def __init__(self, assistant):
+    :param assistant: The assistant owning this page.
+    :param on_retry: Called when the user asks to resume a failed run.
+    """
+
+    def __init__(self, assistant, on_retry=None):
         super().__init__(assistant)
         label = Gtk.Label(label="")
         label.set_line_wrap(True)
@@ -857,18 +952,73 @@ class ConclusionPage(Page):
         self.label = label
         self.pack_start(self.label, False, False, 0)
 
+        self.notice_label = Gtk.Label()
+        self.notice_label.set_line_wrap(True)
+        self.notice_label.set_max_width_chars(60)
+        self.notice_label.set_no_show_all(True)
+        self.notice_label.hide()
+        self.pack_start(self.notice_label, False, False, 10)
+
+        # A failed run would otherwise be a dead end: the only button on a
+        # summary page is Close, and reopening the tool re-downloads and
+        # re-diffs the whole tree for what is usually a transient problem.
+        self.retry_button = Gtk.Button(label=_("Try again"))
+        self.retry_button.set_halign(Gtk.Align.CENTER)
+        self.retry_button.set_no_show_all(True)
+        self.retry_button.hide()
+        if on_retry is not None:
+            self.retry_button.connect("clicked", on_retry)
+        self.pack_start(self.retry_button, False, False, 10)
+
     def prepare(self, session: SyncSession) -> None:
         """Render the final message for ``session``."""
         if session.error is not None:
             self.label.set_text(
                 error_message(session.error.kind, session.error.detail)
             )
-        elif not session.downloaded and not session.uploaded:
-            self.label.set_text(_("Media files are in sync."))
-            LOG.info("Media files are in sync.")
         else:
-            self.label.set_text(self._transfer_summary(session))
+            self.label.set_text(self._outcome_summary(session))
+        self.retry_button.set_visible(session.can_retry)
         self.set_complete()
+
+    def show_notice(self, message: str) -> None:
+        """Show a non-fatal notice alongside the outcome."""
+        self.notice_label.set_markup(f"<i>{GLib.markup_escape_text(message)}</i>")
+        self.notice_label.show()
+
+    def _outcome_summary(self, session: SyncSession) -> str:
+        """Describe what the run actually did, to both trees and to media.
+
+        The old summary reported media only, so a run that applied hundreds of
+        object changes and moved no files said "Media files are in sync."
+        """
+        parts = []
+        applied = len(session.actions)
+        if applied:
+            parts.append(
+                ngettext("Applied %s change.", "Applied %s changes.", applied)
+                % applied
+            )
+        transfer = self._transfer_summary(session)
+        if transfer:
+            parts.append(transfer)
+        elif not session.missing_both:
+            parts.append(_("Media files are in sync."))
+        if session.missing_both:
+            count = len(session.missing_both)
+            parts.append(
+                ngettext(
+                    "%s media file is missing on both sides and could not be "
+                    "transferred.",
+                    "%s media files are missing on both sides and could not be "
+                    "transferred.",
+                    count,
+                )
+                % count
+            )
+        if not parts:
+            parts.append(_("Both trees are already in sync."))
+        return " ".join(parts)
 
     @staticmethod
     def _transfer_summary(session: SyncSession) -> str:

--- a/GrampsWebSync/po/template.pot
+++ b/GrampsWebSync/po/template.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-27 09:45+0200\n"
+"POT-Creation-Date: 2026-07-31 15:54+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,8 +18,8 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
-#: GrampsWebSync/grampswebsync.gpr.py:29 GrampsWebSync/grampswebsync.py:179
-#: GrampsWebSync/grampswebsync.py:237
+#: GrampsWebSync/grampswebsync.gpr.py:29 GrampsWebSync/grampswebsync.py:213
+#: GrampsWebSync/grampswebsync.py:271
 msgid "Gramps Web Sync"
 msgstr ""
 
@@ -27,115 +27,139 @@ msgstr ""
 msgid "Synchronizes a local database with a Gramps Web instance."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:123
-msgid "Authentication failed. Please check your username and password."
-msgstr ""
-
-#: GrampsWebSync/grampswebsync.py:126
-msgid "Access forbidden. Please check username and password."
+#: GrampsWebSync/grampswebsync.py:124
+#, python-format
+msgid ""
+"The password could not be saved to the system keyring. Snap confinement "
+"blocks access until you run: %s"
 msgstr ""
 
 #: GrampsWebSync/grampswebsync.py:128
+msgid ""
+"The password could not be saved to the system keyring. You will need to "
+"enter it each time."
+msgstr ""
+
+#: GrampsWebSync/grampswebsync.py:145
+msgid "Authentication failed. Please check your username and password."
+msgstr ""
+
+#: GrampsWebSync/grampswebsync.py:148
+msgid "Access forbidden. Please check username and password."
+msgstr ""
+
+#: GrampsWebSync/grampswebsync.py:150
 msgid "GrampsWeb service not found. Please check the URL."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:130
+#: GrampsWebSync/grampswebsync.py:152
 msgid "Too many requests, please try again in a few seconds."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:132
+#: GrampsWebSync/grampswebsync.py:154
 msgid "GrampsWeb tree is disabled."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:134
+#: GrampsWebSync/grampswebsync.py:156
 msgid "Connection failed. Please check the URL and your internet connection."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:137
+#: GrampsWebSync/grampswebsync.py:159
 msgid "Invalid server response. Please check the URL."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:140
+#: GrampsWebSync/grampswebsync.py:162
 msgid "Your user does not have sufficient server permissions to use sync."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:142
+#: GrampsWebSync/grampswebsync.py:164
 msgid "Failed importing downloaded XML file."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:144
+#: GrampsWebSync/grampswebsync.py:166
 msgid "Unable to synchronize changes to server: objects have been modified."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:146
+#: GrampsWebSync/grampswebsync.py:168
 msgid "Unexpected error while applying changes."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:149
+#: GrampsWebSync/grampswebsync.py:170
+msgid ""
+"The family tree was modified while the changes were being reviewed. Nothing "
+"has been applied. Please compare again."
+msgstr ""
+
+#: GrampsWebSync/grampswebsync.py:175
+#, python-format
+msgid "The server could not apply the changes: %s"
+msgstr ""
+
+#: GrampsWebSync/grampswebsync.py:177
 #, python-format
 msgid "Server error %s. Please check your connection."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:151 GrampsWebSync/grampswebsync.py:152
+#: GrampsWebSync/grampswebsync.py:179 GrampsWebSync/grampswebsync.py:180
 #, python-format
 msgid "Unexpected error: %s"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:187
+#: GrampsWebSync/grampswebsync.py:221
 msgid "Introduction"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:195
+#: GrampsWebSync/grampswebsync.py:229
 msgid "Login"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:201 GrampsWebSync/grampswebsync.py:223
+#: GrampsWebSync/grampswebsync.py:235 GrampsWebSync/grampswebsync.py:257
 msgid "Progress Information"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:206
+#: GrampsWebSync/grampswebsync.py:240
 msgid "Final confirmation"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:211 GrampsWebSync/grampswebsync.py:227
+#: GrampsWebSync/grampswebsync.py:245 GrampsWebSync/grampswebsync.py:261
 msgid "Summary"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:216
+#: GrampsWebSync/grampswebsync.py:250
 msgid "Media Files"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:289
+#: GrampsWebSync/grampswebsync.py:341
 msgid "Fetching remote data..."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:292
+#: GrampsWebSync/grampswebsync.py:344
 msgid "Comparing local and remote data..."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:296
+#: GrampsWebSync/grampswebsync.py:348
 msgid "Successfully applied changes to local database."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:377
+#: GrampsWebSync/grampswebsync.py:437
 msgid "Continue without transport encryption?"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:379
+#: GrampsWebSync/grampswebsync.py:439
 msgid ""
 "You have specified a URL with http scheme. If you continue, your password "
 "will be sent in clear text over the network. Use only for local testing!"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:384
+#: GrampsWebSync/grampswebsync.py:444
 msgid "Continue with HTTP"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:385
+#: GrampsWebSync/grampswebsync.py:445
 msgid "Use HTTPS"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:435
+#: GrampsWebSync/grampswebsync.py:495
 msgid ""
 "This tool allows to synchronize the currently opened family tree with a "
 "remote family tree served by Gramps Web.\n"
@@ -151,131 +175,180 @@ msgid ""
 "option to make manual modifications, use the Import Merge Tool instead."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:462
+#: GrampsWebSync/grampswebsync.py:522
 msgid "Server URL: "
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:471
+#: GrampsWebSync/grampswebsync.py:531
 msgid "Username: "
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:479
+#: GrampsWebSync/grampswebsync.py:539
 msgid "Password: "
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:571
+#: GrampsWebSync/grampswebsync.py:578
+msgid "Error:"
+msgstr ""
+
+#: GrampsWebSync/grampswebsync.py:646
+msgid "Sync mode"
+msgstr ""
+
+#: GrampsWebSync/grampswebsync.py:656
+msgid ""
+"Changes from both sides are combined. Objects edited in both places are "
+"merged."
+msgstr ""
+
+#: GrampsWebSync/grampswebsync.py:660
+msgid ""
+"The server is made to match this computer. Anything changed only on the "
+"server is discarded."
+msgstr ""
+
+#: GrampsWebSync/grampswebsync.py:664
+msgid ""
+"This computer is made to match the server. Anything changed only here is "
+"discarded."
+msgstr ""
+
+#: GrampsWebSync/grampswebsync.py:671
 msgid "Bidirectional Synchronization"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:580
+#: GrampsWebSync/grampswebsync.py:672
 msgid "Reset remote to local"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:588
+#: GrampsWebSync/grampswebsync.py:673
 msgid "Reset local to remote"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:596
-msgid "Merge"
+#: GrampsWebSync/grampswebsync.py:712
+msgid "Warning:"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:622
+#: GrampsWebSync/grampswebsync.py:722
 msgid "Local changes"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:623 GrampsWebSync/grampswebsync.py:628
+#: GrampsWebSync/grampswebsync.py:723 GrampsWebSync/grampswebsync.py:728
 msgid "Added"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:624 GrampsWebSync/grampswebsync.py:629
+#: GrampsWebSync/grampswebsync.py:724 GrampsWebSync/grampswebsync.py:729
 msgid "Deleted"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:625 GrampsWebSync/grampswebsync.py:630
-#: GrampsWebSync/grampswebsync.py:632
+#: GrampsWebSync/grampswebsync.py:725 GrampsWebSync/grampswebsync.py:730
+#: GrampsWebSync/grampswebsync.py:732
 msgid "Modified"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:627
+#: GrampsWebSync/grampswebsync.py:727
 msgid "Remote changes"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:632
+#: GrampsWebSync/grampswebsync.py:732
 msgid "Simultaneous changes"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:689
+#: GrampsWebSync/grampswebsync.py:790
 msgid "Fetching information about media files..."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:715
+#: GrampsWebSync/grampswebsync.py:816
 msgid "Both trees are the same."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:721
+#: GrampsWebSync/grampswebsync.py:822
 msgid "Applying changes to local database ..."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:723
+#: GrampsWebSync/grampswebsync.py:824
 msgid "No changes to apply to local database."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:727
+#: GrampsWebSync/grampswebsync.py:828
 msgid "Applying changes to remote database ..."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:732
+#: GrampsWebSync/grampswebsync.py:833
 msgid "No changes to apply to remote database."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:761
+#: GrampsWebSync/grampswebsync.py:862
 msgid "Missing locally"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:764
+#: GrampsWebSync/grampswebsync.py:865
 msgid "Missing remotely"
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:804
+#: GrampsWebSync/grampswebsync.py:905
 #, python-format
 msgid "Downloading %s media file"
 msgid_plural "Downloading %s media files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: GrampsWebSync/grampswebsync.py:819
+#: GrampsWebSync/grampswebsync.py:920
 #, python-format
 msgid "Uploading %s media file"
 msgid_plural "Uploading %s media files"
 msgstr[0] ""
 msgstr[1] ""
 
-#: GrampsWebSync/grampswebsync.py:857
+#: GrampsWebSync/grampswebsync.py:965
+msgid "Try again"
+msgstr ""
+
+#: GrampsWebSync/grampswebsync.py:999
+#, python-format
+msgid "Applied %s change."
+msgid_plural "Applied %s changes."
+msgstr[0] ""
+msgstr[1] ""
+
+#: GrampsWebSync/grampswebsync.py:1006
 msgid "Media files are in sync."
 msgstr ""
 
-#: GrampsWebSync/grampswebsync.py:873
+#: GrampsWebSync/grampswebsync.py:1011
+#, python-format
+msgid "%s media file is missing on both sides and could not be transferred."
+msgid_plural ""
+"%s media files are missing on both sides and could not be transferred."
+msgstr[0] ""
+msgstr[1] ""
+
+#: GrampsWebSync/grampswebsync.py:1020
+msgid "Both trees are already in sync."
+msgstr ""
+
+#: GrampsWebSync/grampswebsync.py:1033
 #, python-format
 msgid "Successfully downloaded %s media file."
 msgid_plural "Successfully downloaded %s media files."
 msgstr[0] ""
 msgstr[1] ""
 
-#: GrampsWebSync/grampswebsync.py:883
+#: GrampsWebSync/grampswebsync.py:1043
 #, python-format
 msgid "Encountered %s error during download."
 msgid_plural "Encountered %s errors during download."
 msgstr[0] ""
 msgstr[1] ""
 
-#: GrampsWebSync/grampswebsync.py:896
+#: GrampsWebSync/grampswebsync.py:1056
 #, python-format
 msgid "Successfully uploaded %s media file."
 msgid_plural "Successfully uploaded %s media files."
 msgstr[0] ""
 msgstr[1] ""
 
-#: GrampsWebSync/grampswebsync.py:905
+#: GrampsWebSync/grampswebsync.py:1065
 #, python-format
 msgid "Encountered %s error during upload."
 msgid_plural "Encountered %s errors during upload."

--- a/GrampsWebSync/po/template.pot
+++ b/GrampsWebSync/po/template.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-31 15:54+0200\n"
+"POT-Creation-Date: 2026-07-31 17:35+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -30,14 +30,14 @@ msgstr ""
 #: GrampsWebSync/grampswebsync.py:124
 #, python-format
 msgid ""
-"The password could not be saved to the system keyring. Snap confinement "
-"blocks access until you run: %s"
+"The system keyring could not be used. Snap confinement blocks access until "
+"you run: %s"
 msgstr ""
 
 #: GrampsWebSync/grampswebsync.py:128
 msgid ""
-"The password could not be saved to the system keyring. You will need to "
-"enter it each time."
+"The system keyring could not be used. You will need to enter your password "
+"each time."
 msgstr ""
 
 #: GrampsWebSync/grampswebsync.py:145

--- a/GrampsWebSync/session.py
+++ b/GrampsWebSync/session.py
@@ -105,6 +105,7 @@ class Step(Enum):
     DIFF = auto()  # import it and compare (database)
     APPLY_LOCAL = auto()  # write the local half (database)
     PUSH_REMOTE = auto()  # send the remote half (network)
+    SCAN_MEDIA = auto()  # ask which files the server lacks (network)
     TRANSFER = auto()  # move media files (network)
 
 
@@ -308,6 +309,7 @@ STATE_FOR_STEP: dict[Step, State] = {
     Step.DIFF: State.COMPARING,
     Step.APPLY_LOCAL: State.APPLYING,
     Step.PUSH_REMOTE: State.APPLYING,
+    Step.SCAN_MEDIA: State.APPLYING,  # overridden by _scan_resume_state
     Step.TRANSFER: State.TRANSFERRING,
 }
 
@@ -387,6 +389,8 @@ class SyncSession:
         #: after a failed push must not re-run the local commit. Everything
         #: else a step hands to its successor travels as an argument.
         self._payload: list[dict[str, Any]] | None = None
+        #: Where a media scan was scheduled from, so a retry resumes there.
+        self._scan_resume_state: State = State.COMPARING
         self._closing = False
 
     # --------------------------------------------------------
@@ -491,7 +495,8 @@ class SyncSession:
         """
         runner = (
             self.io_runner
-            if step in (Step.FETCH, Step.PUSH_REMOTE, Step.TRANSFER)
+            if step
+            in (Step.FETCH, Step.PUSH_REMOTE, Step.SCAN_MEDIA, Step.TRANSFER)
             else self.runner
         )
         runner.run(func, on_success, lambda exc: self._on_step_error(exc, step))
@@ -580,7 +585,11 @@ class SyncSession:
         LOG.info("Retrying sync from %s.", step.name)
         self.error = None
         self.failed_in = None
-        self._goto(STATE_FOR_STEP[step])
+        self._goto(
+            self._scan_resume_state
+            if step is Step.SCAN_MEDIA
+            else STATE_FOR_STEP[step]
+        )
         if step is Step.FETCH:
             self._run(Step.FETCH, self._fetch_xml, self._on_fetched)
         elif step is Step.DIFF:
@@ -589,6 +598,8 @@ class SyncSession:
             self._run(Step.APPLY_LOCAL, self._apply_local, self._on_local_applied)
         elif step is Step.PUSH_REMOTE:
             self._run(Step.PUSH_REMOTE, self._push_remote, self._on_applied)
+        elif step is Step.SCAN_MEDIA:
+            self._start_media_scan()
         elif step is Step.TRANSFER:
             self._start_transfer()
 
@@ -667,11 +678,12 @@ class SyncSession:
         """Move on once the diff is available."""
         if self._closing:
             return
-        if not self.changes:
-            LOG.info("Databases are in sync.")
-            self.credentials.set_timestamp(self.url, self.username, self.clock.now())
-            self._scan_media()
-        self._advance()
+        if self.changes:
+            self._advance()
+            return
+        LOG.info("Databases are in sync.")
+        self.credentials.set_timestamp(self.url, self.username, self.clock.now())
+        self._start_media_scan()
 
     # --------------------------------------------------------
     # Applying
@@ -762,28 +774,51 @@ class SyncSession:
         if self._closing:
             return
         self.credentials.set_timestamp(self.url, self.username, self.clock.now())
-        self._scan_media()
-        self._advance()
+        self._start_media_scan()
 
     # --------------------------------------------------------
     # Media
     # --------------------------------------------------------
-    def _scan_media(self) -> None:
+    def _start_media_scan(self) -> None:
+        """Ask the server which files it lacks, off the main loop.
+
+        The state to come back to is captured here, because a failure moves the
+        session to ``FAILED`` and a retry has to resume from where the scan was
+        scheduled rather than from wherever it ended up.
+        """
+        self._scan_resume_state = self.state
+        self._run(Step.SCAN_MEDIA, self._fetch_remote_missing, self._on_media_scanned)
+
+    def _fetch_remote_missing(self) -> list[dict[str, Any]]:
+        """Return the server's list of media objects with no file. Network only."""
+        if self._closing:
+            return []
+        assert self.backend is not None
+        return self.backend.get_missing_files() or []
+
+    def _on_media_scanned(self, remote: list[dict[str, Any]] | None) -> None:
+        """Combine the server's answer with a local scan, back on the main loop."""
+        if self._closing:
+            return
+        self._scan_media(remote or [])
+        self._advance()
+
+    def _scan_media(self, remote: list[dict[str, Any]]) -> None:
         """Work out which media files are missing, and on which side.
 
         A file absent from both sides cannot be transferred in either
         direction, so it is separated out here rather than being attempted
         twice and reported as two failures.
+
+        :param remote: The server's missing-file list, already fetched.
         """
-        assert self.backend is not None
         local_missing = {
             media.handle: media.gramps_id
             for media in self.db1.iter_media()
             if not self.media.exists(media)
         }
         remote_missing = {
-            media["handle"]: media["gramps_id"]
-            for media in self.backend.get_missing_files() or []
+            media["handle"]: media["gramps_id"] for media in remote
         }
         both = set(local_missing) & set(remote_missing)
 

--- a/GrampsWebSync/session.py
+++ b/GrampsWebSync/session.py
@@ -22,12 +22,18 @@
 progressing through the stages in :class:`State`. Callers drive it with
 :meth:`~SyncSession.begin`, :meth:`~SyncSession.submit_credentials`,
 :meth:`~SyncSession.confirm_changes` and :meth:`~SyncSession.confirm_files`,
-and observe it through a :class:`SessionListener`.
+and observe it through a :class:`SessionListener`. A failed run can be resumed
+with :meth:`~SyncSession.retry`.
 
 Collaborators are supplied as ports: :class:`Backend`,
 :class:`CredentialStore`, :class:`MediaStore`, :class:`TaskRunner` and
 :class:`Clock`. Failures are recorded as a :class:`SyncError` carrying an
 :class:`ErrorKind`; callers are responsible for localizing them.
+
+Each stage is split into the part that touches a database and the part that
+talks to the network, because only the latter may leave the main loop -- see
+:class:`adapters.IoRunner`. :data:`Step` names the pieces so that a retry can
+resume at the one that failed rather than redoing the work before it.
 """
 
 from __future__ import annotations
@@ -38,7 +44,6 @@ from dataclasses import dataclass
 from enum import Enum, auto
 from pathlib import Path
 from typing import Any, Protocol
-from urllib.error import HTTPError, URLError
 
 from const import MODE_BIDIRECTIONAL, Actions
 from diffhandler import (
@@ -50,7 +55,7 @@ from diffhandler import (
 from gramps.gen.db import DbTxn
 from gramps.gen.db.utils import import_as_dict
 from gramps.gen.errors import HandleError
-from webapihandler import transaction_to_json
+from webapihandler import ServerTaskFailed, transaction_to_json
 
 LOG = logging.getLogger("grampswebsync")
 
@@ -59,6 +64,9 @@ TXN_MSG = "Apply Gramps Web Sync changes"
 
 #: Server permission required to run a sync at all.
 REQUIRED_PERMISSION = "ViewPrivate"
+
+#: A media transfer, resolved to a local path before it leaves the main loop.
+Transfers = list[tuple[str, str, str]]
 
 #: Stages reported through :meth:`SessionListener.on_status`.
 STATUS_FETCHING = "fetching"
@@ -85,6 +93,21 @@ class State(Enum):
     FAILED = auto()
 
 
+class Step(Enum):
+    """The resumable pieces of a run.
+
+    A stage that both touches a database and talks to the network is two of
+    these, so that a retry after, say, a dropped connection while pushing does
+    not re-apply the local half that already succeeded.
+    """
+
+    FETCH = auto()  # download the remote XML (network)
+    DIFF = auto()  # import it and compare (database)
+    APPLY_LOCAL = auto()  # write the local half (database)
+    PUSH_REMOTE = auto()  # send the remote half (network)
+    TRANSFER = auto()  # move media files (network)
+
+
 class ErrorKind(Enum):
     """Classification of a failure, independent of its localized wording."""
 
@@ -95,11 +118,13 @@ class ErrorKind(Enum):
     TREE_DISABLED = auto()  # HTTP 503
     CONFLICT = auto()  # HTTP 409
     SERVER_ERROR = auto()
+    SERVER_TASK_FAILED = auto()
     CONNECTION_FAILED = auto()
     INVALID_RESPONSE = auto()
     INSUFFICIENT_PERMISSIONS = auto()
     XML_IMPORT_FAILED = auto()
     APPLY_FAILED = auto()
+    STALE_LOCAL_DATA = auto()
     UNEXPECTED = auto()
 
 
@@ -123,6 +148,10 @@ class ApplyFailed(Exception):
     """Applying the confirmed actions to the databases raised."""
 
 
+class StaleLocalData(Exception):
+    """The local tree changed between the comparison and the commit."""
+
+
 # Login and mid-sync failures read a few status codes differently.
 _LOGIN_HTTP_ERRORS: dict[int, ErrorKind] = {
     401: ErrorKind.AUTH_FAILED,
@@ -140,7 +169,7 @@ _SYNC_HTTP_ERRORS: dict[int, ErrorKind] = {
 }
 
 
-def classify_http_error(exc: HTTPError, *, login: bool) -> SyncError:
+def classify_http_error(exc: Any, *, login: bool) -> SyncError:
     """Classify an :class:`HTTPError` into a :class:`SyncError`.
 
     :param exc: The raised error.
@@ -184,7 +213,7 @@ class Backend(Protocol):
 
 
 class CredentialStore(Protocol):
-    """Persistence for server credentials and the last-sync timestamp."""
+    """Persistence for server credentials and per-server sync baselines."""
 
     def get_url(self) -> str: ...
 
@@ -192,11 +221,13 @@ class CredentialStore(Protocol):
 
     def get_password(self) -> str | None: ...
 
-    def get_timestamp(self) -> float: ...
+    def get_timestamp(self, url: str, username: str) -> float: ...
 
-    def set_timestamp(self, timestamp: float) -> None: ...
+    def set_timestamp(self, url: str, username: str, timestamp: float) -> None: ...
 
-    def save_credentials(self, url: str, username: str, password: str) -> None: ...
+    def save_credentials(
+        self, url: str, username: str, password: str, remember_password: bool = True
+    ) -> None: ...
 
 
 class MediaStore(Protocol):
@@ -216,6 +247,8 @@ class TaskRunner(Protocol):
         on_success: Callable[[Any], None],
         on_error: Callable[[BaseException], None],
     ) -> None: ...
+
+    def post(self, func: Callable[[], None]) -> None: ...
 
 
 class Clock(Protocol):
@@ -269,6 +302,16 @@ def next_state(state: State, session: SyncSession) -> State:
     return state
 
 
+#: Which state a retry of each step returns to while it runs.
+STATE_FOR_STEP: dict[Step, State] = {
+    Step.FETCH: State.COMPARING,
+    Step.DIFF: State.COMPARING,
+    Step.APPLY_LOCAL: State.APPLYING,
+    Step.PUSH_REMOTE: State.APPLYING,
+    Step.TRANSFER: State.TRANSFERRING,
+}
+
+
 # ------------------------------------------------------------
 #
 # SyncSession
@@ -287,6 +330,7 @@ class SyncSession:
         runner: TaskRunner,
         clock: Clock,
         listener: SessionListener | None = None,
+        io_runner: TaskRunner | None = None,
     ) -> None:
         """Initialize the session.
 
@@ -294,11 +338,13 @@ class SyncSession:
         :param user: A :class:`gramps.gen.user.User` for import/diff progress.
         :param backend_factory: Builds a :class:`Backend` from url, username
             and password.
-        :param credentials: Where credentials and the last-sync time live.
+        :param credentials: Where credentials and sync baselines live.
         :param media: Access to local media files.
-        :param runner: Executes the slow steps.
+        :param runner: Executes steps that touch a database, on the main loop.
         :param clock: Supplies the time recorded as the last successful sync.
         :param listener: Optional observer of state and progress.
+        :param io_runner: Executes network steps. Defaults to ``runner``, which
+            keeps everything on one thread -- useful in tests.
         """
         self.db1 = db
         self.db2 = None
@@ -307,6 +353,7 @@ class SyncSession:
         self.credentials = credentials
         self.media = media
         self.runner = runner
+        self.io_runner = io_runner if io_runner is not None else runner
         self.clock = clock
         self.listener = listener
 
@@ -314,6 +361,13 @@ class SyncSession:
         self.error: SyncError | None = None
         #: Set when login fails. Recoverable, unlike :attr:`error`.
         self.login_error: SyncError | None = None
+        #: Which step failed, so :meth:`retry` can resume at the right place.
+        self.failed_in: Step | None = None
+
+        self.url: str = ""
+        self.username: str = ""
+        self.password: str = ""
+        self.remember_password: bool = True
 
         self.backend: Backend | None = None
         self.sync: WebApiSyncDiffHandler | None = None
@@ -323,9 +377,16 @@ class SyncSession:
 
         self.missing_local: list[tuple[str, str]] = []
         self.missing_remote: list[tuple[str, str]] = []
+        #: Media absent on both sides. Neither transfer can supply these, so
+        #: they are reported up front rather than as two failures each.
+        self.missing_both: list[tuple[str, str]] = []
         self.downloaded: dict[str, bool] = {}
         self.uploaded: dict[str, bool] = {}
 
+        #: Held between the two halves of the apply stage, because a retry
+        #: after a failed push must not re-run the local commit. Everything
+        #: else a step hands to its successor travels as an argument.
+        self._payload: list[dict[str, Any]] | None = None
         self._closing = False
 
     # --------------------------------------------------------
@@ -333,7 +394,7 @@ class SyncSession:
     # --------------------------------------------------------
     @property
     def has_missing_files(self) -> bool:
-        """Whether any media file is missing on either side."""
+        """Whether any media file can actually be transferred either way."""
         return bool(self.missing_local or self.missing_remote)
 
     @property
@@ -345,6 +406,11 @@ class SyncSession:
     def has_remote_actions(self) -> bool:
         """Whether the pending actions touch the remote database."""
         return has_remote_actions(self.actions)
+
+    @property
+    def can_retry(self) -> bool:
+        """Whether :meth:`retry` has a step to resume."""
+        return self.state is State.FAILED and self.failed_in is not None
 
     # --------------------------------------------------------
     # Internals
@@ -360,10 +426,16 @@ class SyncSession:
         """Move to whatever :func:`next_state` says comes next."""
         self._goto(next_state(self.state, self))
 
-    def _fail(self, error: SyncError) -> None:
-        """Record a terminal failure and move to :attr:`State.FAILED`."""
+    def _fail(self, error: SyncError, step: Step | None = None) -> None:
+        """Record a terminal failure and move to :attr:`State.FAILED`.
+
+        The remote database is deliberately kept open: a retry that had to
+        re-download and re-diff it would throw away the most expensive part of
+        the run for what is usually a transient network problem.
+        """
         LOG.warning("Sync failed: %s (%s)", error.kind.name, error.detail)
         self.error = error
+        self.failed_in = step
         self._goto(State.FAILED)
 
     def _progress(self, kind: str, fraction: float) -> None:
@@ -376,10 +448,29 @@ class SyncSession:
         if self.listener is not None:
             self.listener.on_status(stage)
 
+    def _progress_from_worker(self, kind: str, fraction: float) -> None:
+        """Report progress raised inside a network step.
+
+        Marshalled onto the main loop, since the listener draws widgets and the
+        step is running on a worker thread.
+        """
+        self.io_runner.post(lambda: self._progress(kind, fraction))
+
+    def _status_from_worker(self, stage: str) -> None:
+        """Report a status update raised inside a network step."""
+        self.io_runner.post(lambda: self._status(stage))
+
     def _classify(self, exc: BaseException, *, login: bool = False) -> SyncError:
         """Turn an exception raised by a port into a :class:`SyncError`."""
+        # Imported here so the module stays importable without urllib present.
+        from urllib.error import HTTPError, URLError
+
         if isinstance(exc, XmlImportFailed):
             return SyncError(ErrorKind.XML_IMPORT_FAILED)
+        if isinstance(exc, StaleLocalData):
+            return SyncError(ErrorKind.STALE_LOCAL_DATA)
+        if isinstance(exc, ServerTaskFailed):
+            return SyncError(ErrorKind.SERVER_TASK_FAILED, str(exc))
         if isinstance(exc, ApplyFailed):
             return SyncError(ErrorKind.APPLY_FAILED, str(exc))
         if isinstance(exc, HTTPError):
@@ -391,6 +482,20 @@ class SyncSession:
             return SyncError(kind, str(exc))
         return SyncError(ErrorKind.UNEXPECTED, str(exc))
 
+    def _run(self, step: Step, func, on_success) -> None:
+        """Schedule ``step`` on the runner that is allowed to execute it.
+
+        Network steps go to a worker thread; database steps stay on the main
+        loop, because a Gramps sqlite connection belongs to the thread that
+        created it.
+        """
+        runner = (
+            self.io_runner
+            if step in (Step.FETCH, Step.PUSH_REMOTE, Step.TRANSFER)
+            else self.runner
+        )
+        runner.run(func, on_success, lambda exc: self._on_step_error(exc, step))
+
     # --------------------------------------------------------
     # Intents
     # --------------------------------------------------------
@@ -398,18 +503,30 @@ class SyncSession:
         """Leave the introduction page."""
         self._advance()
 
-    def submit_credentials(self, url: str, username: str, password: str) -> None:
+    def submit_credentials(
+        self,
+        url: str,
+        username: str,
+        password: str,
+        remember_password: bool = True,
+    ) -> None:
         """Connect, authenticate, then download and diff the remote tree.
 
         On an authentication or permission problem the session stays on
-        :attr:`State.LOGIN` with :attr:`login_error` set.
+        :attr:`State.LOGIN` with :attr:`login_error` set. Credentials are stored
+        only once the server has accepted them, so a typo never reaches the
+        keyring.
 
         :param url: Server URL, already sanitized by the caller.
         :param username: Login name.
         :param password: Password.
+        :param remember_password: Whether the password may be stored.
         """
         self.login_error = None
-        self.credentials.save_credentials(url, username, password)
+        self.url = url
+        self.username = username
+        self.password = password
+        self.remember_password = remember_password
 
         try:
             self.backend = self._backend_factory(url, username, password)
@@ -425,8 +542,10 @@ class SyncSession:
             self._goto(State.LOGIN)
             return
 
-        self._goto(State.COMPARING)
-        self.runner.run(self._compare, self._on_compared, self._on_step_error)
+        self.credentials.save_credentials(
+            url, username, password, remember_password
+        )
+        self._start_compare()
 
     def confirm_changes(self, sync_mode: int) -> None:
         """Accept the reviewed changes and apply them.
@@ -435,7 +554,7 @@ class SyncSession:
         """
         self.sync_mode = sync_mode
         self._goto(State.APPLYING)
-        self.runner.run(self._apply, self._on_applied, self._on_step_error)
+        self._run(Step.APPLY_LOCAL, self._apply_local, self._on_local_applied)
 
     def confirm_files(self) -> None:
         """Accept the media file transfer and carry it out.
@@ -446,44 +565,99 @@ class SyncSession:
             self._advance()
             return
         self._goto(State.TRANSFERRING)
-        self.runner.run(self._transfer, self._on_transferred, self._on_step_error)
+        self._start_transfer()
+
+    def retry(self) -> None:
+        """Resume a failed run at the step that failed.
+
+        Everything before that step is left alone: the remote tree is still
+        downloaded and diffed, and a local commit that already succeeded is not
+        repeated.
+        """
+        step = self.failed_in
+        if step is None:
+            return
+        LOG.info("Retrying sync from %s.", step.name)
+        self.error = None
+        self.failed_in = None
+        self._goto(STATE_FOR_STEP[step])
+        if step is Step.FETCH:
+            self._run(Step.FETCH, self._fetch_xml, self._on_fetched)
+        elif step is Step.DIFF:
+            self._start_compare()
+        elif step is Step.APPLY_LOCAL:
+            self._run(Step.APPLY_LOCAL, self._apply_local, self._on_local_applied)
+        elif step is Step.PUSH_REMOTE:
+            self._run(Step.PUSH_REMOTE, self._push_remote, self._on_applied)
+        elif step is Step.TRANSFER:
+            self._start_transfer()
 
     def cancel(self) -> None:
         """Abandon the run and release the in-memory remote database."""
         self._closing = True
+        self._release_remote()
+
+    def _release_remote(self) -> None:
+        """Close the downloaded remote database, if one is open."""
         if self.db2 is not None:
             self.db2.close()
             self.db2 = None
         self.sync = None  # holds references to both databases
 
     # --------------------------------------------------------
-    # Steps
+    # Comparison
     # --------------------------------------------------------
-    def _on_step_error(self, exc: BaseException) -> None:
-        """Handle an exception escaping one of the background steps."""
-        self._fail(self._classify(exc))
+    def _start_compare(self) -> None:
+        """Enter the comparison stage and fetch the remote tree."""
+        self._goto(State.COMPARING)
+        self._run(Step.FETCH, self._fetch_xml, self._on_fetched)
 
-    def _compare(self) -> None:
-        """Download the remote tree and diff it against the local one."""
+    def _fetch_xml(self) -> Path | None:
+        """Download the remote tree as Gramps XML. Network only.
+
+        :returns: Where the export was written, for the next step.
+        """
         if self._closing:
-            return
+            return None
         assert self.backend is not None
         LOG.info("Downloading Gramps XML file.")
-        self._status(STATUS_FETCHING)
+        self._status_from_worker(STATUS_FETCHING)
         path = self.backend.download_xml()
         LOG.debug("Downloaded XML to %s", path)
+        return path
 
+    def _on_fetched(self, path: Path | None) -> None:
+        """Import and diff, back on the main loop."""
+        if self._closing or path is None:
+            return
+        self._run(
+            Step.DIFF, lambda: self._import_and_diff(path), self._on_compared
+        )
+
+    def _import_and_diff(self, path: Path) -> None:
+        """Import the downloaded XML and diff it against the local tree.
+
+        Runs on the main loop: ``import_as_dict`` builds an in-memory sqlite
+        database on the calling thread, and ``diff_dbs`` reads the local one,
+        which belongs to the main thread.
+
+        :param path: The export downloaded by :meth:`_fetch_xml`. It is
+            consumed here, which is why retrying this step downloads again.
+        """
+        if self._closing:
+            return
         try:
             db2 = import_as_dict(str(path), self._user)
         finally:
-            path.unlink()
+            path.unlink(missing_ok=True)
         if db2 is None:
             raise XmlImportFailed()
+        self._release_remote()
         self.db2 = db2
 
         LOG.info("Comparing local and remote data.")
         self._status(STATUS_COMPARING)
-        last_synced = self.credentials.get_timestamp() or None
+        last_synced = self.credentials.get_timestamp(self.url, self.username) or None
         self.sync = WebApiSyncDiffHandler(
             self.db1, self.db2, user=self._user, last_synced=last_synced
         )
@@ -495,19 +669,28 @@ class SyncSession:
             return
         if not self.changes:
             LOG.info("Databases are in sync.")
-            self.credentials.set_timestamp(self.clock.now())
-            self.missing_local = self._find_missing_local()
-            self.missing_remote = self._find_missing_remote()
+            self.credentials.set_timestamp(self.url, self.username, self.clock.now())
+            self._scan_media()
         self._advance()
 
-    def _apply(self) -> None:
-        """Apply the confirmed actions locally, then push them to the server."""
+    # --------------------------------------------------------
+    # Applying
+    # --------------------------------------------------------
+    def _apply_local(self) -> None:
+        """Write the local half of the sync and build the remote payload.
+
+        Runs on the main loop: both halves are prepared inside Gramps
+        transactions against databases owned by this thread.
+        """
         if self._closing:
             return
         assert self.backend is not None and self.sync is not None
         self.actions = changes_to_actions(self.changes, self.sync_mode)
+        self._payload = []
         if not self.actions:
             return
+
+        self._assert_local_unchanged()
 
         LOG.info("Committing %s actions.", len(self.actions))
         try:
@@ -515,50 +698,175 @@ class SyncSession:
                 with DbTxn(TXN_MSG, self.sync.db2) as trans2:
                     self.sync.commit_actions(self.actions, trans1, trans2)
                     lang = self.backend.get_lang()
-                    payload = transaction_to_json(trans2, lang)
+                    self._payload = transaction_to_json(trans2, lang)
+        except StaleLocalData:
+            raise
         except Exception as exc:
             raise ApplyFailed(str(exc)) from exc
 
         if self.has_local_actions:
             self._status(STATUS_LOCAL_APPLIED)
 
+    def _assert_local_unchanged(self) -> None:
+        """Verify the local tree still matches what the comparison saw.
+
+        The comparison captured object snapshots, and the user may have gone on
+        editing the tree while reviewing them -- the tool does not block the
+        main window. Committing those snapshots would silently overwrite any
+        edit made in between, so the run stops instead and re-compares.
+
+        :raises StaleLocalData: If any affected object changed or appeared.
+        """
+        for _typ, handle, obj_type, obj1, _obj2 in self.actions:
+            method = self.db1.method("get_%s_from_handle", obj_type)
+            if method is None:
+                continue
+            try:
+                current = method(handle)
+            except HandleError:
+                current = None
+            if obj1 is None:
+                # Absent locally when compared; anything here now is new.
+                if current is not None:
+                    raise StaleLocalData(f"{obj_type} {handle} was added locally")
+            elif current is None:
+                raise StaleLocalData(f"{obj_type} {handle} was deleted locally")
+            elif current.change != obj1.change:
+                raise StaleLocalData(f"{obj_type} {handle} was modified locally")
+
+    def _on_local_applied(self, _result: Any) -> None:
+        """Push the remote half, off the main loop."""
+        if self._closing:
+            return
+        self._run(Step.PUSH_REMOTE, self._push_remote, self._on_applied)
+
+    def _push_remote(self) -> None:
+        """Send the remote half of the sync to the server. Network only."""
+        if self._closing:
+            return
+        assert self.backend is not None
+        if not self._payload:
+            return
         # Always force: the server compares against the XML-round-tripped
         # object, which differs from the live one through serialization
         # artifacts alone, yielding spurious 409s.
         self.backend.commit(
-            payload, True, lambda fraction: self._progress("api", fraction)
+            self._payload,
+            True,
+            lambda fraction: self._progress_from_worker("api", fraction),
         )
+        self._payload = []
 
     def _on_applied(self, _result: Any) -> None:
         """Record the sync time and collect media state."""
         if self._closing:
             return
-        self.credentials.set_timestamp(self.clock.now())
-        self.missing_local = self._find_missing_local()
-        self.missing_remote = self._find_missing_remote()
+        self.credentials.set_timestamp(self.url, self.username, self.clock.now())
+        self._scan_media()
         self._advance()
 
-    def _transfer(self) -> None:
-        """Download media missing locally, then upload media missing remotely.
+    # --------------------------------------------------------
+    # Media
+    # --------------------------------------------------------
+    def _scan_media(self) -> None:
+        """Work out which media files are missing, and on which side.
 
-        Progress reporting lets the view pump the event loop, so the user can
-        cancel mid-transfer; both loops check for that between files.
+        A file absent from both sides cannot be transferred in either
+        direction, so it is separated out here rather than being attempted
+        twice and reported as two failures.
+        """
+        assert self.backend is not None
+        local_missing = {
+            media.handle: media.gramps_id
+            for media in self.db1.iter_media()
+            if not self.media.exists(media)
+        }
+        remote_missing = {
+            media["handle"]: media["gramps_id"]
+            for media in self.backend.get_missing_files() or []
+        }
+        both = set(local_missing) & set(remote_missing)
+
+        self.missing_both = [(local_missing[h], h) for h in both]
+        self.missing_local = [
+            (gid, h) for h, gid in local_missing.items() if h not in both
+        ]
+        self.missing_remote = [
+            (gid, h) for h, gid in remote_missing.items() if h not in both
+        ]
+        if self.missing_both:
+            LOG.warning(
+                "%s media file(s) are missing on both sides.", len(self.missing_both)
+            )
+
+    def _resolve_transfers(self) -> tuple[Transfers, Transfers]:
+        """Turn the missing-file lists into paths, on the main loop.
+
+        The transfer itself runs on a worker thread and must not touch the
+        local database, so every handle is resolved to a path first. Files a
+        previous attempt already moved are left out, so a retry after a dropped
+        connection resumes rather than starting over.
+
+        :returns: The downloads and uploads still to do.
+        """
+        downloads: Transfers = []
+        uploads: Transfers = []
+        for gramps_id, handle in self.missing_local:
+            path = self._path_for(handle)
+            if path is None:
+                self.downloaded[gramps_id] = False
+            elif not self.downloaded.get(gramps_id):
+                downloads.append((gramps_id, handle, path))
+        for gramps_id, handle in self.missing_remote:
+            path = self._path_for(handle)
+            if path is None:
+                self.uploaded[gramps_id] = False
+            elif not self.uploaded.get(gramps_id):
+                uploads.append((gramps_id, handle, path))
+        return downloads, uploads
+
+    def _start_transfer(self) -> None:
+        """Resolve paths on the main loop, then transfer off it."""
+        downloads, uploads = self._resolve_transfers()
+        self._run(
+            Step.TRANSFER,
+            lambda: self._transfer(downloads, uploads),
+            self._on_transferred,
+        )
+
+    def _path_for(self, handle: str) -> str | None:
+        """Return the local path of a media object, or ``None`` if unusable."""
+        try:
+            obj = self.db1.get_media_from_handle(handle)
+        except HandleError:
+            LOG.warning("Cannot access media object %s", handle)
+            return None
+        return self.media.full_path(obj)
+
+    def _transfer(self, downloads: Transfers, uploads: Transfers) -> None:
+        """Download then upload media files. Network only.
+
+        Both loops check for cancellation between files, so closing the window
+        stops the transfer rather than waiting for it to finish.
+
+        :param downloads: Files to fetch, as ``(gramps_id, handle, path)``.
+        :param uploads: Files to send, in the same form.
         """
         if self._closing:
             return
         assert self.backend is not None
-        for gramps_id, handle in self.missing_local:
+        for index, (gramps_id, handle, path) in enumerate(downloads, start=1):
             if self._closing:
                 return
             LOG.debug("Downloading file %s", gramps_id)
-            self.downloaded[gramps_id] = self._download_one(handle)
-            self._progress("download", len(self.downloaded) / len(self.missing_local))
-        for gramps_id, handle in self.missing_remote:
+            self.downloaded[gramps_id] = self._download_one(handle, path)
+            self._progress_from_worker("download", index / len(downloads))
+        for index, (gramps_id, handle, path) in enumerate(uploads, start=1):
             if self._closing:
                 return
             LOG.debug("Uploading file %s", gramps_id)
-            self.uploaded[gramps_id] = self._upload_one(handle)
-            self._progress("upload", len(self.uploaded) / len(self.missing_remote))
+            self.uploaded[gramps_id] = self._upload_one(handle, path)
+            self._progress_from_worker("upload", index / len(uploads))
 
     def _on_transferred(self, _result: Any) -> None:
         """Finish the run."""
@@ -566,62 +874,38 @@ class SyncSession:
             return
         self._advance()
 
-    # --------------------------------------------------------
-    # Media helpers
-    # --------------------------------------------------------
-    def _find_missing_local(self) -> list[tuple[str, str]]:
-        """Return ``(gramps_id, handle)`` for media whose file is absent locally."""
-        return [
-            (media.gramps_id, media.handle)
-            for media in self.db1.iter_media()
-            if not self.media.exists(media)
-        ]
-
-    def _find_missing_remote(self) -> list[tuple[str, str]]:
-        """Return ``(gramps_id, handle)`` for media whose file is absent remotely."""
-        assert self.backend is not None
-        return [
-            (media["gramps_id"], media["handle"])
-            for media in self.backend.get_missing_files() or []
-        ]
-
-    def _download_one(self, handle: str) -> bool:
+    def _download_one(self, handle: str, path: str) -> bool:
         """Download one media file, reporting failure rather than raising."""
         assert self.backend is not None
         try:
-            obj = self.db1.get_media_from_handle(handle)
-        except HandleError:
-            LOG.warning("Cannot access media object %s", handle)
-            return False
-        try:
-            return self.backend.download_media_file(handle, self.media.full_path(obj))
+            return self.backend.download_media_file(handle, path)
         except Exception as exc:  # noqa: BLE001 -- one bad file must not abort
-            LOG.warning("Failed to download media file %s: %s", obj.gramps_id, exc)
+            LOG.warning("Failed to download media file %s: %s", handle, exc)
             return False
 
-    def _upload_one(self, handle: str) -> bool:
+    def _upload_one(self, handle: str, path: str) -> bool:
         """Upload one media file.
 
-        A file absent on both sides appears in both missing lists: the
-        download cannot supply it and there is nothing local to send, so it is
-        recorded as a failure instead of raising.
-
         :param handle: Handle of the media object to upload.
+        :param path: Where its file lives locally.
         :returns: Whether the file was uploaded.
         """
+        import os
+
         assert self.backend is not None
-        try:
-            obj = self.db1.get_media_from_handle(handle)
-        except HandleError:
-            LOG.warning("Cannot access media object %s", handle)
+        if not os.path.exists(path):
+            LOG.warning("Cannot upload media file %s: not on disk (%s)", handle, path)
             return False
-        if not self.media.exists(obj):
-            LOG.warning(
-                "Cannot upload media file %s: missing locally as well (%s)",
-                obj.gramps_id,
-                self.media.full_path(obj),
-            )
-            return False
-        return self.backend.upload_media_file(handle, self.media.full_path(obj))
+        return self.backend.upload_media_file(handle, path)
 
-
+    # --------------------------------------------------------
+    # Step failure
+    # --------------------------------------------------------
+    def _on_step_error(self, exc: BaseException, step: Step) -> None:
+        """Handle an exception escaping one of the steps."""
+        if self._closing:
+            return
+        # Stale local data means the snapshots are worthless; a retry has to
+        # compare again rather than resume where it stopped.
+        resume = Step.DIFF if isinstance(exc, StaleLocalData) else step
+        self._fail(self._classify(exc), resume)

--- a/GrampsWebSync/session.py
+++ b/GrampsWebSync/session.py
@@ -481,6 +481,9 @@ class SyncSession:
             return classify_http_error(exc, login=login)
         if isinstance(exc, URLError):
             return SyncError(ErrorKind.CONNECTION_FAILED, str(exc.reason))
+        # A read that times out raises this directly, not wrapped in URLError.
+        if isinstance(exc, TimeoutError):
+            return SyncError(ErrorKind.CONNECTION_FAILED, str(exc))
         if isinstance(exc, ValueError):
             kind = ErrorKind.INVALID_RESPONSE if login else ErrorKind.SERVER_ERROR
             return SyncError(kind, str(exc))
@@ -822,7 +825,7 @@ class SyncSession:
         }
         both = set(local_missing) & set(remote_missing)
 
-        self.missing_both = [(local_missing[h], h) for h in both]
+        self.missing_both = sorted((local_missing[h], h) for h in both)
         self.missing_local = [
             (gid, h) for h, gid in local_missing.items() if h not in both
         ]

--- a/GrampsWebSync/tests/fakes.py
+++ b/GrampsWebSync/tests/fakes.py
@@ -235,7 +235,8 @@ class InlineTaskRunner:
     """Runs each task synchronously on the calling thread.
 
     By the time ``run`` returns, the step and its completion callback have
-    both finished.
+    both finished. Standing in for both runners keeps scenarios single-threaded
+    and their assertions deterministic.
     """
 
     def run(
@@ -251,6 +252,10 @@ class InlineTaskRunner:
             on_error(exc)
         else:
             on_success(result)
+
+    def post(self, func: Callable[[], None]) -> None:
+        """Run ``func`` immediately; there is no other thread to marshal from."""
+        func()
 
 
 class FrozenClock:
@@ -274,6 +279,9 @@ class FrozenClock:
 class MemoryCredentialStore:
     """In-memory stand-in for the config file and keyring.
 
+    Keyed by ``(url, username)`` like the real store, so each server keeps its
+    own sync baseline and switching between them does not discard one.
+
     :param url: Initially stored server URL.
     :param username: Initially stored user name.
     :param password: Initially stored password.
@@ -290,10 +298,22 @@ class MemoryCredentialStore:
         self.url = url
         self.username = username
         self.password = password
-        self.timestamp = timestamp
+        #: ``(url, username)`` -> last successful sync time.
+        self.timestamps: dict[tuple[str, str], float] = {(url, username): timestamp}
+        #: ``(url, username)`` -> whether its password may be stored.
+        self.remembered: dict[tuple[str, str], bool] = {}
         #: Every ``(url, username, password)`` passed to
         #: :meth:`save_credentials`.
         self.saved: list[tuple[str, str, str]] = []
+
+    @property
+    def timestamp(self) -> float:
+        """The baseline of the last-used entry, for convenient assertions."""
+        return self.timestamps.get((self.url, self.username), 0.0)
+
+    @timestamp.setter
+    def timestamp(self, value: float) -> None:
+        self.timestamps[(self.url, self.username)] = value
 
     def get_url(self) -> str:
         return self.url
@@ -304,19 +324,22 @@ class MemoryCredentialStore:
     def get_password(self) -> str | None:
         return self.password
 
-    def get_timestamp(self) -> float:
-        return self.timestamp
+    def get_timestamp(self, url: str, username: str) -> float:
+        return self.timestamps.get((url, username), 0.0)
 
-    def set_timestamp(self, timestamp: float) -> None:
-        self.timestamp = timestamp
-
-    def save_credentials(self, url: str, username: str, password: str) -> None:
-        # A changed URL invalidates the last-sync time, as in production.
-        if url != self.url:
-            self.timestamp = 0.0
+    def set_timestamp(self, url: str, username: str, timestamp: float) -> None:
+        self.timestamps[(url, username)] = timestamp
         self.url = url
         self.username = username
-        self.password = password
+
+    def save_credentials(
+        self, url: str, username: str, password: str, remember_password: bool = True
+    ) -> None:
+        self.url = url
+        self.username = username
+        self.password = password if remember_password else None
+        self.remembered[(url, username)] = remember_password
+        self.timestamps.setdefault((url, username), 0.0)
         self.saved.append((url, username, password))
 
 

--- a/GrampsWebSync/tests/scenario.py
+++ b/GrampsWebSync/tests/scenario.py
@@ -58,6 +58,11 @@ from .fakes import (
     RecordingListener,
 )
 
+#: The server a scenario authenticates against unless told otherwise. Named so
+#: that tests asserting on a per-server baseline can name the same entry.
+DEFAULT_URL = "https://example.org/api"
+DEFAULT_USERNAME = "owner"
+
 #: A convenient baseline "already synced" time for scenarios.
 T0 = 1_600_000_000.0
 #: A time after :data:`T0`, for an edit on one side.
@@ -348,8 +353,8 @@ class SyncScenario:
         self,
         mode: int = MODE_BIDIRECTIONAL,
         confirm_files: bool = True,
-        url: str = "https://example.org/api",
-        username: str = "owner",
+        url: str = DEFAULT_URL,
+        username: str = DEFAULT_USERNAME,
         password: str = "secret",
     ) -> RunResult:
         """Drive a complete sync, answering every confirmation.

--- a/GrampsWebSync/tests/test_adapters.py
+++ b/GrampsWebSync/tests/test_adapters.py
@@ -27,35 +27,39 @@ from __future__ import annotations
 import threading
 import unittest
 
-from adapters import GLibTaskRunner
+from adapters import GLibTaskRunner, IoRunner
 from gi.repository import GLib
 
 #: Milliseconds before an unresponsive loop is torn down.
 TIMEOUT_MS = 5000
 
 
-def run_task(func):
-    """Run ``func`` through :class:`GLibTaskRunner` and return the outcome.
+def run_task(func, runner=None):
+    """Run ``func`` through a runner and return the outcome.
 
     :param func: The task to schedule.
-    :returns: Dict with ``result`` or ``error``, and ``thread``.
+    :param runner: The runner to use. Defaults to :class:`GLibTaskRunner`.
+    :returns: Dict with ``result`` or ``error``, ``thread`` and
+        ``callback_thread``.
     """
     outcome: dict = {}
     loop = GLib.MainLoop()
 
     def on_success(result):
         outcome["result"] = result
+        outcome["callback_thread"] = threading.current_thread()
         loop.quit()
 
     def on_error(exc):
         outcome["error"] = exc
+        outcome["callback_thread"] = threading.current_thread()
         loop.quit()
 
     def wrapped():
         outcome["thread"] = threading.current_thread()
         return func()
 
-    GLibTaskRunner().run(wrapped, on_success, on_error)
+    (runner or GLibTaskRunner()).run(wrapped, on_success, on_error)
     GLib.timeout_add(TIMEOUT_MS, loop.quit)
     loop.run()
     return outcome
@@ -88,6 +92,44 @@ class GLibTaskRunnerTest(unittest.TestCase):
         calls = []
         run_task(lambda: calls.append(1))
         self.assertEqual(len(calls), 1)
+
+
+class IoRunnerTest(unittest.TestCase):
+    """Network steps leave the main loop, but their callbacks come back to it."""
+
+    def test_task_runs_off_the_calling_thread(self) -> None:
+        """This is what keeps the window responsive while a request is in
+        flight, and what makes Cancel work at all."""
+        outcome = run_task(lambda: "done", runner=IoRunner())
+        self.assertEqual(outcome.get("result"), "done")
+        self.assertIsNot(outcome["thread"], threading.current_thread())
+
+    def test_callback_returns_to_the_main_loop(self) -> None:
+        """Listeners draw widgets, so they must not run on the worker."""
+        outcome = run_task(lambda: "done", runner=IoRunner())
+        self.assertIs(outcome["callback_thread"], threading.current_thread())
+
+    def test_failure_is_reported_to_the_error_callback(self) -> None:
+        def boom():
+            raise ValueError("boom")
+
+        outcome = run_task(boom, runner=IoRunner())
+        self.assertNotIn("result", outcome)
+        self.assertIsInstance(outcome.get("error"), ValueError)
+
+    def test_post_runs_on_the_main_loop(self) -> None:
+        """Progress raised inside a network step is marshalled through this."""
+        seen: dict = {}
+        loop = GLib.MainLoop()
+
+        def note():
+            seen["thread"] = threading.current_thread()
+            loop.quit()
+
+        threading.Thread(target=lambda: IoRunner().post(note)).start()
+        GLib.timeout_add(TIMEOUT_MS, loop.quit)
+        loop.run()
+        self.assertIs(seen.get("thread"), threading.current_thread())
 
 
 if __name__ == "__main__":

--- a/GrampsWebSync/tests/test_credentials.py
+++ b/GrampsWebSync/tests/test_credentials.py
@@ -354,10 +354,30 @@ class KeyringGuardTest(unittest.TestCase):
         self.assertEqual(backend.calls, ["set"])
 
     def test_deleting_a_missing_entry_is_not_a_failure(self) -> None:
-        """Backends raise when asked to delete something that is not there."""
-        keyring = KeyringOverBackend(ExplodingBackend(RuntimeError("no such item")))
-        keyring.delete("svc", "nobody")
+        """Backends raise when asked to delete something that is not there.
+
+        A working keyring still reads cleanly, which is how that is told apart
+        from a keyring that cannot delete because it is broken.
+        """
+
+        class AbsentEntryBackend(ExplodingBackend):
+            def get_password(self, *_args):
+                return None
+
+        keyring = KeyringOverBackend(AbsentEntryBackend(RuntimeError("no such item")))
+        self.assertTrue(keyring.delete("svc", "nobody"))
         self.assertIsNone(keyring.unavailable)
+
+    def test_a_delete_that_leaves_the_password_behind_is_a_failure(self) -> None:
+        """Otherwise turning off "remember password" silently does nothing."""
+
+        class StubbornBackend(ExplodingBackend):
+            def get_password(self, *_args):
+                return "still here"
+
+        keyring = KeyringOverBackend(StubbornBackend(RuntimeError("denied")))
+        self.assertFalse(keyring.delete("svc", "user"))
+        self.assertIsNotNone(keyring.unavailable)
 
 
 class SnapHintTest(unittest.TestCase):

--- a/GrampsWebSync/tests/test_credentials.py
+++ b/GrampsWebSync/tests/test_credentials.py
@@ -1,0 +1,386 @@
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""Tests for :class:`adapters.ConfigCredentialStore` and its keyring guard.
+
+Every store is built against a config manager in a temporary directory, so no
+test can write to the user's own Gramps configuration.
+"""
+
+from __future__ import annotations
+
+import itertools
+import shutil
+import tempfile
+import unittest
+import unittest.mock
+from typing import cast
+
+from adapters import (
+    LEGACY_TIMESTAMP,
+    LEGACY_URL,
+    LEGACY_USERNAME,
+    ConfigCredentialStore,
+    Keyring,
+    normalize_url,
+    snap_connect_command,
+)
+from gramps.gen.config import config as configman
+
+URL = "https://example.org/api"
+OTHER = "https://other.example/api"
+
+#: Config managers are cached by name, so each store needs its own.
+_counter = itertools.count()
+
+
+class FakeKeyring:
+    """A keyring that records calls and can be made to fail."""
+
+    def __init__(self, fail: Exception | None = None) -> None:
+        self.stored: dict[tuple[str, str], str] = {}
+        self.deleted: list[tuple[str, str]] = []
+        self.unavailable = None
+        self._fail = fail
+
+    def get(self, service, username):
+        return self.stored.get((service, username))
+
+    def set(self, service, username, password):
+        if self._fail is not None:
+            self.unavailable = self._fail
+            return False
+        self.stored[(service, username)] = password
+        return True
+
+    def delete(self, service, username):
+        self.deleted.append((service, username))
+        self.stored.pop((service, username), None)
+
+
+class StoreTestCase(unittest.TestCase):
+    """Builds isolated stores."""
+
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.mkdtemp(prefix="gws_config_")
+        self.addCleanup(shutil.rmtree, self.tmpdir, ignore_errors=True)
+
+    def make_config(self, name: str | None = None):
+        """Return a config manager writing into this test's directory."""
+        name = name or f"webapisync_test_{next(_counter)}"
+        return configman.register_manager(
+            name, self.tmpdir, use_plugins_path=False
+        )
+
+    def make_store(self, config=None, keyring=None) -> ConfigCredentialStore:
+        """Return a store over an isolated config manager."""
+        return ConfigCredentialStore(
+            keyring=cast(Keyring, keyring or FakeKeyring()),
+            config=config or self.make_config(),
+        )
+
+
+class NormalizeUrlTest(unittest.TestCase):
+    """The key has to survive the ways people type a URL."""
+
+    def test_trailing_slash_and_whitespace_are_ignored(self) -> None:
+        """These used to look like different servers and cost the baseline."""
+        self.assertEqual(normalize_url(" https://x.org/ "), "https://x.org")
+        self.assertEqual(normalize_url("https://x.org///"), "https://x.org")
+
+
+class PerServerBaselineTest(StoreTestCase):
+    """Each server keeps its own last-sync time."""
+
+    def test_two_servers_do_not_share_a_baseline(self) -> None:
+        store = self.make_store()
+        store.set_timestamp(URL, "owner", 111.0)
+        store.set_timestamp(OTHER, "owner", 222.0)
+        self.assertEqual(store.get_timestamp(URL, "owner"), 111.0)
+        self.assertEqual(store.get_timestamp(OTHER, "owner"), 222.0)
+
+    def test_same_server_different_users_are_separate_trees(self) -> None:
+        """A Gramps Web account maps to one tree, so the user is part of the key."""
+        store = self.make_store()
+        store.set_timestamp(URL, "alice", 111.0)
+        store.set_timestamp(URL, "bob", 222.0)
+        self.assertEqual(store.get_timestamp(URL, "alice"), 111.0)
+
+    def test_a_trailing_slash_does_not_lose_the_baseline(self) -> None:
+        store = self.make_store()
+        store.set_timestamp(URL, "owner", 111.0)
+        self.assertEqual(store.get_timestamp(URL + "/", "owner"), 111.0)
+
+    def test_an_unknown_server_has_no_baseline(self) -> None:
+        store = self.make_store()
+        self.assertEqual(store.get_timestamp("https://new.example", "owner"), 0.0)
+
+
+class MigrationTest(StoreTestCase):
+    """Upgrading from the pre-multi-server layout must lose nothing."""
+
+    def test_legacy_keys_become_an_entry(self) -> None:
+        config = self.make_config()
+        config.register(LEGACY_URL, "")
+        config.register(LEGACY_USERNAME, "")
+        config.register(LEGACY_TIMESTAMP, 0)
+        config.set(LEGACY_URL, URL)
+        config.set(LEGACY_USERNAME, "owner")
+        config.set(LEGACY_TIMESTAMP, 999)
+
+        store = self.make_store(config=config)
+
+        self.assertEqual(store.get_url(), URL)
+        self.assertEqual(store.get_username(), "owner")
+        self.assertEqual(store.get_timestamp(URL, "owner"), 999.0)
+
+    def test_migration_preserves_the_baseline(self) -> None:
+        """Losing it would make the first run after upgrading a cold sync."""
+        config = self.make_config()
+        for key, value in (
+            (LEGACY_URL, URL),
+            (LEGACY_USERNAME, "owner"),
+            (LEGACY_TIMESTAMP, 4242),
+        ):
+            config.register(key, "" if isinstance(value, str) else 0)
+            config.set(key, value)
+        store = self.make_store(config=config)
+        self.assertNotEqual(store.get_timestamp(URL, "owner"), 0.0)
+
+    def test_nothing_stored_migrates_to_nothing(self) -> None:
+        store = self.make_store()
+        self.assertEqual(store.get_url(), "")
+        self.assertEqual(store.get_username(), "")
+
+
+class LegacyMirrorTest(StoreTestCase):
+    """The old keys stay current so a downgrade still works."""
+
+    def test_saving_mirrors_into_the_legacy_keys(self) -> None:
+        config = self.make_config()
+        store = self.make_store(config=config)
+        store.save_credentials(URL, "owner", "secret")
+        store.set_timestamp(URL, "owner", 777.0)
+
+        self.assertEqual(config.get(LEGACY_URL), URL)
+        self.assertEqual(config.get(LEGACY_USERNAME), "owner")
+        self.assertEqual(config.get(LEGACY_TIMESTAMP), 777)
+
+    def test_a_newer_legacy_baseline_wins_on_re_upgrade(self) -> None:
+        """An older version may have synced while it was installed."""
+        config = self.make_config()
+        store = self.make_store(config=config)
+        store.set_timestamp(URL, "owner", 100.0)
+        # Stand in for an older version syncing and writing only its own keys.
+        config.set(LEGACY_TIMESTAMP, 500)
+        config.save()
+
+        reopened = self.make_store(config=config)
+
+        self.assertEqual(reopened.get_timestamp(URL, "owner"), 500.0)
+
+    def test_an_older_legacy_baseline_does_not_regress_the_entry(self) -> None:
+        config = self.make_config()
+        store = self.make_store(config=config)
+        store.set_timestamp(URL, "owner", 500.0)
+        config.set(LEGACY_TIMESTAMP, 100)
+        config.save()
+
+        reopened = self.make_store(config=config)
+
+        self.assertEqual(reopened.get_timestamp(URL, "owner"), 500.0)
+
+    def test_an_unreadable_server_list_is_treated_as_empty(self) -> None:
+        """A value the config manager could not parse is stored as None.
+
+        Registering a default does not help: defaults apply only when a key is
+        absent, not when it is present and None, so the store has to check the
+        type rather than assume it. Written to the file directly because
+        ``set`` type-checks and would reject it.
+        """
+        config = self.make_config()
+        with open(config.filename, "w", encoding="utf-8") as fobj:
+            fobj.write("[credentials]\nservers=<<<not python\n")
+
+        store = self.make_store(config=config)
+
+        self.assertEqual(store.get_url(), "")
+        self.assertEqual(store.get_timestamp(URL, "owner"), 0.0)
+
+
+class RememberPasswordTest(StoreTestCase):
+    """The password, and only the password, is optional."""
+
+    def test_the_password_is_stored_when_remembered(self) -> None:
+        keyring = FakeKeyring()
+        store = self.make_store(keyring=keyring)
+        store.save_credentials(URL, "owner", "secret", remember_password=True)
+        self.assertEqual(keyring.stored[(URL, "owner")], "secret")
+
+    def test_declining_deletes_rather_than_merely_skipping(self) -> None:
+        """Otherwise the setting appears inert for anyone who had it on."""
+        keyring = FakeKeyring()
+        store = self.make_store(keyring=keyring)
+        store.save_credentials(URL, "owner", "secret", remember_password=True)
+
+        store.save_credentials(URL, "owner", "secret", remember_password=False)
+
+        self.assertNotIn((URL, "owner"), keyring.stored)
+        self.assertIn((URL, "owner"), keyring.deleted)
+
+    def test_the_entry_survives_even_when_the_password_does_not(self) -> None:
+        """The baseline is not a credential; dropping it would force cold syncs."""
+        store = self.make_store()
+        store.set_timestamp(URL, "owner", 321.0)
+        store.save_credentials(URL, "owner", "secret", remember_password=False)
+        self.assertEqual(store.get_timestamp(URL, "owner"), 321.0)
+
+    def test_an_unremembered_password_is_not_returned(self) -> None:
+        store = self.make_store()
+        store.save_credentials(URL, "owner", "secret", remember_password=False)
+        self.assertIsNone(store.get_password())
+
+
+class ForgetTest(StoreTestCase):
+    """Forgetting is the wider case of the same delete."""
+
+    def test_forget_removes_entry_keyring_and_mirror(self) -> None:
+        config = self.make_config()
+        keyring = FakeKeyring()
+        store = self.make_store(config=config, keyring=keyring)
+        store.save_credentials(URL, "owner", "secret")
+
+        store.forget(URL, "owner")
+
+        self.assertEqual(store.get_url(), "")
+        self.assertEqual(store.get_timestamp(URL, "owner"), 0.0)
+        self.assertIn((URL, "owner"), keyring.deleted)
+        self.assertEqual(config.get(LEGACY_URL), "")
+
+    def test_forget_leaves_other_servers_alone(self) -> None:
+        store = self.make_store()
+        store.set_timestamp(URL, "owner", 111.0)
+        store.set_timestamp(OTHER, "owner", 222.0)
+
+        store.forget(URL, "owner")
+
+        self.assertEqual(store.get_timestamp(OTHER, "owner"), 222.0)
+
+
+class ExplodingBackend:
+    """A keyring backend that raises, as one does under snap confinement."""
+
+    def __init__(self, exc: Exception) -> None:
+        self.exc = exc
+        self.calls: list[str] = []
+
+    def get_password(self, *_args):
+        self.calls.append("get")
+        raise self.exc
+
+    def set_password(self, *_args):
+        self.calls.append("set")
+        raise self.exc
+
+    def delete_password(self, *_args):
+        self.calls.append("delete")
+        raise self.exc
+
+
+class KeyringOverBackend(Keyring):
+    """The real guard logic over a backend the test controls."""
+
+    def __init__(self, backend: ExplodingBackend) -> None:
+        super().__init__()
+        self.backend = backend
+
+    def _module(self):
+        return None if self.unavailable is not None else self.backend
+
+
+class KeyringGuardTest(unittest.TestCase):
+    """A broken keyring must not take Gramps down with it."""
+
+    def test_a_backend_raising_is_reported_not_propagated(self) -> None:
+        """Under snap confinement this arrives as a jeepney DBusErrorResponse.
+
+        That does not derive from ``keyring.errors``, because it comes from a
+        transitive dependency of the backend, so guarding on the keyring
+        package's own exception hierarchy would not catch it.
+        """
+
+        class DBusErrorResponse(Exception):
+            pass
+
+        keyring = KeyringOverBackend(
+            ExplodingBackend(DBusErrorResponse("An AppArmor policy prevents..."))
+        )
+
+        self.assertIsNone(keyring.get("svc", "user"))
+        problem = keyring.unavailable
+        self.assertIsNotNone(problem)
+        assert problem is not None  # for the type checker
+        self.assertIn("AppArmor", problem.detail)
+
+    def test_a_write_failure_is_reported_as_not_stored(self) -> None:
+        keyring = KeyringOverBackend(ExplodingBackend(RuntimeError("denied")))
+        self.assertFalse(keyring.set("svc", "user", "pw"))
+        self.assertIsNotNone(keyring.unavailable)
+
+    def test_a_failure_stops_further_attempts(self) -> None:
+        """One denial is enough; retrying each call just repeats the stall."""
+        backend = ExplodingBackend(RuntimeError("denied"))
+        keyring = KeyringOverBackend(backend)
+
+        keyring.set("svc", "user", "pw")
+        keyring.set("svc", "user", "pw")
+        keyring.get("svc", "user")
+
+        self.assertEqual(backend.calls, ["set"])
+
+    def test_deleting_a_missing_entry_is_not_a_failure(self) -> None:
+        """Backends raise when asked to delete something that is not there."""
+        keyring = KeyringOverBackend(ExplodingBackend(RuntimeError("no such item")))
+        keyring.delete("svc", "nobody")
+        self.assertIsNone(keyring.unavailable)
+
+
+class SnapHintTest(unittest.TestCase):
+    """Under snap the failure is a setting the user can change."""
+
+    def test_no_command_outside_snap(self) -> None:
+        with unittest.mock.patch.dict("os.environ", {}, clear=True):
+            self.assertIsNone(snap_connect_command())
+
+    def test_the_instance_name_is_used_when_present(self) -> None:
+        """A parallel install is named gramps_foo, and the command must match."""
+        env = {"SNAP": "/snap/gramps/11", "SNAP_INSTANCE_NAME": "gramps_beta"}
+        with unittest.mock.patch.dict("os.environ", env, clear=True):
+            command = snap_connect_command() or ""
+            self.assertIn("gramps_beta:password-manager-service", command)
+
+    def test_it_falls_back_to_the_snap_name(self) -> None:
+        env = {"SNAP": "/snap/gramps/11", "SNAP_NAME": "gramps"}
+        with unittest.mock.patch.dict("os.environ", env, clear=True):
+            self.assertEqual(
+                snap_connect_command(), "snap connect gramps:password-manager-service"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/GrampsWebSync/tests/test_errors.py
+++ b/GrampsWebSync/tests/test_errors.py
@@ -26,7 +26,13 @@ from urllib.error import URLError
 from session import ErrorKind, State
 
 from .fakes import http_error
-from .scenario import T0, T2, SyncScenario
+from .scenario import (
+    DEFAULT_URL as URL,
+    DEFAULT_USERNAME as USERNAME,
+    T0,
+    T2,
+    SyncScenario,
+)
 
 
 class LoginFailureTest(unittest.TestCase):
@@ -142,12 +148,13 @@ class MidSyncFailureTest(unittest.TestCase):
 
         scenario.run()
 
-        self.assertEqual(scenario.credentials.get_timestamp(), T0)
+        self.assertEqual(scenario.credentials.get_timestamp(URL, USERNAME), T0)
 
     def test_local_changes_survive_a_failed_remote_commit(self) -> None:
-        """The local transaction commits before the upload is attempted."""
+        """The local half commits before the remote half is even attempted."""
         scenario = self.make_scenario()
         scenario.remote.edit_person("I0002", surname="Neu", changed_at=T2)
+        scenario.local.edit_person("I0001", surname="Mueller", changed_at=T2)
         scenario.server.fail_always("commit", http_error(500))
 
         result = scenario.run()
@@ -172,7 +179,7 @@ class CancellationTest(unittest.TestCase):
         session.begin()
         session.cancel()
 
-        session._compare()
+        session._fetch_xml()
 
         self.assertNotIn("download_xml", scenario.server.calls)
 
@@ -185,7 +192,7 @@ class CancellationTest(unittest.TestCase):
         session.submit_credentials("https://example.org/api", "owner", "secret")
         session.cancel()
 
-        session._apply()
+        session._apply_local()
 
         self.assertEqual(scenario.server.committed, [])
 
@@ -199,7 +206,7 @@ class CancellationTest(unittest.TestCase):
         session.submit_credentials("https://example.org/api", "owner", "secret")
         session.cancel()
 
-        session._transfer()
+        session._transfer(*session._resolve_transfers())
 
         self.assertEqual(scenario.server.media_files, {})
 
@@ -229,11 +236,12 @@ class MediaFailureTest(unittest.TestCase):
         self.assertIs(result.final_state, State.DONE)
         self.assertEqual(result.session.downloaded, {"O0001": False, "O0002": True})
 
-    def test_file_missing_on_both_sides_is_recorded_not_fatal(self) -> None:
-        """Such an object is in both missing lists; neither side can supply it.
+    def test_file_missing_on_both_sides_is_reported_once(self) -> None:
+        """Neither side can supply such a file, so neither transfer is tried.
 
-        The download 404s and the upload has nothing to send, so both are
-        recorded as failures and the run still completes.
+        It used to appear in both missing lists, so the download 404d and the
+        upload found nothing to send, and the user was told of two errors for
+        one file that simply does not exist anywhere.
         """
         scenario = self.make_scenario()
         scenario.local.add_media("O0001", "nowhere.jpg", on_disk=False)
@@ -243,8 +251,11 @@ class MediaFailureTest(unittest.TestCase):
 
         self.assertIs(result.final_state, State.DONE)
         self.assertIsNone(result.error)
-        self.assertEqual(result.session.downloaded, {"O0001": False})
-        self.assertEqual(result.session.uploaded, {"O0001": False})
+        self.assertEqual([gid for gid, _h in result.session.missing_both], ["O0001"])
+        self.assertEqual(result.session.missing_local, [])
+        self.assertEqual(result.session.missing_remote, [])
+        self.assertEqual(result.session.downloaded, {})
+        self.assertEqual(result.session.uploaded, {})
 
     def test_upload_still_fails_the_run_on_a_server_error(self) -> None:
         """The new guard must not swallow genuine transport failures."""

--- a/GrampsWebSync/tests/test_recovery.py
+++ b/GrampsWebSync/tests/test_recovery.py
@@ -149,6 +149,24 @@ class RetryTest(RecoveryTestCase):
         self.assertIsNone(session.error)
 
 
+class MediaScanTest(RecoveryTestCase):
+    """Asking the server which files it lacks is a network step of its own."""
+
+    def test_a_failed_scan_is_retryable_as_its_own_step(self) -> None:
+        """It used to run inline on the main loop, freezing the UI while it ran."""
+        scenario = self.make_scenario()
+        scenario.server.fail_next("get_missing_files", http_error(500))
+        session = self.connect(scenario)
+
+        self.assertIs(session.state, State.FAILED)
+        self.assertIs(session.failed_in, Step.SCAN_MEDIA)
+
+        session.retry()
+
+        self.assertIs(session.state, State.DONE)
+        self.assertIsNone(session.error)
+
+
 class StaleComparisonTest(RecoveryTestCase):
     """Edits made while the review page is open must not be overwritten.
 

--- a/GrampsWebSync/tests/test_recovery.py
+++ b/GrampsWebSync/tests/test_recovery.py
@@ -1,0 +1,237 @@
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       David Straub
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""Recovering from a failed run, and refusing to commit a stale comparison."""
+
+from __future__ import annotations
+
+import unittest
+
+from const import MODE_BIDIRECTIONAL
+from gramps.gen.db import DbTxn
+from session import ErrorKind, State, Step, SyncSession
+
+from .fakes import http_error
+from .scenario import (
+    DEFAULT_URL as URL,
+    DEFAULT_USERNAME as USERNAME,
+    T0,
+    T2,
+    SyncScenario,
+)
+
+
+class RecoveryTestCase(unittest.TestCase):
+    """Drives a session by hand, so a run can be interrupted mid-flow."""
+
+    def make_scenario(self) -> SyncScenario:
+        scenario = SyncScenario()
+        self.addCleanup(scenario.close)
+        scenario.seed_person("I0001", surname="Doe", changed_at=T0)
+        scenario.seed_person("I0002", surname="Roe", changed_at=T0)
+        scenario.share()
+        return scenario
+
+    def connect(self, scenario: SyncScenario) -> SyncSession:
+        """Return a session that has connected and compared."""
+        session = scenario.make_session()
+        session.begin()
+        session.submit_credentials(URL, USERNAME, "secret")
+        return session
+
+
+class RetryTest(RecoveryTestCase):
+    """A failed run resumes where it stopped rather than starting over."""
+
+    def test_no_retry_is_offered_without_a_failure(self) -> None:
+        scenario = self.make_scenario()
+        session = self.connect(scenario)
+        self.assertFalse(session.can_retry)
+
+    def test_a_failed_push_can_be_retried(self) -> None:
+        scenario = self.make_scenario()
+        scenario.local.edit_person("I0001", surname="Mueller", changed_at=T2)
+        scenario.server.fail_next("commit", http_error(500))
+        session = self.connect(scenario)
+
+        session.confirm_changes(MODE_BIDIRECTIONAL)
+        self.assertIs(session.state, State.FAILED)
+        self.assertIs(session.failed_in, Step.PUSH_REMOTE)
+
+        session.retry()
+
+        self.assertIsNone(session.error)
+        self.assertEqual(scenario.remote.surname("I0001"), "Mueller")
+
+    def test_retrying_a_push_does_not_re_apply_the_local_half(self) -> None:
+        """Resuming at the failed step is the whole point of tracking it."""
+        scenario = self.make_scenario()
+        scenario.remote.edit_person("I0002", surname="Neu", changed_at=T2)
+        scenario.local.edit_person("I0001", surname="Mueller", changed_at=T2)
+        scenario.server.fail_next("commit", http_error(500))
+        session = self.connect(scenario)
+
+        session.confirm_changes(MODE_BIDIRECTIONAL)
+        session.retry()
+
+        # One payload reached the server: the retry re-sent, it did not stack a
+        # second local transaction on top of the first.
+        self.assertEqual(len(scenario.server.committed), 1)
+        self.assertEqual(scenario.local.surname("I0002"), "Neu")
+
+    def test_retrying_a_push_does_not_download_the_tree_again(self) -> None:
+        """The remote database is kept open precisely so this is cheap."""
+        scenario = self.make_scenario()
+        scenario.local.edit_person("I0001", surname="Mueller", changed_at=T2)
+        scenario.server.fail_next("commit", http_error(500))
+        session = self.connect(scenario)
+
+        session.confirm_changes(MODE_BIDIRECTIONAL)
+        session.retry()
+
+        self.assertEqual(scenario.server.calls.count("download_xml"), 1)
+
+    def test_a_failed_download_is_retried_from_the_start(self) -> None:
+        scenario = self.make_scenario()
+        scenario.server.fail_next("download_xml", http_error(500))
+        session = scenario.make_session()
+        session.begin()
+        session.submit_credentials(URL, USERNAME, "secret")
+
+        self.assertIs(session.state, State.FAILED)
+        self.assertIs(session.failed_in, Step.FETCH)
+
+        session.retry()
+
+        self.assertIsNone(session.error)
+        self.assertEqual(scenario.server.calls.count("download_xml"), 2)
+
+    def test_a_failed_transfer_resumes_with_the_remaining_files(self) -> None:
+        """Files already moved are not sent twice."""
+        scenario = SyncScenario()
+        self.addCleanup(scenario.close)
+        scenario.local.add_media("O0001", "one.jpg", changed_at=T0)
+        scenario.local.add_media("O0002", "two.jpg", changed_at=T0)
+        scenario.share()
+        session = self.connect(scenario)
+        self.assertIs(session.state, State.REVIEW_FILES)
+
+        scenario.server.fail_next("upload_media_file", http_error(500))
+        session.confirm_files()
+        self.assertIs(session.state, State.FAILED)
+
+        session.retry()
+
+        self.assertIs(session.state, State.DONE)
+        self.assertEqual(session.uploaded, {"O0001": True, "O0002": True})
+        self.assertEqual(len(scenario.server.media_files), 2)
+
+    def test_retry_without_a_recorded_step_does_nothing(self) -> None:
+        scenario = self.make_scenario()
+        session = self.connect(scenario)
+        session.failed_in = None
+        session.retry()  # must not raise
+        self.assertIsNone(session.error)
+
+
+class StaleComparisonTest(RecoveryTestCase):
+    """Edits made while the review page is open must not be overwritten.
+
+    The comparison captures object snapshots and the tool does not block the
+    main window, so the user can keep editing. Committing those snapshots would
+    silently discard whatever they did in the meantime.
+    """
+
+    def test_an_edit_during_review_stops_the_commit(self) -> None:
+        scenario = self.make_scenario()
+        scenario.local.edit_person("I0001", surname="Mueller", changed_at=T2)
+        session = self.connect(scenario)
+        self.assertIs(session.state, State.REVIEW_CHANGES)
+
+        scenario.local.edit_person("I0001", surname="Later", changed_at=T2 + 10)
+        session.confirm_changes(MODE_BIDIRECTIONAL)
+
+        self.assertIs(session.state, State.FAILED)
+        self.assertIs(session.error.kind, ErrorKind.STALE_LOCAL_DATA)
+
+    def test_nothing_is_sent_when_the_comparison_is_stale(self) -> None:
+        scenario = self.make_scenario()
+        scenario.local.edit_person("I0001", surname="Mueller", changed_at=T2)
+        session = self.connect(scenario)
+
+        scenario.local.edit_person("I0001", surname="Later", changed_at=T2 + 10)
+        session.confirm_changes(MODE_BIDIRECTIONAL)
+
+        self.assertEqual(scenario.server.committed, [])
+        self.assertEqual(scenario.local.surname("I0001"), "Later")
+
+    def test_a_deletion_during_review_is_caught(self) -> None:
+        """A delete is as destructive as an edit and must be caught too."""
+        scenario = self.make_scenario()
+        scenario.local.edit_person("I0001", surname="Mueller", changed_at=T2)
+        session = self.connect(scenario)
+
+        scenario.local.delete_person("I0001")
+        session.confirm_changes(MODE_BIDIRECTIONAL)
+
+        self.assertIs(session.error.kind, ErrorKind.STALE_LOCAL_DATA)
+
+    def test_an_object_appearing_locally_is_caught(self) -> None:
+        """The action was 'add here', which now would collide with real data."""
+        scenario = self.make_scenario()
+        scenario.remote.add_person("I0003", surname="Nieuw", changed_at=T2)
+        session = self.connect(scenario)
+        self.assertIs(session.state, State.REVIEW_CHANGES)
+
+        person = scenario.remote.person("I0003")
+        with DbTxn("local add", scenario.db1) as trans:
+            scenario.db1.add_person(person, trans)
+
+        session.confirm_changes(MODE_BIDIRECTIONAL)
+
+        self.assertIs(session.error.kind, ErrorKind.STALE_LOCAL_DATA)
+
+    def test_retry_after_a_stale_comparison_compares_again(self) -> None:
+        """The snapshots are worthless, so resuming the commit is not an option."""
+        scenario = self.make_scenario()
+        scenario.local.edit_person("I0001", surname="Mueller", changed_at=T2)
+        session = self.connect(scenario)
+
+        scenario.local.edit_person("I0001", surname="Later", changed_at=T2 + 10)
+        session.confirm_changes(MODE_BIDIRECTIONAL)
+        self.assertIs(session.failed_in, Step.DIFF)
+
+        session.retry()
+
+        self.assertEqual(scenario.server.calls.count("download_xml"), 2)
+        self.assertIsNone(session.error)
+
+    def test_an_untouched_tree_commits_normally(self) -> None:
+        """The guard must not fire on a run where nothing changed underneath."""
+        scenario = self.make_scenario()
+        scenario.local.edit_person("I0001", surname="Mueller", changed_at=T2)
+        session = self.connect(scenario)
+
+        session.confirm_changes(MODE_BIDIRECTIONAL)
+
+        self.assertIsNone(session.error)
+        self.assertEqual(scenario.remote.surname("I0001"), "Mueller")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/GrampsWebSync/tests/test_sync_flow.py
+++ b/GrampsWebSync/tests/test_sync_flow.py
@@ -32,7 +32,6 @@ from const import (
     C_UPD_LOC,
     C_UPD_REM,
     MODE_BIDIRECTIONAL,
-    MODE_MERGE,
     MODE_RESET_TO_LOCAL,
     MODE_RESET_TO_REMOTE,
 )
@@ -43,7 +42,14 @@ from session import (
     State,
 )
 
-from .scenario import T0, T2, T3, SyncScenario
+from .scenario import (
+    DEFAULT_URL as URL,
+    DEFAULT_USERNAME as USERNAME,
+    T0,
+    T2,
+    T3,
+    SyncScenario,
+)
 
 
 class SyncFlowTestCase(unittest.TestCase):
@@ -186,13 +192,12 @@ class SyncModeTest(SyncFlowTestCase):
         self.assertNotIn("I9100", scenario.local.person_ids())
         self.assertNotIn("I9100", scenario.remote.person_ids())
 
-    def test_merge_restores_a_locally_deleted_object(self) -> None:
-        """Merge mode never deletes; a removal on one side is undone."""
+    def test_an_unknown_mode_is_rejected(self) -> None:
+        """Modes are a closed set; an unknown one must not sync silently."""
         scenario = self.make_scenario()
         scenario.local.delete_person("I0002")
-        scenario.run(mode=MODE_MERGE)
-        self.assertIn("I0002", scenario.local.person_ids())
-        self.assertIn("I0002", scenario.remote.person_ids())
+        result = scenario.run(mode=99)
+        self.assertIs(result.final_state, State.FAILED)
 
 
 class MediaFileTest(SyncFlowTestCase):
@@ -265,7 +270,7 @@ class TimestampTest(SyncFlowTestCase):
 
         scenario.run()
 
-        self.assertEqual(scenario.credentials.get_timestamp(), 1_700_000_500.0)
+        self.assertEqual(scenario.credentials.get_timestamp(URL, USERNAME), 1_700_000_500.0)
 
     def test_in_sync_run_also_records_the_sync_time(self) -> None:
         """Finding no differences still counts as a successful sync."""
@@ -274,14 +279,21 @@ class TimestampTest(SyncFlowTestCase):
 
         scenario.run()
 
-        self.assertEqual(scenario.credentials.get_timestamp(), 1_700_000_900.0)
+        self.assertEqual(
+            scenario.credentials.get_timestamp(URL, USERNAME), 1_700_000_900.0
+        )
 
-    def test_changing_the_url_clears_the_stored_timestamp(self) -> None:
-        """A timestamp is meaningless against a different tree."""
+    def test_each_server_keeps_its_own_baseline(self) -> None:
+        """Syncing elsewhere must not disturb this server's baseline.
+
+        The baseline used to be a single value that a changed URL reset, so
+        alternating between two servers discarded it every time and made every
+        run after a switch a full "modified in both" comparison.
+        """
         scenario = self.make_scenario()
-        scenario.credentials.timestamp = T3
+        scenario.credentials.timestamps[(URL, USERNAME)] = T3
         scenario.run(url="https://elsewhere.example/api")
-        self.assertNotEqual(scenario.credentials.get_timestamp(), T3)
+        self.assertEqual(scenario.credentials.get_timestamp(URL, USERNAME), T3)
 
 
 class ProgressTest(SyncFlowTestCase):

--- a/GrampsWebSync/tests/test_view_mapping.py
+++ b/GrampsWebSync/tests/test_view_mapping.py
@@ -26,7 +26,8 @@ from __future__ import annotations
 import unittest
 
 import grampswebsync
-from grampswebsync import PAGE_FOR_STATE, error_message
+from adapters import KeyringUnavailable
+from grampswebsync import PAGE_FOR_STATE, error_message, keyring_message
 from session import ErrorKind, State
 
 
@@ -66,6 +67,28 @@ class ErrorMessageTest(unittest.TestCase):
         """Status codes must reach the user for the otherwise-opaque kinds."""
         self.assertIn("42", error_message(ErrorKind.SERVER_ERROR, "42"))
         self.assertIn("boom", error_message(ErrorKind.UNEXPECTED, "boom"))
+
+    def test_a_failed_server_task_reports_what_the_server_said(self) -> None:
+        """This used to render a stringified status dict plus advice to check
+        the connection, which was neither true nor actionable."""
+        message = error_message(ErrorKind.SERVER_TASK_FAILED, "disk full")
+        self.assertIn("disk full", message)
+        self.assertNotIn("connection", message.lower())
+
+
+class KeyringMessageTest(unittest.TestCase):
+    """An unusable keyring is reported, and under snap it is fixable."""
+
+    def test_the_snap_command_is_included_when_there_is_one(self) -> None:
+        problem = KeyringUnavailable(
+            "denied", snap_command="snap connect gramps:password-manager-service"
+        )
+        self.assertIn("snap connect gramps", keyring_message(problem))
+
+    def test_elsewhere_the_message_says_what_to_expect_instead(self) -> None:
+        message = keyring_message(KeyringUnavailable("no backend"))
+        self.assertNotIn("snap", message.lower())
+        self.assertTrue(message.strip())
 
 
 if __name__ == "__main__":

--- a/GrampsWebSync/webapihandler.py
+++ b/GrampsWebSync/webapihandler.py
@@ -352,7 +352,7 @@ class WebApiHandler:
             )
         try:
             with self._open(req) as res:
-                chunk_size = 1024
+                chunk_size = 64 * 1024
                 chunk = res.read(chunk_size)
                 fobj.write(chunk)
                 while chunk:

--- a/GrampsWebSync/webapihandler.py
+++ b/GrampsWebSync/webapihandler.py
@@ -43,6 +43,41 @@ from gramps.gen.db.dbconst import TXNADD, TXNDEL, TXNUPD
 
 LOG = logging.getLogger("grampswebsync")
 
+#: Seconds before a request that has produced nothing is abandoned. Without
+#: this, ``urlopen`` waits forever and an unreachable-but-listening server
+#: hangs the tool with no way out.
+TIMEOUT = 60
+
+
+class ServerTaskFailed(Exception):
+    """A background task on the server reported failure.
+
+    Carries the server's own description rather than a stringified status dict,
+    so the message shown to the user says what went wrong.
+    """
+
+
+def describe_task_failure(task_status: dict[str, Any]) -> str:
+    """Extract a readable reason from a failed task status.
+
+    The status dict carries the reason in one of a few shapes depending on how
+    the task died. Stringifying the whole dict, as this once did, produced a
+    message no user could act on.
+
+    :param task_status: The server's task status document.
+    :returns: The most specific description available.
+    """
+    info = task_status.get("info")
+    if isinstance(info, dict):
+        for key in ("message", "error", "detail"):
+            value = info.get(key)
+            if value:
+                return str(value)
+    elif info:
+        return str(info)
+    state = task_status.get("state", "FAILURE")
+    return f"The server reported task state {state}."
+
 
 def parse_version(version) -> tuple[int, int]:
     """Simple dependency-free version to parse a SemVer into a list of ints."""
@@ -116,6 +151,10 @@ class WebApiHandler:
         self.fetch_token()
         self._metadata: dict | None = None
 
+    def _open(self, req: Request):
+        """Open ``req`` with this handler's SSL context and timeout."""
+        return urlopen(req, context=self._ctx, timeout=TIMEOUT)
+
     @property
     def access_token(self) -> str:
         """Get the access token. Cached after first call unless refresh needed. Auto-refreshing"""
@@ -153,7 +192,7 @@ class WebApiHandler:
             f"{self.url}/metadata/",
             headers={"Authorization": f"Bearer {self.access_token}", "User-Agent": "GrampsWebSync"},
         )
-        with urlopen(req, context=self._ctx) as res:
+        with self._open(req) as res:
             self._metadata = json.load(res)
 
     def fetch_token(self) -> None:
@@ -166,7 +205,7 @@ class WebApiHandler:
             headers={"Content-Type": "application/json", "User-Agent": "GrampsWebSync"},
         )
         try:
-            with urlopen(req, context=self._ctx) as res:
+            with self._open(req) as res:
                 res_json = json.load(res)
         except (UnicodeDecodeError, json.JSONDecodeError, HTTPError):
             if "/api" not in self.url:
@@ -230,7 +269,7 @@ class WebApiHandler:
                 },
             )
             json_response: dict | None = None
-            with urlopen(req, context=self._ctx) as res:
+            with self._open(req) as res:
                 status_code = res.getcode()
                 if status_code == 202:
                     json_response = json.load(res)
@@ -264,30 +303,23 @@ class WebApiHandler:
             endpoint,
             headers={"Authorization": f"Bearer {self.access_token}", "User-Agent": "GrampsWebSync"},
         )
-        try:
-            with urlopen(req, context=self._ctx) as res:
-                task_status = json.load(res)
-                if task_status["state"] == "SUCCESS":
-                    return True
-                if task_status["state"] in {"FAILURE", "REVOKED"}:
-                    LOG.warning(f"Server task failed: {task_status}")
-                    raise ValueError(str(task_status.get("info", "Server task failed")))
-                if progress_callback:
-                    try:
-                        progress = task_status["result_object"]["progress"]
-                    except (KeyError, TypeError):
-                        progress = -1
-                    progress_callback(progress)
-                return False
-        except HTTPError as e:
-            LOG.warning(f"HTTPError while fetching task status: {e.code} - {e.reason}")
-            raise ValueError(f"HTTP Error: {e.code} - {e.reason}")
-        except URLError as e:
-            LOG.warning(f"URLError while fetching task status: {e.reason}")
-            raise ValueError(f"URL Error: {e.reason}")
-        except socket.timeout as e:
-            LOG.warning(f"Timeout while fetching task status: {e}")
-            raise ValueError("Connection timed out while fetching task status.")
+        # HTTPError and URLError are deliberately not wrapped: the caller
+        # classifies them into specific, actionable messages, which converting
+        # them to a ValueError would flatten into a generic server error.
+        with self._open(req) as res:
+            task_status = json.load(res)
+            if task_status["state"] == "SUCCESS":
+                return True
+            if task_status["state"] in {"FAILURE", "REVOKED"}:
+                LOG.warning("Server task failed: %s", task_status)
+                raise ServerTaskFailed(describe_task_failure(task_status))
+            if progress_callback:
+                try:
+                    progress = task_status["result_object"]["progress"]
+                except (KeyError, TypeError):
+                    progress = -1
+                progress_callback(progress)
+            return False
 
     def get_missing_files(self, retry: bool = True) -> list:
         """Get a list of remote media objects with missing files."""
@@ -296,7 +328,7 @@ class WebApiHandler:
             headers={"Authorization": f"Bearer {self.access_token}", "User-Agent": "GrampsWebSync"},
         )
         try:
-            with urlopen(req, context=self._ctx) as res:
+            with self._open(req) as res:
                 res_json = json.load(res)
         except HTTPError as exc:
             if exc.code == 401 and retry:
@@ -319,7 +351,7 @@ class WebApiHandler:
                 headers={"Authorization": f"Bearer {self.access_token}", "User-Agent": "GrampsWebSync"},
             )
         try:
-            with urlopen(req, context=self._ctx) as res:
+            with self._open(req) as res:
                 chunk_size = 1024
                 chunk = res.read(chunk_size)
                 fobj.write(chunk)
@@ -367,7 +399,7 @@ class WebApiHandler:
             method="PUT",
         )
         try:
-            with urlopen(req, context=self._ctx) as res:
+            with self._open(req) as res:
                 pass
         except HTTPError as exc:
             if exc.code == 401 and retry:


### PR DESCRIPTION
Here comes number 2 of 3-4 big Gramps Web sync enhancement PRs!

The minor version is bumped from 1.4.0 as this changes the config file format and removes one sync mode (but existing installations will continue to work without disruptions).

Claude's PR description:

---

**Title:** Gramps Web Sync: cancellable network steps, recoverable failures, and per-server credentials

## Summary

Follows on from the recent refactoring and test work. The UI is unchanged; this reworks the layer beneath it. Network calls move off the main loop so the window stays responsive and Cancel works, a failed run can be resumed rather than restarted, and credentials are stored per server instead of in one global slot. Version bumped to 1.4.0 rather than left for the automatic patch increment, because a sync mode is removed and the config layout changes.

## Fixes

- **Gramps crashed when the keyring was unusable.** Both helpers caught only `ImportError`. Under snap confinement AppArmor denies `org.freedesktop.secrets` and the backend raises `jeepney.wrappers.DBusErrorResponse`, which does not derive from `keyring.errors` — so the guard has to be a bare `except Exception`. Failures are now reported, and under snap the message gives the fix: `snap connect gramps:password-manager-service`.
- **Edits made while the review page was open were silently overwritten.** The comparison captures object snapshots and the tool does not block the main window, so committing them discarded anything edited in the meantime. Affected objects are re-read just before committing and the run stops if they changed.
- **A trailing slash silently discarded the sync baseline,** because the URL was compared before normalization and the timestamp reset to `0`, reclassifying everything as "modified in both".
- **No request had a timeout,** so an unreachable-but-listening server hung the tool indefinitely.
- **Declining the undo-history warning opened the tool anyway** — `BatchTool` sets `self.fail` and this tool never checked it.
- **Credentials were saved before the server accepted them,** so a failed login wrote a bad password to the keyring.

## Error reporting

Addresses https://github.com/DavidMStraub/gramps-web-sync/issues/47. Failed server tasks rendered a stringified status dict plus advice to check the connection; the reason now comes from the response, and `HTTPError`/`URLError` are no longer flattened into a generic server error. Media missing on *both* sides used to be attempted twice and reported as two failures; it is now identified up front and skipped. The final page reports what was applied to both trees, not just media.

## Credential storage

Addresses https://github.com/DavidMStraub/gramps-web-sync/issues/7. Credentials become a list keyed by `(url, username)`, each entry carrying its own baseline and a `remember_password` flag — a Gramps Web account belongs to one tree, so that pair identifies one. Alternating between two servers no longer destroys the baseline each time. `remember_password` is honoured by the store and turning it off deletes the keyring entry rather than just skipping the write, but there is no checkbox yet, so https://github.com/DavidMStraub/gramps-web-sync/issues/25 stays open.

Upgrading is lossless and keeps the baseline. The old keys are still written as a mirror of the last-used entry so a downgrade keeps working, and Gramps' config manager preserves keys it has no default for, so an older version leaves the new list intact; coming back takes the later of the two baselines.

## Other changes

- Network calls run on a worker thread, so Cancel works during a download, a server transaction, or a media transfer. The comparison stays on the main loop: Gramps' sqlite backend binds a connection to its creating thread, so `import_as_dict` and `diff_dbs` cannot move.
- A failed run offers **Try again**, resuming at the failed step. The remote tree stays open, so retrying a push does not re-download and re-diff it.
- The **Merge** sync mode is removed — it differed from Bidirectional only in resurrecting deletions, which the UI could not explain usefully. It was never persisted, so nothing needs migrating.
- Each mode now has a one-line description and the destructive ones are marked. Other untranslated strings on that page are left alone to keep translation churn small.

## Testing

109 tests, up from 64: credential store migration and downgrade, the keyring guard, the threaded runner, retry at each resumable step, and the staleness guard. The staleness tests were mutation-checked — disabling the guard fails exactly those five.
