### PR TITLE
PostgreSQL: translate LIKE to ILIKE for dialect-consistent case-insensitive matching

### DIFF
--- a/PostgreSQL/postgresql.py
+++ b/PostgreSQL/postgresql.py
@@ -209,6 +209,12 @@ class Connection:
     def execute(self, *args, **kwargs):
         sql = args[0].replace("?", "%s")      # qmark → format paramstyle
         sql = sql.replace(" REGEXP ", " ~ ")  # SQLite REGEXP → PostgreSQL ~
+        # SQLite LIKE is case-insensitive (ASCII); PostgreSQL LIKE is
+        # case-sensitive, so use ILIKE for equivalent behavior. Note that
+        # PostgreSQL's ILIKE case-folding follows the connection's locale/
+        # collation, while SQLite's is ASCII-only, so non-ASCII patterns may
+        # fold slightly differently between the two backends.
+        sql = re.sub(r"\bLIKE\b", "ILIKE", sql, flags=re.IGNORECASE)
         # TODO: remove when gramps PR #2178 (_quote_column) is merged into core
         sql = sql.replace("ON media(desc)", "ON media(desc_)")
         sql = re.sub(r'\bBLOB\b', 'BYTEA', sql)  # SQLite BLOB → PostgreSQL BYTEA

--- a/PostgreSQL/tests/test_sql_translations.py
+++ b/PostgreSQL/tests/test_sql_translations.py
@@ -24,6 +24,7 @@ Unit tests for the PostgreSQL SQL dialect translations in Connection.execute().
 These tests cover every rewrite rule applied before a query reaches psycopg2:
   - qmark → format paramstyle  (? → %s)
   - REGEXP operator             (REGEXP → ~)
+  - LIKE operator                (LIKE → ILIKE)
   - two-arg LIMIT               (LIMIT offset, count → LIMIT count OFFSET offset)
   - unlimited LIMIT             (LIMIT -1 → LIMIT ALL)
 
@@ -141,6 +142,31 @@ class TestExecuteRegexpOperator(unittest.TestCase):
 
     def test_no_regexp_unchanged(self):
         sql = "SELECT * FROM person WHERE name = 'foo'"
+        self.assertEqual(_translated(sql), sql)
+
+
+# -------------------------------------------------------------------------
+#
+# TestExecuteLikeOperator
+#
+# -------------------------------------------------------------------------
+class TestExecuteLikeOperator(unittest.TestCase):
+    """LIKE → ILIKE substitution."""
+
+    def test_like_replaced(self):
+        result = _translated("SELECT * FROM person WHERE surname LIKE ?")
+        self.assertIn("ILIKE", result)
+
+    def test_lowercase_like_replaced(self):
+        result = _translated("SELECT * FROM person WHERE surname like ?")
+        self.assertIn("ILIKE", result)
+
+    def test_ilike_not_double_rewritten(self):
+        sql = "SELECT * FROM person WHERE surname ILIKE %s"
+        self.assertEqual(_translated(sql), sql)
+
+    def test_no_like_unchanged(self):
+        sql = "SELECT * FROM person WHERE surname = %s"
         self.assertEqual(_translated(sql), sql)
 
 


### PR DESCRIPTION
## Summary
- SQLite's `LIKE` is case-insensitive by default (ASCII); PostgreSQL's `LIKE` is case-sensitive, with `ILIKE` as its case-insensitive equivalent.
- Adds a `LIKE` → `ILIKE` rewrite to `Connection.execute()`'s existing set of dialect translations (alongside `REGEXP` → `~`, `LIMIT` reshaping, `BLOB` → `BYTEA`), so any SQLite-flavored `LIKE` query behaves equivalently against PostgreSQL.
- No current caller emits `LIKE` yet — this is a forward-looking addition to the dialect layer, following the same pattern established in the recent `_hack_query()` → dialect-methods refactor.

## Test plan
- [x] Added `TestExecuteLikeOperator` (4 cases: uppercase/lowercase `LIKE`, no double-rewrite of existing `ILIKE`, unchanged when absent) to `PostgreSQL/tests/test_sql_translations.py`.
- [x] `python3 -m unittest PostgreSQL.tests.test_sql_translations -v` — all 32 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)