### PR TITLE
Add GOQLFilter addon

### DIFF
--- a/GOQLFilter/goql.gpr.py
+++ b/GOQLFilter/goql.gpr.py
@@ -1,0 +1,199 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Gramplets providing a gramps-object-query-language filter for each
+primary object view."""
+
+_HELP = "Addon:GrampsObjectQueryLanguage"
+_AUTHORS = ["Douglas Blank"]
+_AUTHORS_EMAIL = ["doug.blank@gmail.com"]
+
+register(
+    GRAMPLET,
+    id="Person GOQL Filter",
+    name=_("Person GOQL Filter"),
+    description=_("Gramplet providing a gramps-object-query-language person filter"),
+    version="1.0.0",
+    gramps_target_version="6.1",
+    status=STABLE,
+    fname="goql.py",
+    height=260,
+    gramplet="PersonQueryFilter",
+    gramplet_title=_("GOQL Filter"),
+    navtypes=["Person"],
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+    requires_mod=["gramps_object_query_language"],
+)
+
+register(
+    GRAMPLET,
+    id="Family GOQL Filter",
+    name=_("Family GOQL Filter"),
+    description=_("Gramplet providing a gramps-object-query-language family filter"),
+    version="1.0.0",
+    gramps_target_version="6.1",
+    status=STABLE,
+    fname="goql.py",
+    height=260,
+    gramplet="FamilyQueryFilter",
+    gramplet_title=_("GOQL Filter"),
+    navtypes=["Family"],
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+    requires_mod=["gramps_object_query_language"],
+)
+
+register(
+    GRAMPLET,
+    id="Event GOQL Filter",
+    name=_("Event GOQL Filter"),
+    description=_("Gramplet providing a gramps-object-query-language event filter"),
+    version="1.0.0",
+    gramps_target_version="6.1",
+    status=STABLE,
+    fname="goql.py",
+    height=260,
+    gramplet="EventQueryFilter",
+    gramplet_title=_("GOQL Filter"),
+    navtypes=["Event"],
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+    requires_mod=["gramps_object_query_language"],
+)
+
+register(
+    GRAMPLET,
+    id="Place GOQL Filter",
+    name=_("Place GOQL Filter"),
+    description=_("Gramplet providing a gramps-object-query-language place filter"),
+    version="1.0.0",
+    gramps_target_version="6.1",
+    status=STABLE,
+    fname="goql.py",
+    height=260,
+    gramplet="PlaceQueryFilter",
+    gramplet_title=_("GOQL Filter"),
+    navtypes=["Place"],
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+    requires_mod=["gramps_object_query_language"],
+)
+
+register(
+    GRAMPLET,
+    id="Repository GOQL Filter",
+    name=_("Repository GOQL Filter"),
+    description=_(
+        "Gramplet providing a gramps-object-query-language repository filter"
+    ),
+    version="1.0.0",
+    gramps_target_version="6.1",
+    status=STABLE,
+    fname="goql.py",
+    height=260,
+    gramplet="RepositoryQueryFilter",
+    gramplet_title=_("GOQL Filter"),
+    navtypes=["Repository"],
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+    requires_mod=["gramps_object_query_language"],
+)
+
+register(
+    GRAMPLET,
+    id="Source GOQL Filter",
+    name=_("Source GOQL Filter"),
+    description=_("Gramplet providing a gramps-object-query-language source filter"),
+    version="1.0.0",
+    gramps_target_version="6.1",
+    status=STABLE,
+    fname="goql.py",
+    height=260,
+    gramplet="SourceQueryFilter",
+    gramplet_title=_("GOQL Filter"),
+    navtypes=["Source"],
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+    requires_mod=["gramps_object_query_language"],
+)
+
+register(
+    GRAMPLET,
+    id="Citation GOQL Filter",
+    name=_("Citation GOQL Filter"),
+    description=_("Gramplet providing a gramps-object-query-language citation filter"),
+    version="1.0.0",
+    gramps_target_version="6.1",
+    status=STABLE,
+    fname="goql.py",
+    height=260,
+    gramplet="CitationQueryFilter",
+    gramplet_title=_("GOQL Filter"),
+    navtypes=["Citation"],
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+    requires_mod=["gramps_object_query_language"],
+)
+
+register(
+    GRAMPLET,
+    id="Media GOQL Filter",
+    name=_("Media GOQL Filter"),
+    description=_("Gramplet providing a gramps-object-query-language media filter"),
+    version="1.0.0",
+    gramps_target_version="6.1",
+    status=STABLE,
+    fname="goql.py",
+    height=260,
+    gramplet="MediaQueryFilter",
+    gramplet_title=_("GOQL Filter"),
+    navtypes=["Media"],
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+    requires_mod=["gramps_object_query_language"],
+)
+
+register(
+    GRAMPLET,
+    id="Note GOQL Filter",
+    name=_("Note GOQL Filter"),
+    description=_("Gramplet providing a gramps-object-query-language note filter"),
+    version="1.0.0",
+    gramps_target_version="6.1",
+    status=STABLE,
+    fname="goql.py",
+    height=260,
+    gramplet="NoteQueryFilter",
+    gramplet_title=_("GOQL Filter"),
+    navtypes=["Note"],
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+    requires_mod=["gramps_object_query_language"],
+)

--- a/GOQLFilter/goql.py
+++ b/GOQLFilter/goql.py
@@ -56,7 +56,18 @@ from typing import Any
 # GTK/Gnome modules
 #
 # -------------------------------------------------------------------------
-from gi.repository import Gdk, GLib, Gtk
+import warnings
+
+with warnings.catch_warnings():
+    # PyGObject warns on *import* of GLib -- not on use -- when the
+    # underlying GLib build has moved unix_signal_add_full() to GLibUnix
+    # (GLib >= 2.88). This addon never calls that function; the warning is
+    # just noise from gi's override machinery. See
+    # https://gitlab.gnome.org/GNOME/pygobject/-/work_items/757
+    warnings.filterwarnings(
+        "ignore", message=".*unix_signal_add_full.*", category=DeprecationWarning
+    )
+    from gi.repository import Gdk, GLib, Gtk
 
 # -------------------------------------------------------------------------
 #

--- a/GOQLFilter/goql.py
+++ b/GOQLFilter/goql.py
@@ -1,0 +1,623 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Gramplets providing a gramps-object-query-language (GOQL) filter for each
+primary object view: a multi-line text area for a where-expression plus
+Find / Reset / Define filter buttons, the same shape as core's sidebar
+filters.
+
+"Find" compiles the expression, wraps it in a real ``GenericFilter`` (a
+one-rule filter whose rule evaluates the compiled GOQL ``where`` AST via
+``evaluate_where``), and drops it straight into ``view.generic_filter`` --
+the exact mechanism ``plugins/gramplet/filter.py`` uses for the built-in
+rule-based sidebar filters, just fed from a compiled expression instead of a
+rule-picker widget. "Define filter" hands the same expression to Gramps'
+own ``EditFilter`` dialog as a single ``MatchesExpression`` rule (see
+``whereexprrule.py``), so it can be named and saved as an ordinary Custom
+Filter -- reusable anywhere a Custom Filter is, not just in this gramplet.
+
+The text area is a plain ``Enter``-inserts-a-newline ``Gtk.TextView`` (not a
+``Gtk.Entry``) since where-expressions with ``and``/``or`` read better over
+several lines; ``Ctrl+Return`` runs Find instead. Up/Down at the first/last
+line of the buffer recall previous expressions from an in-memory,
+per-gramplet-instance history (session-scoped -- not persisted to disk),
+the same first/last-line-aware convention multiline REPL inputs use so
+plain cursor movement inside a multi-line expression still works.
+"""
+
+# -------------------------------------------------------------------------
+#
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import logging
+import time
+from typing import Any
+
+# -------------------------------------------------------------------------
+#
+# GTK/Gnome modules
+#
+# -------------------------------------------------------------------------
+from gi.repository import Gdk, Gtk
+
+# -------------------------------------------------------------------------
+#
+# Gramps modules
+#
+# -------------------------------------------------------------------------
+from gramps.gen.plug import Gramplet
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+from gramps.gen.filters import (
+    CustomFilters,
+    GenericFilterFactory,
+    reload_custom_filters,
+)
+from gramps.gui.display import display_help, display_url
+from gramps.gui.editors import EditFilter
+
+# -------------------------------------------------------------------------
+#
+# gramps-object-query-language modules
+#
+# -------------------------------------------------------------------------
+try:
+    from gramps_object_query_language.query_lang import QueryLangError, compile_expr
+except ImportError as err:
+    raise ImportError(
+        "GOQLFilter requires the gramps-object-query-language "
+        "package.\nInstall with: pip install gramps-object-query-language"
+    ) from err
+
+from whereexprrule import (
+    CitationMatchesExpression,
+    EventMatchesExpression,
+    FamilyMatchesExpression,
+    MediaMatchesExpression,
+    NoteMatchesExpression,
+    PersonMatchesExpression,
+    PlaceMatchesExpression,
+    RepositoryMatchesExpression,
+    SourceMatchesExpression,
+)
+from goql_completion_popup import CompletionController
+from goql_highlight import classify_tokens
+
+try:
+    _trans = glocale.get_addon_translator(__file__)
+except ValueError:
+    _trans = glocale.translation
+_ = _trans.gettext
+
+LOG = logging.getLogger(".GOQLFilter")
+
+# Minimum pixel height for the text area's scrolled window -- a floor, not
+# the actual displayed size (the Paned in init() splits editor/buttons ~50%
+# of whatever space is actually available; this just keeps the editor from
+# collapsing to something unreadable if the user drags the divider all the
+# way down). Not computed from font metrics (needs a realized widget), just
+# a reasonable fixed default.
+TEXT_AREA_HEIGHT = 90
+
+# Cap on saved history entries -- self.gui.data round-trips through the
+# gramplet's saved placement config (an .ini file) on every save, so an
+# unbounded history would keep growing that file forever.
+HISTORY_MAX_ENTRIES = 50
+
+# Foreground colors for goql_highlight.classify_tokens' categories -- muted,
+# mid-tone hex values chosen to stay legible on both light and dark GTK
+# themes, since a plain Gtk.TextView has no adaptive-theme color mechanism
+# to hook into (no runtime dark/light detection here).
+HIGHLIGHT_COLORS = {
+    "keyword": "#7C3AED",
+    "string": "#15803D",
+    "number": "#B45309",
+    "constant-class": "#BE185D",
+    "operator": "#6B7280",
+}
+
+
+def _icon_button(icon_name, label_text):
+    """A ``Gtk.Button`` with an icon beside its label.
+
+    Same construction ``_sidebarfilter.py``'s ``_init_interface`` uses for
+    its own "Reset" button (``edit-undo`` + label in an ``Gtk.Box``) --
+    matched here for a consistent look, and reused for "Help".
+    """
+    button = Gtk.Button()
+    box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=4)
+    image = Gtk.Image()
+    image.set_from_icon_name(icon_name, Gtk.IconSize.BUTTON)
+    box.pack_start(image, False, False, 0)
+    box.pack_start(Gtk.Label(label=label_text), False, True, 0)
+    button.add(box)
+    return button
+
+
+# -------------------------------------------------------------------------
+#
+# QueryFilter
+#
+# -------------------------------------------------------------------------
+class QueryFilter(Gramplet):
+    """Base class for all GOQL filter gramplets."""
+
+    NAMESPACE: str = ""  # e.g. "Person"; set by subclass
+    RULE_CLASS: Any = None  # e.g. PersonMatchesExpression; set by subclass
+
+    def init(self):
+        self.history = []
+        self.history_index = None  # None == live/current input, not browsing
+        self.history_draft = ""  # the not-yet-submitted text, saved on history-back
+
+        self.text_view = Gtk.TextView()
+        self.text_view.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
+        self.text_view.set_monospace(True)
+        self.text_buffer = self.text_view.get_buffer()
+        self.text_view.set_tooltip_text(
+            _("A gramps-object-query-language where-expression, e.g.\n")
+            + "gender == Person.MALE and 'Anderson' in primary_name.surname\n\n"
+            + _("Enter inserts a newline; Ctrl+Enter runs Find.\n")
+            + _("Up/Down at the first/last line recalls previous expressions.\n")
+            + _("Tab always completes -- it never inserts a tab character.")
+        )
+        for tag_name, color in HIGHLIGHT_COLORS.items():
+            self.text_buffer.create_tag(tag_name, foreground=color)
+
+        self.completion = CompletionController(
+            self.text_view, get_namespace=lambda: self.NAMESPACE
+        )
+        self.text_view.connect("key-press-event", self._on_key_press)
+        self.text_buffer.connect("changed", self._on_text_changed)
+        self.text_view.connect("button-press-event", self._on_textview_defocus)
+        self.text_view.connect("focus-out-event", self._on_textview_defocus)
+
+        scroller = Gtk.ScrolledWindow()
+        scroller.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        scroller.set_shadow_type(Gtk.ShadowType.IN)
+        scroller.set_min_content_height(TEXT_AREA_HEIGHT)
+        scroller.add(self.text_view)
+
+        # Same button shapes/icons as the built-in rule-based sidebar filter
+        # (`gui/filters/sidebar/_sidebarfilter.py`'s `_init_interface`): a
+        # plain mnemonic "Find" button, an icon+label "Reset", plain-text
+        # "Define filter", grouped into two ButtonBox rows the same way.
+        find_button = Gtk.Button.new_with_mnemonic(_("_Find"))
+        find_button.set_tooltip_text(
+            _("This updates the view with the current filter parameters.")
+        )
+        find_button.connect("clicked", self.find_clicked)
+
+        reset_button = _icon_button("edit-undo", _("Reset"))
+        reset_button.set_tooltip_text(
+            _("This resets the filter parameters to empty state.")
+        )
+        reset_button.connect("clicked", self.reset_clicked)
+
+        define_button = Gtk.Button(label=_("Define filter"))
+        define_button.set_tooltip_text(
+            _("This opens a dialog to save the current expression as a named filter.")
+        )
+        define_button.connect("clicked", self.define_clicked)
+
+        help_button = _icon_button("help-browser", _("Help"))
+        help_button.set_tooltip_text(_("Open this gramplet's help page in a browser."))
+        help_button.connect("clicked", self.help_clicked)
+
+        self.msg_label = Gtk.Label(label="")
+        self.msg_label.set_line_wrap(True)
+        self.msg_label.set_xalign(0)
+
+        action_row = Gtk.ButtonBox()
+        action_row.set_layout(Gtk.ButtonBoxStyle.START)
+        action_row.set_spacing(6)
+        action_row.add(find_button)
+        action_row.add(reset_button)
+
+        secondary_row = Gtk.ButtonBox()
+        secondary_row.set_layout(Gtk.ButtonBoxStyle.START)
+        secondary_row.set_spacing(6)
+        secondary_row.add(define_button)
+        secondary_row.add(help_button)
+
+        bottom_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+        bottom_box.pack_start(action_row, False, False, 0)
+        bottom_box.pack_start(secondary_row, False, False, 0)
+        bottom_box.pack_start(self.msg_label, False, False, 0)
+
+        # A Paned (same widget core's own gui/views/pageview.py uses for its
+        # sidebar/main-content split) rather than a plain Box with
+        # expand=True on the scroller: a Box has no notion of "50% of
+        # whatever's available," only "give the expanding child all
+        # leftover space" -- the text area would end up taller than half
+        # the gramplet on any reasonably tall placement. A Paned's handle
+        # is also user-draggable afterward, which a fixed split wouldn't be.
+        self.paned = Gtk.Paned(orientation=Gtk.Orientation.VERTICAL)
+        self.paned.set_border_width(6)
+        self.paned.pack1(scroller, True, True)
+        self.paned.pack2(bottom_box, False, True)
+        self._paned_position_set = False
+        self.paned.connect("size-allocate", self._init_paned_position)
+
+        self.gui.get_container_widget().remove(self.gui.textview)
+        self.gui.get_container_widget().add(self.paned)
+        self.paned.show_all()
+
+    def _init_paned_position(self, widget, allocation):
+        """Split the editor/buttons area ~50/50 the first time this pane is
+        actually sized.
+
+        ``Gtk.Paned`` has no percentage-based position, only pixels, and
+        the real allocated height isn't known until the widget is
+        realized -- so this can't just be set once up front in ``init()``.
+        Runs exactly once (``self._paned_position_set``): after that, the
+        divider is the user's own drag to keep, not something to keep
+        resetting back to 50% on every later resize.
+        """
+        if self._paned_position_set or allocation.height <= 1:
+            return
+        widget.set_position(allocation.height // 2)
+        self._paned_position_set = True
+
+    def on_load(self):
+        """Restore history saved by a previous session.
+
+        Called once, right after ``init()``, with ``self.gui.data`` already
+        populated from this gramplet's saved placement config (an .ini
+        file) -- the same mechanism core gramplets like
+        ``pedigreegramplet.py`` use for their own persisted options. Each
+        gramplet *instance* (Person filter, Family filter, ...) has its own
+        ``self.gui.data``, so histories stay independent automatically.
+        """
+        self.history = [str(item) for item in self.gui.data]
+
+    def on_save(self):
+        """Called on app/view shutdown, before ``self.gui.data`` is written
+        to disk -- see ``GrampletBar.on_delete``.
+        """
+        self.gui.data = list(self.history)
+
+    def _on_text_changed(self, _buffer):
+        self._apply_highlighting()
+        self.completion.on_buffer_changed()
+
+    def _on_textview_defocus(self, _widget, _event):
+        """Close the completion popover on a click or focus-out -- shared
+        handler for both signals (``button-press-event``,
+        ``focus-out-event``), matching ``GrampyScript.py``'s
+        ``on_textview_click``/``on_editor_focus_out``. Never consumes the
+        event: a click still needs to move the cursor normally.
+        """
+        self.completion.close()
+        return False
+
+    def _apply_highlighting(self):
+        start, end = self.text_buffer.get_bounds()
+        for tag_name in HIGHLIGHT_COLORS:
+            self.text_buffer.remove_tag_by_name(tag_name, start, end)
+        source = self.text_buffer.get_text(start, end, False)
+        for start_line, start_col, end_line, end_col, category in classify_tokens(
+            source
+        ):
+            start_iter = self.text_buffer.get_iter_at_line_offset(start_line, start_col)
+            end_iter = self.text_buffer.get_iter_at_line_offset(end_line, end_col)
+            self.text_buffer.apply_tag_by_name(category, start_iter, end_iter)
+
+    def _get_expr_text(self):
+        start, end = self.text_buffer.get_bounds()
+        return self.text_buffer.get_text(start, end, False).strip()
+
+    def _set_expr_text(self, text):
+        self.text_buffer.set_text(text)
+        self.text_buffer.place_cursor(self.text_buffer.get_end_iter())
+
+    def _set_message(self, text):
+        self.msg_label.set_text(text)
+
+    def _run_with_filter_progress(self, action):
+        """Run ``action()`` with Gramps' own filter-application phase
+        timings routed into this gramplet's message area, mirroring
+        ``gui/filters/sidebar/_sidebarfilter.py``'s ``clicked()``.
+
+        ``GenericFilter.apply()`` (``gen/filters/_genericfilter.py``)
+        already reports "Prepare time: Xs" / "Apply time: Ys" via
+        ``user.notify(...)`` on every call -- but ``User._gui_print``
+        (``gui/user.py``) only routes that to a widget if
+        ``uistate.filter_print_func`` is set; otherwise it falls through to
+        stdout, which is exactly why those lines showed up in a terminal
+        instead of this gramplet. Returns the collected phase messages.
+        """
+        phase_msgs = []
+
+        def pump_events():
+            while Gtk.events_pending():
+                Gtk.main_iteration()
+
+        def live_print(msg):
+            phase_msgs.append(msg)
+            self._set_message("\n".join(phase_msgs))
+            pump_events()
+
+        def live_step():
+            pump_events()
+
+        self.uistate.filter_print_func = live_print
+        self.uistate.filter_step_func = live_step
+        self.uistate.set_busy_cursor(True)
+        try:
+            action()
+        finally:
+            self.uistate.filter_print_func = None
+            self.uistate.filter_step_func = None
+            self.uistate.set_busy_cursor(False)
+        return phase_msgs
+
+    def _filter_method_label(self, gfilter):
+        """ "SQL" if any rule in ``gfilter`` resolved a precomputed match set
+        (``MatchesExpression.prepare`` sets ``selected_handles`` only when
+        it pushed the expression down to SQL), else "Python evaluation".
+        """
+        for rule in gfilter.get_rules():
+            if getattr(rule, "selected_handles", None) is not None:
+                return _("SQL")
+        return _("Python evaluation")
+
+    def _remember_history(self, expr):
+        """Append ``expr`` to history, skipping an immediate repeat."""
+        if expr and (not self.history or self.history[-1] != expr):
+            self.history.append(expr)
+            del self.history[:-HISTORY_MAX_ENTRIES]
+        self.history_index = None
+
+    def _history_back(self):
+        if not self.history:
+            return
+        if self.history_index is None:
+            self.history_draft = self._get_expr_text()
+            self.history_index = len(self.history) - 1
+        elif self.history_index > 0:
+            self.history_index -= 1
+        else:
+            return  # already at the oldest entry
+        self._set_expr_text(self.history[self.history_index])
+
+    def _history_forward(self):
+        if self.history_index is None:
+            return  # not browsing
+        if self.history_index < len(self.history) - 1:
+            self.history_index += 1
+            self._set_expr_text(self.history[self.history_index])
+        else:
+            self.history_index = None
+            self._set_expr_text(self.history_draft)
+
+    def _on_key_press(self, _widget, event):
+        # Completion first: when its popover is open, Up/Down/Enter/Escape
+        # navigate/accept/dismiss it rather than falling through to history
+        # navigation or a newline below -- see CompletionController's own
+        # key-press dispatch.
+        if self.completion.on_key_press(event):
+            return True
+
+        ctrl = bool(event.state & Gdk.ModifierType.CONTROL_MASK)
+
+        if event.keyval == Gdk.KEY_Tab:
+            # Tab is always completion, never a literal tab/space insert:
+            # self.completion.on_key_press already tried above and
+            # returned False here only because there was nothing
+            # completable -- still consume the key rather than falling
+            # back to GTK's default (inserting a tab character).
+            return True
+
+        if ctrl and event.keyval in (Gdk.KEY_Return, Gdk.KEY_KP_Enter):
+            self.find_clicked(_widget)
+            return True  # don't also insert a newline
+
+        if not ctrl and event.keyval in (Gdk.KEY_Up, Gdk.KEY_Down):
+            cursor = self.text_buffer.get_iter_at_mark(self.text_buffer.get_insert())
+            at_first_line = cursor.get_line() == 0
+            at_last_line = cursor.get_line() == self.text_buffer.get_line_count() - 1
+            if event.keyval == Gdk.KEY_Up and at_first_line:
+                self._history_back()
+                return True
+            if event.keyval == Gdk.KEY_Down and at_last_line:
+                self._history_forward()
+                return True
+
+        return False  # let GTK handle it normally
+
+    def _hide_quick_search_bar(self):
+        """Close the view's own quick-search bar, if open.
+
+        ``ListView.build_tree()`` only reads ``generic_filter`` when its
+        quick-search bar (the small text-search box built into every list
+        view, independent of this gramplet) is hidden -- otherwise it uses
+        *that* bar's own filter instead and ``generic_filter`` is silently
+        ignored. The bar auto-hides when the view's Sidebar pane is toggled
+        on, but this gramplet may just as well be docked in the bottombar,
+        so hide it explicitly rather than depending on where the user put
+        the gramplet.
+        """
+        search_bar = getattr(self.gui.view, "search_bar", None)
+        if search_bar is not None and search_bar.is_visible():
+            search_bar.hide()
+
+    def _build_generic_filter(self, expr):
+        """A ``GenericFilter`` for ``expr``, or ``None`` if it fails to compile.
+
+        Validates ``expr`` up front so a bad expression reports a clear error
+        here rather than silently matching nothing -- ``RULE_CLASS.prepare()``
+        recompiles it a second time when the filter is applied, since a
+        ``Rule`` only ever receives its arguments as plain strings.
+        """
+        try:
+            compile_expr(self.NAMESPACE, expr)
+        except QueryLangError as err:
+            self._set_message(str(err))
+            return None
+        gfilter = GenericFilterFactory(self.NAMESPACE)()
+        gfilter.add_rule(self.RULE_CLASS([expr]))
+        return gfilter
+
+    def find_clicked(self, _obj):
+        expr = self._get_expr_text()
+        self._set_message("")
+        if not expr:
+            self.reset_clicked(_obj)
+            return
+        gfilter = self._build_generic_filter(expr)
+        if gfilter is None:
+            return
+        self._remember_history(expr)
+        phase_msgs = []
+        try:
+            self._hide_quick_search_bar()
+            self.gui.view.generic_filter = gfilter
+
+            def do_build_tree():
+                self.gui.view.build_tree()
+
+            phase_msgs = self._run_with_filter_progress(do_build_tree)
+        except Exception as err:  # never let a click silently fail
+            LOG.exception("GOQL Filter gramplet: Find failed")
+            self._set_message(_("Error applying filter: %s") % err)
+            return
+        model = self.gui.view.model
+        summary = _("Showing %(shown)d of %(total)d (%(method)s)") % {
+            "shown": model.displayed(),
+            "total": model.total(),
+            "method": self._filter_method_label(gfilter),
+        }
+        self._set_message("\n".join(phase_msgs + [summary]))
+
+    def reset_clicked(self, _obj):
+        self._set_expr_text("")
+        try:
+            self._hide_quick_search_bar()
+            self.gui.view.generic_filter = None
+            self.gui.view.build_tree()
+        except Exception as err:
+            LOG.exception("GOQL Filter gramplet: Reset failed")
+            self._set_message(_("Error resetting filter: %s") % err)
+            return
+        self._set_message("")
+
+    def define_clicked(self, _obj):
+        expr = self._get_expr_text()
+        if not expr:
+            self._set_message(_("Enter an expression first"))
+            return
+        try:
+            compile_expr(self.NAMESPACE, expr)
+        except QueryLangError as err:
+            self._set_message(str(err))
+            return
+        self._set_message("")
+        self._remember_history(expr)
+
+        gfilter = GenericFilterFactory(self.NAMESPACE)()
+        gfilter.add_rule(self.RULE_CLASS([expr]))
+        comment = _("Created by the GOQL Filter gramplet on {today}").format(
+            today=time.strftime("%Y-%m-%d", time.localtime())
+        )
+        gfilter.set_comment(comment)
+
+        EditFilter(
+            self.NAMESPACE,
+            self.dbstate,
+            self.uistate,
+            [],
+            gfilter,
+            CustomFilters,
+            selection_callback=self._filter_defined,
+        )
+
+    def _filter_defined(self, filterdb, _filter_name):
+        filterdb.save()
+        reload_custom_filters()
+        self.uistate.emit("filters-changed", (self.NAMESPACE,))
+
+    def help_clicked(self, _obj):
+        """Open this gramplet's registered ``help_url`` in a browser.
+
+        ``self.gui.help_url`` is set from the ``.gpr.py`` registration's
+        ``help_url=`` (``GuiGramplet.__init__``, ``gui/widgets/
+        grampletpane.py``) -- the same attribute the built-in "Help" menu
+        item on every gramplet tab already reads, via the same
+        ``http(s)://`` vs. wiki-page-name dispatch used there
+        (``grampletpane.py``/``grampletbar.py``'s own right-click "Help").
+        """
+        help_url = getattr(self.gui, "help_url", None)
+        if not help_url:
+            return
+        if help_url.startswith(("http://", "https://")):
+            display_url(help_url)
+        else:
+            display_help(help_url)
+
+
+# -------------------------------------------------------------------------
+#
+# Per-type gramplets
+#
+# -------------------------------------------------------------------------
+class PersonQueryFilter(QueryFilter):
+    NAMESPACE = "Person"
+    RULE_CLASS = PersonMatchesExpression
+
+
+class FamilyQueryFilter(QueryFilter):
+    NAMESPACE = "Family"
+    RULE_CLASS = FamilyMatchesExpression
+
+
+class EventQueryFilter(QueryFilter):
+    NAMESPACE = "Event"
+    RULE_CLASS = EventMatchesExpression
+
+
+class PlaceQueryFilter(QueryFilter):
+    NAMESPACE = "Place"
+    RULE_CLASS = PlaceMatchesExpression
+
+
+class RepositoryQueryFilter(QueryFilter):
+    NAMESPACE = "Repository"
+    RULE_CLASS = RepositoryMatchesExpression
+
+
+class SourceQueryFilter(QueryFilter):
+    NAMESPACE = "Source"
+    RULE_CLASS = SourceMatchesExpression
+
+
+class CitationQueryFilter(QueryFilter):
+    NAMESPACE = "Citation"
+    RULE_CLASS = CitationMatchesExpression
+
+
+class MediaQueryFilter(QueryFilter):
+    NAMESPACE = "Media"
+    RULE_CLASS = MediaMatchesExpression
+
+
+class NoteQueryFilter(QueryFilter):
+    NAMESPACE = "Note"
+    RULE_CLASS = NoteMatchesExpression

--- a/GOQLFilter/goql.py
+++ b/GOQLFilter/goql.py
@@ -56,7 +56,7 @@ from typing import Any
 # GTK/Gnome modules
 #
 # -------------------------------------------------------------------------
-from gi.repository import Gdk, Gtk
+from gi.repository import Gdk, GLib, Gtk
 
 # -------------------------------------------------------------------------
 #
@@ -195,6 +195,18 @@ class QueryFilter(Gramplet):
         scroller.set_min_content_height(TEXT_AREA_HEIGHT)
         scroller.add(self.text_view)
 
+        # Reminds the user this expression's fields are specific to this
+        # view -- e.g. "gender" compiles here but not in the Family filter.
+        namespace_label = Gtk.Label()
+        namespace_label.set_markup(
+            "<b>%s</b>" % GLib.markup_escape_text(_("%s filter") % _(self.NAMESPACE))
+        )
+        namespace_label.set_xalign(0)
+
+        editor_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=3)
+        editor_box.pack_start(namespace_label, False, False, 0)
+        editor_box.pack_start(scroller, True, True, 0)
+
         # Same button shapes/icons as the built-in rule-based sidebar filter
         # (`gui/filters/sidebar/_sidebarfilter.py`'s `_init_interface`): a
         # plain mnemonic "Find" button, an icon+label "Reset", plain-text
@@ -251,7 +263,7 @@ class QueryFilter(Gramplet):
         # is also user-draggable afterward, which a fixed split wouldn't be.
         self.paned = Gtk.Paned(orientation=Gtk.Orientation.VERTICAL)
         self.paned.set_border_width(6)
-        self.paned.pack1(scroller, True, True)
+        self.paned.pack1(editor_box, True, True)
         self.paned.pack2(bottom_box, False, True)
         self._paned_position_set = False
         self.paned.connect("size-allocate", self._init_paned_position)

--- a/GOQLFilter/goql_completion.py
+++ b/GOQLFilter/goql_completion.py
@@ -1,0 +1,142 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""GOQL-specific completion source for ``goql_completion_popup``'s
+``CompletionController``.
+
+Kept free of GTK imports, mirroring ``GrampyScript/completion.py``'s own
+"testable without a display" convention -- ``goql.py`` is responsible for
+turning a ``Gtk.TextBuffer`` cursor position into ``(source, line, column)``.
+
+Deliberately not jedi-based, unlike GrampyScript's completion engine: a
+where-expression is never executed, has no live namespace of real Python
+objects to introspect, and its grammar is a small closed set (see
+``gramps_object_query_language.query_lang``'s module docstring) -- general
+Python completion would suggest names (arbitrary methods, ``import``, ...)
+that are simply invalid here. This only ever offers two things, matching
+what was actually asked for:
+
+- At the top level (no ``.`` immediately before the word being typed): the
+  current namespace's own vocabulary -- flat column names, relationship
+  names (``birth``, ``father``, ...), collection names (``children``,
+  ``events``, ...), the where-expression keywords (``and``/``or``/``not``/
+  ``in``/``like``/``Date``/``exists``/``count``), the comparison operators
+  (``==``/``!=``/``<``/``<=``/``>``/``>=``) -- included even though most are
+  a single character and so only ever surface with an empty prefix (Tab on
+  its own), not because they're likely to be *typed* out via completion --
+  and the constant class names themselves (``Person``, ``EventType``, ...)
+  so typing far enough to reach one and then ``.`` is a smooth continuation.
+- Right after ``ClassName.``, where ``ClassName`` is one of the constant
+  classes ``query_lang.py`` recognizes on the value side of a comparison
+  (``Person.MALE``, ``EventType.BIRTH``, ...): that class's own ALL_CAPS
+  int constants.
+
+Anything else (e.g. completing a nested JSON field inside
+``primary_name.``) returns no completions -- out of scope for now, not a
+silent failure to fix.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Set
+
+# `_RELATIONSHIPS`/`_COLLECTIONS` (query.py) and `_CONSTANT_CLASSES`/
+# `_CONSTANTS` (query_lang.py) are module-private -- there is no public way
+# to *enumerate* every relationship/collection/constant name for a spec
+# (only to resolve one given name, via the public `resolve_collection`/
+# `resolve_column_path`). Reaching into them here is a deliberate, narrow
+# exception for exactly this reason, not an oversight; if
+# gramps-object-query-language grows a public enumeration API, switch to it.
+from gramps_object_query_language.query import _COLLECTIONS, _RELATIONSHIPS
+from gramps_object_query_language.query_lang import (
+    QueryLangError,
+    _CONSTANT_CLASSES,
+    _CONSTANTS,
+    resolve_namespace,
+)
+
+from goql_vocabulary import COMPARISON_OPERATORS, KEYWORDS
+
+_DOTTED_RE = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z0-9_]*)$")
+_WORD_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _text_before_cursor(source: str, line: int, column: int) -> str:
+    """``source`` truncated to the cursor position.
+
+    ``line`` is 1-indexed, ``column`` is a 0-indexed character offset
+    within that line -- the same convention ``CompletionController`` uses
+    (``GrampyScript/completion_popup.py``'s ``_cursor_line_column``,
+    matching ``Gtk.TextIter.get_line() + 1`` / ``get_line_offset()``).
+    """
+    lines = source.split("\n")
+    index = max(0, min(line - 1, len(lines) - 1)) if lines else 0
+    before_lines = lines[:index]
+    current_line = lines[index] if lines else ""
+    return "\n".join(before_lines + [current_line[:column]])
+
+
+def _top_level_names(namespace: str) -> Set[str]:
+    try:
+        spec = resolve_namespace(namespace)
+    except QueryLangError:
+        return set()
+    names: Set[str] = set(spec.columns)
+    names.update(_RELATIONSHIPS.get(spec.table, {}).keys())
+    names.update(_COLLECTIONS.get(spec.table, {}).keys())
+    names.update(KEYWORDS)
+    names.update(COMPARISON_OPERATORS)
+    names.update(_CONSTANT_CLASSES.keys())
+    return names
+
+
+def _constant_names(class_name: str) -> Set[str]:
+    return set(_CONSTANTS.get(class_name, {}).keys())
+
+
+def get_completion_items(
+    source: str, line: int, column: int, namespace: str
+) -> List[Dict[str, Any]]:
+    """Candidate completions at ``(line, column)`` in ``source``, for the
+    given GOQL ``namespace`` ("Person", "Family", ...).
+
+    Same return shape as ``GrampyScript/completion.py``'s
+    ``get_completion_items`` -- ``{"name": ..., "complete": ..., "cursor_offset":
+    0}`` dicts -- so ``goql_completion_popup.CompletionController`` (adapted
+    from ``GrampyScript/completion_popup.py``) can drive either unchanged.
+    Always flat: no attempt to parse the surrounding expression's grammar,
+    only what immediately precedes the word being completed.
+    """
+    text_before = _text_before_cursor(source, line, column)
+    dotted = _DOTTED_RE.search(text_before)
+    if dotted:
+        class_name, prefix = dotted.group(1), dotted.group(2)
+        names = _constant_names(class_name)
+    else:
+        word = _WORD_RE.search(text_before)
+        prefix = word.group(0) if word else ""
+        names = _top_level_names(namespace)
+
+    matches = sorted(name for name in names if name.startswith(prefix))
+    return [
+        {"name": name, "complete": name[len(prefix) :], "cursor_offset": 0}
+        for name in matches
+    ]

--- a/GOQLFilter/goql_completion_popup.py
+++ b/GOQLFilter/goql_completion_popup.py
@@ -1,0 +1,336 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2025      Doug Blank
+# Copyright (C) 2026       Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""A Tab-triggered, live-filtering completion popover for a ``Gtk.TextView``.
+
+Vendored from the ``GrampyScript`` addon's ``completion_popup.py``
+(``CompletionController``), which is deliberately GTK-only and
+completion-source-agnostic already -- its own docstring says it's "kept as
+a standalone controller... so it can be driven directly against a plain
+Gtk.TextView", touching its jedi-based backend through exactly one import
+(``from completion import get_completion_items``). That's the only line
+changed here: swapped for ``goql_completion``'s namespace-aware, non-jedi
+source (see that module's docstring for why a where-expression can't reuse
+GrampyScript's actual completion engine, only its popup).
+
+Named differently from GrampyScript's own ``completion_popup.py``/
+``completion.py`` on purpose -- if both addons are ever installed at once,
+Gramps' plugin loader puts each addon's own directory on ``sys.path``, and
+a bare ``import completion_popup`` here could resolve to whichever one
+happened to be imported first instead of this file (the same
+namespace-collision hazard as Mantis 12691, just at the addon-to-addon
+level instead of within one addon).
+
+Two further deltas from the vendored original, both because this editor's
+Tab key has no fallback behavior to protect (GrampyScript's Tab inserts 4
+spaces when nothing is completable; this one never inserts anything):
+
+- ``_is_completable_context`` always returns True here -- GrampyScript
+  gates completion on the preceding character (alnum/``_``/``.``/``]``) so
+  Tab's whitespace-insert fallback doesn't fire in a confusing spot; this
+  editor has no such fallback to protect, and "Tab on an empty buffer
+  shows every top-level name for the current namespace" is exactly the
+  wanted behavior, not an edge case to guard against.
+- Callers are expected to unconditionally consume ``Gdk.KEY_Tab``
+  themselves (return ``True``) regardless of what ``on_key_press`` reports,
+  rather than falling back to inserting a tab character the way
+  GrampyScript's own key handler does.
+
+Wiring it into a host widget requires forwarding four things:
+    textview "key-press-event"   -> controller.on_key_press(event)
+                                     (if it returns True, treat the event
+                                     as handled and stop further processing)
+    buffer   "changed"           -> controller.on_buffer_changed()
+    textview "button-press-event"/"focus-out-event" -> controller.close()
+"""
+
+import logging
+
+from gi.repository import Gdk, Gtk
+
+from goql_completion import get_completion_items
+
+_LOG = logging.getLogger(".GOQLFilter.completion")
+
+_NAVIGATION_KEYS = (
+    Gdk.KEY_Left,
+    Gdk.KEY_Right,
+    Gdk.KEY_Home,
+    Gdk.KEY_End,
+    Gdk.KEY_Page_Up,
+    Gdk.KEY_Page_Down,
+)
+
+
+class CompletionController:
+    def __init__(self, textview, get_namespace):
+        """
+        `textview`: the Gtk.TextView to attach completion to.
+        `get_namespace`: zero-arg callable returning the current GOQL
+        namespace string ("Person", "Family", ...) for
+        `get_completion_items()`; called fresh on every request so it
+        always reflects whichever gramplet/rule this controller is
+        attached to.
+        """
+        self.textview = textview
+        self.buffer = textview.get_buffer()
+        self.get_namespace = get_namespace
+        self.popover = None
+        self.listbox = None
+        self.scrolled = None
+        self.items = []
+        self.selected_index = 0
+
+    # ---- public event entry points -----------------------------------
+
+    def on_key_press(self, event):
+        """Return True if the event was consumed and should not be
+        processed any further by the caller."""
+        try:
+            return self._on_key_press(event)
+        except Exception:
+            # Never let a bug here swallow the keypress entirely -- that
+            # would leave GTK's own default handler to run instead, which
+            # looks like "completion silently does nothing." Log and fall
+            # back to "not handled" instead.
+            _LOG.exception("completion on_key_press failed")
+            self.close()
+            return False
+
+    def _on_key_press(self, event):
+        keyval = event.keyval
+        _LOG.debug(
+            "on_key_press keyval=%s open=%s", Gdk.keyval_name(keyval), self.is_open()
+        )
+        if keyval == Gdk.KEY_Tab:
+            if self.is_open():
+                self.accept()
+                return True
+            return self.trigger()
+        if self.is_open():
+            if keyval == Gdk.KEY_Up:
+                self.move_selection(-1)
+                return True
+            if keyval == Gdk.KEY_Down:
+                self.move_selection(1)
+                return True
+            if keyval in (Gdk.KEY_Return, Gdk.KEY_KP_Enter):
+                self.accept()
+                return True
+            if keyval == Gdk.KEY_Escape:
+                self.close()
+                return True
+            if keyval in _NAVIGATION_KEYS:
+                # The cursor is about to move out from under the popover;
+                # let it move normally, just stop completing at this spot.
+                self.close()
+                return False
+        return False
+
+    def on_buffer_changed(self):
+        if not self.is_open():
+            return
+        try:
+            self.refresh()
+        except Exception:
+            _LOG.exception("completion refresh failed")
+            self.close()
+
+    def is_open(self):
+        return self.popover is not None
+
+    # ---- core -----------------------------------------------------------
+
+    def _cursor_iter(self):
+        return self.buffer.get_iter_at_mark(self.buffer.get_insert())
+
+    def _cursor_line_column(self):
+        it = self._cursor_iter()
+        return it.get_line() + 1, it.get_line_offset()
+
+    def _word_prefix(self):
+        it = self._cursor_iter()
+        start = it.copy()
+        while start.backward_char():
+            ch = start.get_char()
+            if ch.isalnum() or ch == "_":
+                continue
+            start.forward_char()
+            break
+        return self.buffer.get_text(start, it, True)
+
+    def _is_completable_context(self):
+        # Always True here -- see this module's docstring for why, unlike
+        # GrampyScript's version, this editor has no whitespace-insert
+        # fallback to protect Tab from firing into.
+        return True
+
+    def _compute_items(self):
+        source = self.buffer.get_text(
+            self.buffer.get_start_iter(), self.buffer.get_end_iter(), True
+        )
+        line, column = self._cursor_line_column()
+        prefix = self._word_prefix()
+        _LOG.debug(
+            "computing completions at line=%s column=%s prefix=%r", line, column, prefix
+        )
+        try:
+            namespace = self.get_namespace()
+            items = get_completion_items(source, line, column, namespace)
+        except Exception:
+            _LOG.exception("building completion items failed")
+            return []
+        if not prefix.startswith("_"):
+            items = [item for item in items if not item["name"].startswith("_")]
+        _LOG.debug(
+            "found %d completion(s): %s", len(items), [i["name"] for i in items[:10]]
+        )
+        return items
+
+    def trigger(self):
+        """Try to complete at the cursor. Returns True if there was
+        something completable to show. A single match is inserted
+        directly instead of opening a popover with one row in it;
+        multiple matches open the popover as usual."""
+        if not self._is_completable_context():
+            return False
+        items = self._compute_items()
+        if not items:
+            _LOG.debug("trigger: no completions")
+            return False
+        self.items = items
+        self.selected_index = 0
+        if len(items) == 1:
+            _LOG.debug(
+                "trigger: single match, inserting directly: %s", items[0]["name"]
+            )
+            self.accept()
+            return True
+        self._open_popover()
+        return True
+
+    def refresh(self):
+        """Recompute matches for an already-open popover, following the
+        cursor as the user keeps typing. Closes if nothing matches
+        anymore."""
+        items = self._compute_items()
+        if not items:
+            self.close()
+            return
+        self.items = items
+        self.selected_index = min(self.selected_index, len(items) - 1)
+        self._rebuild_listbox()
+        self._reposition()
+
+    def move_selection(self, delta):
+        if not self.items:
+            return
+        self.selected_index = max(
+            0, min(len(self.items) - 1, self.selected_index + delta)
+        )
+        self._update_row_selection()
+
+    def accept(self):
+        if self.items:
+            item = self.items[self.selected_index]
+            self.buffer.insert(self._cursor_iter(), item["complete"])
+            offset = item.get("cursor_offset", 0)
+            if offset:
+                it = self._cursor_iter()
+                it.backward_chars(offset)
+                self.buffer.place_cursor(it)
+        self.close()
+
+    def close(self):
+        if self.popover is not None:
+            self.popover.destroy()
+        self.popover = None
+        self.listbox = None
+        self.scrolled = None
+        self.items = []
+        self.selected_index = 0
+
+    # ---- widget building --------------------------------------------------
+
+    def _open_popover(self):
+        self.popover = Gtk.Popover()
+        self.popover.set_relative_to(self.textview)
+        self.popover.set_modal(False)
+        self.popover.set_position(Gtk.PositionType.BOTTOM)
+
+        self.scrolled = Gtk.ScrolledWindow()
+        self.scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        self.scrolled.set_max_content_height(200)
+        self.scrolled.set_propagate_natural_height(True)
+
+        self.listbox = Gtk.ListBox()
+        self.listbox.set_activate_on_single_click(True)
+        self.listbox.connect("row-activated", self._on_row_activated)
+        self.scrolled.add(self.listbox)
+        self.popover.add(self.scrolled)
+
+        self._rebuild_listbox()
+        self.popover.show_all()
+        self._reposition()
+        self.popover.popup()
+
+    def _rebuild_listbox(self):
+        for child in self.listbox.get_children():
+            self.listbox.remove(child)
+        for item in self.items:
+            label = Gtk.Label(label=item["name"], xalign=0)
+            label.set_margin_start(6)
+            label.set_margin_end(6)
+            row = Gtk.ListBoxRow()
+            row.add(label)
+            self.listbox.add(row)
+        self.listbox.show_all()
+        self._update_row_selection()
+
+    def _update_row_selection(self):
+        row = self.listbox.get_row_at_index(self.selected_index)
+        if row is not None:
+            self.listbox.select_row(row)
+            self._scroll_to_row(row)
+
+    def _scroll_to_row(self, row):
+        alloc = row.get_allocation()
+        adj = self.scrolled.get_vadjustment()
+        if alloc.y < adj.get_value():
+            adj.set_value(alloc.y)
+        elif alloc.y + alloc.height > adj.get_value() + adj.get_page_size():
+            adj.set_value(alloc.y + alloc.height - adj.get_page_size())
+
+    def _reposition(self):
+        rect = self.textview.get_iter_location(self._cursor_iter())
+        x, y = self.textview.buffer_to_window_coords(
+            Gtk.TextWindowType.WIDGET, rect.x, rect.y
+        )
+        pointing = Gdk.Rectangle()
+        pointing.x = x
+        pointing.y = y
+        pointing.width = 1
+        pointing.height = rect.height
+        self.popover.set_pointing_to(pointing)
+
+    def _on_row_activated(self, listbox, row):
+        self.selected_index = row.get_index()
+        self.accept()

--- a/GOQLFilter/goql_highlight.py
+++ b/GOQLFilter/goql_highlight.py
@@ -1,0 +1,100 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Token-span classification for GOQL where-expression syntax highlighting.
+
+Kept free of GTK imports -- same "testable without a display" convention as
+``goql_completion.py`` -- ``goql.py`` is responsible for turning a span into
+a ``Gtk.TextTag`` range.
+
+Uses Python's own ``tokenize`` module rather than a hand-written lexer: a
+where-expression's tokens (names, string/number literals, comparison
+operators) are a strict subset of Python's own, so there's no new grammar
+to maintain here -- just a classification on top of what ``tokenize``
+already produces. This is lexical only (keyword/string/number/operator/
+known-constant-class recognition from token text alone), not a real parse
+-- it never rejects anything ``query_lang.py`` wouldn't also accept or
+reject on its own; ``compile_expr``'s own error message is still the
+source of truth for whether an expression is valid.
+"""
+
+from __future__ import annotations
+
+import io
+import tokenize
+from typing import Iterator, Tuple
+
+from gramps_object_query_language.query_lang import _CONSTANT_CLASSES
+
+from goql_vocabulary import COMPARISON_OPERATORS, KEYWORDS
+
+# (start_line, start_col, end_line, end_col, category) -- 0-indexed lines,
+# matching Gtk.TextIter's own convention (tokenize's rows are 1-indexed).
+Span = Tuple[int, int, int, int, str]
+
+
+def classify_tokens(source: str) -> Iterator[Span]:
+    """Yield a ``Span`` for each highlightable token in ``source``.
+
+    Incomplete/invalid source -- the normal state of this buffer while
+    still being typed, not an error case -- is handled by
+    ``_tokenize_best_effort``: whatever ``tokenize`` managed to produce
+    before hitting the unparseable part is still yielded.
+    """
+    for tok in _tokenize_best_effort(source):
+        category = _classify(tok)
+        if category is None:
+            continue
+        start_line, start_col = tok.start
+        end_line, end_col = tok.end
+        yield (start_line - 1, start_col, end_line - 1, end_col, category)
+
+
+def _classify(tok) -> str | None:
+    if tok.type == tokenize.STRING:
+        return "string"
+    if tok.type == tokenize.NUMBER:
+        return "number"
+    if tok.type == tokenize.NAME:
+        if tok.string in KEYWORDS:
+            return "keyword"
+        if tok.string in _CONSTANT_CLASSES:
+            return "constant-class"
+        return None
+    if tok.type == tokenize.OP and tok.string in COMPARISON_OPERATORS:
+        return "operator"
+    return None
+
+
+def _tokenize_best_effort(source: str):
+    """``tokenize.generate_tokens`` raises on unterminated strings,
+    unbalanced brackets, or an expression that just stops mid-line -- all
+    routine while typing, not something to surface as a highlighting
+    failure. Whatever was already yielded before the exception is kept
+    (the loop below appends token-by-token, so a raise partway through
+    only truncates the tail, not the whole result).
+    """
+    tokens = []
+    try:
+        for tok in tokenize.generate_tokens(io.StringIO(source).readline):
+            tokens.append(tok)
+    except Exception:
+        pass
+    return tokens

--- a/GOQLFilter/goql_vocabulary.py
+++ b/GOQLFilter/goql_vocabulary.py
@@ -1,0 +1,37 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Shared where-expression token vocabulary.
+
+The small, fixed set of non-column tokens a where-expression can use --
+``goql_completion.py`` (Tab completion) and ``goql_highlight.py`` (syntax
+coloring) both need this same list and previously each kept their own
+copy, which is exactly the kind of thing that quietly drifts apart when
+one gets updated and the other doesn't. One source of truth instead.
+
+``and``/``or``/``not``/``in`` are real Python keywords (and thus real
+where_expr operators); ``like``/``Date``/``exists``/``count`` are the
+whitelisted function-call forms ``gramps_object_query_language.query_lang``
+recognizes -- see that module's docstring.
+"""
+
+KEYWORDS = frozenset({"and", "or", "not", "in", "like", "Date", "exists", "count"})
+
+COMPARISON_OPERATORS = frozenset({"==", "!=", "<", "<=", ">", ">="})

--- a/GOQLFilter/tests/test_goql.py
+++ b/GOQLFilter/tests/test_goql.py
@@ -1,0 +1,593 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Mocked unit tests for the ``QueryFilter`` gramplet's click handlers.
+
+No live Gramps window, no database on disk -- ``self.gui``/``self.dbstate``/
+``self.uistate`` are replaced with mocks (``PersonQueryFilter.__new__``
+bypasses ``Gramplet.__init__``, the same pattern
+``Form/tests/test_editform_save_guards.py`` uses to avoid needing a running
+main window). ``compile_expr``/``GenericFilterFactory`` run for real --
+they're pure/fast and need no display.
+
+Run with::
+
+    python3 -m unittest GOQLFilter.tests.test_goql -v
+"""
+
+import os
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+ADDON_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ADDON_DIR not in sys.path:
+    sys.path.insert(0, ADDON_DIR)
+
+try:
+    import gi  # noqa: F401
+    from gi.repository import Gdk
+except ImportError as err:
+    raise unittest.SkipTest("PyGObject not available: %s" % err)
+
+try:
+    import goql as goql_gramplet
+except ImportError as exc:
+    raise unittest.SkipTest(
+        "goql import failed (likely missing gramps-object-query-language): %s" % exc
+    )
+
+
+def _make_gramplet(initial_text=""):
+    """A ``PersonQueryFilter`` with only the attributes its click handlers
+    touch -- bypasses ``Gramplet.__init__``, which wants a live
+    ``GuiGramplet``/``dbstate``/``uistate`` and builds real widgets against
+    a running Gramps window. ``_get_expr_text``/``_set_expr_text`` stand in
+    for the real ``Gtk.TextBuffer``-backed versions -- what they read from
+    and write to is exactly the seam ``find_clicked``/``reset_clicked``/
+    ``define_clicked``/history navigation go through.
+    """
+    gramplet = goql_gramplet.PersonQueryFilter.__new__(goql_gramplet.PersonQueryFilter)
+    text = {"value": initial_text}
+    gramplet._get_expr_text = MagicMock(side_effect=lambda: text["value"].strip())
+    gramplet._set_expr_text = MagicMock(
+        side_effect=lambda t: text.__setitem__("value", t)
+    )
+    gramplet.msg_label = MagicMock()
+    gramplet.dbstate = MagicMock()
+    gramplet.uistate = MagicMock()
+    gramplet.gui = MagicMock()
+    gramplet.history = []
+    gramplet.history_index = None
+    gramplet.history_draft = ""
+    gramplet.completion = MagicMock()
+    gramplet.completion.on_key_press.return_value = False
+    return gramplet
+
+
+def _key_event(keyval, ctrl=False):
+    return types.SimpleNamespace(
+        keyval=keyval,
+        state=(Gdk.ModifierType.CONTROL_MASK if ctrl else Gdk.ModifierType(0)),
+    )
+
+
+# ------------------------------------------------------------
+#
+# DefineFilterCallbackTest
+#
+# ------------------------------------------------------------
+class DefineFilterCallbackTest(unittest.TestCase):
+    """Regression test: interactively, "Define filter" -> OK raised
+    ``TypeError: QueryFilter._filter_defined() missing 2 required
+    positional arguments: 'filterdb' and '_filter_name'``.
+
+    Cause: ``define_clicked`` passed ``_filter_defined`` to ``EditFilter``'s
+    ``update`` parameter, which ``EditFilter.on_ok_clicked`` calls with zero
+    arguments (``self.update()``). The two-argument call
+    (``self.selection_callback(self.filterdb, self.filter.get_name())``)
+    is a separate parameter, ``selection_callback`` -- see
+    ``gramps/gui/editors/filtereditor.py``. Fixed by passing
+    ``_filter_defined`` as ``selection_callback`` instead.
+    """
+
+    def test_define_clicked_uses_selection_callback_not_update(self):
+        gramplet = _make_gramplet("gender == Person.MALE")
+
+        with patch.object(goql_gramplet, "EditFilter") as mock_edit_filter:
+            gramplet.define_clicked(None)
+
+        mock_edit_filter.assert_called_once()
+        _args, kwargs = mock_edit_filter.call_args
+        # Bound methods aren't identical objects across separate attribute
+        # accesses even for the same instance+function, so compare by
+        # equality (bound methods implement __eq__), not identity.
+        self.assertEqual(kwargs.get("selection_callback"), gramplet._filter_defined)
+        self.assertIsNone(kwargs.get("update"))
+
+    def test_filter_defined_matches_editfilter_call_signature(self):
+        """``EditFilter.on_ok_clicked`` calls
+        ``self.selection_callback(self.filterdb, self.filter.get_name())``
+        -- ``_filter_defined`` must accept exactly that shape and use it to
+        persist + reload the custom filter list.
+        """
+        gramplet = _make_gramplet()
+        filterdb = MagicMock()
+
+        with patch.object(goql_gramplet, "reload_custom_filters") as mock_reload:
+            gramplet._filter_defined(filterdb, "My Filter")
+
+        filterdb.save.assert_called_once()
+        mock_reload.assert_called_once()
+        gramplet.uistate.emit.assert_called_once_with("filters-changed", ("Person",))
+
+    def test_define_clicked_reports_compile_error_without_opening_dialog(self):
+        gramplet = _make_gramplet("this is not valid GOQL !!")
+
+        with patch.object(goql_gramplet, "EditFilter") as mock_edit_filter:
+            gramplet.define_clicked(None)
+
+        mock_edit_filter.assert_not_called()
+        gramplet.msg_label.set_text.assert_called()
+
+
+# ------------------------------------------------------------
+#
+# FindResetTest
+#
+# ------------------------------------------------------------
+class FindResetTest(unittest.TestCase):
+    """Happy-path coverage for the Find/Reset mechanism itself: setting
+    ``view.generic_filter`` and calling ``view.build_tree()`` -- the same
+    two calls core's own ``plugins/gramplet/filter.py`` uses.
+    """
+
+    def test_find_clicked_sets_generic_filter_and_rebuilds(self):
+        gramplet = _make_gramplet("gender == Person.MALE")
+        gramplet.gui.view.search_bar.is_visible.return_value = False
+
+        gramplet.find_clicked(None)
+
+        self.assertIsNotNone(gramplet.gui.view.generic_filter)
+        gramplet.gui.view.build_tree.assert_called_once()
+
+    def test_find_clicked_reports_compile_error_without_touching_view(self):
+        gramplet = _make_gramplet("this is not valid GOQL !!")
+
+        gramplet.find_clicked(None)
+
+        gramplet.gui.view.build_tree.assert_not_called()
+        gramplet.msg_label.set_text.assert_called()
+
+    def test_find_clicked_with_empty_expression_resets_instead(self):
+        gramplet = _make_gramplet("   ")
+        gramplet.gui.view.search_bar.is_visible.return_value = False
+
+        gramplet.find_clicked(None)
+
+        gramplet._set_expr_text.assert_called_once_with("")
+        self.assertIsNone(gramplet.gui.view.generic_filter)
+        gramplet.gui.view.build_tree.assert_called_once()
+
+    def test_reset_clicked_clears_filter_and_rebuilds(self):
+        gramplet = _make_gramplet()
+        gramplet.gui.view.search_bar.is_visible.return_value = False
+
+        gramplet.reset_clicked(None)
+
+        gramplet._set_expr_text.assert_called_once_with("")
+        self.assertIsNone(gramplet.gui.view.generic_filter)
+        gramplet.gui.view.build_tree.assert_called_once()
+
+    def test_hide_quick_search_bar_hides_when_visible(self):
+        gramplet = _make_gramplet()
+        gramplet.gui.view.search_bar.is_visible.return_value = True
+
+        gramplet._hide_quick_search_bar()
+
+        gramplet.gui.view.search_bar.hide.assert_called_once()
+
+    def test_hide_quick_search_bar_leaves_hidden_bar_alone(self):
+        gramplet = _make_gramplet()
+        gramplet.gui.view.search_bar.is_visible.return_value = False
+
+        gramplet._hide_quick_search_bar()
+
+        gramplet.gui.view.search_bar.hide.assert_not_called()
+
+    def test_hide_quick_search_bar_tolerates_a_view_without_one(self):
+        gramplet = _make_gramplet()
+        del gramplet.gui.view.search_bar  # e.g. a non-ListView pageview
+
+        gramplet._hide_quick_search_bar()  # must not raise
+
+
+def _make_gramplet_for_keypress(cursor_line=0, line_count=1):
+    """A gramplet with a mocked ``text_buffer`` reporting a fixed cursor
+    line / line count, and mocked ``find_clicked``/``_history_back``/
+    ``_history_forward`` -- enough to test ``_on_key_press``'s dispatch in
+    isolation, without constructing a real ``Gtk.TextView`` (needs a real
+    display connection to construct at all, which the documented test
+    invocation's ``GDK_BACKEND=-`` deliberately does without -- see
+    ``HistoryNavigationTest`` for the text-content-level coverage this
+    dispatch-only test doesn't duplicate).
+    """
+    gramplet = goql_gramplet.PersonQueryFilter.__new__(goql_gramplet.PersonQueryFilter)
+    cursor_iter = MagicMock()
+    cursor_iter.get_line.return_value = cursor_line
+    gramplet.text_buffer = MagicMock()
+    gramplet.text_buffer.get_iter_at_mark.return_value = cursor_iter
+    gramplet.text_buffer.get_line_count.return_value = line_count
+    gramplet.find_clicked = MagicMock()
+    gramplet._history_back = MagicMock()
+    gramplet._history_forward = MagicMock()
+    gramplet.completion = MagicMock()
+    gramplet.completion.on_key_press.return_value = False
+    return gramplet
+
+
+# ------------------------------------------------------------
+#
+# HistoryNavigationTest
+#
+# ------------------------------------------------------------
+class HistoryNavigationTest(unittest.TestCase):
+    """``_remember_history``/``_history_back``/``_history_forward`` in
+    isolation, through the ``_get_expr_text``/``_set_expr_text`` seam.
+    """
+
+    def test_remember_history_appends_and_resets_index(self):
+        gramplet = _make_gramplet()
+        gramplet.history_index = 0  # pretend we were mid-browse
+
+        gramplet._remember_history("gender == Person.MALE")
+
+        self.assertEqual(gramplet.history, ["gender == Person.MALE"])
+        self.assertIsNone(gramplet.history_index)
+
+    def test_remember_history_skips_immediate_repeat(self):
+        gramplet = _make_gramplet()
+        gramplet._remember_history("gender == Person.MALE")
+        gramplet._remember_history("gender == Person.MALE")
+
+        self.assertEqual(gramplet.history, ["gender == Person.MALE"])
+
+    def test_remember_history_ignores_empty_expression(self):
+        gramplet = _make_gramplet()
+        gramplet._remember_history("")
+
+        self.assertEqual(gramplet.history, [])
+
+    def test_history_back_recalls_most_recent_first_and_saves_draft(self):
+        gramplet = _make_gramplet("draft in progress")
+        gramplet.history = ["first", "second"]
+
+        gramplet._history_back()
+
+        self.assertEqual(gramplet._get_expr_text(), "second")
+        self.assertEqual(gramplet.history_draft, "draft in progress")
+
+    def test_history_back_twice_walks_further_back(self):
+        gramplet = _make_gramplet()
+        gramplet.history = ["first", "second"]
+
+        gramplet._history_back()
+        gramplet._history_back()
+
+        self.assertEqual(gramplet._get_expr_text(), "first")
+
+    def test_history_back_stops_at_oldest_entry(self):
+        gramplet = _make_gramplet()
+        gramplet.history = ["only"]
+
+        gramplet._history_back()
+        gramplet._history_back()
+
+        self.assertEqual(gramplet._get_expr_text(), "only")
+
+    def test_history_back_with_empty_history_is_a_no_op(self):
+        gramplet = _make_gramplet("still typing")
+
+        gramplet._history_back()
+
+        self.assertEqual(gramplet._get_expr_text(), "still typing")
+
+    def test_history_forward_returns_to_draft_past_newest(self):
+        gramplet = _make_gramplet("draft in progress")
+        gramplet.history = ["first", "second"]
+        gramplet._history_back()  # -> "second", saves the draft
+
+        gramplet._history_forward()
+
+        self.assertEqual(gramplet._get_expr_text(), "draft in progress")
+        self.assertIsNone(gramplet.history_index)
+
+    def test_history_forward_without_browsing_is_a_no_op(self):
+        gramplet = _make_gramplet("still typing")
+
+        gramplet._history_forward()
+
+        self.assertEqual(gramplet._get_expr_text(), "still typing")
+
+
+# ------------------------------------------------------------
+#
+# KeyPressTest
+#
+# ------------------------------------------------------------
+class KeyPressTest(unittest.TestCase):
+    """``_on_key_press``'s dispatch: completion gets first look at every key
+    (so its popover's Up/Down/Enter/Escape work); Ctrl+Enter runs Find;
+    Tab is always consumed -- it never inserts a tab character, even when
+    there was nothing to complete; Up/Down (when completion didn't
+    consume them) only recall history at the first/last line of the
+    buffer, so normal cursor movement inside a multi-line expression
+    still works.
+    """
+
+    def test_ctrl_enter_runs_find_and_is_consumed(self):
+        gramplet = _make_gramplet_for_keypress()
+
+        handled = gramplet._on_key_press(None, _key_event(Gdk.KEY_Return, ctrl=True))
+
+        self.assertTrue(handled)
+        gramplet.find_clicked.assert_called_once()
+
+    def test_plain_enter_is_not_consumed(self):
+        gramplet = _make_gramplet_for_keypress()
+
+        handled = gramplet._on_key_press(None, _key_event(Gdk.KEY_Return, ctrl=False))
+
+        self.assertFalse(handled)
+        gramplet.find_clicked.assert_not_called()
+
+    def test_up_at_first_line_of_single_line_buffer_recalls_history(self):
+        gramplet = _make_gramplet_for_keypress(cursor_line=0, line_count=1)
+
+        handled = gramplet._on_key_press(None, _key_event(Gdk.KEY_Up))
+
+        self.assertTrue(handled)
+        gramplet._history_back.assert_called_once()
+
+    def test_up_on_a_later_line_of_a_multiline_buffer_is_not_consumed(self):
+        gramplet = _make_gramplet_for_keypress(cursor_line=1, line_count=2)
+
+        handled = gramplet._on_key_press(None, _key_event(Gdk.KEY_Up))
+
+        self.assertFalse(handled)
+        gramplet._history_back.assert_not_called()
+
+    def test_down_on_an_earlier_line_of_a_multiline_buffer_is_not_consumed(self):
+        gramplet = _make_gramplet_for_keypress(cursor_line=0, line_count=2)
+
+        handled = gramplet._on_key_press(None, _key_event(Gdk.KEY_Down))
+
+        self.assertFalse(handled)
+        gramplet._history_forward.assert_not_called()
+
+    def test_down_at_last_line_recalls_history(self):
+        gramplet = _make_gramplet_for_keypress(cursor_line=1, line_count=2)
+
+        handled = gramplet._on_key_press(None, _key_event(Gdk.KEY_Down))
+
+        self.assertTrue(handled)
+        gramplet._history_forward.assert_called_once()
+
+    def test_tab_is_consumed_even_with_nothing_to_complete(self):
+        gramplet = _make_gramplet_for_keypress()
+        gramplet.completion.on_key_press.return_value = False  # nothing completable
+
+        handled = gramplet._on_key_press(None, _key_event(Gdk.KEY_Tab))
+
+        self.assertTrue(handled)  # never falls back to inserting a tab
+
+    def test_tab_delegates_to_completion_first(self):
+        gramplet = _make_gramplet_for_keypress()
+        gramplet.completion.on_key_press.return_value = True  # triggered/accepted
+
+        handled = gramplet._on_key_press(None, _key_event(Gdk.KEY_Tab))
+
+        self.assertTrue(handled)
+        gramplet.completion.on_key_press.assert_called_once()
+
+    def test_completion_open_intercepts_up_before_history_navigation(self):
+        """When the completion popover is open, Up/Down navigate it, not
+        history -- CompletionController.on_key_press itself decides this
+        (returns True while open); this just checks _on_key_press honors
+        that decision instead of also running its own Up/Down handling.
+        """
+        gramplet = _make_gramplet_for_keypress(cursor_line=0, line_count=1)
+        gramplet.completion.on_key_press.return_value = True
+
+        handled = gramplet._on_key_press(None, _key_event(Gdk.KEY_Up))
+
+        self.assertTrue(handled)
+        gramplet._history_back.assert_not_called()
+
+
+# ------------------------------------------------------------
+#
+# HistoryPersistenceTest
+#
+# ------------------------------------------------------------
+class HistoryPersistenceTest(unittest.TestCase):
+    """``on_load``/``on_save`` round-trip history through ``self.gui.data``
+    -- the same per-instance saved-placement mechanism core gramplets like
+    ``plugins/gramplet/pedigreegramplet.py`` use for their own persisted
+    options (``Gramplet.__init__`` calls ``init()`` then ``on_load()``;
+    ``GrampletBar.on_delete`` calls ``on_save()`` before writing
+    ``self.gui.data`` to the gramplet's saved-placement .ini file).
+    """
+
+    def test_on_load_restores_history_from_gui_data(self):
+        gramplet = goql_gramplet.PersonQueryFilter.__new__(
+            goql_gramplet.PersonQueryFilter
+        )
+        gramplet.gui = MagicMock()
+        gramplet.gui.data = ["first", "second"]
+
+        gramplet.on_load()
+
+        self.assertEqual(gramplet.history, ["first", "second"])
+
+    def test_on_save_writes_history_to_gui_data(self):
+        gramplet = _make_gramplet()
+        gramplet.history = ["first", "second"]
+
+        gramplet.on_save()
+
+        self.assertEqual(gramplet.gui.data, ["first", "second"])
+
+    def test_remember_history_caps_at_max_entries(self):
+        gramplet = _make_gramplet()
+        total = goql_gramplet.HISTORY_MAX_ENTRIES + 5
+        for i in range(total):
+            gramplet._remember_history("expr %d" % i)
+
+        self.assertEqual(len(gramplet.history), goql_gramplet.HISTORY_MAX_ENTRIES)
+        self.assertEqual(gramplet.history[0], "expr 5")
+        self.assertEqual(gramplet.history[-1], "expr %d" % (total - 1))
+
+
+# ------------------------------------------------------------
+#
+# FilterProgressTest
+#
+# ------------------------------------------------------------
+class FilterProgressTest(unittest.TestCase):
+    """``_run_with_filter_progress``/``_filter_method_label`` -- the
+    Prepare-time/Apply-time + SQL-vs-eval diagnostics mirrored from
+    ``gui/filters/sidebar/_sidebarfilter.py``'s ``clicked()``.
+    ``GenericFilter.apply()`` already reports those phase timings via
+    ``user.notify(...)``; without ``uistate.filter_print_func`` wired up,
+    ``gui/user.py``'s ``User._gui_print`` sends them to stdout instead of
+    any widget -- which is exactly why they only ever showed up in a
+    terminal before this.
+    """
+
+    def test_run_with_filter_progress_wires_and_clears_the_hooks(self):
+        gramplet = _make_gramplet()
+        seen = {}
+
+        def action():
+            seen["print_func_during"] = gramplet.uistate.filter_print_func
+            seen["step_func_during"] = gramplet.uistate.filter_step_func
+
+        gramplet._run_with_filter_progress(action)
+
+        self.assertIsNotNone(seen["print_func_during"])
+        self.assertIsNotNone(seen["step_func_during"])
+        self.assertIsNone(gramplet.uistate.filter_print_func)
+        self.assertIsNone(gramplet.uistate.filter_step_func)
+
+    def test_run_with_filter_progress_clears_hooks_even_on_exception(self):
+        gramplet = _make_gramplet()
+
+        def action():
+            raise RuntimeError("boom")
+
+        with self.assertRaises(RuntimeError):
+            gramplet._run_with_filter_progress(action)
+
+        self.assertIsNone(gramplet.uistate.filter_print_func)
+        self.assertIsNone(gramplet.uistate.filter_step_func)
+
+    def test_run_with_filter_progress_collects_messages(self):
+        gramplet = _make_gramplet()
+
+        def action():
+            gramplet.uistate.filter_print_func("Prepare time: 0.01s")
+            gramplet.uistate.filter_print_func("Apply time: 0.02s")
+
+        phase_msgs = gramplet._run_with_filter_progress(action)
+
+        self.assertEqual(phase_msgs, ["Prepare time: 0.01s", "Apply time: 0.02s"])
+
+    def test_filter_method_label_reports_sql_when_a_rule_has_selected_handles(self):
+        gramplet = _make_gramplet()
+        rule = MagicMock()
+        rule.selected_handles = {"h1"}
+        gfilter = MagicMock()
+        gfilter.get_rules.return_value = [rule]
+
+        self.assertEqual(gramplet._filter_method_label(gfilter), "SQL")
+
+    def test_filter_method_label_reports_eval_when_no_rule_has_selected_handles(self):
+        gramplet = _make_gramplet()
+        rule = MagicMock()
+        rule.selected_handles = None
+        gfilter = MagicMock()
+        gfilter.get_rules.return_value = [rule]
+
+        self.assertEqual(gramplet._filter_method_label(gfilter), "Python evaluation")
+
+
+# ------------------------------------------------------------
+#
+# HelpButtonTest
+#
+# ------------------------------------------------------------
+class HelpButtonTest(unittest.TestCase):
+    """``self.gui.help_url`` is set from the ``.gpr.py`` registration's
+    ``help_url=`` -- the same attribute/dispatch the built-in per-gramplet
+    "Help" menu item already uses (``gui/widgets/grampletpane.py``/
+    ``grampletbar.py``).
+    """
+
+    def test_help_clicked_opens_wiki_page_for_a_non_url_help_url(self):
+        gramplet = _make_gramplet()
+        gramplet.gui.help_url = "Addon:GrampsObjectQueryLanguage"
+
+        with patch.object(goql_gramplet, "display_help") as mock_help, patch.object(
+            goql_gramplet, "display_url"
+        ) as mock_url:
+            gramplet.help_clicked(None)
+
+        mock_help.assert_called_once_with("Addon:GrampsObjectQueryLanguage")
+        mock_url.assert_not_called()
+
+    def test_help_clicked_opens_a_raw_url_directly(self):
+        gramplet = _make_gramplet()
+        gramplet.gui.help_url = "https://example.org/help"
+
+        with patch.object(goql_gramplet, "display_help") as mock_help, patch.object(
+            goql_gramplet, "display_url"
+        ) as mock_url:
+            gramplet.help_clicked(None)
+
+        mock_url.assert_called_once_with("https://example.org/help")
+        mock_help.assert_not_called()
+
+    def test_help_clicked_with_no_help_url_does_nothing(self):
+        gramplet = _make_gramplet()
+        gramplet.gui.help_url = None
+
+        with patch.object(goql_gramplet, "display_help") as mock_help, patch.object(
+            goql_gramplet, "display_url"
+        ) as mock_url:
+            gramplet.help_clicked(None)
+
+        mock_help.assert_not_called()
+        mock_url.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/GOQLFilter/tests/test_goql_completion.py
+++ b/GOQLFilter/tests/test_goql_completion.py
@@ -1,0 +1,125 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Tests for ``goql_completion.py``'s completion source -- pure logic, no
+GTK, no database, matching the module's own "no display needed" design.
+
+Run with::
+
+    python3 -m unittest GOQLFilter.tests.test_goql_completion -v
+"""
+
+import os
+import sys
+import unittest
+
+ADDON_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ADDON_DIR not in sys.path:
+    sys.path.insert(0, ADDON_DIR)
+
+try:
+    from goql_completion import get_completion_items
+except ImportError as exc:
+    raise unittest.SkipTest(
+        "goql_completion import failed (likely missing "
+        "gramps-object-query-language): %s" % exc
+    )
+
+
+def _names(source, line, column, namespace):
+    return sorted(
+        item["name"] for item in get_completion_items(source, line, column, namespace)
+    )
+
+
+# ------------------------------------------------------------
+#
+# TopLevelCompletionTest
+#
+# ------------------------------------------------------------
+class TopLevelCompletionTest(unittest.TestCase):
+    def test_person_top_level_includes_columns_relationships_and_keywords(self):
+        names = _names("", 1, 0, "Person")
+        for expected in ("gender", "birth", "death", "families", "and", "or", "not"):
+            self.assertIn(expected, names)
+
+    def test_person_top_level_includes_constant_class_names(self):
+        names = _names("", 1, 0, "Person")
+        self.assertIn("Person", names)
+        self.assertIn("EventType", names)
+
+    def test_top_level_includes_comparison_operators(self):
+        """A blank Tab press shows the comparison operators too -- most are
+        a single character, so they only ever surface with an empty
+        prefix, but they should still be there to see."""
+        names = _names("", 1, 0, "Person")
+        for op in ("==", "!=", "<", "<=", ">", ">="):
+            self.assertIn(op, names)
+
+    def test_family_namespace_differs_from_person(self):
+        family_names = _names("", 1, 0, "Family")
+        self.assertIn("father", family_names)
+        self.assertIn("mother", family_names)
+        self.assertIn("children", family_names)
+        self.assertNotIn("birth", family_names)
+        self.assertNotIn("death", family_names)
+
+    def test_top_level_prefix_filters_matches(self):
+        names = _names("gen", 1, 3, "Person")
+        self.assertIn("gender", names)
+        self.assertNotIn("birth", names)
+
+    def test_unknown_namespace_returns_no_completions(self):
+        names = _names("", 1, 0, "NotARealType")
+        self.assertEqual(names, [])
+
+
+# ------------------------------------------------------------
+#
+# DottedConstantCompletionTest
+#
+# ------------------------------------------------------------
+class DottedConstantCompletionTest(unittest.TestCase):
+    def test_person_dot_lists_gender_constants(self):
+        source = "gender == Person."
+        names = _names(source, 1, len(source), "Person")
+        self.assertEqual(names, sorted(["FEMALE", "MALE", "OTHER", "UNKNOWN"]))
+
+    def test_person_dot_prefix_filters_to_matching_constants(self):
+        source = "gender == Person.MA"
+        items = get_completion_items(source, 1, len(source), "Person")
+        self.assertEqual([(i["name"], i["complete"]) for i in items], [("MALE", "LE")])
+
+    def test_unrecognized_class_name_before_dot_returns_no_completions(self):
+        source = "primary_name."
+        names = _names(source, 1, len(source), "Person")
+        self.assertEqual(names, [])
+
+    def test_dotted_completion_ignores_the_active_namespace(self):
+        """`Date.MOD_ABOUT` is valid regardless of which namespace
+        (Person/Family/...) the expression is being written for -- the
+        constant-class table isn't namespace-scoped."""
+        source = "birth.date.modifier == Date."
+        names = _names(source, 1, len(source), "Family")
+        self.assertIn("MOD_ABOUT", names)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/GOQLFilter/tests/test_goql_completion_popup.py
+++ b/GOQLFilter/tests/test_goql_completion_popup.py
@@ -1,0 +1,215 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Tests for ``goql_completion_popup.CompletionController``'s decision
+logic, driven with a mocked ``Gtk.TextView``/``Gtk.TextBuffer`` rather than
+real ones -- ``Gtk.TextView()`` needs an actual display connection just to
+construct (see ``test_goql.py``'s ``KeyPressTest`` fixtures for the same
+constraint under this repo's documented ``GDK_BACKEND=-`` test invocation).
+Real-popover paths (multi-match) aren't covered here for the same reason;
+``_compute_items`` is patched directly to isolate ``trigger()``'s own
+single/zero-match branching from how items get computed.
+
+Run with::
+
+    python3 -m unittest GOQLFilter.tests.test_goql_completion_popup -v
+"""
+
+import os
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock
+
+ADDON_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ADDON_DIR not in sys.path:
+    sys.path.insert(0, ADDON_DIR)
+
+try:
+    import gi  # noqa: F401
+    from gi.repository import Gdk
+except ImportError as err:
+    raise unittest.SkipTest("PyGObject not available: %s" % err)
+
+try:
+    from goql_completion_popup import CompletionController
+except ImportError as exc:
+    raise unittest.SkipTest(
+        "goql_completion_popup import failed (likely missing "
+        "gramps-object-query-language): %s" % exc
+    )
+
+
+def _make_controller():
+    textview = MagicMock()
+    buffer = MagicMock()
+    textview.get_buffer.return_value = buffer
+    controller = CompletionController(textview, get_namespace=lambda: "Person")
+    return controller, buffer
+
+
+def _key_event(keyval):
+    return types.SimpleNamespace(keyval=keyval, state=Gdk.ModifierType(0))
+
+
+# ------------------------------------------------------------
+#
+# TriggerTest
+#
+# ------------------------------------------------------------
+class TriggerTest(unittest.TestCase):
+    def test_single_match_inserts_directly_without_opening_a_popover(self):
+        controller, buffer = _make_controller()
+        controller._compute_items = MagicMock(
+            return_value=[{"name": "MALE", "complete": "LE", "cursor_offset": 0}]
+        )
+
+        handled = controller.trigger()
+
+        self.assertTrue(handled)
+        self.assertFalse(controller.is_open())
+        buffer.insert.assert_called_once()
+        self.assertEqual(buffer.insert.call_args.args[1], "LE")
+
+    def test_no_matches_is_a_no_op(self):
+        controller, buffer = _make_controller()
+        controller._compute_items = MagicMock(return_value=[])
+
+        handled = controller.trigger()
+
+        self.assertFalse(handled)
+        self.assertFalse(controller.is_open())
+        buffer.insert.assert_not_called()
+
+
+# ------------------------------------------------------------
+#
+# AcceptCloseTest
+#
+# ------------------------------------------------------------
+class AcceptCloseTest(unittest.TestCase):
+    def test_accept_inserts_the_selected_items_complete_text(self):
+        controller, buffer = _make_controller()
+        controller.items = [
+            {"name": "count(...)", "complete": "count()", "cursor_offset": 0}
+        ]
+        controller.selected_index = 0
+
+        controller.accept()
+
+        buffer.insert.assert_called_once()
+        self.assertEqual(buffer.insert.call_args.args[1], "count()")
+
+    def test_accept_moves_cursor_back_by_cursor_offset(self):
+        controller, buffer = _make_controller()
+        controller.items = [
+            {"name": "count(...)", "complete": "count()", "cursor_offset": 1}
+        ]
+        controller.selected_index = 0
+        cursor_iter = MagicMock()
+        buffer.get_iter_at_mark.return_value = cursor_iter
+
+        controller.accept()
+
+        cursor_iter.backward_chars.assert_called_once_with(1)
+        buffer.place_cursor.assert_called_once_with(cursor_iter)
+
+    def test_close_resets_state(self):
+        controller, _buffer = _make_controller()
+        controller.items = [{"name": "x", "complete": "", "cursor_offset": 0}]
+        controller.selected_index = 2
+        controller.popover = MagicMock()
+
+        controller.close()
+
+        self.assertIsNone(controller.popover)
+        self.assertEqual(controller.items, [])
+        self.assertEqual(controller.selected_index, 0)
+
+
+# ------------------------------------------------------------
+#
+# OnKeyPressTest
+#
+# ------------------------------------------------------------
+class OnKeyPressTest(unittest.TestCase):
+    """Mirrors GOQLFilter/goql.py's own reliance on this dispatch: Tab
+    triggers when closed and accepts when open; Up/Down/Enter/Escape only
+    do anything while the popover is open, so a closed controller leaves
+    them for the host widget (goql.py's own history navigation) to handle.
+    """
+
+    def test_tab_triggers_when_closed(self):
+        controller, _buffer = _make_controller()
+        controller.trigger = MagicMock(return_value=True)
+
+        handled = controller.on_key_press(_key_event(Gdk.KEY_Tab))
+
+        self.assertTrue(handled)
+        controller.trigger.assert_called_once()
+
+    def test_tab_accepts_when_open(self):
+        controller, _buffer = _make_controller()
+        controller.popover = MagicMock()  # is_open() -> True
+        controller.accept = MagicMock()
+
+        handled = controller.on_key_press(_key_event(Gdk.KEY_Tab))
+
+        self.assertTrue(handled)
+        controller.accept.assert_called_once()
+
+    def test_escape_closes_when_open(self):
+        controller, _buffer = _make_controller()
+        controller.popover = MagicMock()
+        controller.close = MagicMock()
+
+        handled = controller.on_key_press(_key_event(Gdk.KEY_Escape))
+
+        self.assertTrue(handled)
+        controller.close.assert_called_once()
+
+    def test_up_is_not_consumed_when_closed(self):
+        controller, _buffer = _make_controller()
+
+        handled = controller.on_key_press(_key_event(Gdk.KEY_Up))
+
+        self.assertFalse(handled)
+
+    def test_up_moves_selection_when_open(self):
+        controller, _buffer = _make_controller()
+        controller.popover = MagicMock()
+        controller.move_selection = MagicMock()
+
+        handled = controller.on_key_press(_key_event(Gdk.KEY_Up))
+
+        self.assertTrue(handled)
+        controller.move_selection.assert_called_once_with(-1)
+
+    def test_never_propagates_an_exception(self):
+        controller, _buffer = _make_controller()
+        controller.trigger = MagicMock(side_effect=RuntimeError("boom"))
+
+        handled = controller.on_key_press(_key_event(Gdk.KEY_Tab))
+
+        self.assertFalse(handled)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/GOQLFilter/tests/test_goql_highlight.py
+++ b/GOQLFilter/tests/test_goql_highlight.py
@@ -1,0 +1,110 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Tests for ``goql_highlight.py``'s token classification -- pure logic, no
+GTK, no database.
+
+Run with::
+
+    python3 -m unittest GOQLFilter.tests.test_goql_highlight -v
+"""
+
+import os
+import sys
+import unittest
+
+ADDON_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ADDON_DIR not in sys.path:
+    sys.path.insert(0, ADDON_DIR)
+
+try:
+    from goql_highlight import classify_tokens
+except ImportError as exc:
+    raise unittest.SkipTest(
+        "goql_highlight import failed (likely missing "
+        "gramps-object-query-language): %s" % exc
+    )
+
+
+def _spans_by_text(source):
+    """(category, matched substring) pairs, in source order -- easier to
+    assert against than raw line/column spans."""
+    lines = source.splitlines()
+    result = []
+    for start_line, start_col, end_line, end_col, category in classify_tokens(source):
+        text = (
+            lines[start_line][start_col:end_col]
+            if start_line == end_line
+            else "<multiline>"
+        )
+        result.append((category, text))
+    return result
+
+
+# ------------------------------------------------------------
+#
+# ClassifyTokensTest
+#
+# ------------------------------------------------------------
+class ClassifyTokensTest(unittest.TestCase):
+    def test_classifies_operator_constant_class_keyword_string_and_number(self):
+        source = "gender == Person.MALE and 'Anderson' in primary_name.surname_list[0].surname"
+        spans = _spans_by_text(source)
+        self.assertIn(("operator", "=="), spans)
+        self.assertIn(("constant-class", "Person"), spans)
+        self.assertIn(("keyword", "and"), spans)
+        self.assertIn(("string", "'Anderson'"), spans)
+        self.assertIn(("keyword", "in"), spans)
+        self.assertIn(("number", "0"), spans)
+
+    def test_plain_field_names_are_not_classified(self):
+        spans = _spans_by_text("gender == Person.MALE")
+        categories_by_text = dict((text, category) for category, text in spans)
+        self.assertNotIn("gender", categories_by_text)
+
+    def test_incomplete_expression_still_yields_tokens_before_the_break(self):
+        """An unterminated string is the normal state of this buffer mid-typing,
+        not an error to surface -- whatever tokenized cleanly before it is
+        still returned."""
+        spans = _spans_by_text("gender == Person.MALE and 'Anders")
+        self.assertIn(("operator", "=="), spans)
+        self.assertIn(("constant-class", "Person"), spans)
+        self.assertIn(("keyword", "and"), spans)
+
+    def test_empty_source_yields_no_spans(self):
+        self.assertEqual(list(classify_tokens("")), [])
+
+    def test_like_date_exists_count_are_keywords(self):
+        spans = _spans_by_text(
+            "like(x, 'A%') and exists(children) and count(events) > 1"
+        )
+        categories_by_text = dict((text, category) for category, text in spans)
+        self.assertEqual(categories_by_text.get("like"), "keyword")
+        self.assertEqual(categories_by_text.get("exists"), "keyword")
+        self.assertEqual(categories_by_text.get("count"), "keyword")
+
+    def test_comparison_operators_are_all_recognized(self):
+        for op in ("==", "!=", "<", "<=", ">", ">="):
+            spans = _spans_by_text("gender %s 1" % op)
+            self.assertIn(("operator", op), spans, "missing operator %r" % op)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/GOQLFilter/tests/test_integration_whereexprrule.py
+++ b/GOQLFilter/tests/test_integration_whereexprrule.py
@@ -1,0 +1,264 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Integration tests for ``whereexprrule.py``.
+
+Drives the rule the same way ``GenericFilter.apply()`` does -- through a
+real ``GenericFilter``/``CacheProxyDb`` against a real temp SQLite db, since
+that composition (Rule -> GenericFilter -> what a gramplet hands to
+``view.generic_filter``) is the thing actually being tested, not the GOQL
+compiler in isolation (already covered by gramps-object-query-language's
+own test suite). DB-backed, so this is Linux-only in CI (``test_integration_``
+prefix) rather than the plain ``test_`` prefix.
+
+Run with::
+
+    python3 -m unittest GOQLFilter.tests.test_integration_whereexprrule -v
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+ADDON_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ADDON_DIR not in sys.path:
+    sys.path.insert(0, ADDON_DIR)
+
+try:
+    import gi
+except ImportError as err:
+    raise unittest.SkipTest("PyGObject not available: %s" % err)
+
+try:
+    from whereexprrule import (
+        FamilyMatchesExpression,
+        PersonMatchesExpression,
+        _resolve_dialect,
+        _unwrap_cache_proxy,
+    )
+except ImportError as exc:
+    raise unittest.SkipTest(
+        "whereexprrule import failed (likely missing "
+        "gramps-object-query-language): %s" % exc
+    )
+
+from gramps.gen.db import DbTxn
+from gramps.gen.db.utils import make_database
+from gramps.gen.filters import GenericFilterFactory
+from gramps.gen.lib import Family, Name, Person, Surname
+from gramps.gen.proxy import CacheProxyDb, PrivateProxyDb
+from gramps_object_query_language.query import Dialect
+
+
+def _name(given, surname):
+    name = Name()
+    name.set_first_name(given)
+    surn = Surname()
+    surn.set_surname(surname)
+    name.set_surname_list([surn])
+    return name
+
+
+# ------------------------------------------------------------
+#
+# WhereExprRuleTest
+#
+# ------------------------------------------------------------
+class WhereExprRuleTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp(prefix="goql_addon_")
+        self.db = make_database("sqlite")
+        self.db.load(self.tmp_dir)
+
+        self.handles = {}
+        with DbTxn("build test db", self.db) as trans:
+            father = Person()
+            father.set_primary_name(_name("Karl", "Anderson"))
+            father.set_gender(Person.MALE)
+            self.handles["father"] = self.db.add_person(father, trans)
+
+            mother = Person()
+            mother.set_primary_name(_name("Lena", "Baker"))
+            mother.set_gender(Person.FEMALE)
+            self.handles["mother"] = self.db.add_person(mother, trans)
+
+            son = Person()
+            son.set_primary_name(_name("Otto", "Anderson"))
+            son.set_gender(Person.MALE)
+            self.handles["son"] = self.db.add_person(son, trans)
+
+            family = Family()
+            family.set_father_handle(self.handles["father"])
+            family.set_mother_handle(self.handles["mother"])
+            self.handles["family"] = self.db.add_family(family, trans)
+
+    def tearDown(self):
+        self.db.close()
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+    def _apply_person_filter(self, expr):
+        gfilter = GenericFilterFactory("Person")()
+        gfilter.add_rule(PersonMatchesExpression([expr]))
+        cdb = CacheProxyDb(self.db)
+        return set(gfilter.apply(cdb, self.db.get_person_handles()))
+
+    def test_flat_column_match(self):
+        matched = self._apply_person_filter("gender == Person.MALE")
+        self.assertEqual(matched, {self.handles["father"], self.handles["son"]})
+
+    def test_json_path_and_boolean_combination(self):
+        matched = self._apply_person_filter(
+            "gender == Person.MALE and "
+            "'Anderson' in primary_name.surname_list[0].surname"
+        )
+        self.assertEqual(matched, {self.handles["father"], self.handles["son"]})
+
+    def test_no_match(self):
+        matched = self._apply_person_filter("gender == Person.UNKNOWN")
+        self.assertEqual(matched, set())
+
+    def test_empty_expression_matches_nothing(self):
+        matched = self._apply_person_filter("")
+        self.assertEqual(matched, set())
+
+    def test_invalid_expression_matches_nothing_rather_than_raising(self):
+        matched = self._apply_person_filter("this is not valid GOQL !!")
+        self.assertEqual(matched, set())
+
+    def test_family_related_object_path(self):
+        gfilter = GenericFilterFactory("Family")()
+        gfilter.add_rule(FamilyMatchesExpression(["father.surname == 'Anderson'"]))
+        cdb = CacheProxyDb(self.db)
+        matched = set(gfilter.apply(cdb, self.db.get_family_handles()))
+        self.assertEqual(matched, {self.handles["family"]})
+
+
+# ------------------------------------------------------------
+#
+# SqlPushDownTest
+#
+# ------------------------------------------------------------
+class SqlPushDownTest(unittest.TestCase):
+    """Regression coverage for two bugs found wiring up SQL push-down:
+
+    1. ``_resolve_dialect`` used to do ``isinstance(db, SQLite)``, but
+       Gramps' plugin loader imports ``sqlite.py`` as a bare top-level
+       module named ``sqlite``, not via ``gramps.plugins.db.dbapi.sqlite``
+       -- so a live ``dbstate.db``'s class is never ``isinstance``-
+       compatible with a normally-imported ``SQLite``, and dialect
+       resolution silently fell through every time. Fixed by matching
+       ``type(db).__name__`` instead of ``isinstance``.
+    2. Every real filter application wraps ``db`` in ``CacheProxyDb``
+       (``gui/views/treemodels/flatbasemodel.py``'s ``_rebuild_filter``:
+       ``cdb = CacheProxyDb(self.db); self.search.apply(cdb, ...)``), which
+       is not a ``ProxyDbBase`` subclass and forwards attribute access via
+       ``__getattr__``. Left unpeeled, that defeats the
+       ``isinstance(db, ProxyDbBase)`` privacy check whenever a real
+       privacy proxy is nested *underneath* it
+       (``CacheProxyDb(PrivateProxyDb(db))``) -- SQL would run straight
+       past privacy filtering. Fixed with ``_unwrap_cache_proxy``.
+    """
+
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp(prefix="goql_sql_pushdown_")
+        self.db = make_database("sqlite")
+        self.db.load(self.tmp_dir)
+        with DbTxn("build test db", self.db) as trans:
+            father = Person()
+            father.set_primary_name(_name("Karl", "Anderson"))
+            father.set_gender(Person.MALE)
+            self.father_handle = self.db.add_person(father, trans)
+
+            mother = Person()
+            mother.set_primary_name(_name("Lena", "Baker"))
+            mother.set_gender(Person.FEMALE)
+            self.mother_handle = self.db.add_person(mother, trans)
+
+    def tearDown(self):
+        self.db.close()
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+    def test_resolve_dialect_matches_live_sqlite_db_by_class_name(self):
+        self.assertEqual(_resolve_dialect(self.db), Dialect.SQLITE)
+
+    def test_resolve_dialect_is_none_for_an_unrecognized_backend(self):
+        self.assertIsNone(_resolve_dialect(object()))
+
+    def test_unwrap_cache_proxy_peels_to_the_raw_db(self):
+        cdb = CacheProxyDb(self.db)
+        self.assertIs(_unwrap_cache_proxy(cdb), self.db)
+
+    def test_unwrap_cache_proxy_stops_at_a_nested_privacy_proxy(self):
+        pdb = PrivateProxyDb(self.db)
+        cdb = CacheProxyDb(pdb)
+        self.assertIs(_unwrap_cache_proxy(cdb), pdb)
+
+    def test_sql_push_down_engages_through_the_cache_proxy_wrapping(self):
+        """The exact wrapping every real GenericFilter.apply() call uses."""
+        cdb = CacheProxyDb(self.db)
+        rule = PersonMatchesExpression(["gender == Person.MALE"])
+
+        rule.prepare(cdb, None)
+
+        self.assertEqual(rule.selected_handles, {self.father_handle})
+
+    def test_privacy_proxy_nested_under_cache_proxy_disables_sql_push_down(self):
+        cdb = CacheProxyDb(PrivateProxyDb(self.db))
+        rule = PersonMatchesExpression(["gender == Person.MALE"])
+
+        rule.prepare(cdb, None)
+
+        self.assertIsNone(rule.selected_handles)
+        # Still correct via the per-object eval fallback:
+        father = cdb.get_person_from_handle(self.father_handle)
+        mother = cdb.get_person_from_handle(self.mother_handle)
+        self.assertTrue(rule.apply_to_one(cdb, father))
+        self.assertFalse(rule.apply_to_one(cdb, mother))
+
+    def test_optimizer_recognizes_selected_handles(self):
+        """Regression test for the actual ~8s "Apply time" bug: the
+        precomputed match set used to be stored as ``_matched_handles``,
+        a name ``gen.filters.optimizer.Optimizer`` doesn't look for.
+        ``compute_potential_handles_for_rule`` only checks
+        ``hasattr(rule, "selected_handles")`` -- anything else is
+        invisible to it, so ``GenericFilter.apply()`` fetched and
+        deserialized every candidate via ``get_object()`` before
+        ``apply_to_one`` ever ran, no matter how fast ``apply_to_one``
+        itself was. Renaming the attribute to what the Optimizer actually
+        checks for is the fix; this asserts that contract directly rather
+        than just re-checking ``apply_to_one``'s own behavior.
+        """
+        from gramps.gen.filters.optimizer import Optimizer
+
+        cdb = CacheProxyDb(self.db)
+        rule = PersonMatchesExpression(["gender == Person.MALE"])
+        rule.prepare(cdb, None)
+
+        optimizer = Optimizer(GenericFilterFactory("Person")())
+        handles_in, handles_out = optimizer.compute_potential_handles_for_rule(rule)
+
+        self.assertEqual(handles_in, {self.father_handle})
+        self.assertIsNone(handles_out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/GOQLFilter/whereexprrule.gpr.py
+++ b/GOQLFilter/whereexprrule.gpr.py
@@ -1,0 +1,205 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Filter rules matching objects against a GOQL where-expression."""
+
+_HELP = "Addon:GrampsObjectQueryLanguage"
+_AUTHORS = ["Douglas Blank"]
+_AUTHORS_EMAIL = ["doug.blank@gmail.com"]
+
+register(
+    RULE,
+    id="PersonMatchesExpression",
+    name=_("People matching the <GOQL expression>"),
+    description=_(
+        "Matches people for which the given gramps-object-query-language "
+        "where-expression evaluates to true"
+    ),
+    version="1.0.0",
+    gramps_target_version="6.1",
+    status=STABLE,
+    fname="whereexprrule.py",
+    ruleclass="PersonMatchesExpression",  # must be rule class name
+    namespace="Person",  # one of the primary object classes
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+    requires_mod=["gramps_object_query_language"],
+)
+
+register(
+    RULE,
+    id="FamilyMatchesExpression",
+    name=_("Families matching the <GOQL expression>"),
+    description=_(
+        "Matches families for which the given gramps-object-query-language "
+        "where-expression evaluates to true"
+    ),
+    version="1.0.0",
+    gramps_target_version="6.1",
+    status=STABLE,
+    fname="whereexprrule.py",
+    ruleclass="FamilyMatchesExpression",
+    namespace="Family",
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+    requires_mod=["gramps_object_query_language"],
+)
+
+register(
+    RULE,
+    id="EventMatchesExpression",
+    name=_("Events matching the <GOQL expression>"),
+    description=_(
+        "Matches events for which the given gramps-object-query-language "
+        "where-expression evaluates to true"
+    ),
+    version="1.0.0",
+    gramps_target_version="6.1",
+    status=STABLE,
+    fname="whereexprrule.py",
+    ruleclass="EventMatchesExpression",
+    namespace="Event",
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+    requires_mod=["gramps_object_query_language"],
+)
+
+register(
+    RULE,
+    id="PlaceMatchesExpression",
+    name=_("Places matching the <GOQL expression>"),
+    description=_(
+        "Matches places for which the given gramps-object-query-language "
+        "where-expression evaluates to true"
+    ),
+    version="1.0.0",
+    gramps_target_version="6.1",
+    status=STABLE,
+    fname="whereexprrule.py",
+    ruleclass="PlaceMatchesExpression",
+    namespace="Place",
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+    requires_mod=["gramps_object_query_language"],
+)
+
+register(
+    RULE,
+    id="RepositoryMatchesExpression",
+    name=_("Repositories matching the <GOQL expression>"),
+    description=_(
+        "Matches repositories for which the given gramps-object-query-language "
+        "where-expression evaluates to true"
+    ),
+    version="1.0.0",
+    gramps_target_version="6.1",
+    status=STABLE,
+    fname="whereexprrule.py",
+    ruleclass="RepositoryMatchesExpression",
+    namespace="Repository",
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+    requires_mod=["gramps_object_query_language"],
+)
+
+register(
+    RULE,
+    id="SourceMatchesExpression",
+    name=_("Sources matching the <GOQL expression>"),
+    description=_(
+        "Matches sources for which the given gramps-object-query-language "
+        "where-expression evaluates to true"
+    ),
+    version="1.0.0",
+    gramps_target_version="6.1",
+    status=STABLE,
+    fname="whereexprrule.py",
+    ruleclass="SourceMatchesExpression",
+    namespace="Source",
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+    requires_mod=["gramps_object_query_language"],
+)
+
+register(
+    RULE,
+    id="CitationMatchesExpression",
+    name=_("Citations matching the <GOQL expression>"),
+    description=_(
+        "Matches citations for which the given gramps-object-query-language "
+        "where-expression evaluates to true"
+    ),
+    version="1.0.0",
+    gramps_target_version="6.1",
+    status=STABLE,
+    fname="whereexprrule.py",
+    ruleclass="CitationMatchesExpression",
+    namespace="Citation",
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+    requires_mod=["gramps_object_query_language"],
+)
+
+register(
+    RULE,
+    id="MediaMatchesExpression",
+    name=_("Media matching the <GOQL expression>"),
+    description=_(
+        "Matches media for which the given gramps-object-query-language "
+        "where-expression evaluates to true"
+    ),
+    version="1.0.0",
+    gramps_target_version="6.1",
+    status=STABLE,
+    fname="whereexprrule.py",
+    ruleclass="MediaMatchesExpression",
+    namespace="Media",
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+    requires_mod=["gramps_object_query_language"],
+)
+
+register(
+    RULE,
+    id="NoteMatchesExpression",
+    name=_("Notes matching the <GOQL expression>"),
+    description=_(
+        "Matches notes for which the given gramps-object-query-language "
+        "where-expression evaluates to true"
+    ),
+    version="1.0.0",
+    gramps_target_version="6.1",
+    status=STABLE,
+    fname="whereexprrule.py",
+    ruleclass="NoteMatchesExpression",
+    namespace="Note",
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+    requires_mod=["gramps_object_query_language"],
+)

--- a/GOQLFilter/whereexprrule.py
+++ b/GOQLFilter/whereexprrule.py
@@ -1,0 +1,302 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Filter rule matching objects against a gramps-object-query-language
+where-expression, one subclass per primary object type.
+
+Registering these as ordinary ``RULE`` plugins (see ``whereexprrule.gpr.py``)
+lets a GOQL expression be dropped into Gramps' own Custom Filter Editor
+(``EditFilter``) as a single rule, so a filter built from one now shows up
+everywhere a normal Custom Filter would -- other views' sidebar filters,
+reports, exports -- not just in this addon's own gramplet.
+
+When ``prepare()`` sees an unproxied, DB-API-backed ``db``, it pushes the
+expression down to SQL (``gramps_object_query_language.query.compile_query``)
+instead of evaluating it per-object -- the same fast/slow split
+gramps-web-api's ``resources/object_query.py`` makes (``_post_sql`` vs.
+``_post_proxied``), just reached from ``Rule.prepare(db, user)`` instead of
+a request handler. Re-decided on every ``prepare()`` call, never cached on
+the rule instance: a saved Custom Filter can be applied against a different
+db, or the same db behind a different proxy, at any later time, and each
+application must see its own, current ``db``.
+"""
+
+# -------------------------------------------------------------------------
+#
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import logging
+from typing import Any, Optional
+
+# -------------------------------------------------------------------------
+#
+# Gramps modules
+#
+# -------------------------------------------------------------------------
+from gramps.gen.filters.rules import Rule
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+from gramps.gen.proxy import CacheProxyDb
+from gramps.gen.proxy.proxybase import ProxyDbBase
+
+# -------------------------------------------------------------------------
+#
+# gramps-object-query-language modules
+#
+# -------------------------------------------------------------------------
+try:
+    from gramps_object_query_language.query_lang import (
+        QueryLangError,
+        compile_expr_for_spec,
+    )
+    from gramps_object_query_language.evaluator import evaluate_where
+    from gramps_object_query_language.query import (
+        CITATION,
+        EVENT,
+        FAMILY,
+        MEDIA,
+        NOTE,
+        PERSON,
+        PLACE,
+        REPOSITORY,
+        SOURCE,
+        Dialect,
+        Query,
+        compile_query,
+    )
+except ImportError as err:
+    raise ImportError(
+        "GOQLFilter requires the gramps-object-query-language "
+        "package.\nInstall with: pip install gramps-object-query-language"
+    ) from err
+
+try:
+    _trans = glocale.get_addon_translator(__file__)
+except ValueError:
+    _trans = glocale.translation
+_ = _trans.gettext
+
+LOG = logging.getLogger(".GOQLFilter.whereexprrule")
+
+# Adapted from gramps-web-api's resources/object_query.py (_DIALECT_BY_NAME /
+# _resolve_dialect) -- core DBAPI/SQLite and the SharedPostgreSQL addon
+# don't advertise a `.dialect` attribute yet (proposed but unmerged
+# core-side: gramps-project/gramps#2178); the single-user PostgreSQL addon
+# already does (`dialect = "postgresql"`), so that's read straight off `db`
+# when present. Once core grows a real `.dialect` property, this whole
+# function collapses to `getattr(db, "dialect", None)` and this copy can be
+# deleted.
+#
+# Diverges from gramps-web-api's version in one deliberate way: that one
+# falls back to `isinstance(basedb, SQLite)` for the common case, but a live
+# `dbstate.db` here was constructed through Gramps' *plugin* loader, which
+# imports `sqlite.py` as a bare top-level module named `sqlite` -- not via
+# `gramps.plugins.db.dbapi.sqlite`, the normal package path this file (and
+# gramps-web-api) imports `SQLite` through. That makes `type(db)` a
+# *different* class object from the `SQLite` imported here even for a real
+# SQLite-backed db (confirmed live: `type(make_database("sqlite")).__module__
+# == "sqlite"`, not `"gramps.plugins.db.dbapi.sqlite"`) -- `isinstance` never
+# matches, and the dialect check would fall through silently. Matching by
+# class *name* instead sidesteps the module-identity split. Unrecognized
+# class names return `None` (never a guessed dialect) so an unknown backend
+# just skips SQL push-down rather than risking wrong-dialect SQL -- the
+# caller falls back to per-object eval either way.
+_DIALECT_BY_NAME = {
+    "sqlite": Dialect.SQLITE,
+    "postgres": Dialect.POSTGRESQL,
+    "postgresql": Dialect.POSTGRESQL,
+}
+_DIALECT_BY_CLASS_NAME = {
+    "SQLite": Dialect.SQLITE,
+    "PostgreSQL": Dialect.POSTGRESQL,
+    "SharedPostgreSQL": Dialect.POSTGRESQL,
+}
+
+
+def _resolve_dialect(db: Any) -> Optional[Dialect]:
+    name: Optional[str] = getattr(db, "dialect", None)
+    if name:
+        dialect = _DIALECT_BY_NAME.get(name)
+        if dialect is not None:
+            return dialect
+    return _DIALECT_BY_CLASS_NAME.get(type(db).__name__)
+
+
+def _unwrap_cache_proxy(db: Any) -> Any:
+    """Peel off ``CacheProxyDb`` wrapping to find what SQL-eligibility
+    checks should actually look at.
+
+    Every real call into a ``Rule`` from Gramps' own filtering goes through
+    ``CacheProxyDb`` -- ``gui/views/treemodels/flatbasemodel.py``'s
+    ``_rebuild_filter`` unconditionally does ``cdb = CacheProxyDb(self.db);
+    self.search.apply(cdb, ...)`` -- so ``db`` here is *never* the raw
+    backend object, even with no privacy proxy in play. ``CacheProxyDb``
+    has no privacy relevance (it exists purely to cache fetched objects)
+    but, unlike ``PrivateProxyDb``/``LivingProxyDb``/etc., it doesn't
+    subclass ``ProxyDbBase`` -- so both ``isinstance(db, ProxyDbBase)`` and
+    ``_resolve_dialect(db)``'s class-name lookup silently see straight past
+    a real backend/proxy underneath it without this unwrap: the former
+    would miss a nested privacy proxy entirely (treating it as
+    "unproxied"), the latter would miss the real backend's class name
+    entirely (``type(CacheProxyDb(...)).__name__ == "CacheProxyDb"``, never
+    a recognized dialect).
+
+    Stops the moment the current layer is anything other than
+    ``CacheProxyDb`` -- including a real ``ProxyDbBase`` -- so a privacy
+    proxy nested underneath (``CacheProxyDb(PrivateProxyDb(raw_db))``) is
+    correctly left in place for the caller's ``isinstance(_, ProxyDbBase)``
+    check to catch, not unwrapped past.
+    """
+    while isinstance(db, CacheProxyDb):
+        db = db.db
+    return db
+
+
+def _sql_matched_handles(db: Any, spec: Any, where: Any):
+    """Matching handles via SQL push-down, or ``None`` if not possible.
+
+    Only ever called with a ``db`` already confirmed unproxied and
+    DB-API-backed (see ``MatchesExpression.prepare``) -- mirrors
+    gramps-web-api's ``_post_sql`` dispatch, minus the privacy predicate,
+    which is exactly why an unproxied `db` is required before this runs at
+    all (see ``query.py``'s ``compile_query`` docstring: "carries no
+    privacy predicate"). Never raises: an unrecognized backend (no
+    resolvable dialect) is a routine, silent "skip the optimization";
+    a genuine compile/execute failure is logged, then also falls back to
+    per-object evaluation rather than breaking the filter outright.
+    """
+    dialect = _resolve_dialect(db)
+    if dialect is None:
+        return None
+    try:
+        query = Query(select=["handle"], where=where, limit=None)
+        sql, params = compile_query(spec, query, dialect=dialect)
+        db.dbapi.execute(sql, params)
+        return {row[0] for row in db.dbapi.fetchall()}
+    except Exception:
+        LOG.exception("GOQL SQL push-down failed; falling back to per-object eval")
+        return None
+
+
+# -------------------------------------------------------------------------
+#
+# MatchesExpression
+#
+# -------------------------------------------------------------------------
+class MatchesExpression(Rule):
+    """Base rule: true for objects a GOQL where-expression evaluates true for.
+
+    Not registered directly -- each object type needs its own registered
+    subclass (below) since a ``RULE`` plugin's ``namespace``/``ruleclass``
+    pair, and the ``ObjectTypeSpec`` GOQL needs to compile the expression
+    against, are fixed per type.
+    """
+
+    labels = [_("GOQL expression")]
+    description = _(
+        "Matches objects for which the given gramps-object-query-language "
+        "where-expression evaluates to true"
+    )
+    category = _("General filters")
+    spec: Any = None  # set by each subclass below
+
+    def prepare(self, db, user):
+        self._where = None
+        # NOT a private name: `gen.filters.optimizer.Optimizer` specifically
+        # looks for `selected_handles` (`hasattr(rule, "selected_handles")`)
+        # to narrow `possible_handles` in `GenericFilter.apply()` *before*
+        # any `get_object()` fetch -- see `apply_logical_op_to_all`. A rule
+        # holding its precomputed match set under any other name is
+        # invisible to the Optimizer: every candidate still gets fetched
+        # and deserialized before `apply_to_one` ever runs, no matter how
+        # fast `apply_to_one` itself is. This was set as `_matched_handles`
+        # originally and measured ~8s "Apply time" on a real tree as a
+        # result -- renaming it to the name the Optimizer actually checks
+        # for is the fix, not a cosmetic one.
+        self.selected_handles = None
+        expr = (self.list[0] or "").strip()
+        if not expr:
+            return
+        try:
+            self._where = compile_expr_for_spec(self.spec, expr)
+        except QueryLangError:
+            # Leave self._where as None -- an invalid/incomplete expression
+            # matches nothing rather than raising out of GenericFilter.apply().
+            self._where = None
+            return
+        # SQL push-down only when `db`, past any CacheProxyDb wrapping, is
+        # unproxied (no privacy predicate to lose) and DB-API-backed
+        # (something to push down to). Re-checked here, every call -- see
+        # this module's docstring.
+        basedb = _unwrap_cache_proxy(db)
+        if not isinstance(basedb, ProxyDbBase) and hasattr(basedb, "dbapi"):
+            self.selected_handles = _sql_matched_handles(basedb, self.spec, self._where)
+
+    def apply_to_one(self, db, obj) -> bool:
+        if self._where is None or obj is None:
+            return False
+        if self.selected_handles is not None:
+            return obj.handle in self.selected_handles
+        return evaluate_where(db, obj, self._where, self.spec)
+
+
+class PersonMatchesExpression(MatchesExpression):
+    name = _("People matching the <GOQL expression>")
+    spec = PERSON
+
+
+class FamilyMatchesExpression(MatchesExpression):
+    name = _("Families matching the <GOQL expression>")
+    spec = FAMILY
+
+
+class EventMatchesExpression(MatchesExpression):
+    name = _("Events matching the <GOQL expression>")
+    spec = EVENT
+
+
+class PlaceMatchesExpression(MatchesExpression):
+    name = _("Places matching the <GOQL expression>")
+    spec = PLACE
+
+
+class RepositoryMatchesExpression(MatchesExpression):
+    name = _("Repositories matching the <GOQL expression>")
+    spec = REPOSITORY
+
+
+class SourceMatchesExpression(MatchesExpression):
+    name = _("Sources matching the <GOQL expression>")
+    spec = SOURCE
+
+
+class CitationMatchesExpression(MatchesExpression):
+    name = _("Citations matching the <GOQL expression>")
+    spec = CITATION
+
+
+class MediaMatchesExpression(MatchesExpression):
+    name = _("Media matching the <GOQL expression>")
+    spec = MEDIA
+
+
+class NoteMatchesExpression(MatchesExpression):
+    name = _("Notes matching the <GOQL expression>")
+    spec = NOTE


### PR DESCRIPTION
## Screen Capture Example

<img width="1046" height="764" alt="image" src="https://github.com/user-attachments/assets/a11e6de6-5d2f-4965-a673-adf379106e7f" />


## Summary
- Adds a gramps-object-query-language (GOQL) filter gramplet and a matching "MatchesExpression" custom-filter rule for each primary object type (Person, Family, Event, Place, Repository, Source, Citation, Media, Note).
- The gramplet is a multi-line where-expression editor (Tab completion, syntax highlighting, session-scoped history) that runs the expression as a real `GenericFilter` via `view.generic_filter` -- the same mechanism the built-in rule-based sidebar filter uses -- and can hand the same expression to Gramps' own `EditFilter` dialog to save it as an ordinary Custom Filter, reusable anywhere a Custom Filter is (other views' sidebar filters, reports, exports), not just in this gramplet.
- `MatchesExpression` pushes the expression down to SQL when the database is unproxied and DB-API-backed (SQLite, or the SharedPostgreSQL addon), falling back to per-object evaluation otherwise -- the same fast/slow split gramps-web-api's `object_query` resource makes.
- Requires the `gramps-object-query-language` package (`pip install gramps-object-query-language`); `requires_mod` in the `.gpr` registrations surfaces that as a Plugin Manager prerequisite.

## Connections

1. https://github.com/dsblank/gramps-object-query-language - the query language
2. https://gramps-project.org/wiki/index.php?title=Addon:GrampsObjectQueryLanguage - help page

## Test plan
- [x] `black --check` passes on all files in `GOQLFilter/`
- [x] Unit tests included under `GOQLFilter/tests/` (`test_goql.py`, `test_goql_completion.py`, `test_goql_completion_popup.py`, `test_goql_highlight.py`) plus an integration test (`test_integration_whereexprrule.py`)
- [ ] CI run of the test suite (this addon's tests rely on the repo-root GTK3 pin in `tests/__init__.py`, not exercised when run standalone on a host that defaults to GTK4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)