### PR TITLE
Add GrampsWebApiDb: use a Gramps Web API server as a live database backend

### DIFF
--- a/GrampsWebApiDb/MANIFEST
+++ b/GrampsWebApiDb/MANIFEST
@@ -1,0 +1,1 @@
+GrampsWebApiDb/README.md

--- a/GrampsWebApiDb/README.md
+++ b/GrampsWebApiDb/README.md
@@ -1,0 +1,38 @@
+GrampsWebApiDb is a Gramps database backend that uses a Gramps Web API
+server (e.g. gramps-connect or Gramps Web) as a live database, mirrored
+locally in SQLite for speed. Reads are served from the local mirror, which
+is kept current via the server's transaction-history feed; local edits are
+pushed back to the server as they're committed.
+
+## Credentials
+
+The addon takes a single credential, via the `GRAMPS_WEB_API_KEY`
+environment variable, shaped `<REFRESH_TOKEN>*<BASE64URL(URL)>`. There is
+deliberately no login dialog and no per-tree settings.ini. Use
+`WebApiHandler.mint_api_key(url, username, password)` (see
+`webapi_client.py`) once to turn a username/password into this key.
+
+**Security tradeoff:** the token embedded in `GRAMPS_WEB_API_KEY` is a
+standard JWT *refresh* token obtained from the server's normal `/token/`
+login endpoint — the same endpoint and flow the official web client uses,
+not an undocumented or exploited access path. gramps-web-api leaves refresh
+tokens non-expiring by default, so this key is a long-lived, general-purpose
+credential carrying the full permissions of the account that minted it. It
+is *not* the same as a real scoped, independently revocable personal access
+token (gramps-web-api has that machinery, but it isn't generally wired into
+request auth yet). Practically, that means:
+
+* A leaked `GRAMPS_WEB_API_KEY` is as damaging as a leaked password — it
+  grants full account access until the underlying password is changed.
+  There is no "revoke this key" action independent of that.
+* Treat it accordingly: don't commit it, don't log it, and store it the
+  same way you'd store a password.
+
+This is a documented engineering tradeoff, made because the properly-scoped
+alternative isn't available server-side today — not a vulnerability in
+gramps-web-api or a loophole being exploited.
+
+## See also
+
+* `grampswebapidb.py` for the sync/write-through design (module docstring).
+* `webapi_client.py` for the token fetch/refresh implementation.

--- a/GrampsWebApiDb/README.md
+++ b/GrampsWebApiDb/README.md
@@ -8,9 +8,20 @@ pushed back to the server as they're committed.
 
 The addon takes a single credential, via the `GRAMPS_WEB_API_KEY`
 environment variable, shaped `<REFRESH_TOKEN>*<BASE64URL(URL)>`. There is
-deliberately no login dialog and no per-tree settings.ini. Use
+deliberately no login dialog and no per-tree settings.ini. Mint one once
+via username/password, either from the command line with the standalone
+`gramps-web-api-client` package (not yet published; pip-installable from
+its own repo, e.g. `pip install -e path/to/gramps-web-api-client`):
+
+```bash
+export GRAMPS_WEB_API_KEY=$(gramps-web-api-client generate-key --url https://your-server/api --username youruser)
+```
+
+or from Python, using either that package's `Client.mint_api_key(url,
+username, password)` or this addon's own vendored copy,
 `WebApiHandler.mint_api_key(url, username, password)` (see
-`webapi_client.py`) once to turn a username/password into this key.
+`webapi_client.py`) — same method, same result, no addon-specific
+dependency either way.
 
 **Security tradeoff:** the token embedded in `GRAMPS_WEB_API_KEY` is a
 standard JWT *refresh* token obtained from the server's normal `/token/`
@@ -35,4 +46,7 @@ gramps-web-api or a loophole being exploited.
 ## See also
 
 * `grampswebapidb.py` for the sync/write-through design (module docstring).
-* `webapi_client.py` for the token fetch/refresh implementation.
+* `webapi_client.py` for the token fetch/refresh implementation. This is a
+  hand-synced vendored copy (see its own docstring) -- the canonical,
+  standalone source is the `gramps-web-api-client` package, which also
+  has the `generate-key` CLI referenced above.

--- a/GrampsWebApiDb/README.md
+++ b/GrampsWebApiDb/README.md
@@ -1,8 +1,14 @@
 GrampsWebApiDb is a Gramps database backend that uses a Gramps Web API
 server (e.g. gramps-connect or Gramps Web) as a live database, mirrored
 locally in SQLite for speed. Reads are served from the local mirror, which
-is kept current via the server's transaction-history feed; local edits are
-pushed back to the server as they're committed.
+is kept current via the server's transaction-history feed -- both at load
+time and on an ongoing poll while the tree stays open, so a change made
+from another client (the web app, another desktop instance) shows up here
+without closing and reopening the tree; local edits are pushed back to the
+server as they're committed. Every already-open Gramps view (People,
+Families, ...) refreshes itself automatically as synced changes land, the
+same as it would for a local edit -- see `grampswebapidb.py`'s module
+docstring for how.
 
 ## Credentials
 

--- a/GrampsWebApiDb/README.md
+++ b/GrampsWebApiDb/README.md
@@ -10,11 +10,11 @@ The addon takes a single credential, via the `GRAMPS_WEB_API_KEY`
 environment variable, shaped `<REFRESH_TOKEN>*<BASE64URL(URL)>`. There is
 deliberately no login dialog and no per-tree settings.ini. Mint one once
 via username/password, either from the command line with the standalone
-`gramps-web-api-client` package (not yet published; pip-installable from
-its own repo, e.g. `pip install -e path/to/gramps-web-api-client`):
+`gramps-api-client` package (not yet published; pip-installable from
+its own repo, e.g. `pip install -e path/to/gramps-api-client`):
 
 ```bash
-export GRAMPS_WEB_API_KEY=$(gramps-web-api-client generate-key --url https://your-server/api --username youruser)
+export GRAMPS_WEB_API_KEY=$(gramps-api-client generate-key --url https://your-server/api --username youruser)
 ```
 
 or from Python, using either that package's `Client.mint_api_key(url,
@@ -48,5 +48,5 @@ gramps-web-api or a loophole being exploited.
 * `grampswebapidb.py` for the sync/write-through design (module docstring).
 * `webapi_client.py` for the token fetch/refresh implementation. This is a
   hand-synced vendored copy (see its own docstring) -- the canonical,
-  standalone source is the `gramps-web-api-client` package, which also
+  standalone source is the `gramps-api-client` package, which also
   has the `generate-key` CLI referenced above.

--- a/GrampsWebApiDb/README.md
+++ b/GrampsWebApiDb/README.md
@@ -8,7 +8,9 @@ without closing and reopening the tree; local edits are pushed back to the
 server as they're committed. Every already-open Gramps view (People,
 Families, ...) refreshes itself automatically as synced changes land, the
 same as it would for a local edit -- see `grampswebapidb.py`'s module
-docstring for how.
+docstring for how. The initial sync when opening a tree reports real
+progress through Gramps' own load-progress bar, not just a spinning
+cursor.
 
 ## Credentials
 
@@ -48,6 +50,25 @@ request auth yet). Practically, that means:
 This is a documented engineering tradeoff, made because the properly-scoped
 alternative isn't available server-side today — not a vulnerability in
 gramps-web-api or a loophole being exploited.
+
+## Family Tree naming
+
+Because credentials come from an environment variable rather than a
+per-tree setting, nothing else ties a Family Tree's local mirror to one
+particular server account. Gramps must therefore name each Family Tree
+using this backend `<username>@<host>` for the account `GRAMPS_WEB_API_KEY`
+authenticates as — e.g. `dblank@hadaly.duckdns.org`. Opening a Family Tree
+whose name doesn't match the currently-set `GRAMPS_WEB_API_KEY` fails to
+load rather than silently mixing that account's data into a mirror synced
+from a different one. To connect to a different server or account, create
+a new Family Tree named accordingly rather than reusing an existing one.
+
+Gramps' own Family Tree Manager silently replaces characters like `.` with
+`_` in any name you type (it needs the name safe to use as a filename), so
+a hostname's dots never survive intact — name the tree
+`dblank@hadaly_duckdns_org`, not `dblank@hadaly.duckdns.org`. The error
+dialog shown for a mismatch always spells out the exact typeable name to
+use.
 
 ## See also
 

--- a/GrampsWebApiDb/grampswebapidb.gpr.py
+++ b/GrampsWebApiDb/grampswebapidb.gpr.py
@@ -1,0 +1,36 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026 Douglas S. Blank <doug.blank@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+register(
+    DATABASE,
+    id="grampswebapidb",
+    status=UNSTABLE,
+    name=_("GrampsWebApiDb"),
+    name_accell=_("Gramps _Web API Database"),
+    description=_(
+        "Use a Gramps Web API server (e.g. gramps-connect or Gramps Web) "
+        "as a live database, mirrored locally for speed."
+    ),
+    version="0.1.0",
+    gramps_target_version="6.0",
+    fname="grampswebapidb.py",
+    databaseclass="WebApiDB",
+    authors=["Doug Blank"],
+    authors_email=["doug.blank@gmail.com"],
+)

--- a/GrampsWebApiDb/grampswebapidb.gpr.py
+++ b/GrampsWebApiDb/grampswebapidb.gpr.py
@@ -33,4 +33,5 @@ register(
     databaseclass="WebApiDB",
     authors=["Doug Blank"],
     authors_email=["doug.blank@gmail.com"],
+    help_url="Addon:GrampsWebApiDb",
 )

--- a/GrampsWebApiDb/grampswebapidb.gpr.py
+++ b/GrampsWebApiDb/grampswebapidb.gpr.py
@@ -20,7 +20,7 @@
 register(
     DATABASE,
     id="grampswebapidb",
-    status=UNSTABLE,
+    status=BETA,
     name=_("GrampsWebApiDb"),
     name_accell=_("Gramps _Web API Database"),
     description=_(

--- a/GrampsWebApiDb/grampswebapidb.py
+++ b/GrampsWebApiDb/grampswebapidb.py
@@ -134,7 +134,11 @@ from gramps.plugins.db.dbapi.sqlite import SQLite
 
 from webapi_client import WebApiHandler, WebApiPushConflict
 
-_ = glocale.translation.gettext
+try:
+    _trans = glocale.get_addon_translator(__file__)
+except ValueError:
+    _trans = glocale.translation
+_ = _trans.gettext
 LOG = logging.getLogger("grampswebapidb")
 
 #: How many transactions to request per page while syncing.

--- a/GrampsWebApiDb/grampswebapidb.py
+++ b/GrampsWebApiDb/grampswebapidb.py
@@ -81,14 +81,22 @@ transaction_to_json() naturally sees nothing there and no push happens.
 No separate "am I currently syncing" flag is needed to stop synced
 changes from being echoed straight back to the server.
 
-Conflict handling is not implemented: pushes go out with force=1, which
-skips the server's old-data-matches check entirely (see
-gramps_webapi/api/tasks.py's process_transactions), so this is
-last-write-wins by design. If the push itself fails (network error,
-non-conflict validation error), the local commit has already happened
-and is not rolled back -- the local mirror just drifts from the server
-until the next successful push or read sync. Undo/redo integration is
-also still out of scope.
+Pushes go out without force=1, so the server compares each item's "old"
+snapshot against its own current data and rejects the whole batch with
+WebApiPushConflict (see webapi_client.push_transaction()) if anything
+changed server-side since the local mirror last synced -- a real, if
+coarse, optimistic-concurrency check: the whole push either applies or
+none of it does, with no indication of which item conflicted. On a
+conflict, transaction_commit() below resyncs from the server so the
+local mirror stops showing an edit the server never accepted; it does
+not retry the push or attempt a merge, so the local edit is simply lost
+from the server's perspective (still present, stale, in the local
+mirror's edit history) -- real conflict *resolution* (merge, prompt the
+user) is still out of scope. If the push fails for a non-conflict reason
+(network error, auth failure), the local commit has already happened and
+is not rolled back -- the local mirror just drifts from the server until
+the next successful push or read sync. Undo/redo integration is also
+still out of scope.
 """
 
 import logging
@@ -108,7 +116,7 @@ from gramps.gen.db.exceptions import DbConnectionError
 from gramps.gen.lib.json_utils import data_to_object, remove_object
 from gramps.plugins.db.dbapi.sqlite import SQLite
 
-from webapi_client import WebApiHandler
+from webapi_client import WebApiHandler, WebApiPushConflict
 
 _ = glocale.translation.gettext
 LOG = logging.getLogger("grampswebapidb")
@@ -181,16 +189,29 @@ class WebApiDB(SQLite):
         # Must run before super(): it clears the transaction's records.
         payload = transaction_to_json(transaction)
         super().transaction_commit(transaction)
-        if payload:
+        if not payload:
+            return
+        try:
+            self.web_client.push_transaction(payload)
+        except WebApiPushConflict:
+            LOG.warning(
+                "Server rejected %d local change(s): the object(s) changed "
+                "server-side since the local mirror last synced. The local "
+                "edit was applied to this mirror but was NOT accepted by "
+                "the server; resyncing the mirror from the server now.",
+                len(payload),
+            )
             try:
-                self.web_client.push_transaction(payload)
+                self._sync_from_server()
             except _CONNECTION_ERRORS:
-                LOG.exception(
-                    "Failed to push %d local change(s) to the server; "
-                    "local mirror has drifted from the server until the "
-                    "next successful push or read sync.",
-                    len(payload),
-                )
+                LOG.exception("Resync after a push conflict also failed.")
+        except _CONNECTION_ERRORS:
+            LOG.exception(
+                "Failed to push %d local change(s) to the server; "
+                "local mirror has drifted from the server until the "
+                "next successful push or read sync.",
+                len(payload),
+            )
 
     def _sync_from_server(self):
         """

--- a/GrampsWebApiDb/grampswebapidb.py
+++ b/GrampsWebApiDb/grampswebapidb.py
@@ -1,0 +1,231 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026 Douglas S. Blank <doug.blank@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Database backend that mirrors a Gramps Web API server locally.
+
+Design
+------
+This subclasses the stock SQLite DBAPI backend rather than DbReadBase /
+DbWriteBase directly. DbGeneric (gramps.gen.db.generic) already implements
+every get_*_from_handle / iter_* / get_number_of_* method generically on
+top of a small Connection-like object (execute/fetchone/fetchall/commit/
+table_exists/...) -- see SQLite in gramps/plugins/db/dbapi/sqlite.py. So
+reads only need a local, fast, complete SQLite mirror; nothing above the
+Connection layer needs reimplementing.
+
+The mirror is kept current via GET /api/transactions/history/?after=<ts>,
+the same per-object transaction log gramps-web-api's own undo system uses
+(gramps_webapi/undodb.py's DbUndoSQLWeb.get_transactions()). Confirmed
+against a live server: each entry is a *transaction* dict with a nested
+"changes" list, each change carrying obj_class ("Person", "Family", ...),
+trans_type (TXNADD=0/TXNUPD=1/TXNDEL=2), obj_handle, and -- when the
+"new" query param is set -- new_data, a "_class"-tagged dict in the same
+shape gramps.gen.lib.json_utils.data_to_object() reconstructs objects
+from (it's literally what the server's own object_to_data(obj) produced
+when the change was committed). So syncing is: remember the timestamp of
+the last transaction applied, ask for everything after it, and for each
+change either data_to_object(new_data) + commit_<type>() (add and update
+both being upserts, no need to distinguish) or remove_<type>() for a
+delete.
+
+Credentials come from a single environment variable, GRAMPS_WEB_API_KEY
+(see webapi_client.py for its "<REFRESH_TOKEN>*<BASE64URL(URL)>" shape and
+the tradeoffs of using a refresh token here rather than a real scoped
+personal-access-token). There is deliberately no per-tree settings.ini and
+no login dialog: the same env var also works as a bare SDK credential
+(WebApiHandler.from_env()) for scripts that talk to the server directly,
+without going through Gramps at all -- one credential, two consumers.
+
+Write-through (local edits pushed back to the server) hooks
+transaction_commit() rather than the individual commit_person/
+commit_family/... methods: DbTxn.__exit__ calls self.db.transaction_commit
+(gramps/gen/db/txn.py) exactly once per completed local transaction, and
+DbTxn already accumulates every add/update/delete in that transaction via
+its own get_recnos()/get_record() -- transaction_to_json() below turns
+that into the flat {type, handle, _class, old, new} list POST
+/transactions/ expects (confirmed against base.py's own POST /people/
+handler, which builds its response the same way). This must run *before*
+super().transaction_commit(), since DBAPI.transaction_commit() clears the
+transaction's records as its last step.
+
+The other place a DbTxn gets used is _sync_from_server() itself, applying
+server-pulled changes -- that uses batch=True, and DBAPI._commit_base()
+skips trans.add() entirely for batch transactions (see dbapi.py), so
+transaction_to_json() naturally sees nothing there and no push happens.
+No separate "am I currently syncing" flag is needed to stop synced
+changes from being echoed straight back to the server.
+
+Conflict handling is not implemented: pushes go out with force=1, which
+skips the server's old-data-matches check entirely (see
+gramps_webapi/api/tasks.py's process_transactions), so this is
+last-write-wins by design. If the push itself fails (network error,
+non-conflict validation error), the local commit has already happened
+and is not rolled back -- the local mirror just drifts from the server
+until the next successful push or read sync. Undo/redo integration is
+also still out of scope.
+"""
+
+import logging
+from urllib.error import HTTPError, URLError
+
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+from gramps.gen.db import DbTxn
+from gramps.gen.db.dbconst import (
+    CLASS_TO_KEY_MAP,
+    KEY_TO_CLASS_MAP,
+    KEY_TO_NAME_MAP,
+    TXNADD,
+    TXNDEL,
+    TXNUPD,
+)
+from gramps.gen.db.exceptions import DbConnectionError
+from gramps.gen.lib.json_utils import data_to_object, remove_object
+from gramps.plugins.db.dbapi.sqlite import SQLite
+
+from webapi_client import WebApiHandler
+
+_ = glocale.translation.gettext
+LOG = logging.getLogger("grampswebapidb")
+
+#: How many transactions to request per page while syncing.
+SYNC_PAGE_SIZE = 100
+
+#: Failure modes from WebApiHandler.from_env()/push_transaction(): a
+#: malformed/missing key (ValueError), a bad server response shape
+#: (KeyError/JSONDecodeError, the latter a ValueError subclass), or the
+#: server being unreachable (HTTPError/URLError/OSError -- socket.timeout
+#: is an OSError subclass).
+_CONNECTION_ERRORS = (ValueError, KeyError, HTTPError, URLError, OSError)
+
+_TRANS_TYPE_NAME = {TXNADD: "add", TXNUPD: "update", TXNDEL: "delete"}
+
+
+def transaction_to_json(transaction):
+    """
+    Build the flat change-list payload POST /transactions/ expects, from
+    a just-committed local DbTxn. Ported from GrampsWebSync's
+    webapihandler.transaction_to_json (same repo, same license, credit
+    David Straub) instead of imported, for the same no-cross-addon-
+    dependency reason as webapi_client.py.
+    """
+    out = []
+    for recno in transaction.get_recnos(reverse=False):
+        key, action, handle, old_data, new_data = transaction.get_record(recno)
+        obj_cls_name = KEY_TO_CLASS_MAP.get(key)
+        if obj_cls_name is None:
+            continue  # reference-type record, not a primary object
+        out.append(
+            {
+                "type": _TRANS_TYPE_NAME[action],
+                "handle": handle,
+                "_class": obj_cls_name,
+                "old": None if old_data is None else remove_object(old_data),
+                "new": None if new_data is None else remove_object(new_data),
+            }
+        )
+    return out
+
+
+class WebApiDB(SQLite):
+    """
+    DBAPI backend whose local SQLite connection is a mirror of a
+    Gramps Web API server, kept in sync via the server's transaction
+    history endpoint.
+    """
+
+    def requires_login(self):
+        # Credentials come from GRAMPS_WEB_API_KEY, not a login dialog.
+        return False
+
+    def _initialize(self, directory, username, password):
+        try:
+            self.web_client = WebApiHandler.from_env()
+        except _CONNECTION_ERRORS as err:
+            raise DbConnectionError(str(err), directory) from err
+
+        # Local mirror: reuse SQLite's own _initialize for the on-disk
+        # cache file, then sync from the server on load().
+        super()._initialize(directory, username, password)
+
+    def load(self, *args, **kwargs):
+        super().load(*args, **kwargs)
+        self._sync_from_server()
+
+    def transaction_commit(self, transaction):
+        # Must run before super(): it clears the transaction's records.
+        payload = transaction_to_json(transaction)
+        super().transaction_commit(transaction)
+        if payload:
+            try:
+                self.web_client.push_transaction(payload)
+            except _CONNECTION_ERRORS:
+                LOG.exception(
+                    "Failed to push %d local change(s) to the server; "
+                    "local mirror has drifted from the server until the "
+                    "next successful push or read sync.",
+                    len(payload),
+                )
+
+    def _sync_from_server(self):
+        """
+        Pull every transaction after the last-seen timestamp and replay
+        its changes into the local mirror. Returns the number of changes
+        applied.
+        """
+        after = self._get_metadata("sync_last_time", default=0)
+        applied = 0
+        page = 1
+        while True:
+            transactions, _total = self.web_client.get_transaction_history(
+                after=after, page=page, pagesize=SYNC_PAGE_SIZE
+            )
+            if not transactions:
+                break
+            with DbTxn("Sync from server", self, batch=True) as trans:
+                for server_trans in transactions:
+                    for change in server_trans["changes"]:
+                        if self._apply_change(change, trans):
+                            applied += 1
+                    after = max(after, server_trans["timestamp"])
+            if len(transactions) < SYNC_PAGE_SIZE:
+                break
+            page += 1
+        self._set_metadata("sync_last_time", after)
+        return applied
+
+    def _apply_change(self, change, trans):
+        """Replay one server change into the local mirror. Returns True
+        if it was a recognized primary-object change (as opposed to a
+        reference-type change, which carries no obj_class we can map)."""
+        obj_class = change["obj_class"]
+        key = CLASS_TO_KEY_MAP.get(obj_class)
+        if key is None:
+            return False
+        name = KEY_TO_NAME_MAP[key]
+        handle = change["obj_handle"]
+        if change["trans_type"] == TXNDEL:
+            getattr(self, f"remove_{name}")(handle, trans)
+        else:
+            # add and update are both upserts at the DBAPI level, so
+            # there's no need to treat them differently here.
+            obj = data_to_object(change["new_data"])
+            getattr(self, f"commit_{name}")(obj, trans)
+        return True

--- a/GrampsWebApiDb/grampswebapidb.py
+++ b/GrampsWebApiDb/grampswebapidb.py
@@ -81,6 +81,23 @@ transaction_to_json() naturally sees nothing there and no push happens.
 No separate "am I currently syncing" flag is needed to stop synced
 changes from being echoed straight back to the server.
 
+_sync_from_server() can only replay what the history feed actually
+logged, and a batch=True commit -- any bulk import, merge, or tool run
+through gramps-web-api, not just a one-off -- logs nothing per-object:
+DBAPI's own commit_*/remove_* methods guard their trans.add() undo-log
+call with `if not trans.batch`, so a batch transaction leaves behind an
+empty-changes marker (a real Transaction row, but with no Change rows)
+instead of the usual per-object entries. Confirmed live: bulk-importing
+example.gramps produced exactly one such marker, and the 2157 people it
+added were otherwise invisible to this addon's sync no matter how often
+it resynced, because the transaction history itself never recorded
+them. _sync_from_server() treats an empty-changes transaction as a
+signal that its history-replay approach cannot describe what happened,
+and falls back to _full_resync() -- downloading the server's current
+full Gramps XML export and reimporting it into a wiped local mirror,
+the only way to recover completeness when the incremental feed has a
+blind spot by construction.
+
 Pushes go out without force=1, so the server compares each item's "old"
 snapshot against its own current data and rejects the whole batch with
 WebApiPushConflict (see webapi_client.push_transaction()) if anything
@@ -116,6 +133,8 @@ persisted, so this only ever matters within a single running session.
 """
 
 import logging
+import os
+from tempfile import NamedTemporaryFile
 from urllib.error import HTTPError, URLError
 
 from gramps.gen.const import GRAMPS_LOCALE as glocale
@@ -130,7 +149,9 @@ from gramps.gen.db.dbconst import (
 )
 from gramps.gen.db.exceptions import DbConnectionError
 from gramps.gen.lib.json_utils import data_to_object, remove_object
+from gramps.gen.user import User
 from gramps.plugins.db.dbapi.sqlite import SQLite
+from gramps.plugins.importer.importxml import importData
 
 from webapi_client import WebApiHandler, WebApiPushConflict
 
@@ -265,9 +286,19 @@ class WebApiDB(SQLite):
         Pull every transaction after the last-seen timestamp and replay
         its changes into the local mirror. Returns the number of changes
         applied.
+
+        An empty "changes" list on a transaction is not a no-op: it is
+        what a batch=True commit leaves behind (see the module
+        docstring's note on trans.batch guards around trans.add()) --
+        something happened server-side that this feed cannot describe.
+        Flagged rather than silently skipped; _full_resync() is the
+        fallback once the whole page range has been walked (so
+        sync_last_time still advances past it and any *describable*
+        changes around it are applied normally either way).
         """
         after = self._get_metadata("sync_last_time", default=0)
         applied = 0
+        needs_full_resync = False
         page = 1
         while True:
             transactions, _total = self.web_client.get_transaction_history(
@@ -277,6 +308,8 @@ class WebApiDB(SQLite):
                 break
             with DbTxn("Sync from server", self, batch=True) as trans:
                 for server_trans in transactions:
+                    if not server_trans["changes"]:
+                        needs_full_resync = True
                     for change in server_trans["changes"]:
                         if self._apply_change(change, trans):
                             applied += 1
@@ -285,7 +318,52 @@ class WebApiDB(SQLite):
                 break
             page += 1
         self._set_metadata("sync_last_time", after)
+        if needs_full_resync:
+            self._full_resync()
         return applied
+
+    def _full_resync(self):
+        """
+        Rebuild the local mirror from scratch: download the server's own
+        current Gramps XML export and reimport it, after clearing every
+        local primary object first. Called by _sync_from_server() when
+        the transaction-history feed contains an empty-changes marker --
+        by definition there is nothing in that history to replay for
+        whatever produced it, so the only way to recover is to fetch the
+        server's current state wholesale, the same way populating a
+        brand new local mirror already works.
+
+        Deliberately reuses the stock ImportXml importer against a raw
+        XML export rather than reconstructing objects from the REST
+        /people/, /families/, ... endpoints: those return a marshalled
+        display schema (plain ints for GrampsType fields, no "_class"
+        tag), not the json_utils shape data_to_object() needs. Only the
+        transaction-history feed's new_data and a raw XML export share
+        that shape, and the whole point of this method is that the
+        former can't be trusted here.
+
+        The clear-then-import pair each run inside their own batch=True
+        DbTxn (ImportXml's own, internally, for the import half -- see
+        importxml.py), so neither triggers transaction_commit()'s
+        push-to-server path (transaction_to_json() sees nothing to
+        push for a batch transaction) -- this is a purely local rebuild,
+        same as _sync_from_server()'s own transactions.
+        """
+        data = self.web_client.download_export()
+        with NamedTemporaryFile(suffix=".gramps", delete=False) as tmp_file:
+            tmp_file.write(data)
+            tmp_path = tmp_file.name
+        try:
+            with DbTxn(_("Clear local mirror before full resync"), self, batch=True) as trans:
+                for key in set(CLASS_TO_KEY_MAP.values()):
+                    name = KEY_TO_NAME_MAP[key]
+                    handles = list(getattr(self, f"get_{name}_handles")())
+                    remove = getattr(self, f"remove_{name}")
+                    for handle in handles:
+                        remove(handle, trans)
+            importData(self, tmp_path, User())
+        finally:
+            os.remove(tmp_path)
 
     def _apply_change(self, change, trans):
         """Replay one server change into the local mirror. Returns True

--- a/GrampsWebApiDb/grampswebapidb.py
+++ b/GrampsWebApiDb/grampswebapidb.py
@@ -114,6 +114,45 @@ user) is still out of scope. If the push fails for a non-conflict reason
 is not rolled back -- the local mirror just drifts from the server until
 the next successful push or read sync.
 
+The mirror stays current while the tree is open, not just at load() time:
+load() also schedules a GLib.timeout_add_seconds() tick (POLL_INTERVAL_SECONDS)
+that re-runs _sync_from_server() for as long as the database stays open --
+the same timestamp-cursor poll gramps-connect's browser client uses against
+this same endpoint (see gramps-connect's store/historyPoll.ts), so a change
+made from any other client shows up here without closing and reopening the
+tree. It runs synchronously on the GTK main thread (like the initial
+load()-time sync already did, and like viewmanager.py's own autobackup
+timer) rather than on a background thread -- correct but simple, at the
+cost of a brief UI pause during each poll's network round trip; moving it
+off-thread (GrampsWebSync's GLibTaskRunner is the precedent, not imported
+here for the same no-cross-addon-dependency reason as transaction_to_json()
+below) is a reasonable future improvement, not attempted here. close()
+cancels the pending timeout so a closed database doesn't keep polling.
+
+_sync_from_server()'s replay runs inside a batch=True DbTxn deliberately
+(see the write-through section below for why), but that has a side effect
+beyond suppressing trans.add(): DBAPI.transaction_commit() only emits its
+person-add/family-update/event-delete/... signals `if not transaction.batch`
+(see dbapi.py), so a batch replay is otherwise invisible to every
+already-open GTK view -- the local mirror would update on disk with nothing
+on screen changing. _emit_change_signals() reproduces just that signal half
+by hand, once per synced page, using the exact same
+KEY_TO_NAME_MAP[key] + {"add"/"update"/"delete"} signal names DBAPI itself
+emits for a normal (non-batch) local edit -- so every view refreshes exactly
+the way it already knows how to for a local change, with no new view-side
+code needed. Collapsed to one signal per (obj_class, handle) -- the net
+effect across everything applied in that page, so e.g. an update
+immediately followed by a delete of the same object only fires the delete
+signal, not both.
+
+A _full_resync() (see below) is the one path that doesn't go through
+_emit_change_signals(): a full wipe-and-reimport is exactly the "too much
+changed to describe incrementally" case DbGeneric's own request_rebuild()
+exists for (it emits a single <type>-rebuild signal per object type,
+telling every view to reload wholesale rather than replay a specific
+add/update/delete) -- so _full_resync() calls that once after a successful
+reimport instead.
+
 Undo/redo integration hooks undo()/redo() the same way transaction_commit()
 hooks commits: Gramps core's own DbGenericUndo._undo()/_redo()
 (gramps/gen/db/generic.py) revert the local mirror directly via low-level
@@ -136,6 +175,8 @@ import logging
 import os
 from tempfile import NamedTemporaryFile
 from urllib.error import HTTPError, URLError
+
+from gi.repository import GLib
 
 from gramps.gen.const import GRAMPS_LOCALE as glocale
 from gramps.gen.db import DbTxn
@@ -165,6 +206,11 @@ LOG = logging.getLogger("grampswebapidb")
 #: How many transactions to request per page while syncing.
 SYNC_PAGE_SIZE = 100
 
+#: How often (seconds) load() re-polls the server for as long as the
+#: database stays open -- see the module docstring's note on why this runs
+#: synchronously on the GTK main thread rather than a background timer.
+POLL_INTERVAL_SECONDS = 10
+
 #: Failure modes from WebApiHandler.from_env()/push_transaction(): a
 #: malformed/missing key (ValueError), a bad server response shape
 #: (KeyError/JSONDecodeError, the latter a ValueError subclass), or the
@@ -173,6 +219,10 @@ SYNC_PAGE_SIZE = 100
 _CONNECTION_ERRORS = (ValueError, KeyError, HTTPError, URLError, OSError)
 
 _TRANS_TYPE_NAME = {TXNADD: "add", TXNUPD: "update", TXNDEL: "delete"}
+
+#: Same signal-name suffixes DBAPI.transaction_commit() uses (dbapi.py's
+#: own `action` dict) -- see _emit_change_signals().
+_TRANS_TYPE_ACTION = {TXNADD: "-add", TXNUPD: "-update", TXNDEL: "-delete"}
 
 
 def transaction_to_json(transaction):
@@ -225,6 +275,30 @@ class WebApiDB(SQLite):
     def load(self, *args, **kwargs):
         super().load(*args, **kwargs)
         self._sync_from_server()
+        self._poll_source_id = GLib.timeout_add_seconds(
+            POLL_INTERVAL_SECONDS, self._poll_tick
+        )
+
+    def close(self, *args, **kwargs):
+        # Stop polling a database that's no longer open -- otherwise the
+        # next tick would run _sync_from_server() (and touch self.dbapi)
+        # against a connection that's about to be (or already) closed.
+        poll_source_id = getattr(self, "_poll_source_id", None)
+        if poll_source_id is not None:
+            GLib.source_remove(poll_source_id)
+            self._poll_source_id = None
+        super().close(*args, **kwargs)
+
+    def _poll_tick(self):
+        """GLib.timeout_add_seconds callback -- see the module docstring's
+        polling section. Must return True (GLib.SOURCE_CONTINUE) to keep
+        firing; returning a falsy value cancels the timeout, so a network
+        error is caught and logged here rather than left to propagate."""
+        try:
+            self._sync_from_server()
+        except _CONNECTION_ERRORS:
+            LOG.exception("Periodic sync from server failed; will retry.")
+        return GLib.SOURCE_CONTINUE
 
     def transaction_commit(self, transaction):
         # Must run before super(): it clears the transaction's records.
@@ -306,6 +380,9 @@ class WebApiDB(SQLite):
             )
             if not transactions:
                 break
+            # (obj_class, handle) -> trans_type, collapsed to the net
+            # effect within this page -- see _emit_change_signals().
+            net_changes = {}
             with DbTxn("Sync from server", self, batch=True) as trans:
                 for server_trans in transactions:
                     if not server_trans["changes"]:
@@ -313,7 +390,11 @@ class WebApiDB(SQLite):
                     for change in server_trans["changes"]:
                         if self._apply_change(change, trans):
                             applied += 1
+                            net_changes[
+                                (change["obj_class"], change["obj_handle"])
+                            ] = change["trans_type"]
                     after = max(after, server_trans["timestamp"])
+            self._emit_change_signals(net_changes)
             if len(transactions) < SYNC_PAGE_SIZE:
                 break
             page += 1
@@ -362,6 +443,13 @@ class WebApiDB(SQLite):
                     for handle in handles:
                         remove(handle, trans)
             importData(self, tmp_path, User())
+            # importData() runs its own batch=True DbTxn internally, so
+            # (like _sync_from_server()'s replay) it emits nothing to
+            # already-open views on its own -- request_rebuild() is the
+            # "too much changed to describe incrementally" signal DbGeneric
+            # itself defines for exactly this case (one <type>-rebuild per
+            # object type, telling every view to reload wholesale).
+            self.request_rebuild()
         finally:
             os.remove(tmp_path)
 
@@ -383,3 +471,31 @@ class WebApiDB(SQLite):
             obj = data_to_object(change["new_data"])
             getattr(self, f"commit_{name}")(obj, trans)
         return True
+
+    def _emit_change_signals(self, net_changes):
+        """Emit the person-add/family-update/event-delete/... signals a
+        normal (non-batch) local commit would have emitted for these same
+        changes -- see the module docstring's note on why
+        _sync_from_server()'s batch=True replay needs this done by hand.
+
+        net_changes: {(obj_class, obj_handle): trans_type}, already
+        collapsed to the net effect per handle (see _sync_from_server()).
+        Unrecognized obj_class values (reference-type changes never reach
+        here in the first place -- see _apply_change()) are skipped the
+        same way _apply_change() skips them.
+
+        Grouped and emitted in the same order DBAPI.transaction_commit()
+        uses for a normal commit -- deletes and adds before updates -- so
+        a view that (for instance) cares about total counts sees them
+        change before it sees an in-place update to one of the survivors.
+        """
+        by_type = {TXNDEL: {}, TXNADD: {}, TXNUPD: {}}
+        for (obj_class, handle), trans_type in net_changes.items():
+            key = CLASS_TO_KEY_MAP.get(obj_class)
+            if key is None:
+                continue
+            name = KEY_TO_NAME_MAP[key]
+            by_type[trans_type].setdefault(name, []).append(handle)
+        for trans_type in (TXNDEL, TXNADD, TXNUPD):
+            for name, handles in by_type[trans_type].items():
+                self.emit(name + _TRANS_TYPE_ACTION[trans_type], (handles,))

--- a/GrampsWebApiDb/grampswebapidb.py
+++ b/GrampsWebApiDb/grampswebapidb.py
@@ -46,6 +46,14 @@ change either data_to_object(new_data) + commit_<type>() (add and update
 both being upserts, no need to distinguish) or remove_<type>() for a
 delete.
 
+This "_class"-tagged new_data shape is only produced by gramps-web-api
+servers running against Gramps >= 6.0; a server still on Gramps 5.2 (e.g.
+gramps-web-api itself untouched) serializes objects differently (no
+"_class"/"value"/"string" triplet on GrampsType-derived fields), and
+data_to_object() raises KeyError on it. Confirmed against a live gramps52
+server: read-only endpoints (auth, /trees/, /people/ counts, etc.) work
+fine, but _sync_from_server() cannot deserialize its transaction history.
+
 Credentials come from a single environment variable, GRAMPS_WEB_API_KEY
 (see webapi_client.py for its "<REFRESH_TOKEN>*<BASE64URL(URL)>" shape and
 the tradeoffs of using a refresh token here rather than a real scoped

--- a/GrampsWebApiDb/grampswebapidb.py
+++ b/GrampsWebApiDb/grampswebapidb.py
@@ -87,16 +87,32 @@ WebApiPushConflict (see webapi_client.push_transaction()) if anything
 changed server-side since the local mirror last synced -- a real, if
 coarse, optimistic-concurrency check: the whole push either applies or
 none of it does, with no indication of which item conflicted. On a
-conflict, transaction_commit() below resyncs from the server so the
-local mirror stops showing an edit the server never accepted; it does
-not retry the push or attempt a merge, so the local edit is simply lost
+conflict, _push_payload() below resyncs from the server so the local
+mirror stops showing an edit the server never accepted; it does not
+retry the push or attempt a merge, so the losing edit is simply lost
 from the server's perspective (still present, stale, in the local
 mirror's edit history) -- real conflict *resolution* (merge, prompt the
 user) is still out of scope. If the push fails for a non-conflict reason
 (network error, auth failure), the local commit has already happened and
 is not rolled back -- the local mirror just drifts from the server until
-the next successful push or read sync. Undo/redo integration is also
-still out of scope.
+the next successful push or read sync.
+
+Undo/redo integration hooks undo()/redo() the same way transaction_commit()
+hooks commits: Gramps core's own DbGenericUndo._undo()/_redo()
+(gramps/gen/db/generic.py) revert the local mirror directly via low-level
+_txn_begin()/undo_data()/_txn_commit() calls that never go through
+transaction_commit(), so without this override a local Undo/Redo would
+silently desync the server -- worse than a push conflict, since nothing
+would even be logged. The fix reuses transaction_to_json() on the DbTxn
+DbGenericUndo already stores in its undo/redo queues (the same object
+transaction_commit() turned into a payload the first time), then pushes
+it again: undo() sends it to POST /transactions/?undo=1, where the server
+reverses it itself (swaps old/new, add<->delete -- see
+gramps_webapi/api/resources/util.py's reverse_transaction()); redo() just
+pushes the original forward payload again, no different from a fresh
+commit. Both go through the same conflict-detection/resync path as a
+normal commit. Gramps' own undo history is in-memory/per-session, not
+persisted, so this only ever matters within a single running session.
 """
 
 import logging
@@ -189,10 +205,37 @@ class WebApiDB(SQLite):
         # Must run before super(): it clears the transaction's records.
         payload = transaction_to_json(transaction)
         super().transaction_commit(transaction)
+        self._push_payload(payload)
+
+    def undo(self, update_history=True):
+        # Peek before super(): DbGenericUndo._undo() pops this DbTxn off
+        # undoq. The DbTxn's own backing data isn't touched by that (it
+        # just moves queues), so building its JSON payload could happen
+        # either side of super() -- only grabbing the reference itself
+        # can't wait.
+        transaction = self.undodb.undoq[-1] if self.undodb.undo_count else None
+        result = super().undo(update_history)
+        if result and transaction is not None:
+            self._push_payload(transaction_to_json(transaction), undo=True)
+        return result
+
+    def redo(self, update_history=True):
+        transaction = self.undodb.redoq[-1] if self.undodb.redo_count else None
+        result = super().redo(update_history)
+        if result and transaction is not None:
+            # Redo is just re-applying the original transaction forward --
+            # not a variant of undo=True. See push_transaction()'s docstring.
+            self._push_payload(transaction_to_json(transaction))
+        return result
+
+    def _push_payload(self, payload, undo=False):
+        """Push a change-list payload to the server, handling a rejected
+        push (conflict or otherwise) the same way regardless of whether it
+        came from a plain commit, an undo, or a redo."""
         if not payload:
             return
         try:
-            self.web_client.push_transaction(payload)
+            self.web_client.push_transaction(payload, undo=undo)
         except WebApiPushConflict:
             LOG.warning(
                 "Server rejected %d local change(s): the object(s) changed "

--- a/GrampsWebApiDb/grampswebapidb.py
+++ b/GrampsWebApiDb/grampswebapidb.py
@@ -104,11 +104,29 @@ WebApiPushConflict (see webapi_client.push_transaction()) if anything
 changed server-side since the local mirror last synced -- a real, if
 coarse, optimistic-concurrency check: the whole push either applies or
 none of it does, with no indication of which item conflicted. On a
-conflict, _push_payload() below resyncs from the server so the local
-mirror stops showing an edit the server never accepted; it does not
-retry the push or attempt a merge, so the losing edit is simply lost
-from the server's perspective (still present, stale, in the local
-mirror's edit history) -- real conflict *resolution* (merge, prompt the
+conflict, _push_payload() below resyncs from the server (so the local
+mirror picks up whatever changed) and then, for a plain commit (not an
+undo/redo -- see _retry_after_conflict()), replays each object's intended
+*new* state as a fresh local edit via commit_<type>()/remove_<type>() on
+top of that just-resynced data. That fresh edit goes through the normal
+transaction_commit() -> _push_payload() path again with is_retry=True,
+so it carries an up-to-date "old" snapshot and will only be rejected a
+second time if something changes server-side in the brief window between
+the resync and the retry -- in which case it is logged and dropped rather
+than retried again, to avoid retrying forever against a genuinely hot
+object.
+
+For an add/update whose handle still exists after the resync (i.e. the
+conflicting server-side edit changed the same object rather than deleting
+it), _merge_or_overwrite() below combines the two edits with the object's
+own merge() -- the same list-unioning logic behind Gramps' Merge People/
+Family/... tools (ported from GrampsWebSync's diffhandler.py, credit
+David Straub, same license) -- rather than letting the retry blindly
+clobber whatever the other side changed. merge() only unions *list*-valued
+fields (notes, citations, media, urls, event/family refs, ...); it never
+touches scalar fields (a name, a date, a gender), so two edits to the
+exact same scalar field still resolve as local-overwrites-remote -- real
+field-level conflict *resolution* for that narrower case (diff, prompt the
 user) is still out of scope. If the push fails for a non-conflict reason
 (network error, auth failure), the local commit has already happened and
 is not rolled back -- the local mirror just drifts from the server until
@@ -173,6 +191,7 @@ persisted, so this only ever matters within a single running session.
 
 import logging
 import os
+from copy import deepcopy
 from tempfile import NamedTemporaryFile
 from urllib.error import HTTPError, URLError
 
@@ -189,6 +208,7 @@ from gramps.gen.db.dbconst import (
     TXNUPD,
 )
 from gramps.gen.db.exceptions import DbConnectionError
+from gramps.gen.lib.baseobj import BaseObject
 from gramps.gen.lib.json_utils import data_to_object, remove_object
 from gramps.gen.user import User
 from gramps.plugins.db.dbapi.sqlite import SQLite
@@ -251,12 +271,42 @@ def transaction_to_json(transaction):
     return out
 
 
+def _merge_or_overwrite(current, local_obj):
+    """Combine local_obj's content into current via the object's own
+    merge() -- the same list-unioning logic behind Gramps' Merge People/
+    Family/... tools (ported from GrampsWebSync's diffhandler.py, credit
+    David Straub, same license) -- when the type actually implements it.
+
+    Falls back to local_obj outright for a type (e.g. Tag) that only
+    inherits BaseObject's no-op merge(): "merging" into a no-op would
+    silently keep current's content and discard the local edit entirely,
+    which is worse than the plain overwrite this replaces.
+
+    local_obj's gramps_id is cleared before merging so merge() doesn't
+    misread it as a real second object being absorbed (which is what
+    merge() is for) and tag on a spurious "Merged Gramps ID" attribute --
+    this is the same object, edited twice, not two objects becoming one.
+    """
+    if type(current).merge is BaseObject.merge:
+        return local_obj
+    merged = deepcopy(current)
+    local_copy = deepcopy(local_obj)
+    local_copy.gramps_id = None
+    merged.merge(local_copy)
+    return merged
+
+
 class WebApiDB(SQLite):
     """
     DBAPI backend whose local SQLite connection is a mirror of a
     Gramps Web API server, kept in sync via the server's transaction
     history endpoint.
     """
+
+    #: Set around _retry_after_conflict()'s own DbTxn so the
+    #: transaction_commit() it triggers can tell _push_payload() this push
+    #: is itself a conflict retry -- see _push_payload().
+    _retrying = False
 
     def requires_login(self):
         # Credentials come from GRAMPS_WEB_API_KEY, not a login dialog.
@@ -304,7 +354,11 @@ class WebApiDB(SQLite):
         # Must run before super(): it clears the transaction's records.
         payload = transaction_to_json(transaction)
         super().transaction_commit(transaction)
-        self._push_payload(payload)
+        # self._retrying is set by _retry_after_conflict() while it holds
+        # its own DbTxn open, so the push this commit triggers knows it is
+        # itself a conflict retry and won't retry again on a second
+        # conflict -- see _push_payload().
+        self._push_payload(payload, is_retry=self._retrying)
 
     def undo(self, update_history=True):
         # Peek before super(): DbGenericUndo._undo() pops this DbTxn off
@@ -327,10 +381,16 @@ class WebApiDB(SQLite):
             self._push_payload(transaction_to_json(transaction))
         return result
 
-    def _push_payload(self, payload, undo=False):
+    def _push_payload(self, payload, undo=False, is_retry=False):
         """Push a change-list payload to the server, handling a rejected
         push (conflict or otherwise) the same way regardless of whether it
-        came from a plain commit, an undo, or a redo."""
+        came from a plain commit, an undo, or a redo.
+
+        is_retry marks a push that is itself the replay _retry_after_conflict()
+        made from an earlier conflict -- a second conflict on that replay is
+        logged and dropped rather than retried again, so a genuinely hot
+        object can't send this into an unbounded retry loop.
+        """
         if not payload:
             return
         try:
@@ -338,15 +398,24 @@ class WebApiDB(SQLite):
         except WebApiPushConflict:
             LOG.warning(
                 "Server rejected %d local change(s): the object(s) changed "
-                "server-side since the local mirror last synced. The local "
-                "edit was applied to this mirror but was NOT accepted by "
-                "the server; resyncing the mirror from the server now.",
+                "server-side since the local mirror last synced. Resyncing "
+                "the mirror from the server now.",
                 len(payload),
             )
             try:
                 self._sync_from_server()
             except _CONNECTION_ERRORS:
                 LOG.exception("Resync after a push conflict also failed.")
+                return
+            if undo or is_retry:
+                LOG.warning(
+                    "Giving up on %d local change(s) after a repeated or "
+                    "undo/redo conflict; the local mirror was not resent to "
+                    "the server.",
+                    len(payload),
+                )
+                return
+            self._retry_after_conflict(payload)
         except _CONNECTION_ERRORS:
             LOG.exception(
                 "Failed to push %d local change(s) to the server; "
@@ -354,6 +423,42 @@ class WebApiDB(SQLite):
                 "next successful push or read sync.",
                 len(payload),
             )
+
+    def _retry_after_conflict(self, payload):
+        """Reapply each locally-intended change on top of the mirror
+        _push_payload() just resynced, as a fresh local edit -- see the
+        module docstring's write-through section. An add/update whose
+        object still exists after the resync is combined with the current
+        (server-fresh) object via _merge_or_overwrite() rather than
+        blindly replacing it.
+
+        Runs as one ordinary (non-batch) DbTxn, so it goes through the
+        normal transaction_commit() -> _push_payload() path again -- this
+        time with an "old" snapshot that matches what the resync just
+        pulled down, so it will only be rejected again if something else
+        changed server-side in the brief window since that resync.
+        """
+        self._retrying = True
+        try:
+            with DbTxn(_("Retry local change after server conflict"), self) as trans:
+                for entry in payload:
+                    key = CLASS_TO_KEY_MAP.get(entry["_class"])
+                    if key is None:
+                        continue
+                    name = KEY_TO_NAME_MAP[key]
+                    handle = entry["handle"]
+                    has_handle = getattr(self, f"has_{name}_handle")
+                    if entry["type"] == "delete":
+                        if has_handle(handle):
+                            getattr(self, f"remove_{name}")(handle, trans)
+                    else:
+                        obj = data_to_object(entry["new"])
+                        if has_handle(handle):
+                            current = getattr(self, f"get_{name}_from_handle")(handle)
+                            obj = _merge_or_overwrite(current, obj)
+                        getattr(self, f"commit_{name}")(obj, trans)
+        finally:
+            self._retrying = False
 
     def _sync_from_server(self):
         """
@@ -390,9 +495,9 @@ class WebApiDB(SQLite):
                     for change in server_trans["changes"]:
                         if self._apply_change(change, trans):
                             applied += 1
-                            net_changes[
-                                (change["obj_class"], change["obj_handle"])
-                            ] = change["trans_type"]
+                            net_changes[(change["obj_class"], change["obj_handle"])] = (
+                                change["trans_type"]
+                            )
                     after = max(after, server_trans["timestamp"])
             self._emit_change_signals(net_changes)
             if len(transactions) < SYNC_PAGE_SIZE:
@@ -435,7 +540,9 @@ class WebApiDB(SQLite):
             tmp_file.write(data)
             tmp_path = tmp_file.name
         try:
-            with DbTxn(_("Clear local mirror before full resync"), self, batch=True) as trans:
+            with DbTxn(
+                _("Clear local mirror before full resync"), self, batch=True
+            ) as trans:
                 for key in set(CLASS_TO_KEY_MAP.values()):
                     name = KEY_TO_NAME_MAP[key]
                     handles = list(getattr(self, f"get_{name}_handles")())

--- a/GrampsWebApiDb/grampswebapidb.py
+++ b/GrampsWebApiDb/grampswebapidb.py
@@ -62,6 +62,15 @@ no login dialog: the same env var also works as a bare SDK credential
 (WebApiHandler.from_env()) for scripts that talk to the server directly,
 without going through Gramps at all -- one credential, two consumers.
 
+Because of that, nothing but the Family Tree's own name ties its local
+mirror to one particular server account. _check_identity() requires that
+name to be "<username>@<host>" (modulo Gramps' own filename-safe-character
+substitution on tree names, e.g. dots -> underscores -- see
+_FAMILY_TREE_NAME_UNSAFE_CHARS) for whoever GRAMPS_WEB_API_KEY currently
+authenticates as, checked on every load() -- so pointing the env var at a
+different account while reopening the same Family Tree fails loudly
+instead of quietly mixing that account's data into the old mirror.
+
 Write-through (local edits pushed back to the server) hooks
 transaction_commit() rather than the individual commit_person/
 commit_family/... methods: DbTxn.__exit__ calls self.db.transaction_commit
@@ -191,6 +200,7 @@ persisted, so this only ever matters within a single running session.
 
 import logging
 import os
+import re
 from copy import deepcopy
 from tempfile import NamedTemporaryFile
 from urllib.error import HTTPError, URLError
@@ -237,6 +247,14 @@ POLL_INTERVAL_SECONDS = 10
 #: server being unreachable (HTTPError/URLError/OSError -- socket.timeout
 #: is an OSError subclass).
 _CONNECTION_ERRORS = (ValueError, KeyError, HTTPError, URLError, OSError)
+
+#: Same substitution gramps.gui.dbman's Family Tree Manager applies to
+#: whatever a user types renaming a tree (dbman.py's __change_name(): "kill
+#: special characters so can use as file name in backup"). A hostname-
+#: bearing name can't survive that GUI round-trip with its dots intact, so
+#: _check_identity() normalizes through this same substitution on both
+#: sides before comparing -- see that method.
+_FAMILY_TREE_NAME_UNSAFE_CHARS = re.compile(r"[':<>|,;=\"\[\]\.\+\*\/\?\\]")
 
 _TRANS_TYPE_NAME = {TXNADD: "add", TXNUPD: "update", TXNDEL: "delete"}
 
@@ -323,11 +341,74 @@ class WebApiDB(SQLite):
         super()._initialize(directory, username, password)
 
     def load(self, *args, **kwargs):
+        # callback is Gramps' own load-progress hook -- position 2 in
+        # DbGeneric.load()'s signature, or the "callback" kwarg -- the same
+        # plain percentage function cli/grampscli.py's _pulse_progress and
+        # gui/dbloader.py's real progress-bar wiring already provide.
+        # Forwarded to _sync_from_server() so a slow initial catch-up (a
+        # new mirror, or one that's been offline a while) shows real
+        # progress instead of Gramps just looking hung; _poll_tick()'s own
+        # background-poll call deliberately leaves this at its None
+        # default, since a 10-second background tick shouldn't pop a
+        # progress bar.
+        callback = kwargs.get("callback")
+        if callback is None and len(args) >= 2:
+            callback = args[1]
         super().load(*args, **kwargs)
-        self._sync_from_server()
+        self._check_identity()
+        self._sync_from_server(progress_callback=callback)
         self._poll_source_id = GLib.timeout_add_seconds(
             POLL_INTERVAL_SECONDS, self._poll_tick
         )
+
+    def _check_identity(self):
+        """Require this Family Tree's own name to be "<username>@<host>"
+        for whoever GRAMPS_WEB_API_KEY currently authenticates as.
+
+        Nothing else ties a local mirror to one particular server account:
+        there is no per-tree settings.ini (see the module docstring), and
+        _sync_from_server() only ever asks for changes *after* its stored
+        sync_last_time -- it has no way to notice the mirror belongs to a
+        different account entirely and would just quietly go on mixing old
+        and new data. Requiring (and reading back) the account identity in
+        the tree's own display name catches that at load time instead, and
+        costs nothing extra: get_dbname() just rereads the same name.txt
+        Gramps already writes for the Family Tree Manager.
+
+        Both sides are compared after _FAMILY_TREE_NAME_UNSAFE_CHARS's
+        substitution, not the raw "<username>@<host>" string: the Family
+        Tree Manager's own rename callback silently applies that same
+        substitution to anything typed in (dbman.py's __change_name()), so
+        a hostname's dots can never actually reach name.txt intact -- an
+        exact-string comparison would reject every tree name Gramps itself
+        would let you type.
+        """
+        try:
+            expected = self.web_client.get_identity()
+        except _CONNECTION_ERRORS as err:
+            raise DbConnectionError(str(err), self._directory) from err
+        expected_typeable = _FAMILY_TREE_NAME_UNSAFE_CHARS.sub("_", expected)
+        actual = self.get_dbname()
+        actual_normalized = _FAMILY_TREE_NAME_UNSAFE_CHARS.sub("_", actual)
+        if actual_normalized != expected_typeable:
+            raise DbConnectionError(
+                _(
+                    'This Family Tree is named "%(actual)s", but '
+                    "GRAMPS_WEB_API_KEY currently authenticates as "
+                    '"%(expected)s". Rename this Family Tree to '
+                    '"%(expected_typeable)s" (Family Trees -> Manage '
+                    "Family Trees) if it's meant to mirror that account, "
+                    "or open/create the Family Tree already named that -- "
+                    "reusing this one would mix its existing local data "
+                    "with the other account's."
+                )
+                % {
+                    "actual": actual,
+                    "expected": expected,
+                    "expected_typeable": expected_typeable,
+                },
+                self._directory,
+            )
 
     def close(self, *args, **kwargs):
         # Stop polling a database that's no longer open -- otherwise the
@@ -460,7 +541,7 @@ class WebApiDB(SQLite):
         finally:
             self._retrying = False
 
-    def _sync_from_server(self):
+    def _sync_from_server(self, progress_callback=None):
         """
         Pull every transaction after the last-seen timestamp and replay
         its changes into the local mirror. Returns the number of changes
@@ -474,13 +555,20 @@ class WebApiDB(SQLite):
         fallback once the whole page range has been walked (so
         sync_last_time still advances past it and any *describable*
         changes around it are applied normally either way).
+
+        progress_callback, if given, is called with an int 0-100 after
+        each page -- see load()'s callback param. "total" comes from the
+        server's X-Total-Count for this "after" filter (get_transaction_
+        history()'s docstring), so it stays a stable denominator across
+        pages barring concurrent server-side writes during the sync.
         """
         after = self._get_metadata("sync_last_time", default=0)
         applied = 0
         needs_full_resync = False
         page = 1
+        seen = 0
         while True:
-            transactions, _total = self.web_client.get_transaction_history(
+            transactions, total = self.web_client.get_transaction_history(
                 after=after, page=page, pagesize=SYNC_PAGE_SIZE
             )
             if not transactions:
@@ -500,15 +588,18 @@ class WebApiDB(SQLite):
                             )
                     after = max(after, server_trans["timestamp"])
             self._emit_change_signals(net_changes)
+            seen += len(transactions)
+            if progress_callback is not None and total:
+                progress_callback(min(100, int(seen * 100 / total)))
             if len(transactions) < SYNC_PAGE_SIZE:
                 break
             page += 1
         self._set_metadata("sync_last_time", after)
         if needs_full_resync:
-            self._full_resync()
+            self._full_resync(progress_callback=progress_callback)
         return applied
 
-    def _full_resync(self):
+    def _full_resync(self, progress_callback=None):
         """
         Rebuild the local mirror from scratch: download the server's own
         current Gramps XML export and reimport it, after clearing every
@@ -534,7 +625,14 @@ class WebApiDB(SQLite):
         push-to-server path (transaction_to_json() sees nothing to
         push for a batch transaction) -- this is a purely local rebuild,
         same as _sync_from_server()'s own transactions.
+
+        progress_callback, if given, only gets 0/100 markers bookending
+        the download+reimport -- unlike _sync_from_server()'s page-by-page
+        reporting, ImportXml has no internal step reporting to forward
+        finer-grained progress from.
         """
+        if progress_callback is not None:
+            progress_callback(0)
         data = self.web_client.download_export()
         with NamedTemporaryFile(suffix=".gramps", delete=False) as tmp_file:
             tmp_file.write(data)
@@ -559,6 +657,8 @@ class WebApiDB(SQLite):
             self.request_rebuild()
         finally:
             os.remove(tmp_path)
+        if progress_callback is not None:
+            progress_callback(100)
 
     def _apply_change(self, change, trans):
         """Replay one server change into the local mirror. Returns True

--- a/GrampsWebApiDb/po/template.pot
+++ b/GrampsWebApiDb/po/template.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-04 14:40-0700\n"
+"POT-Creation-Date: 2026-08-07 11:38-0700\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -29,4 +29,23 @@ msgstr ""
 msgid ""
 "Use a Gramps Web API server (e.g. gramps-connect or Gramps Web) as a live "
 "database, mirrored locally for speed."
+msgstr ""
+
+#: GrampsWebApiDb/grampswebapidb.py:396
+#, python-format
+msgid ""
+"This Family Tree is named \"%(actual)s\", but GRAMPS_WEB_API_KEY currently "
+"authenticates as \"%(expected)s\". Rename this Family Tree to "
+"\"%(expected_typeable)s\" (Family Trees -> Manage Family Trees) if it's "
+"meant to mirror that account, or open/create the Family Tree already named "
+"that -- reusing this one would mix its existing local data with the other "
+"account's."
+msgstr ""
+
+#: GrampsWebApiDb/grampswebapidb.py:524
+msgid "Retry local change after server conflict"
+msgstr ""
+
+#: GrampsWebApiDb/grampswebapidb.py:642
+msgid "Clear local mirror before full resync"
 msgstr ""

--- a/GrampsWebApiDb/po/template.pot
+++ b/GrampsWebApiDb/po/template.pot
@@ -1,0 +1,32 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-04 14:40-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: GrampsWebApiDb/grampswebapidb.gpr.py:24
+msgid "GrampsWebApiDb"
+msgstr ""
+
+#: GrampsWebApiDb/grampswebapidb.gpr.py:25
+msgid "Gramps _Web API Database"
+msgstr ""
+
+#: GrampsWebApiDb/grampswebapidb.gpr.py:27
+msgid ""
+"Use a Gramps Web API server (e.g. gramps-connect or Gramps Web) as a live "
+"database, mirrored locally for speed."
+msgstr ""

--- a/GrampsWebApiDb/tests/test_grampswebapidb.py
+++ b/GrampsWebApiDb/tests/test_grampswebapidb.py
@@ -432,6 +432,55 @@ class TestSyncFromServer(unittest.TestCase):
         self.db._sync_from_server()
         self.db.emit.assert_not_called()
 
+    def test_no_progress_callback_by_default(self):
+        # _poll_tick()'s background call relies on this: no callback means
+        # no attempt to report progress, so a periodic poll can't raise
+        # trying to call None.
+        page = [{"timestamp": 1.0, "changes": []}]
+        self.db.web_client.get_transaction_history.return_value = (page, 1)
+        self.db._sync_from_server()  # must not raise
+
+    def test_progress_reported_as_percent_of_total(self):
+        page = [{"timestamp": 1.0, "changes": []}] * 25
+        self.db.web_client.get_transaction_history.return_value = (page, 100)
+        progress = mock.MagicMock()
+        self.db._sync_from_server(progress_callback=progress)
+        progress.assert_called_once_with(25)
+
+    def test_progress_accumulates_and_caps_at_100_across_pages(self):
+        full_page = [
+            {"timestamp": float(i), "changes": []}
+            for i in range(grampswebapidb.SYNC_PAGE_SIZE)
+        ]
+        short_page = [{"timestamp": 999.0, "changes": []}]
+        total = grampswebapidb.SYNC_PAGE_SIZE  # short page pushes seen > total
+        self.db.web_client.get_transaction_history.side_effect = [
+            (full_page, total),
+            (short_page, total),
+        ]
+        progress = mock.MagicMock()
+        self.db._sync_from_server(progress_callback=progress)
+        self.assertEqual(
+            [call.args[0] for call in progress.call_args_list], [100, 100]
+        )
+
+    def test_no_progress_call_when_total_is_zero(self):
+        # An empty-history sync (a brand new server-side tree, or nothing
+        # new since last sync) has no meaningful denominator to report
+        # against -- guards a ZeroDivisionError, not just noise.
+        page = [{"timestamp": 1.0, "changes": []}]
+        self.db.web_client.get_transaction_history.return_value = (page, 0)
+        progress = mock.MagicMock()
+        self.db._sync_from_server(progress_callback=progress)
+        progress.assert_not_called()
+
+    def test_progress_callback_passed_through_to_full_resync(self):
+        page = [{"timestamp": 1.0, "changes": []}]
+        self.db.web_client.get_transaction_history.return_value = (page, 1)
+        progress = mock.MagicMock()
+        self.db._sync_from_server(progress_callback=progress)
+        self.db._full_resync.assert_called_once_with(progress_callback=progress)
+
 
 # -------------------------------------------------------------------------
 #
@@ -463,7 +512,7 @@ class TestFullResyncTrigger(unittest.TestCase):
         page = [{"timestamp": 1.0, "changes": []}]
         self.db.web_client.get_transaction_history.return_value = (page, 1)
         self.db._sync_from_server()
-        self.db._full_resync.assert_called_once_with()
+        self.db._full_resync.assert_called_once_with(progress_callback=None)
 
     def test_normal_transactions_do_not_trigger_full_resync(self):
         change = {"obj_class": "Person", "trans_type": TXNADD, "obj_handle": "H1"}
@@ -486,7 +535,7 @@ class TestFullResyncTrigger(unittest.TestCase):
         with mock.patch.object(self.db, "_apply_change", return_value=True):
             applied = self.db._sync_from_server()
         self.assertEqual(applied, 1)
-        self.db._full_resync.assert_called_once_with()
+        self.db._full_resync.assert_called_once_with(progress_callback=None)
 
     def test_marker_still_advances_sync_last_time(self):
         page = [{"timestamp": 42.0, "changes": []}]
@@ -566,6 +615,44 @@ class TestFullResync(unittest.TestCase):
                 self.db._full_resync()
 
         self.db.emit.assert_not_called()
+
+    def test_no_progress_callback_by_default(self):
+        for key, name in grampswebapidb.KEY_TO_NAME_MAP.items():
+            if key not in grampswebapidb.CLASS_TO_KEY_MAP.values():
+                continue
+            setattr(self.db, f"get_{name}_handles", mock.MagicMock(return_value=[]))
+            setattr(self.db, f"remove_{name}", mock.MagicMock())
+        with mock.patch.object(grampswebapidb, "importData"):
+            self.db._full_resync()  # must not raise
+
+    def test_progress_bookends_the_download_and_reimport(self):
+        for key, name in grampswebapidb.KEY_TO_NAME_MAP.items():
+            if key not in grampswebapidb.CLASS_TO_KEY_MAP.values():
+                continue
+            setattr(self.db, f"get_{name}_handles", mock.MagicMock(return_value=[]))
+            setattr(self.db, f"remove_{name}", mock.MagicMock())
+        progress = mock.MagicMock()
+        with mock.patch.object(grampswebapidb, "importData"):
+            self.db._full_resync(progress_callback=progress)
+        self.assertEqual([call.args[0] for call in progress.call_args_list], [0, 100])
+
+    def test_progress_not_completed_if_import_fails(self):
+        # The 100% marker means "the rebuild finished" -- a failed reimport
+        # must not claim that, same reasoning as request_rebuild() above.
+        for key, name in grampswebapidb.KEY_TO_NAME_MAP.items():
+            if key not in grampswebapidb.CLASS_TO_KEY_MAP.values():
+                continue
+            setattr(self.db, f"get_{name}_handles", mock.MagicMock(return_value=[]))
+            setattr(self.db, f"remove_{name}", mock.MagicMock())
+
+        def failing_import_data(database, filename, user):
+            raise RuntimeError("boom")
+
+        progress = mock.MagicMock()
+        with mock.patch.object(grampswebapidb, "importData", failing_import_data):
+            with self.assertRaises(RuntimeError):
+                self.db._full_resync(progress_callback=progress)
+        progress.assert_called_once_with(0)
 
 
 # -------------------------------------------------------------------------
@@ -1052,6 +1139,58 @@ class TestMisc(unittest.TestCase):
 
 # -------------------------------------------------------------------------
 #
+# TestCheckIdentity
+#
+# Nothing but a Family Tree's own name ties its local mirror to one
+# particular GRAMPS_WEB_API_KEY account (see the module docstring) --
+# _check_identity() requires that name to be "<username>@<host>" for
+# whoever the current key authenticates as, so pointing the key at a
+# different account while reopening the same tree fails loudly at load()
+# instead of quietly mixing that account's data into the old mirror.
+#
+# -------------------------------------------------------------------------
+class TestCheckIdentity(unittest.TestCase):
+    def setUp(self):
+        self.db = new_instance()
+        self.db._directory = "/tmp/some-tree"
+        self.db.web_client = mock.MagicMock()
+        self.db.web_client.get_identity.return_value = "dblank@hadaly.duckdns.org"
+
+    def test_matching_name_passes(self):
+        self.db.get_dbname = mock.MagicMock(return_value="dblank@hadaly.duckdns.org")
+        self.db._check_identity()  # must not raise
+
+    def test_name_sanitized_the_same_way_dbman_does_still_passes(self):
+        # gramps.gui.dbman's Family Tree Manager replaces "." (among other
+        # characters) with "_" in any name typed through its rename UI, so
+        # a hostname's dots can never actually reach name.txt -- the check
+        # must accept the sanitized form as a match, not just the literal
+        # "<username>@<host>" string.
+        self.db.get_dbname = mock.MagicMock(return_value="dblank@hadaly_duckdns_org")
+        self.db._check_identity()  # must not raise
+
+    def test_mismatched_name_raises(self):
+        self.db.get_dbname = mock.MagicMock(return_value="Gramps Web API DB")
+        with self.assertRaises(DbConnectionError):
+            self.db._check_identity()
+
+    def test_mismatch_error_names_the_typeable_form(self):
+        self.db.get_dbname = mock.MagicMock(return_value="Gramps Web API DB")
+        with self.assertRaises(DbConnectionError) as ctx:
+            self.db._check_identity()
+        self.assertIn("dblank@hadaly_duckdns_org", str(ctx.exception))
+
+    def test_connection_error_resolving_identity_is_wrapped(self):
+        self.db.get_dbname = mock.MagicMock(return_value="dblank@hadaly.duckdns.org")
+        self.db.web_client.get_identity.side_effect = HTTPError(
+            "https://example.com/api/users/-/", 500, "boom", None, None
+        )
+        with self.assertRaises(DbConnectionError):
+            self.db._check_identity()
+
+
+# -------------------------------------------------------------------------
+#
 # TestPolling
 #
 # load() schedules a GLib.timeout_add_seconds() tick that re-syncs for as
@@ -1068,17 +1207,44 @@ class TestPolling(unittest.TestCase):
         with mock.patch.object(
             grampswebapidb.SQLite, "load"
         ) as super_load, mock.patch.object(
+            self.db, "_check_identity"
+        ) as check_identity, mock.patch.object(
             self.db, "_sync_from_server"
         ) as sync, mock.patch.object(
             grampswebapidb.GLib, "timeout_add_seconds", return_value=42
         ) as timeout_add:
             self.db.load("some/path")
         super_load.assert_called_once_with("some/path")
-        sync.assert_called_once_with()
+        check_identity.assert_called_once_with()
+        sync.assert_called_once_with(progress_callback=None)
         timeout_add.assert_called_once_with(
             grampswebapidb.POLL_INTERVAL_SECONDS, self.db._poll_tick
         )
         self.assertEqual(self.db._poll_source_id, 42)
+
+    def test_load_forwards_positional_callback_to_sync(self):
+        # DbGeneric.load()'s own signature is (directory, callback=None,
+        # mode=..., ...) -- cli/grampscli.py calls it positionally
+        # (db.load(filename, self._pulse_progress, mode, ...)), so load()
+        # must recognize the callback there too, not just as a kwarg.
+        my_callback = mock.MagicMock()
+        with mock.patch.object(grampswebapidb.SQLite, "load"), mock.patch.object(
+            self.db, "_check_identity"
+        ), mock.patch.object(self.db, "_sync_from_server") as sync, mock.patch.object(
+            grampswebapidb.GLib, "timeout_add_seconds"
+        ):
+            self.db.load("some/path", my_callback, "w")
+        sync.assert_called_once_with(progress_callback=my_callback)
+
+    def test_load_forwards_keyword_callback_to_sync(self):
+        my_callback = mock.MagicMock()
+        with mock.patch.object(grampswebapidb.SQLite, "load"), mock.patch.object(
+            self.db, "_check_identity"
+        ), mock.patch.object(self.db, "_sync_from_server") as sync, mock.patch.object(
+            grampswebapidb.GLib, "timeout_add_seconds"
+        ):
+            self.db.load("some/path", callback=my_callback)
+        sync.assert_called_once_with(progress_callback=my_callback)
 
     def test_close_cancels_pending_poll(self):
         self.db._poll_source_id = 42

--- a/GrampsWebApiDb/tests/test_grampswebapidb.py
+++ b/GrampsWebApiDb/tests/test_grampswebapidb.py
@@ -1,0 +1,397 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026 Douglas S. Blank <doug.blank@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Unit tests for grampswebapidb.WebApiDB: the sync/write-through logic.
+
+WebApiDB subclasses the stock SQLite DBAPI backend, but these tests never
+open a real database file -- SQLite's own commit_*/remove_* methods and
+transaction machinery are stubbed out (WebApiDB.__new__() plus per-test
+attribute overrides), the same pattern SharedPostgreSQL/tests/
+test_initialize.py uses to test _create_settings() without a real Postgres
+connection. This isolates exactly the logic this addon adds:
+
+  - transaction_to_json(): local DbTxn -> flat change-list payload
+  - _apply_change(): one server change -> a commit_*/remove_* call
+  - _sync_from_server(): pagination + sync_last_time bookkeeping
+  - transaction_commit(): push-after-commit, ordering, and error swallowing
+
+Run with::
+
+    python3 -m unittest GrampsWebApiDb.tests.test_grampswebapidb -v
+"""
+
+# -------------------------------------------------------------------------
+#
+# Standard python modules
+#
+# -------------------------------------------------------------------------
+import os
+import sys
+import unittest
+from urllib.error import HTTPError
+from unittest import mock
+
+# -------------------------------------------------------------------------
+#
+# Make the addon importable the way Gramps loads it: its own directory on
+# sys.path (grampswebapidb.py does a bare ``from webapi_client import
+# WebApiHandler`` -- see CLAUDE.md Testing conventions).
+#
+# -------------------------------------------------------------------------
+ADDON_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ADDON_DIR not in sys.path:
+    sys.path.insert(0, ADDON_DIR)
+
+try:
+    import gramps
+except ImportError as _err:
+    raise unittest.SkipTest("gramps package not available: %s" % _err)
+
+from gramps.gen.db.dbconst import REFERENCE_KEY, TXNADD, TXNDEL, TXNUPD
+from gramps.gen.db.exceptions import DbConnectionError
+from gramps.gen.lib import Person
+from gramps.gen.lib.json_utils import object_to_data, remove_object
+
+from GrampsWebApiDb import grampswebapidb
+from GrampsWebApiDb.grampswebapidb import WebApiDB, transaction_to_json
+
+
+# -------------------------------------------------------------------------
+#
+# Test helpers
+#
+# -------------------------------------------------------------------------
+def person_data(handle="H1", gramps_id="I0001"):
+    """A real Person's data-dict, the shape new_data/old_data actually take."""
+    person = Person()
+    person.set_handle(handle)
+    person.set_gramps_id(gramps_id)
+    return object_to_data(person)
+
+
+class FakeTransaction:
+    """Duck-types the bit of DbTxn that transaction_to_json() reads:
+    get_recnos()/get_record(). Avoids needing a real commitdb/pickle round
+    trip just to test the flattening logic."""
+
+    def __init__(self, records):
+        # records: list of (key, action, handle, old_data, new_data)
+        self._records = records
+
+    def get_recnos(self, reverse=False):
+        idx = range(len(self._records))
+        return reversed(idx) if reverse else idx
+
+    def get_record(self, recno):
+        return self._records[recno]
+
+
+def new_instance():
+    """A WebApiDB that never touched a real SQLite file or server."""
+    return WebApiDB.__new__(WebApiDB)
+
+
+# -------------------------------------------------------------------------
+#
+# TestTransactionToJson
+#
+# -------------------------------------------------------------------------
+class TestTransactionToJson(unittest.TestCase):
+    def test_add_record_shape(self):
+        new_data = person_data()
+        trans = FakeTransaction([(0, TXNADD, "H1", None, new_data)])  # PERSON_KEY
+        out = transaction_to_json(trans)
+        self.assertEqual(len(out), 1)
+        entry = out[0]
+        self.assertEqual(entry["type"], "add")
+        self.assertEqual(entry["handle"], "H1")
+        self.assertEqual(entry["_class"], "Person")
+        self.assertIsNone(entry["old"])
+        self.assertNotIn("_object", entry["new"])
+
+    def test_update_record_carries_old_and_new(self):
+        old_data = person_data(gramps_id="I0001")
+        new_data = person_data(gramps_id="I0002")
+        trans = FakeTransaction([(0, TXNUPD, "H1", old_data, new_data)])
+        out = transaction_to_json(trans)
+        self.assertEqual(out[0]["type"], "update")
+        self.assertNotIn("_object", out[0]["old"])
+        self.assertNotIn("_object", out[0]["new"])
+
+    def test_delete_record_has_no_new_data(self):
+        old_data = person_data()
+        trans = FakeTransaction([(0, TXNDEL, "H1", old_data, None)])
+        out = transaction_to_json(trans)
+        self.assertEqual(out[0]["type"], "delete")
+        self.assertIsNone(out[0]["new"])
+        self.assertIsNotNone(out[0]["old"])
+
+    def test_reference_type_record_is_skipped(self):
+        # REFERENCE_KEY has no entry in KEY_TO_CLASS_MAP -- see dbconst.py.
+        trans = FakeTransaction([(REFERENCE_KEY, TXNADD, "H1", None, {})])
+        self.assertEqual(transaction_to_json(trans), [])
+
+    def test_multiple_records_preserve_order(self):
+        trans = FakeTransaction(
+            [
+                (0, TXNADD, "H1", None, person_data("H1")),
+                (0, TXNUPD, "H2", person_data("H2"), person_data("H2", "I0002")),
+            ]
+        )
+        out = transaction_to_json(trans)
+        self.assertEqual([e["handle"] for e in out], ["H1", "H2"])
+
+
+# -------------------------------------------------------------------------
+#
+# TestApplyChange
+#
+# -------------------------------------------------------------------------
+class TestApplyChange(unittest.TestCase):
+    def setUp(self):
+        self.db = new_instance()
+        self.db.commit_person = mock.MagicMock()
+        self.db.remove_person = mock.MagicMock()
+        self.trans = object()  # opaque; just forwarded
+
+    def test_unrecognized_obj_class_is_ignored(self):
+        change = {"obj_class": "NotAThing", "trans_type": TXNADD, "obj_handle": "H1"}
+        applied = self.db._apply_change(change, self.trans)
+        self.assertFalse(applied)
+        self.db.commit_person.assert_not_called()
+        self.db.remove_person.assert_not_called()
+
+    def test_delete_calls_remove(self):
+        change = {"obj_class": "Person", "trans_type": TXNDEL, "obj_handle": "H1"}
+        applied = self.db._apply_change(change, self.trans)
+        self.assertTrue(applied)
+        self.db.remove_person.assert_called_once_with("H1", self.trans)
+        self.db.commit_person.assert_not_called()
+
+    def test_add_calls_commit_with_reconstructed_object(self):
+        new_data = remove_object(person_data("H1", "I0001"))
+        change = {
+            "obj_class": "Person",
+            "trans_type": TXNADD,
+            "obj_handle": "H1",
+            "new_data": new_data,
+        }
+        applied = self.db._apply_change(change, self.trans)
+        self.assertTrue(applied)
+        self.db.commit_person.assert_called_once()
+        obj, trans = self.db.commit_person.call_args[0]
+        self.assertIsInstance(obj, Person)
+        self.assertEqual(obj.get_handle(), "H1")
+        self.assertIs(trans, self.trans)
+
+    def test_update_is_also_an_upsert(self):
+        new_data = remove_object(person_data("H1", "I0002"))
+        change = {
+            "obj_class": "Person",
+            "trans_type": TXNUPD,
+            "obj_handle": "H1",
+            "new_data": new_data,
+        }
+        applied = self.db._apply_change(change, self.trans)
+        self.assertTrue(applied)
+        self.db.commit_person.assert_called_once()
+        self.db.remove_person.assert_not_called()
+
+
+# -------------------------------------------------------------------------
+#
+# TestSyncFromServer
+#
+# -------------------------------------------------------------------------
+class FakeDbTxn:
+    """Stand-in for gramps.gen.db.DbTxn: a plain context manager, so
+    _sync_from_server's pagination/bookkeeping can be tested without a
+    real transaction_begin/transaction_commit or get_undodb()."""
+
+    def __init__(self, msg, grampsdb, batch=False):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+
+class TestSyncFromServer(unittest.TestCase):
+    def setUp(self):
+        self.db = new_instance()
+        self.db.web_client = mock.MagicMock()
+        self.metadata = {}
+        self.db._get_metadata = lambda key, default=0: self.metadata.get(
+            key, default
+        )
+        self.db._set_metadata = lambda key, value, use_txn=True: self.metadata.__setitem__(
+            key, value
+        )
+        self.patcher = mock.patch.object(grampswebapidb, "DbTxn", FakeDbTxn)
+        self.patcher.start()
+        self.addCleanup(self.patcher.stop)
+
+    def test_stops_after_short_page(self):
+        change = {"obj_class": "Person", "trans_type": TXNADD, "obj_handle": "H1"}
+        self.db.web_client.get_transaction_history.return_value = (
+            [{"timestamp": 5.0, "changes": [change]}],
+            1,
+        )
+        with mock.patch.object(self.db, "_apply_change", return_value=True) as apply:
+            applied = self.db._sync_from_server()
+        self.assertEqual(applied, 1)
+        apply.assert_called_once_with(change, mock.ANY)
+        self.db.web_client.get_transaction_history.assert_called_once()
+
+    def test_pagination_continues_on_full_page(self):
+        full_page = [
+            {"timestamp": float(i), "changes": []}
+            for i in range(grampswebapidb.SYNC_PAGE_SIZE)
+        ]
+        short_page = [{"timestamp": 999.0, "changes": []}]
+        self.db.web_client.get_transaction_history.side_effect = [
+            (full_page, len(full_page) + 1),
+            (short_page, 1),
+        ]
+        applied = self.db._sync_from_server()
+        self.assertEqual(applied, 0)
+        self.assertEqual(self.db.web_client.get_transaction_history.call_count, 2)
+        calls = self.db.web_client.get_transaction_history.call_args_list
+        self.assertEqual(calls[0].kwargs["page"], 1)
+        self.assertEqual(calls[1].kwargs["page"], 2)
+
+    def test_no_transactions_leaves_sync_time_unchanged(self):
+        self.metadata["sync_last_time"] = 42.0
+        self.db.web_client.get_transaction_history.return_value = ([], 0)
+        applied = self.db._sync_from_server()
+        self.assertEqual(applied, 0)
+        self.assertEqual(self.metadata["sync_last_time"], 42.0)
+
+    def test_sync_last_time_advances_to_max_timestamp_seen(self):
+        page = [
+            {"timestamp": 10.0, "changes": []},
+            {"timestamp": 30.0, "changes": []},
+            {"timestamp": 20.0, "changes": []},
+        ]
+        self.db.web_client.get_transaction_history.return_value = (page, 3)
+        self.db._sync_from_server()
+        self.assertEqual(self.metadata["sync_last_time"], 30.0)
+
+    def test_unrecognized_changes_are_not_counted(self):
+        page = [
+            {
+                "timestamp": 1.0,
+                "changes": [
+                    {"obj_class": "Bogus", "trans_type": TXNADD, "obj_handle": "H1"}
+                ],
+            }
+        ]
+        self.db.web_client.get_transaction_history.return_value = (page, 1)
+        applied = self.db._sync_from_server()
+        self.assertEqual(applied, 0)
+
+
+# -------------------------------------------------------------------------
+#
+# TestTransactionCommit
+#
+# -------------------------------------------------------------------------
+class TestTransactionCommit(unittest.TestCase):
+    def setUp(self):
+        self.db = new_instance()
+        self.db.web_client = mock.MagicMock()
+
+    def test_no_local_changes_does_not_push(self):
+        trans = FakeTransaction([])
+        with mock.patch.object(grampswebapidb.SQLite, "transaction_commit"):
+            self.db.transaction_commit(trans)
+        self.db.web_client.push_transaction.assert_not_called()
+
+    def test_local_changes_are_pushed(self):
+        trans = FakeTransaction([(0, TXNADD, "H1", None, person_data("H1"))])
+        with mock.patch.object(grampswebapidb.SQLite, "transaction_commit"):
+            self.db.transaction_commit(trans)
+        self.db.web_client.push_transaction.assert_called_once()
+        payload = self.db.web_client.push_transaction.call_args[0][0]
+        self.assertEqual(payload[0]["handle"], "H1")
+
+    def test_payload_built_before_super_clears_records(self):
+        # The base class's transaction_commit() clears the transaction's
+        # records as its last step -- see the module docstring's "must run
+        # before super()" note. Simulate that by having the (mocked) super
+        # call wipe the fake transaction, and confirm the push still saw
+        # the pre-clear data.
+        trans = FakeTransaction([(0, TXNADD, "H1", None, person_data("H1"))])
+
+        def clear_records(transaction):
+            transaction._records = []
+
+        with mock.patch.object(
+            grampswebapidb.SQLite, "transaction_commit", side_effect=clear_records
+        ):
+            self.db.transaction_commit(trans)
+        payload = self.db.web_client.push_transaction.call_args[0][0]
+        self.assertEqual(len(payload), 1)
+
+    def test_push_failure_is_logged_not_raised(self):
+        trans = FakeTransaction([(0, TXNADD, "H1", None, person_data("H1"))])
+        self.db.web_client.push_transaction.side_effect = HTTPError(
+            "https://example.com/api/transactions/", 500, "boom", None, None
+        )
+        with mock.patch.object(grampswebapidb.SQLite, "transaction_commit"):
+            with self.assertLogs(grampswebapidb.LOG, level="ERROR"):
+                self.db.transaction_commit(trans)  # must not raise
+
+
+# -------------------------------------------------------------------------
+#
+# TestMisc
+#
+# -------------------------------------------------------------------------
+class TestMisc(unittest.TestCase):
+    def test_requires_login_is_false(self):
+        self.assertFalse(new_instance().requires_login())
+
+    def test_initialize_wraps_connection_errors(self):
+        db = new_instance()
+        with mock.patch.object(
+            grampswebapidb.WebApiHandler,
+            "from_env",
+            side_effect=ValueError("GRAMPS_WEB_API_KEY is not set"),
+        ):
+            with self.assertRaises(DbConnectionError):
+                db._initialize("/tmp/some-tree", None, None)
+
+    def test_initialize_stores_web_client_and_calls_super(self):
+        db = new_instance()
+        sentinel_client = mock.MagicMock()
+        with mock.patch.object(
+            grampswebapidb.WebApiHandler, "from_env", return_value=sentinel_client
+        ), mock.patch.object(grampswebapidb.SQLite, "_initialize") as super_init:
+            db._initialize("/tmp/some-tree", "user", "pw")
+        self.assertIs(db.web_client, sentinel_client)
+        super_init.assert_called_once_with("/tmp/some-tree", "user", "pw")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/GrampsWebApiDb/tests/test_grampswebapidb.py
+++ b/GrampsWebApiDb/tests/test_grampswebapidb.py
@@ -71,7 +71,17 @@ from gramps.gen.lib import Person
 from gramps.gen.lib.json_utils import object_to_data, remove_object
 
 from GrampsWebApiDb import grampswebapidb
-from GrampsWebApiDb.grampswebapidb import WebApiDB, transaction_to_json
+from GrampsWebApiDb.grampswebapidb import WebApiDB, WebApiPushConflict, transaction_to_json
+
+# grampswebapidb.py imports webapi_client with a bare `from webapi_client
+# import ...` (see CLAUDE.md Testing conventions -- this addon has no
+# __init__.py, so Gramps and tests alike add its own directory to
+# sys.path). That makes "webapi_client" and "GrampsWebApiDb.webapi_client"
+# two distinct sys.modules entries for the same file, so an exception
+# class must come from whichever import path the code under test actually
+# uses -- grampswebapidb.WebApiPushConflict here, not a fresh
+# `from GrampsWebApiDb.webapi_client import WebApiPushConflict`, or
+# `except WebApiPushConflict` in transaction_commit() won't match it.
 
 
 # -------------------------------------------------------------------------
@@ -360,6 +370,39 @@ class TestTransactionCommit(unittest.TestCase):
         )
         with mock.patch.object(grampswebapidb.SQLite, "transaction_commit"):
             with self.assertLogs(grampswebapidb.LOG, level="ERROR"):
+                self.db.transaction_commit(trans)  # must not raise
+
+    def test_conflict_triggers_resync_not_raise(self):
+        # A WebApiPushConflict means the server rejected the whole batch
+        # because something changed server-side since the local mirror's
+        # snapshot -- the response is to resync from the server, not to
+        # propagate the exception (the local commit already happened).
+        trans = FakeTransaction([(0, TXNADD, "H1", None, person_data("H1"))])
+        self.db.web_client.push_transaction.side_effect = WebApiPushConflict(
+            "Object has changed"
+        )
+        with mock.patch.object(
+            grampswebapidb.SQLite, "transaction_commit"
+        ), mock.patch.object(self.db, "_sync_from_server") as resync:
+            with self.assertLogs(grampswebapidb.LOG, level="WARNING"):
+                self.db.transaction_commit(trans)  # must not raise
+        resync.assert_called_once_with()
+
+    def test_conflict_resync_failure_is_also_swallowed(self):
+        trans = FakeTransaction([(0, TXNADD, "H1", None, person_data("H1"))])
+        self.db.web_client.push_transaction.side_effect = WebApiPushConflict(
+            "Object has changed"
+        )
+        with mock.patch.object(
+            grampswebapidb.SQLite, "transaction_commit"
+        ), mock.patch.object(
+            self.db,
+            "_sync_from_server",
+            side_effect=HTTPError(
+                "https://example.com/api/transactions/history/", 500, "boom", None, None
+            ),
+        ):
+            with self.assertLogs(grampswebapidb.LOG, level="WARNING"):
                 self.db.transaction_commit(trans)  # must not raise
 
 

--- a/GrampsWebApiDb/tests/test_grampswebapidb.py
+++ b/GrampsWebApiDb/tests/test_grampswebapidb.py
@@ -228,6 +228,59 @@ class TestApplyChange(unittest.TestCase):
 
 # -------------------------------------------------------------------------
 #
+# TestEmitChangeSignals
+#
+# -------------------------------------------------------------------------
+class TestEmitChangeSignals(unittest.TestCase):
+    """_emit_change_signals() reproduces the person-add/family-update/...
+    signals a normal (non-batch) local commit would have emitted -- see
+    _sync_from_server()'s batch=True DbTxn and the module docstring's note
+    on why that otherwise leaves already-open views unaware anything
+    changed."""
+
+    def setUp(self):
+        self.db = new_instance()
+        self.db.emit = mock.MagicMock()
+
+    def emitted(self):
+        return {call.args[0]: call.args[1][0] for call in self.db.emit.call_args_list}
+
+    def test_add_emits_person_add_with_handle(self):
+        self.db._emit_change_signals({("Person", "H1"): TXNADD})
+        self.assertEqual(self.emitted(), {"person-add": ["H1"]})
+
+    def test_update_emits_dash_update(self):
+        self.db._emit_change_signals({("Family", "F1"): TXNUPD})
+        self.assertEqual(self.emitted(), {"family-update": ["F1"]})
+
+    def test_delete_emits_dash_delete(self):
+        self.db._emit_change_signals({("Event", "E1"): TXNDEL})
+        self.assertEqual(self.emitted(), {"event-delete": ["E1"]})
+
+    def test_unrecognized_obj_class_is_skipped(self):
+        self.db._emit_change_signals({("NotAThing", "H1"): TXNADD})
+        self.db.emit.assert_not_called()
+
+    def test_same_class_and_trans_type_batched_into_one_call(self):
+        self.db._emit_change_signals(
+            {("Person", "H1"): TXNUPD, ("Person", "H2"): TXNUPD}
+        )
+        self.db.emit.assert_called_once()
+        name, (handles,) = self.db.emit.call_args[0]
+        self.assertEqual(name, "person-update")
+        self.assertEqual(set(handles), {"H1", "H2"})
+
+    def test_deletes_and_adds_emitted_before_updates(self):
+        # Same ordering as DBAPI.transaction_commit()'s own signal loop.
+        self.db._emit_change_signals(
+            {("Person", "H1"): TXNUPD, ("Family", "F1"): TXNDEL}
+        )
+        names = [call.args[0] for call in self.db.emit.call_args_list]
+        self.assertEqual(names, ["family-delete", "person-update"])
+
+
+# -------------------------------------------------------------------------
+#
 # TestSyncFromServer
 #
 # -------------------------------------------------------------------------
@@ -250,6 +303,12 @@ class TestSyncFromServer(unittest.TestCase):
     def setUp(self):
         self.db = new_instance()
         self.db.web_client = mock.MagicMock()
+        # _sync_from_server() now emits change signals per page (see
+        # TestEmitChangeSignals for that logic in isolation) -- emit()
+        # itself needs Callback.__init__'s instance state, which
+        # new_instance()'s bare __new__() never runs, so it's stubbed here
+        # the same way commit_person/remove_person are stubbed elsewhere.
+        self.db.emit = mock.MagicMock()
         self.metadata = {}
         self.db._get_metadata = lambda key, default=0: self.metadata.get(
             key, default
@@ -326,6 +385,51 @@ class TestSyncFromServer(unittest.TestCase):
         applied = self.db._sync_from_server()
         self.assertEqual(applied, 0)
 
+    def test_emits_a_signal_per_applied_change(self):
+        change = {"obj_class": "Person", "trans_type": TXNADD, "obj_handle": "H1"}
+        self.db.web_client.get_transaction_history.return_value = (
+            [{"timestamp": 5.0, "changes": [change]}],
+            1,
+        )
+        with mock.patch.object(self.db, "_apply_change", return_value=True):
+            self.db._sync_from_server()
+        self.db.emit.assert_called_once_with("person-add", (["H1"],))
+
+    def test_repeated_changes_to_one_handle_collapse_to_the_last(self):
+        # Same handle, updated then deleted within one page/poll -- only
+        # the net (delete) signal should fire, not both.
+        page = [
+            {
+                "timestamp": 1.0,
+                "changes": [
+                    {"obj_class": "Person", "trans_type": TXNUPD, "obj_handle": "H1"}
+                ],
+            },
+            {
+                "timestamp": 2.0,
+                "changes": [
+                    {"obj_class": "Person", "trans_type": TXNDEL, "obj_handle": "H1"}
+                ],
+            },
+        ]
+        self.db.web_client.get_transaction_history.return_value = (page, 2)
+        with mock.patch.object(self.db, "_apply_change", return_value=True):
+            self.db._sync_from_server()
+        self.db.emit.assert_called_once_with("person-delete", (["H1"],))
+
+    def test_unrecognized_changes_emit_no_signal(self):
+        page = [
+            {
+                "timestamp": 1.0,
+                "changes": [
+                    {"obj_class": "Bogus", "trans_type": TXNADD, "obj_handle": "H1"}
+                ],
+            }
+        ]
+        self.db.web_client.get_transaction_history.return_value = (page, 1)
+        self.db._sync_from_server()
+        self.db.emit.assert_not_called()
+
 
 # -------------------------------------------------------------------------
 #
@@ -342,6 +446,7 @@ class TestFullResyncTrigger(unittest.TestCase):
     def setUp(self):
         self.db = new_instance()
         self.db.web_client = mock.MagicMock()
+        self.db.emit = mock.MagicMock()  # see TestSyncFromServer.setUp's note
         self.metadata = {}
         self.db._get_metadata = lambda key, default=0: self.metadata.get(
             key, default
@@ -400,6 +505,7 @@ class TestFullResync(unittest.TestCase):
         self.db = new_instance()
         self.db.web_client = mock.MagicMock()
         self.db.web_client.download_export.return_value = b"fake gramps xml bytes"
+        self.db.emit = mock.MagicMock()  # see TestSyncFromServer.setUp's note
         self.patcher = mock.patch.object(grampswebapidb, "DbTxn", FakeDbTxn)
         self.patcher.start()
         self.addCleanup(self.patcher.stop)
@@ -434,6 +540,32 @@ class TestFullResync(unittest.TestCase):
             getattr(self.db, f"remove_{name}").assert_called_once_with("H1", mock.ANY)
         # The temp file is cleaned up after import, not left behind.
         self.assertFalse(os.path.exists(captured_path["path"]))
+        # A successful reimport can't be described as specific add/update/
+        # delete signals, so every view is told to reload wholesale instead
+        # -- see request_rebuild() in gramps.gen.db.generic.
+        emitted = [call.args[0] for call in self.db.emit.call_args_list]
+        self.assertIn("person-rebuild", emitted)
+        self.assertIn("family-rebuild", emitted)
+
+    def test_failed_import_does_not_trigger_rebuild(self):
+        # request_rebuild() sits after importData() in _full_resync(), not
+        # in a finally -- a reimport that raised partway through left the
+        # mirror in an unknown state, which is not something to tell every
+        # view "reload, this is now correct" about.
+        for key, name in grampswebapidb.KEY_TO_NAME_MAP.items():
+            if key not in grampswebapidb.CLASS_TO_KEY_MAP.values():
+                continue
+            setattr(self.db, f"get_{name}_handles", mock.MagicMock(return_value=[]))
+            setattr(self.db, f"remove_{name}", mock.MagicMock())
+
+        def failing_import_data(database, filename, user):
+            raise RuntimeError("boom")
+
+        with mock.patch.object(grampswebapidb, "importData", failing_import_data):
+            with self.assertRaises(RuntimeError):
+                self.db._full_resync()
+
+        self.db.emit.assert_not_called()
 
 
 # -------------------------------------------------------------------------
@@ -640,6 +772,75 @@ class TestMisc(unittest.TestCase):
             db._initialize("/tmp/some-tree", "user", "pw")
         self.assertIs(db.web_client, sentinel_client)
         super_init.assert_called_once_with("/tmp/some-tree", "user", "pw")
+
+
+# -------------------------------------------------------------------------
+#
+# TestPolling
+#
+# load() schedules a GLib.timeout_add_seconds() tick that re-syncs for as
+# long as the database stays open (see the module docstring's polling
+# section); close() must cancel it so a closed database doesn't keep
+# polling on a connection that's going away.
+#
+# -------------------------------------------------------------------------
+class TestPolling(unittest.TestCase):
+    def setUp(self):
+        self.db = new_instance()
+
+    def test_load_syncs_and_schedules_polling(self):
+        with mock.patch.object(
+            grampswebapidb.SQLite, "load"
+        ) as super_load, mock.patch.object(
+            self.db, "_sync_from_server"
+        ) as sync, mock.patch.object(
+            grampswebapidb.GLib, "timeout_add_seconds", return_value=42
+        ) as timeout_add:
+            self.db.load("some/path")
+        super_load.assert_called_once_with("some/path")
+        sync.assert_called_once_with()
+        timeout_add.assert_called_once_with(
+            grampswebapidb.POLL_INTERVAL_SECONDS, self.db._poll_tick
+        )
+        self.assertEqual(self.db._poll_source_id, 42)
+
+    def test_close_cancels_pending_poll(self):
+        self.db._poll_source_id = 42
+        with mock.patch.object(
+            grampswebapidb.SQLite, "close"
+        ) as super_close, mock.patch.object(
+            grampswebapidb.GLib, "source_remove"
+        ) as source_remove:
+            self.db.close()
+        source_remove.assert_called_once_with(42)
+        self.assertIsNone(self.db._poll_source_id)
+        super_close.assert_called_once_with()
+
+    def test_close_without_a_poll_scheduled_is_a_no_op(self):
+        # e.g. close() called after a failed load(), before the timeout
+        # was ever scheduled.
+        with mock.patch.object(
+            grampswebapidb.SQLite, "close"
+        ) as super_close, mock.patch.object(
+            grampswebapidb.GLib, "source_remove"
+        ) as source_remove:
+            self.db.close()
+        source_remove.assert_not_called()
+        super_close.assert_called_once_with()
+
+    def test_poll_tick_syncs_and_keeps_repeating(self):
+        with mock.patch.object(self.db, "_sync_from_server") as sync:
+            result = self.db._poll_tick()
+        sync.assert_called_once_with()
+        self.assertEqual(result, grampswebapidb.GLib.SOURCE_CONTINUE)
+
+    def test_poll_tick_swallows_connection_errors_and_keeps_repeating(self):
+        with mock.patch.object(
+            self.db, "_sync_from_server", side_effect=OSError("network down")
+        ):
+            with self.assertLogs(grampswebapidb.LOG, level="ERROR"):
+                result = self.db._poll_tick()
+        self.assertEqual(result, grampswebapidb.GLib.SOURCE_CONTINUE)
 
 
 if __name__ == "__main__":

--- a/GrampsWebApiDb/tests/test_grampswebapidb.py
+++ b/GrampsWebApiDb/tests/test_grampswebapidb.py
@@ -67,11 +67,15 @@ except ImportError as _err:
 
 from gramps.gen.db.dbconst import REFERENCE_KEY, TXNADD, TXNDEL, TXNUPD
 from gramps.gen.db.exceptions import DbConnectionError
-from gramps.gen.lib import Person
+from gramps.gen.lib import Person, Tag
 from gramps.gen.lib.json_utils import object_to_data, remove_object
 
 from GrampsWebApiDb import grampswebapidb
-from GrampsWebApiDb.grampswebapidb import WebApiDB, WebApiPushConflict, transaction_to_json
+from GrampsWebApiDb.grampswebapidb import (
+    WebApiDB,
+    WebApiPushConflict,
+    transaction_to_json,
+)
 
 # grampswebapidb.py imports webapi_client with a bare `from webapi_client
 # import ...` (see CLAUDE.md Testing conventions -- this addon has no
@@ -310,11 +314,9 @@ class TestSyncFromServer(unittest.TestCase):
         # the same way commit_person/remove_person are stubbed elsewhere.
         self.db.emit = mock.MagicMock()
         self.metadata = {}
-        self.db._get_metadata = lambda key, default=0: self.metadata.get(
-            key, default
-        )
-        self.db._set_metadata = lambda key, value, use_txn=True: self.metadata.__setitem__(
-            key, value
+        self.db._get_metadata = lambda key, default=0: self.metadata.get(key, default)
+        self.db._set_metadata = (
+            lambda key, value, use_txn=True: self.metadata.__setitem__(key, value)
         )
         self.patcher = mock.patch.object(grampswebapidb, "DbTxn", FakeDbTxn)
         self.patcher.start()
@@ -448,11 +450,9 @@ class TestFullResyncTrigger(unittest.TestCase):
         self.db.web_client = mock.MagicMock()
         self.db.emit = mock.MagicMock()  # see TestSyncFromServer.setUp's note
         self.metadata = {}
-        self.db._get_metadata = lambda key, default=0: self.metadata.get(
-            key, default
-        )
-        self.db._set_metadata = lambda key, value, use_txn=True: self.metadata.__setitem__(
-            key, value
+        self.db._get_metadata = lambda key, default=0: self.metadata.get(key, default)
+        self.db._set_metadata = (
+            lambda key, value, use_txn=True: self.metadata.__setitem__(key, value)
         )
         self.db._full_resync = mock.MagicMock()
         self.patcher = mock.patch.object(grampswebapidb, "DbTxn", FakeDbTxn)
@@ -619,21 +619,28 @@ class TestTransactionCommit(unittest.TestCase):
             with self.assertLogs(grampswebapidb.LOG, level="ERROR"):
                 self.db.transaction_commit(trans)  # must not raise
 
-    def test_conflict_triggers_resync_not_raise(self):
+    def test_conflict_triggers_resync_then_retry(self):
         # A WebApiPushConflict means the server rejected the whole batch
         # because something changed server-side since the local mirror's
-        # snapshot -- the response is to resync from the server, not to
-        # propagate the exception (the local commit already happened).
+        # snapshot -- the response is to resync from the server and then
+        # retry the local edit on top of that fresh data (see
+        # _retry_after_conflict()), not to propagate the exception (the
+        # local commit already happened).
         trans = FakeTransaction([(0, TXNADD, "H1", None, person_data("H1"))])
         self.db.web_client.push_transaction.side_effect = WebApiPushConflict(
             "Object has changed"
         )
         with mock.patch.object(
             grampswebapidb.SQLite, "transaction_commit"
-        ), mock.patch.object(self.db, "_sync_from_server") as resync:
+        ), mock.patch.object(self.db, "_sync_from_server") as resync, mock.patch.object(
+            self.db, "_retry_after_conflict"
+        ) as retry:
             with self.assertLogs(grampswebapidb.LOG, level="WARNING"):
                 self.db.transaction_commit(trans)  # must not raise
         resync.assert_called_once_with()
+        retry.assert_called_once()
+        payload = retry.call_args[0][0]
+        self.assertEqual(payload[0]["handle"], "H1")
 
     def test_conflict_resync_failure_is_also_swallowed(self):
         trans = FakeTransaction([(0, TXNADD, "H1", None, person_data("H1"))])
@@ -648,9 +655,278 @@ class TestTransactionCommit(unittest.TestCase):
             side_effect=HTTPError(
                 "https://example.com/api/transactions/history/", 500, "boom", None, None
             ),
-        ):
+        ), mock.patch.object(
+            self.db, "_retry_after_conflict"
+        ) as retry:
             with self.assertLogs(grampswebapidb.LOG, level="WARNING"):
                 self.db.transaction_commit(trans)  # must not raise
+        # A failed resync means the mirror still doesn't reflect the
+        # server, so retrying the edit on top of it would be pointless.
+        retry.assert_not_called()
+
+    def test_repeated_conflict_on_a_retry_is_not_retried_again(self):
+        # is_retry=True marks a push that is itself _retry_after_conflict()'s
+        # replay -- a second conflict on that replay must not recurse into
+        # another retry, or a genuinely hot object could retry forever.
+        trans = FakeTransaction([(0, TXNADD, "H1", None, person_data("H1"))])
+        self.db.web_client.push_transaction.side_effect = WebApiPushConflict(
+            "Object has changed"
+        )
+        with mock.patch.object(
+            grampswebapidb.SQLite, "transaction_commit"
+        ), mock.patch.object(self.db, "_sync_from_server") as resync, mock.patch.object(
+            self.db, "_retry_after_conflict"
+        ) as retry:
+            with self.assertLogs(grampswebapidb.LOG, level="WARNING"):
+                self.db._push_payload(
+                    transaction_to_json(trans), is_retry=True
+                )  # must not raise
+        resync.assert_called_once_with()
+        retry.assert_not_called()
+
+    def test_undo_conflict_is_not_retried(self):
+        # Retrying an undo/redo against data that changed underneath it is
+        # a murkier case (are we replaying the reversal, or the original
+        # edit?) than retrying a plain commit -- see the module docstring.
+        # Left as resync-and-drop, same as before this feature existed.
+        trans = FakeTransaction([(0, TXNADD, "H1", None, person_data("H1"))])
+        self.db.web_client.push_transaction.side_effect = WebApiPushConflict(
+            "Object has changed"
+        )
+        with mock.patch.object(
+            grampswebapidb.SQLite, "transaction_commit"
+        ), mock.patch.object(self.db, "_sync_from_server") as resync, mock.patch.object(
+            self.db, "_retry_after_conflict"
+        ) as retry:
+            with self.assertLogs(grampswebapidb.LOG, level="WARNING"):
+                self.db._push_payload(transaction_to_json(trans), undo=True)
+        resync.assert_called_once_with()
+        retry.assert_not_called()
+
+
+# -------------------------------------------------------------------------
+#
+# TestRetryAfterConflict
+#
+# -------------------------------------------------------------------------
+class TestRetryAfterConflict(unittest.TestCase):
+    """_retry_after_conflict() replays each payload entry as a fresh
+    commit_<type>()/remove_<type>() call on top of the mirror _push_payload()
+    just resynced -- see the module docstring's write-through section.
+    DbTxn itself is stubbed out (a bare context-manager stand-in) so this
+    isolates just the replay logic, the same way TestApplyChange isolates
+    _apply_change() from a real transaction. _merge_or_overwrite() itself
+    is covered separately by TestMergeOrOverwrite, so here it's mocked out
+    to just confirm it's consulted (and with what) when the handle still
+    exists after the resync."""
+
+    def setUp(self):
+        self.db = new_instance()
+        self.db.commit_person = mock.MagicMock()
+        self.db.remove_person = mock.MagicMock()
+        self.db.has_person_handle = mock.MagicMock()
+        self.db.get_person_from_handle = mock.MagicMock()
+        dbtxn_patch = mock.patch.object(grampswebapidb, "DbTxn")
+        mock_dbtxn_class = dbtxn_patch.start()
+        mock_dbtxn_class.return_value.__enter__.return_value = "TRANS"
+        self.addCleanup(dbtxn_patch.stop)
+
+    def test_add_to_a_handle_that_does_not_exist_is_committed_as_is(self):
+        # A true add (or an update whose object was deleted server-side in
+        # the same window) has nothing to merge into.
+        self.db.has_person_handle.return_value = False
+        new_data = remove_object(person_data("H1", "I0001"))
+        payload = [
+            {
+                "type": "add",
+                "handle": "H1",
+                "_class": "Person",
+                "old": None,
+                "new": new_data,
+            }
+        ]
+        self.db._retry_after_conflict(payload)
+        self.db.get_person_from_handle.assert_not_called()
+        self.db.commit_person.assert_called_once()
+        obj, trans = self.db.commit_person.call_args[0]
+        self.assertIsInstance(obj, Person)
+        self.assertEqual(obj.get_handle(), "H1")
+        self.assertEqual(trans, "TRANS")
+
+    def test_update_of_a_still_present_handle_is_merged_with_the_current_object(self):
+        self.db.has_person_handle.return_value = True
+        current = Person()
+        current.set_handle("H1")
+        self.db.get_person_from_handle.return_value = current
+        new_data = remove_object(person_data("H1", "I0002"))
+        payload = [
+            {
+                "type": "update",
+                "handle": "H1",
+                "_class": "Person",
+                "old": None,
+                "new": new_data,
+            }
+        ]
+        with mock.patch.object(grampswebapidb, "_merge_or_overwrite") as merge_fn:
+            merge_fn.return_value = "MERGED"
+            self.db._retry_after_conflict(payload)
+        merge_current, merge_local = merge_fn.call_args[0]
+        self.assertIs(merge_current, current)
+        self.assertIsInstance(merge_local, Person)
+        self.assertEqual(merge_local.get_gramps_id(), "I0002")
+        self.db.commit_person.assert_called_once_with("MERGED", "TRANS")
+
+    def test_delete_removes_if_handle_still_present(self):
+        self.db.has_person_handle.return_value = True
+        payload = [
+            {
+                "type": "delete",
+                "handle": "H1",
+                "_class": "Person",
+                "old": remove_object(person_data("H1")),
+                "new": None,
+            }
+        ]
+        self.db._retry_after_conflict(payload)
+        self.db.remove_person.assert_called_once_with("H1", "TRANS")
+
+    def test_delete_is_skipped_if_handle_already_gone(self):
+        # The conflicting server-side change may have been a delete of the
+        # same object -- nothing left to remove a second time.
+        self.db.has_person_handle.return_value = False
+        payload = [
+            {
+                "type": "delete",
+                "handle": "H1",
+                "_class": "Person",
+                "old": remove_object(person_data("H1")),
+                "new": None,
+            }
+        ]
+        self.db._retry_after_conflict(payload)
+        self.db.remove_person.assert_not_called()
+
+    def test_unrecognized_class_is_skipped(self):
+        payload = [
+            {
+                "type": "update",
+                "handle": "H1",
+                "_class": "NotAThing",
+                "old": None,
+                "new": {},
+            }
+        ]
+        self.db._retry_after_conflict(payload)  # must not raise
+        self.db.commit_person.assert_not_called()
+        self.db.has_person_handle.assert_not_called()
+
+    def test_retrying_flag_set_during_replay_and_cleared_after(self):
+        self.db.has_person_handle.return_value = False
+        seen = {}
+
+        def check_flag(obj, trans):
+            seen["during"] = self.db._retrying
+
+        self.db.commit_person.side_effect = check_flag
+        new_data = remove_object(person_data("H1"))
+        payload = [
+            {
+                "type": "update",
+                "handle": "H1",
+                "_class": "Person",
+                "old": None,
+                "new": new_data,
+            }
+        ]
+        self.db._retry_after_conflict(payload)
+        self.assertTrue(seen["during"])
+        self.assertFalse(self.db._retrying)
+
+    def test_retrying_flag_cleared_even_if_commit_raises(self):
+        self.db.has_person_handle.return_value = False
+        self.db.commit_person.side_effect = RuntimeError("boom")
+        new_data = remove_object(person_data("H1"))
+        payload = [
+            {
+                "type": "update",
+                "handle": "H1",
+                "_class": "Person",
+                "old": None,
+                "new": new_data,
+            }
+        ]
+        with self.assertRaises(RuntimeError):
+            self.db._retry_after_conflict(payload)
+        self.assertFalse(self.db._retrying)
+
+
+# -------------------------------------------------------------------------
+#
+# TestMergeOrOverwrite
+#
+# -------------------------------------------------------------------------
+class TestMergeOrOverwrite(unittest.TestCase):
+    """_merge_or_overwrite() ports GrampsWebSync's diffhandler.py A_MRG_REM
+    handling: combine two edits of the same object via the object's own
+    merge() -- the same list-unioning logic behind Gramps' Merge People/
+    Family/... tools -- rather than letting one edit silently clobber the
+    other. Uses real Person/Tag objects rather than mocks, since the whole
+    point is exercising Gramps' own merge() implementation."""
+
+    def test_list_valued_fields_from_both_sides_are_unioned(self):
+        current = Person()
+        current.set_handle("H1")
+        current.set_gramps_id("I0001")
+        current.add_note("N-remote")
+
+        local = Person()
+        local.set_handle("H1")
+        local.set_gramps_id("I0002")
+        local.add_note("N-local")
+
+        merged = grampswebapidb._merge_or_overwrite(current, local)
+        self.assertEqual(set(merged.get_note_list()), {"N-remote", "N-local"})
+
+    def test_current_object_is_not_mutated(self):
+        current = Person()
+        current.set_handle("H1")
+        current.add_note("N-remote")
+        local = Person()
+        local.set_handle("H1")
+        local.add_note("N-local")
+
+        grampswebapidb._merge_or_overwrite(current, local)
+        self.assertEqual(current.get_note_list(), ["N-remote"])
+
+    def test_local_obj_gramps_id_is_cleared_before_merging(self):
+        # merge() tags on a "Merged Gramps ID" attribute if the acquisition
+        # has a gramps_id -- appropriate for absorbing a second, separate
+        # object (Gramps' Merge People tool), but this is one object edited
+        # twice, not two objects becoming one, so that attribute must not
+        # appear, and local's own gramps_id object must be untouched.
+        current = Person()
+        current.set_handle("H1")
+        local = Person()
+        local.set_handle("H1")
+        local.set_gramps_id("I0002")
+
+        merged = grampswebapidb._merge_or_overwrite(current, local)
+        self.assertEqual(merged.get_attribute_list(), [])
+        self.assertEqual(local.get_gramps_id(), "I0002")
+
+    def test_type_without_a_real_merge_falls_back_to_local_obj(self):
+        # Tag only inherits BaseObject's no-op merge() -- "merging" into it
+        # would silently keep current's content and drop the local edit.
+        current = Tag()
+        current.set_handle("H1")
+        current.set_name("Remote name")
+        local = Tag()
+        local.set_handle("H1")
+        local.set_name("Local name")
+
+        result = grampswebapidb._merge_or_overwrite(current, local)
+        self.assertIs(result, local)
 
 
 # -------------------------------------------------------------------------

--- a/GrampsWebApiDb/tests/test_grampswebapidb.py
+++ b/GrampsWebApiDb/tests/test_grampswebapidb.py
@@ -260,6 +260,12 @@ class TestSyncFromServer(unittest.TestCase):
         self.patcher = mock.patch.object(grampswebapidb, "DbTxn", FakeDbTxn)
         self.patcher.start()
         self.addCleanup(self.patcher.stop)
+        # Every existing test here predates the empty-changes-marker ->
+        # full-resync fallback (see TestFullResyncTrigger below) and uses
+        # "changes": [] purely as pagination/timestamp filler, not to
+        # exercise that fallback -- stub it out so those tests keep
+        # testing what they always tested.
+        self.db._full_resync = mock.MagicMock()
 
     def test_stops_after_short_page(self):
         change = {"obj_class": "Person", "trans_type": TXNADD, "obj_handle": "H1"}
@@ -319,6 +325,115 @@ class TestSyncFromServer(unittest.TestCase):
         self.db.web_client.get_transaction_history.return_value = (page, 1)
         applied = self.db._sync_from_server()
         self.assertEqual(applied, 0)
+
+
+# -------------------------------------------------------------------------
+#
+# TestFullResyncTrigger
+#
+# A batch=True commit (any bulk import/merge/tool run through
+# gramps-web-api) leaves an empty "changes" list on its transaction
+# row -- see the module docstring's note on trans.batch guards around
+# trans.add(). _sync_from_server() can't replay what was never logged,
+# so it falls back to _full_resync() whenever it sees one.
+#
+# -------------------------------------------------------------------------
+class TestFullResyncTrigger(unittest.TestCase):
+    def setUp(self):
+        self.db = new_instance()
+        self.db.web_client = mock.MagicMock()
+        self.metadata = {}
+        self.db._get_metadata = lambda key, default=0: self.metadata.get(
+            key, default
+        )
+        self.db._set_metadata = lambda key, value, use_txn=True: self.metadata.__setitem__(
+            key, value
+        )
+        self.db._full_resync = mock.MagicMock()
+        self.patcher = mock.patch.object(grampswebapidb, "DbTxn", FakeDbTxn)
+        self.patcher.start()
+        self.addCleanup(self.patcher.stop)
+
+    def test_empty_changes_transaction_triggers_full_resync(self):
+        page = [{"timestamp": 1.0, "changes": []}]
+        self.db.web_client.get_transaction_history.return_value = (page, 1)
+        self.db._sync_from_server()
+        self.db._full_resync.assert_called_once_with()
+
+    def test_normal_transactions_do_not_trigger_full_resync(self):
+        change = {"obj_class": "Person", "trans_type": TXNADD, "obj_handle": "H1"}
+        page = [{"timestamp": 1.0, "changes": [change]}]
+        self.db.web_client.get_transaction_history.return_value = (page, 1)
+        with mock.patch.object(self.db, "_apply_change", return_value=True):
+            self.db._sync_from_server()
+        self.db._full_resync.assert_not_called()
+
+    def test_marker_alongside_real_changes_still_applies_the_real_ones(self):
+        # A marker transaction doesn't block replaying whatever *is*
+        # describable elsewhere in the same page -- only the parts the
+        # history feed genuinely has no record of need the fallback.
+        change = {"obj_class": "Person", "trans_type": TXNADD, "obj_handle": "H1"}
+        page = [
+            {"timestamp": 1.0, "changes": []},
+            {"timestamp": 2.0, "changes": [change]},
+        ]
+        self.db.web_client.get_transaction_history.return_value = (page, 2)
+        with mock.patch.object(self.db, "_apply_change", return_value=True):
+            applied = self.db._sync_from_server()
+        self.assertEqual(applied, 1)
+        self.db._full_resync.assert_called_once_with()
+
+    def test_marker_still_advances_sync_last_time(self):
+        page = [{"timestamp": 42.0, "changes": []}]
+        self.db.web_client.get_transaction_history.return_value = (page, 1)
+        self.db._sync_from_server()
+        self.assertEqual(self.metadata["sync_last_time"], 42.0)
+
+
+# -------------------------------------------------------------------------
+#
+# TestFullResync
+#
+# -------------------------------------------------------------------------
+class TestFullResync(unittest.TestCase):
+    def setUp(self):
+        self.db = new_instance()
+        self.db.web_client = mock.MagicMock()
+        self.db.web_client.download_export.return_value = b"fake gramps xml bytes"
+        self.patcher = mock.patch.object(grampswebapidb, "DbTxn", FakeDbTxn)
+        self.patcher.start()
+        self.addCleanup(self.patcher.stop)
+
+    def test_downloads_export_wipes_and_reimports(self):
+        # get_<name>_handles/remove_<name> for every primary type, plus
+        # importData itself, are all faked out -- this test is only
+        # confirming the wiring (download -> wipe every type -> import
+        # the downloaded file -> clean up the temp file), not any real
+        # Gramps object storage.
+        for key, name in grampswebapidb.KEY_TO_NAME_MAP.items():
+            if key not in grampswebapidb.CLASS_TO_KEY_MAP.values():
+                continue
+            setattr(self.db, f"get_{name}_handles", mock.MagicMock(return_value=["H1"]))
+            setattr(self.db, f"remove_{name}", mock.MagicMock())
+
+        captured_path = {}
+
+        def fake_import_data(database, filename, user):
+            captured_path["path"] = filename
+            self.assertTrue(os.path.exists(filename))
+            with open(filename, "rb") as f:
+                self.assertEqual(f.read(), b"fake gramps xml bytes")
+
+        with mock.patch.object(grampswebapidb, "importData", fake_import_data):
+            self.db._full_resync()
+
+        self.db.web_client.download_export.assert_called_once_with()
+        for key, name in grampswebapidb.KEY_TO_NAME_MAP.items():
+            if key not in grampswebapidb.CLASS_TO_KEY_MAP.values():
+                continue
+            getattr(self.db, f"remove_{name}").assert_called_once_with("H1", mock.ANY)
+        # The temp file is cleaned up after import, not left behind.
+        self.assertFalse(os.path.exists(captured_path["path"]))
 
 
 # -------------------------------------------------------------------------

--- a/GrampsWebApiDb/tests/test_grampswebapidb.py
+++ b/GrampsWebApiDb/tests/test_grampswebapidb.py
@@ -408,6 +408,97 @@ class TestTransactionCommit(unittest.TestCase):
 
 # -------------------------------------------------------------------------
 #
+# TestUndoRedo
+#
+# -------------------------------------------------------------------------
+class TestUndoRedo(unittest.TestCase):
+    """undo()/redo() peek the relevant DbTxn off DbGenericUndo's queue,
+    turn it back into a change-list payload, and push it -- undo via
+    push_transaction(..., undo=True) (server reverses it), redo via a
+    plain push (same as an ordinary commit). Both delegate to
+    _push_payload(), whose conflict/error handling is already covered by
+    TestTransactionCommit, so these just confirm the wiring: the right
+    payload, the right undo flag, and the peek-before-super ordering."""
+
+    def setUp(self):
+        self.db = new_instance()
+        self.db.undodb = mock.MagicMock()
+
+    def test_undo_pushes_with_undo_flag(self):
+        txn = FakeTransaction([(0, TXNADD, "H1", None, person_data("H1"))])
+        self.db.undodb.undo_count = 1
+        self.db.undodb.undoq = [txn]
+        self.db.undodb.undo.return_value = True
+        with mock.patch.object(self.db, "_push_payload") as push:
+            result = self.db.undo()
+        self.assertTrue(result)
+        push.assert_called_once()
+        payload = push.call_args[0][0]
+        self.assertEqual(payload[0]["handle"], "H1")
+        self.assertEqual(push.call_args.kwargs, {"undo": True})
+
+    def test_redo_pushes_without_undo_flag(self):
+        txn = FakeTransaction([(0, TXNDEL, "H1", person_data("H1"), None)])
+        self.db.undodb.redo_count = 1
+        self.db.undodb.redoq = [txn]
+        self.db.undodb.redo.return_value = True
+        with mock.patch.object(self.db, "_push_payload") as push:
+            result = self.db.redo()
+        self.assertTrue(result)
+        payload = push.call_args[0][0]
+        self.assertEqual(payload[0]["handle"], "H1")
+        self.assertEqual(push.call_args.kwargs, {})
+
+    def test_no_push_when_nothing_to_undo(self):
+        self.db.undodb.undo_count = 0
+        self.db.undodb.undo.return_value = False
+        with mock.patch.object(self.db, "_push_payload") as push:
+            result = self.db.undo()
+        self.assertFalse(result)
+        push.assert_not_called()
+
+    def test_no_push_when_nothing_to_redo(self):
+        self.db.undodb.redo_count = 0
+        self.db.undodb.redo.return_value = False
+        with mock.patch.object(self.db, "_push_payload") as push:
+            result = self.db.redo()
+        self.assertFalse(result)
+        push.assert_not_called()
+
+    def test_undo_not_pushed_if_super_reports_nothing_undone(self):
+        # undo_count > 0 doesn't guarantee _undo() actually ran (e.g. a
+        # readonly db -- see DbUndo.undo()); only a truthy result pushes.
+        txn = FakeTransaction([(0, TXNADD, "H1", None, person_data("H1"))])
+        self.db.undodb.undo_count = 1
+        self.db.undodb.undoq = [txn]
+        self.db.undodb.undo.return_value = False
+        with mock.patch.object(self.db, "_push_payload") as push:
+            result = self.db.undo()
+        self.assertFalse(result)
+        push.assert_not_called()
+
+    def test_transaction_grabbed_before_super_pops_the_queue(self):
+        # WebApiDB.undo() must read undoq[-1] before delegating to
+        # super().undo() (-> DbGenericUndo._undo(), which pops it) -- grab
+        # it too late and the payload would be built from the wrong (or a
+        # missing) transaction.
+        txn = FakeTransaction([(0, TXNADD, "H1", None, person_data("H1"))])
+        self.db.undodb.undo_count = 1
+        self.db.undodb.undoq = [txn]
+
+        def pop_on_undo(update_history):
+            self.db.undodb.undoq.pop()
+            return True
+
+        self.db.undodb.undo.side_effect = pop_on_undo
+        with mock.patch.object(self.db, "_push_payload") as push:
+            self.db.undo()
+        payload = push.call_args[0][0]
+        self.assertEqual(payload[0]["handle"], "H1")
+
+
+# -------------------------------------------------------------------------
+#
 # TestMisc
 #
 # -------------------------------------------------------------------------

--- a/GrampsWebApiDb/tests/test_webapi_client.py
+++ b/GrampsWebApiDb/tests/test_webapi_client.py
@@ -343,6 +343,63 @@ class TestAccessTokenProperty(unittest.TestCase):
         self.assertEqual(handler.get_permissions(), ["edit", "view"])
 
 
+# -------------------------------------------------------------------------
+#
+# TestIdentity
+#
+# hostname/get_current_username()/get_identity() resolve who and where a
+# credential authenticates as -- grampswebapidb.py's _check_identity() uses
+# get_identity() to bind a local mirror to one particular server account
+# (see that module's docstring).
+#
+# -------------------------------------------------------------------------
+class TestIdentity(unittest.TestCase):
+    def _handler(self):
+        fake = QueuedUrlopen([FakeResponse({"access_token": token("AT1")})])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            handler = WebApiHandler("https://example.com/api", refresh_token="RT")
+        return handler, fake
+
+    def test_hostname_strips_scheme_and_path(self):
+        handler, _fake = self._handler()
+        self.assertEqual(handler.hostname, "example.com")
+
+    def test_get_current_username_resolves_via_users_dash_and_caches(self):
+        # A refresh-token credential (the normal from_env() path) carries
+        # no plaintext username -- unlike get_permissions()'s claim, this
+        # isn't in the JWT at all, so it takes a real GET /users/-/.
+        handler, fake = self._handler()
+        fake._items.append(FakeResponse({"name": "dblank"}))
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            self.assertEqual(handler.get_current_username(), "dblank")
+        self.assertEqual(handler.username, "dblank")
+        self.assertEqual(fake.requests[-1].full_url, "https://example.com/api/users/-/")
+
+        # Cached: a second call makes no further request.
+        fake._items.append(FakeResponse({"name": "someone-else"}))
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            self.assertEqual(handler.get_current_username(), "dblank")
+
+    def test_get_current_username_skips_lookup_for_password_login(self):
+        # A username+password login already knows its own username --
+        # no need to ask the server to confirm it.
+        fake = QueuedUrlopen(
+            [FakeResponse({"access_token": token("AT1"), "refresh_token": "RT"})]
+        )
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            handler = WebApiHandler(
+                "https://example.com/api", username="dblank", password="pw"
+            )
+            self.assertEqual(handler.get_current_username(), "dblank")
+        self.assertEqual(len(fake.requests), 1)
+
+    def test_get_identity_combines_username_and_hostname(self):
+        handler, fake = self._handler()
+        fake._items.append(FakeResponse({"name": "dblank"}))
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            self.assertEqual(handler.get_identity(), "dblank@example.com")
+
+
 def time_now():
     import time
 

--- a/GrampsWebApiDb/tests/test_webapi_client.py
+++ b/GrampsWebApiDb/tests/test_webapi_client.py
@@ -126,6 +126,24 @@ class FakeResponse:
         return False
 
 
+class FakeBinaryResponse:
+    """Like FakeResponse, but for endpoints that return a raw file body
+    rather than JSON (see download_export()/_get_binary())."""
+
+    def __init__(self, body: bytes, headers=None):
+        self._body = body
+        self.headers = headers or {}
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+
 def http_error(code, url="https://example.com/api"):
     return HTTPError(url, code, f"HTTP {code}", None, None)
 
@@ -482,6 +500,74 @@ class TestTransactionHistory(unittest.TestCase):
         with mock.patch.object(webapi_client, "urlopen", fake):
             _transactions, total = handler.get_transaction_history()
         self.assertEqual(total, 3)
+
+
+# -------------------------------------------------------------------------
+#
+# TestDownloadExport
+#
+# -------------------------------------------------------------------------
+class TestDownloadExport(unittest.TestCase):
+    """download_export() (grampswebapidb.py's _full_resync() fallback)
+    hits GET /exporters/<extension>/file and returns the raw body,
+    sharing _get_binary()'s 401/429/network retry behavior with
+    _get_json()."""
+
+    def _authed_handler(self):
+        fake = QueuedUrlopen([FakeResponse({"access_token": token("AT0")})])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            handler = WebApiHandler("https://example.com/api", refresh_token="RT")
+        return handler
+
+    def test_request_url_and_returns_raw_bytes(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen([FakeBinaryResponse(b"gzip-bytes-here")])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            data = handler.download_export()
+        self.assertEqual(data, b"gzip-bytes-here")
+        self.assertEqual(
+            fake.requests[0].full_url, "https://example.com/api/exporters/gramps/file"
+        )
+
+    def test_extension_is_configurable(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen([FakeBinaryResponse(b"gedcom-bytes")])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            handler.download_export(extension="ged")
+        self.assertEqual(
+            fake.requests[0].full_url, "https://example.com/api/exporters/ged/file"
+        )
+
+    def test_401_triggers_reauth_and_retry(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen(
+            [
+                http_error(401),
+                FakeResponse({"access_token": token("AT1")}),  # the re-auth call
+                FakeBinaryResponse(b"data-after-reauth"),
+            ]
+        )
+        with mock.patch.object(webapi_client, "urlopen", fake), mock.patch.object(
+            webapi_client, "sleep"
+        ):
+            data = handler.download_export()
+        self.assertEqual(data, b"data-after-reauth")
+
+    def test_429_retries_once(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen([http_error(429), FakeBinaryResponse(b"data")])
+        with mock.patch.object(webapi_client, "urlopen", fake), mock.patch.object(
+            webapi_client, "sleep"
+        ):
+            data = handler.download_export()
+        self.assertEqual(data, b"data")
+
+    def test_second_failure_propagates(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen([http_error(500), http_error(500)])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            with self.assertRaises(HTTPError):
+                handler.download_export()
 
 
 # -------------------------------------------------------------------------

--- a/GrampsWebApiDb/tests/test_webapi_client.py
+++ b/GrampsWebApiDb/tests/test_webapi_client.py
@@ -44,6 +44,7 @@ Run with::
 #
 # -------------------------------------------------------------------------
 import base64
+import io
 import json
 import os
 import sys
@@ -70,6 +71,7 @@ except ImportError as _err:
 from GrampsWebApiDb import webapi_client
 from GrampsWebApiDb.webapi_client import (
     WebApiHandler,
+    WebApiPushConflict,
     decode_jwt_payload,
     make_api_key,
     parse_api_key,
@@ -126,6 +128,13 @@ class FakeResponse:
 
 def http_error(code, url="https://example.com/api"):
     return HTTPError(url, code, f"HTTP {code}", None, None)
+
+
+def http_error_with_body(code, body, url="https://example.com/api"):
+    """An HTTPError whose .read() yields a JSON-encoded body, the way a
+    real gramps-web-api error response (abort_with_message()) looks."""
+    fp = io.BytesIO(json.dumps(body).encode())
+    return HTTPError(url, code, f"HTTP {code}", None, fp)
 
 
 class QueuedUrlopen:
@@ -494,14 +503,17 @@ class TestPushTransaction(unittest.TestCase):
             handler.push_transaction([])
         self.assertEqual(fake.requests, [])
 
-    def test_non_empty_payload_posts_with_force(self):
+    def test_non_empty_payload_posts_without_force(self):
+        # No force=1: the server's old-data-mismatch check must run, or
+        # WebApiPushConflict can never fire -- see push_transaction()'s
+        # docstring.
         handler = self._authed_handler()
         payload = [{"type": "add", "handle": "H1", "_class": "Person"}]
         fake = QueuedUrlopen([FakeResponse({})])
         with mock.patch.object(webapi_client, "urlopen", fake):
             handler.push_transaction(payload)
         req = fake.requests[0]
-        self.assertEqual(req.full_url, "https://example.com/api/transactions/?force=1")
+        self.assertEqual(req.full_url, "https://example.com/api/transactions/")
         self.assertEqual(req.get_method(), "POST")
         self.assertEqual(json.loads(req.data), payload)
         self.assertEqual(req.get_header("Authorization"), f"Bearer {token('AT0')}")
@@ -525,6 +537,45 @@ class TestPushTransaction(unittest.TestCase):
         ):
             handler.push_transaction([{"type": "add"}])
         self.assertEqual(len(fake.requests), 2)
+
+    def test_object_changed_400_raises_push_conflict(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen(
+            [
+                http_error_with_body(
+                    400, {"error": {"code": 400, "message": "Object has changed"}}
+                )
+            ]
+        )
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            with self.assertRaises(WebApiPushConflict):
+                handler.push_transaction([{"type": "add"}])
+        # Not retried -- a conflict isn't transient, so exactly one request.
+        self.assertEqual(len(fake.requests), 1)
+
+    def test_other_400_reasons_are_not_conflicts(self):
+        # e.g. a payload item missing a required Gramps ID -- our own bug,
+        # not a concurrent edit -- must propagate as a plain HTTPError.
+        handler = self._authed_handler()
+        fake = QueuedUrlopen(
+            [
+                http_error_with_body(
+                    400, {"error": {"code": 400, "message": "Gramps ID missing"}}
+                )
+            ]
+        )
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            with self.assertRaises(HTTPError) as ctx:
+                handler.push_transaction([{"type": "add"}])
+        self.assertNotIsInstance(ctx.exception, WebApiPushConflict)
+
+    def test_400_with_unparseable_body_propagates_as_http_error(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen([http_error_with_body(400, "not-a-dict-body")])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            with self.assertRaises(HTTPError) as ctx:
+                handler.push_transaction([{"type": "add"}])
+        self.assertNotIsInstance(ctx.exception, WebApiPushConflict)
 
 
 if __name__ == "__main__":

--- a/GrampsWebApiDb/tests/test_webapi_client.py
+++ b/GrampsWebApiDb/tests/test_webapi_client.py
@@ -518,6 +518,45 @@ class TestPushTransaction(unittest.TestCase):
         self.assertEqual(json.loads(req.data), payload)
         self.assertEqual(req.get_header("Authorization"), f"Bearer {token('AT0')}")
 
+    def test_undo_appends_query_param(self):
+        handler = self._authed_handler()
+        payload = [{"type": "add", "handle": "H1", "_class": "Person"}]
+        fake = QueuedUrlopen([FakeResponse({})])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            handler.push_transaction(payload, undo=True)
+        req = fake.requests[0]
+        self.assertEqual(
+            req.full_url, "https://example.com/api/transactions/?undo=1"
+        )
+        # The payload itself is the original (forward) one -- the server
+        # reverses it, not the caller. See push_transaction()'s docstring.
+        self.assertEqual(json.loads(req.data), payload)
+
+    def test_undo_defaults_to_false(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen([FakeResponse({})])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            handler.push_transaction([{"type": "add"}])
+        self.assertEqual(fake.requests[0].full_url, "https://example.com/api/transactions/")
+
+    def test_undo_flag_survives_401_retry(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen(
+            [
+                http_error(401),
+                FakeResponse({"access_token": token("AT1")}),
+                FakeResponse({}),
+            ]
+        )
+        with mock.patch.object(webapi_client, "urlopen", fake), mock.patch.object(
+            webapi_client, "sleep"
+        ):
+            handler.push_transaction([{"type": "add"}], undo=True)
+        # requests[0] = failed push, [1] = re-auth, [2] = retried push
+        self.assertEqual(
+            fake.requests[2].full_url, "https://example.com/api/transactions/?undo=1"
+        )
+
     def test_401_triggers_reauth_and_retry(self):
         handler = self._authed_handler()
         fake = QueuedUrlopen(

--- a/GrampsWebApiDb/tests/test_webapi_client.py
+++ b/GrampsWebApiDb/tests/test_webapi_client.py
@@ -1,0 +1,531 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026 Douglas S. Blank <doug.blank@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Unit tests for webapi_client.WebApiHandler and its helper functions.
+
+No real Gramps Web API server is contacted: urlopen() is patched throughout,
+via a small FakeResponse context manager and a queue of canned
+responses/exceptions. Covers:
+
+  - the GRAMPS_WEB_API_KEY codec (make_api_key/parse_api_key round trip)
+  - JWT payload decoding
+  - username/password vs. refresh-token authentication
+  - the 429 rate-limit backoff-and-retry-once behavior
+  - the "no /api prefix yet" fallback retry
+  - 401 re-authentication on expired access tokens
+  - transaction_history/push_transaction request shape
+
+Run with::
+
+    python3 -m unittest GrampsWebApiDb.tests.test_webapi_client -v
+"""
+
+# -------------------------------------------------------------------------
+#
+# Standard python modules
+#
+# -------------------------------------------------------------------------
+import base64
+import json
+import os
+import sys
+import unittest
+from urllib.error import HTTPError, URLError
+from unittest import mock
+
+# -------------------------------------------------------------------------
+#
+# Make the addon importable the way Gramps loads it: its own directory on
+# sys.path (grampswebapidb.py/webapi_client.py use bare, not package-
+# relative, imports of each other -- see CLAUDE.md Testing conventions).
+#
+# -------------------------------------------------------------------------
+ADDON_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ADDON_DIR not in sys.path:
+    sys.path.insert(0, ADDON_DIR)
+
+try:
+    import gramps  # noqa: F401  (only to trigger the SkipTest below if absent)
+except ImportError as _err:
+    raise unittest.SkipTest("gramps package not available: %s" % _err)
+
+from GrampsWebApiDb import webapi_client
+from GrampsWebApiDb.webapi_client import (
+    WebApiHandler,
+    decode_jwt_payload,
+    make_api_key,
+    parse_api_key,
+)
+
+
+# -------------------------------------------------------------------------
+#
+# Test helpers
+#
+# -------------------------------------------------------------------------
+def b64url_json(payload: dict) -> str:
+    """Base64url-encode a dict, stripped of padding, like a real JWT segment."""
+    raw = json.dumps(payload).encode()
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+def fake_jwt(payload: dict) -> str:
+    """A JWT-shaped string whose payload segment decodes to ``payload``.
+
+    decode_jwt_payload() only ever looks at segment [1], so the header and
+    signature segments don't need to be real.
+    """
+    return f"header.{b64url_json(payload)}.signature"
+
+
+def token(tag: str) -> str:
+    """A distinct, real-JWT-shaped access token for ``tag``.
+
+    Every access token this module hands back (even a canned "AT1"-style
+    placeholder) is real enough to satisfy decode_jwt_payload(), because
+    access_token's getter unconditionally checks the token's remaining
+    lifetime -- see get_access_token_remaining_time().
+    """
+    return fake_jwt({"tag": tag})
+
+
+class FakeResponse:
+    """Stand-in for the object returned by ``urlopen(...).__enter__()``."""
+
+    def __init__(self, body=None, headers=None):
+        self._body = json.dumps(body if body is not None else {}).encode()
+        self.headers = headers or {}
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+
+def http_error(code, url="https://example.com/api"):
+    return HTTPError(url, code, f"HTTP {code}", None, None)
+
+
+class QueuedUrlopen:
+    """``urlopen`` replacement that returns/raises each queued item in turn,
+    recording every ``Request`` it was called with."""
+
+    def __init__(self, items):
+        self._items = list(items)
+        self.requests = []
+
+    def __call__(self, req, context=None, timeout=None):
+        self.requests.append(req)
+        item = self._items.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+
+# -------------------------------------------------------------------------
+#
+# TestApiKeyCodec
+#
+# -------------------------------------------------------------------------
+class TestApiKeyCodec(unittest.TestCase):
+    """make_api_key()/parse_api_key() are inverses, and reject malformed input."""
+
+    def test_roundtrip(self):
+        key = make_api_key("refresh-tok-123", "https://example.com/api")
+        self.assertEqual(
+            parse_api_key(key), ("refresh-tok-123", "https://example.com/api")
+        )
+
+    def test_roundtrip_with_padding_needed(self):
+        # A URL whose base64url encoding needs '=' padding restored.
+        url = "https://example.com/api/x"
+        key = make_api_key("tok", url)
+        self.assertEqual(parse_api_key(key), ("tok", url))
+
+    def test_missing_delimiter_is_malformed(self):
+        with self.assertRaises(ValueError):
+            parse_api_key("no-delimiter-here")
+
+    def test_bad_url_encoding_is_malformed(self):
+        with self.assertRaises(ValueError):
+            parse_api_key("tok*not-valid-base64---")
+
+    def test_empty_token_is_rejected(self):
+        encoded_url = base64.urlsafe_b64encode(b"https://example.com").decode()
+        with self.assertRaises(ValueError):
+            parse_api_key("*" + encoded_url)
+
+    def test_empty_url_is_rejected(self):
+        encoded_empty = base64.urlsafe_b64encode(b"").decode()
+        with self.assertRaises(ValueError):
+            parse_api_key("tok*" + encoded_empty)
+
+
+# -------------------------------------------------------------------------
+#
+# TestDecodeJwtPayload
+#
+# -------------------------------------------------------------------------
+class TestDecodeJwtPayload(unittest.TestCase):
+    def test_decodes_payload_claims(self):
+        jwt_str = fake_jwt({"sub": "user1", "exp": 1234})
+        self.assertEqual(decode_jwt_payload(jwt_str), {"sub": "user1", "exp": 1234})
+
+    def test_handles_payload_needing_padding(self):
+        # Pick a payload whose base64url segment length isn't a multiple of 4,
+        # to exercise the padding-restoration branch.
+        jwt_str = fake_jwt({"a": "bit-of-text-to-shift-the-length"})
+        payload = decode_jwt_payload(jwt_str)
+        self.assertEqual(payload["a"], "bit-of-text-to-shift-the-length")
+
+
+# -------------------------------------------------------------------------
+#
+# TestAuthentication
+#
+# -------------------------------------------------------------------------
+class TestAuthentication(unittest.TestCase):
+    """Constructing a handler authenticates once, via whichever credential
+    was supplied."""
+
+    def test_username_password_login(self):
+        fake = QueuedUrlopen(
+            [FakeResponse({"access_token": token("AT1"), "refresh_token": "RT1"})]
+        )
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            handler = WebApiHandler(
+                "https://example.com/api", username="alice", password="secret"
+            )
+        self.assertEqual(handler._access_token, token("AT1"))
+        self.assertEqual(handler._refresh_token, "RT1")
+        req = fake.requests[0]
+        self.assertEqual(req.full_url, "https://example.com/api/token/")
+        self.assertEqual(
+            json.loads(req.data), {"username": "alice", "password": "secret"}
+        )
+
+    def test_refresh_token_login(self):
+        fake = QueuedUrlopen([FakeResponse({"access_token": token("AT2")})])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            handler = WebApiHandler("https://example.com/api", refresh_token="RT0")
+        self.assertEqual(handler._access_token, token("AT2"))
+        # Refresh token is unchanged; the endpoint used is /token/refresh/.
+        self.assertEqual(handler._refresh_token, "RT0")
+        req = fake.requests[0]
+        self.assertEqual(req.full_url, "https://example.com/api/token/refresh/")
+        self.assertEqual(req.get_header("Authorization"), "Bearer RT0")
+
+    def test_mint_api_key_returns_encoded_key(self):
+        fake = QueuedUrlopen(
+            [FakeResponse({"access_token": token("AT1"), "refresh_token": "RT1"})]
+        )
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            key = WebApiHandler.mint_api_key(
+                "https://example.com/api", "alice", "secret"
+            )
+        self.assertEqual(parse_api_key(key), ("RT1", "https://example.com/api"))
+
+    def test_mint_api_key_requires_refresh_token_in_response(self):
+        fake = QueuedUrlopen([FakeResponse({"access_token": token("AT1")})])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            with self.assertRaises(ValueError):
+                WebApiHandler.mint_api_key("https://example.com/api", "alice", "pw")
+
+    def test_from_env_missing_var_raises(self):
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with self.assertRaises(ValueError):
+                WebApiHandler.from_env()
+
+    def test_from_env_builds_handler_from_refresh_key(self):
+        key = make_api_key("RT9", "https://example.com/api")
+        fake = QueuedUrlopen([FakeResponse({"access_token": token("AT9")})])
+        with mock.patch.dict(os.environ, {webapi_client.API_KEY_ENV_VAR: key}):
+            with mock.patch.object(webapi_client, "urlopen", fake):
+                handler = WebApiHandler.from_env()
+        self.assertEqual(handler.url, "https://example.com/api")
+        self.assertEqual(handler._access_token, token("AT9"))
+
+
+# -------------------------------------------------------------------------
+#
+# TestAccessTokenProperty
+#
+# -------------------------------------------------------------------------
+class TestAccessTokenProperty(unittest.TestCase):
+    def _handler_with_token(self, exp_offset):
+        """A handler whose access token expires ``exp_offset`` seconds from now."""
+        fake = QueuedUrlopen(
+            [FakeResponse({"access_token": fake_jwt({"exp": time_now() + exp_offset})})]
+        )
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            handler = WebApiHandler("https://example.com/api", refresh_token="RT")
+        return handler, fake
+
+    def test_remaining_time_none_without_exp_claim(self):
+        fake = QueuedUrlopen([FakeResponse({"access_token": fake_jwt({})})])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            handler = WebApiHandler("https://example.com/api", refresh_token="RT")
+        self.assertIsNone(handler.get_access_token_remaining_time())
+
+    def test_access_token_refreshes_when_near_expiry(self):
+        handler, fake = self._handler_with_token(exp_offset=30)  # < 60s left
+        fake._items.append(FakeResponse({"access_token": token("FRESH")}))
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            refreshed = handler.access_token
+        self.assertEqual(refreshed, token("FRESH"))
+        self.assertEqual(len(fake.requests), 2)  # initial auth + re-auth
+
+    def test_access_token_reused_when_far_from_expiry(self):
+        handler, fake = self._handler_with_token(exp_offset=3600)
+        access_token = handler.access_token
+        self.assertEqual(len(fake.requests), 1)  # no re-auth triggered
+        self.assertTrue(access_token)
+
+    def test_get_permissions_reads_token_claim(self):
+        fake = QueuedUrlopen(
+            [
+                FakeResponse(
+                    {"access_token": fake_jwt({"permissions": ["edit", "view"]})}
+                )
+            ]
+        )
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            handler = WebApiHandler("https://example.com/api", refresh_token="RT")
+        self.assertEqual(handler.get_permissions(), ["edit", "view"])
+
+
+def time_now():
+    import time
+
+    return time.time()
+
+
+# -------------------------------------------------------------------------
+#
+# TestRateLimitAndFallbackRetries
+#
+# -------------------------------------------------------------------------
+class TestRateLimitAndFallbackRetries(unittest.TestCase):
+    """429 responses back off and retry once; a URL missing '/api' is
+    retried with it appended."""
+
+    def test_fetch_token_retries_once_after_429(self):
+        fake = QueuedUrlopen(
+            [
+                http_error(429),
+                FakeResponse({"access_token": token("AT"), "refresh_token": "RT"}),
+            ]
+        )
+        with mock.patch.object(webapi_client, "urlopen", fake), mock.patch.object(
+            webapi_client, "sleep"
+        ) as mock_sleep:
+            handler = WebApiHandler(
+                "https://example.com/api", username="alice", password="pw"
+            )
+        self.assertEqual(handler._access_token, token("AT"))
+        mock_sleep.assert_called_once_with(webapi_client.RATE_LIMIT_BACKOFF)
+
+    def test_refresh_retries_once_after_429(self):
+        fake = QueuedUrlopen([http_error(429), FakeResponse({"access_token": token("AT")})])
+        with mock.patch.object(webapi_client, "urlopen", fake), mock.patch.object(
+            webapi_client, "sleep"
+        ):
+            handler = WebApiHandler("https://example.com/api", refresh_token="RT")
+        self.assertEqual(handler._access_token, token("AT"))
+
+    def test_fetch_token_appends_api_prefix_on_non_rate_limit_error(self):
+        fake = QueuedUrlopen(
+            [
+                http_error(404, url="https://example.com/token/"),
+                FakeResponse({"access_token": token("AT"), "refresh_token": "RT"}),
+            ]
+        )
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            handler = WebApiHandler(
+                "https://example.com", username="alice", password="pw"
+            )
+        self.assertEqual(handler.url, "https://example.com/api")
+        self.assertEqual(fake.requests[1].full_url, "https://example.com/api/token/")
+
+    def test_fetch_token_does_not_re_append_api_prefix(self):
+        # If the URL already ends in /api, a second failure must propagate
+        # rather than looping.
+        fake = QueuedUrlopen([http_error(404), http_error(404)])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            with self.assertRaises(HTTPError):
+                WebApiHandler("https://example.com/api", username="a", password="p")
+
+
+# -------------------------------------------------------------------------
+#
+# TestGetJsonRetries
+#
+# -------------------------------------------------------------------------
+class TestGetJsonRetries(unittest.TestCase):
+    """_get_json() re-authenticates on 401, backs off on 429, and retries
+    once on a transient network error."""
+
+    def _authed_handler(self):
+        fake = QueuedUrlopen([FakeResponse({"access_token": token("AT0")})])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            handler = WebApiHandler("https://example.com/api", refresh_token="RT")
+        return handler
+
+    def test_401_triggers_reauth_and_one_retry(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen(
+            [
+                http_error(401),
+                FakeResponse({"access_token": token("AT1")}),  # the re-auth call
+                FakeResponse({"ok": True}),
+            ]
+        )
+        with mock.patch.object(webapi_client, "urlopen", fake), mock.patch.object(
+            webapi_client, "sleep"
+        ):
+            body, _headers = handler._get_json("https://example.com/api/thing/")
+        self.assertEqual(body, {"ok": True})
+        self.assertEqual(handler._access_token, token("AT1"))
+
+    def test_429_retries_once(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen([http_error(429), FakeResponse({"ok": True})])
+        with mock.patch.object(webapi_client, "urlopen", fake), mock.patch.object(
+            webapi_client, "sleep"
+        ):
+            body, _headers = handler._get_json("https://example.com/api/thing/")
+        self.assertEqual(body, {"ok": True})
+
+    def test_network_error_retries_once(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen(
+            [URLError("connection refused"), FakeResponse({"ok": True})]
+        )
+        with mock.patch.object(webapi_client, "urlopen", fake), mock.patch.object(
+            webapi_client, "sleep"
+        ):
+            body, _headers = handler._get_json("https://example.com/api/thing/")
+        self.assertEqual(body, {"ok": True})
+
+    def test_second_failure_propagates(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen([http_error(500), http_error(500)])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            with self.assertRaises(HTTPError):
+                handler._get_json("https://example.com/api/thing/")
+
+
+# -------------------------------------------------------------------------
+#
+# TestTransactionHistory
+#
+# -------------------------------------------------------------------------
+class TestTransactionHistory(unittest.TestCase):
+    def _authed_handler(self):
+        fake = QueuedUrlopen([FakeResponse({"access_token": token("AT0")})])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            handler = WebApiHandler("https://example.com/api", refresh_token="RT")
+        return handler
+
+    def test_request_shape_and_total_count_header(self):
+        handler = self._authed_handler()
+        body = [{"id": 1, "timestamp": 10.0, "changes": []}]
+        fake = QueuedUrlopen([FakeResponse(body, headers={"X-Total-Count": "5"})])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            transactions, total = handler.get_transaction_history(
+                after=100, page=2, pagesize=50
+            )
+        self.assertEqual(transactions, body)
+        self.assertEqual(total, 5)
+        url = fake.requests[0].full_url
+        self.assertIn("after=100", url)
+        self.assertIn("new=1", url)
+        self.assertIn("sort=id", url)
+        self.assertIn("page=2", url)
+        self.assertIn("pagesize=50", url)
+
+    def test_total_count_falls_back_to_body_length(self):
+        handler = self._authed_handler()
+        body = [{"id": 1, "timestamp": 1.0, "changes": []}] * 3
+        fake = QueuedUrlopen([FakeResponse(body)])  # no X-Total-Count header
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            _transactions, total = handler.get_transaction_history()
+        self.assertEqual(total, 3)
+
+
+# -------------------------------------------------------------------------
+#
+# TestPushTransaction
+#
+# -------------------------------------------------------------------------
+class TestPushTransaction(unittest.TestCase):
+    def _authed_handler(self):
+        fake = QueuedUrlopen([FakeResponse({"access_token": token("AT0")})])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            handler = WebApiHandler("https://example.com/api", refresh_token="RT")
+        return handler
+
+    def test_empty_payload_sends_no_request(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen([])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            handler.push_transaction([])
+        self.assertEqual(fake.requests, [])
+
+    def test_non_empty_payload_posts_with_force(self):
+        handler = self._authed_handler()
+        payload = [{"type": "add", "handle": "H1", "_class": "Person"}]
+        fake = QueuedUrlopen([FakeResponse({})])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            handler.push_transaction(payload)
+        req = fake.requests[0]
+        self.assertEqual(req.full_url, "https://example.com/api/transactions/?force=1")
+        self.assertEqual(req.get_method(), "POST")
+        self.assertEqual(json.loads(req.data), payload)
+        self.assertEqual(req.get_header("Authorization"), f"Bearer {token('AT0')}")
+
+    def test_401_triggers_reauth_and_retry(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen(
+            [http_error(401), FakeResponse({"access_token": token("AT1")}), FakeResponse({})]
+        )
+        with mock.patch.object(webapi_client, "urlopen", fake), mock.patch.object(
+            webapi_client, "sleep"
+        ):
+            handler.push_transaction([{"type": "add"}])
+        self.assertEqual(handler._access_token, token("AT1"))
+
+    def test_429_retries_once(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen([http_error(429), FakeResponse({})])
+        with mock.patch.object(webapi_client, "urlopen", fake), mock.patch.object(
+            webapi_client, "sleep"
+        ):
+            handler.push_transaction([{"type": "add"}])
+        self.assertEqual(len(fake.requests), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/GrampsWebApiDb/webapi_client.py
+++ b/GrampsWebApiDb/webapi_client.py
@@ -31,6 +31,17 @@ feed for now. Re-add pieces here (rather than importing GrampsWebSync
 directly) so this addon has no runtime dependency on another addon being
 installed.
 
+This file is a vendored copy: the canonical, standalone source is now the
+gramps-web-api-client package (not yet published; local checkout at
+~/gramps/gramps-web-api-client as of this writing), module
+gramps_web_api_client/client.py, class Client -- the same class as
+WebApiHandler below, just renamed. It was split out so the client could
+be discoverable/pip-installable on its own, independent of the Gramps
+addon ecosystem. Gramps addons are self-contained tarballs with no
+mechanism to declare a pip dependency, so this copy has to stay vendored
+here rather than importing that package directly; sync changes by hand in
+both directions.
+
 Credentials
 -----------
 Two ways in: username+password (POST /token/, matches GrampsWebSync), or
@@ -81,6 +92,33 @@ TIMEOUT = 60
 #: immediately constructing another WebApiHandler in the same second
 #: reliably 429s otherwise.
 RATE_LIMIT_BACKOFF = 1.1
+
+#: The exact message gramps_webapi/api/tasks.py's old_unchanged() check
+#: raises as ValueError("Object has changed"), which POST /transactions/
+#: (without force=1) surfaces as HTTP 400 {"error": {"message": ...}}.
+#: push_transaction() matches on this to tell a real conflict apart from
+#: the endpoint's other 400s (malformed payload, missing Gramps ID, ...),
+#: which are our own bugs, not conflicts, and should propagate as-is.
+_CONFLICT_MESSAGE = "Object has changed"
+
+
+class WebApiPushConflict(Exception):
+    """A push was rejected because the server-side object changed since
+    the local mirror's snapshot of it (see push_transaction())."""
+
+
+def _raise_for_push_conflict(exc: HTTPError) -> None:
+    """Given a 400 from POST /transactions/, raise WebApiPushConflict if
+    it's the server's old-data-mismatch check; otherwise re-raise ``exc``
+    unchanged (a genuinely different 400, e.g. a malformed payload)."""
+    try:
+        body = json.loads(exc.read())
+        message = body["error"]["message"]
+    except (ValueError, KeyError, TypeError):
+        raise exc
+    if message == _CONFLICT_MESSAGE:
+        raise WebApiPushConflict(message) from exc
+    raise exc
 
 
 def create_macos_ssl_context():
@@ -351,20 +389,27 @@ class WebApiHandler:
         self, payload: list[dict[str, Any]], retry: bool = True
     ) -> None:
         """
-        POST a batch of local changes to /transactions/. Uses force=1:
-        without it, the server compares each item's "old" snapshot
-        against its own current data and rejects the whole batch on any
-        mismatch (POST /transactions/?force=... semantics, see
-        gramps_webapi/api/tasks.py's process_transactions -> old_unchanged
-        check) -- real conflict detection/resolution is out of scope for
-        now (see grampswebapidb.py), so this is last-write-wins by design,
-        not an oversight.
+        POST a batch of local changes to /transactions/ (no force=1): the
+        server compares each item's "old" snapshot -- the local mirror's
+        state of the object *before* the local edit -- against its own
+        current data, and rejects the whole batch with HTTP 400
+        ``{"error": {"message": "Object has changed"}}`` on any mismatch
+        (see gramps_webapi/api/tasks.py's process_transactions ->
+        old_unchanged()). That's a real, if coarse, optimistic-concurrency
+        check: it fires whenever the server-side object was edited (by
+        anyone) since the local mirror last synced, which is exactly what
+        a conflict is. Raised here as WebApiPushConflict so the caller
+        (grampswebapidb.py's transaction_commit) can tell "the server
+        rejected this because something changed underneath it" apart from
+        a network/auth failure. Actual merge resolution is still out of
+        scope -- the caller's response to a conflict is to resync from the
+        server, not to retry the push.
         """
         if not payload:
             return
         data = json.dumps(payload).encode()
         req = Request(
-            f"{self.url}/transactions/?force=1",
+            f"{self.url}/transactions/",
             data=data,
             method="POST",
             headers={
@@ -384,6 +429,8 @@ class WebApiHandler:
             if exc.code == 429 and retry:
                 sleep(RATE_LIMIT_BACKOFF)
                 return self.push_transaction(payload, retry=False)
+            if exc.code == 400:
+                _raise_for_push_conflict(exc)
             raise
         except (URLError, socket.timeout):
             if retry:

--- a/GrampsWebApiDb/webapi_client.py
+++ b/GrampsWebApiDb/webapi_client.py
@@ -73,7 +73,7 @@ from tempfile import NamedTemporaryFile
 from time import sleep
 from typing import Any
 from urllib.error import HTTPError, URLError
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse
 from urllib.request import Request, urlopen
 
 LOG = logging.getLogger("grampswebapidb")
@@ -332,6 +332,33 @@ class WebApiHandler:
     def get_permissions(self) -> set[str]:
         """Get the permissions of the current user."""
         return decode_jwt_payload(self.access_token).get("permissions", set())
+
+    @property
+    def hostname(self) -> str:
+        """Server hostname, e.g. "hadaly.duckdns.org" for a url of
+        "https://hadaly.duckdns.org/api"."""
+        return urlparse(self.url).hostname or self.url
+
+    def get_current_username(self) -> str:
+        """Name of the user this handler is authenticated as.
+
+        Set directly for a username+password login (mint_api_key()); the
+        refresh-token credential the normal from_env() path uses carries no
+        plaintext username (the access token's "sub" claim is a user id,
+        not a name -- see gramps-web-api's token.py), so it is resolved
+        once via GET /users/-/ (the "current user" alias) and cached here.
+        """
+        if self.username is None:
+            data, _headers = self._get_json(f"{self.url}/users/-/")
+            self.username = data["name"]
+        return self.username
+
+    def get_identity(self) -> str:
+        """"<username>@<hostname>" identifying the account+server this
+        handler authenticates as -- see grampswebapidb.py's
+        _check_identity(), which requires a Family Tree's own name to
+        match this before trusting its local mirror."""
+        return f"{self.get_current_username()}@{self.hostname}"
 
     def _get_json(self, url: str, retry: bool = True) -> tuple[Any, dict]:
         """GET ``url`` with the bearer token and return ``(body, headers)``."""

--- a/GrampsWebApiDb/webapi_client.py
+++ b/GrampsWebApiDb/webapi_client.py
@@ -361,6 +361,50 @@ class WebApiHandler:
                 return self._get_json(url, retry=False)
             raise
 
+    def _get_binary(self, url: str, retry: bool = True) -> bytes:
+        """GET ``url`` with the bearer token and return the raw response
+        body, unlike _get_json() -- for endpoints that return a file
+        rather than a JSON document (see download_export())."""
+        req = Request(
+            url,
+            headers={
+                "Authorization": f"Bearer {self.access_token}",
+                "User-Agent": "GrampsWebApiDb",
+            },
+        )
+        try:
+            with self._open(req) as res:
+                return res.read()
+        except HTTPError as exc:
+            if exc.code == 401 and retry:
+                sleep(RATE_LIMIT_BACKOFF)
+                self._authenticate()
+                return self._get_binary(url, retry=False)
+            if exc.code == 429 and retry:
+                sleep(RATE_LIMIT_BACKOFF)
+                return self._get_binary(url, retry=False)
+            raise
+        except (URLError, socket.timeout):
+            if retry:
+                sleep(1)
+                return self._get_binary(url, retry=False)
+            raise
+
+    def download_export(self, extension: str = "gramps") -> bytes:
+        """
+        Download a full backup export of the tree from the server --
+        by default a gzip-compressed Gramps XML file, the exact on-disk
+        shape Gramps' own ImportXml importer already reads (confirmed
+        against a live server: GET /exporters/gramps/file runs
+        synchronously and streams the file back, no task polling
+        needed). Used by grampswebapidb.py's WebApiDB._full_resync() to
+        rebuild the local mirror wholesale when the transaction-history
+        feed can't describe what changed -- see that method's own doc
+        comment on why.
+        """
+        url = f"{self.url}/exporters/{extension}/file"
+        return self._get_binary(url)
+
     def get_transaction_history(
         self, after: float = 0, page: int = 1, pagesize: int = 100
     ) -> tuple[list[dict[str, Any]], int]:

--- a/GrampsWebApiDb/webapi_client.py
+++ b/GrampsWebApiDb/webapi_client.py
@@ -32,9 +32,9 @@ directly) so this addon has no runtime dependency on another addon being
 installed.
 
 This file is a vendored copy: the canonical, standalone source is now the
-gramps-web-api-client package (not yet published; local checkout at
-~/gramps/gramps-web-api-client as of this writing), module
-gramps_web_api_client/client.py, class Client -- the same class as
+gramps-api-client package (not yet published; local checkout at
+~/gramps/gramps-api-client as of this writing), module
+gramps_api_client/client.py, class Client -- the same class as
 WebApiHandler below, just renamed. It was split out so the client could
 be discoverable/pip-installable on its own, independent of the Gramps
 addon ecosystem. Gramps addons are self-contained tarballs with no

--- a/GrampsWebApiDb/webapi_client.py
+++ b/GrampsWebApiDb/webapi_client.py
@@ -1,0 +1,392 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2021-2024 David Straub
+# Copyright (C) 2026      Douglas S. Blank <doug.blank@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Minimal Gramps Web API client: authentication and read access.
+
+Trimmed from the WebApiHandler class in the GrampsWebSync addon (same
+repo, same license) -- credit to David Straub for the original token
+fetch/refresh and SSL-context handling. Dropped everything specific to
+GrampsWebSync's push-a-local-transaction / XML-export / media-file-sync
+job, since WebApiDB only needs auth plus reading the transaction-history
+feed for now. Re-add pieces here (rather than importing GrampsWebSync
+directly) so this addon has no runtime dependency on another addon being
+installed.
+
+Credentials
+-----------
+Two ways in: username+password (POST /token/, matches GrampsWebSync), or
+a GRAMPS_WEB_API_KEY-shaped string: "<REFRESH_TOKEN>*<BASE64URL(URL)>".
+
+The REFRESH_TOKEN half is a JWT *refresh* token obtained once via
+POST /token/ with include_refresh (gramps-web-api's JWT_REFRESH_TOKEN_EXPIRES
+is False by default, so it doesn't expire on its own). From then on,
+POST /token/refresh/ trades it for fresh short-lived access tokens --
+no username/password re-entry, no server-side change needed. This is
+*not* the same as a real scoped/revocable personal access token
+(gramps-web-api has that machinery too, but today it's hardcoded to a
+single "anniversaries_ics" scope and isn't wired into general request
+auth) -- it's a shortcut that works today at the cost of not being
+independently revocable. '*' is a safe delimiter here: neither a JWT
+(base64url segments joined by '.') nor base64url output ever contains it.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import os
+import platform
+import socket
+import time
+from tempfile import NamedTemporaryFile
+from time import sleep
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+LOG = logging.getLogger("grampswebapidb")
+
+#: Environment variable read by WebApiHandler.from_env().
+API_KEY_ENV_VAR = "GRAMPS_WEB_API_KEY"
+
+#: Seconds before a request that has produced nothing is abandoned. Without
+#: this, ``urlopen`` waits forever and an unreachable-but-listening server
+#: hangs Gramps with no way out.
+TIMEOUT = 60
+
+#: gramps-web-api rate-limits /token/ and /token/refresh/ to 1/second (no
+#: Retry-After header is sent on 429); this is how long to back off before
+#: the one retry attempt. Found by live testing: minting a key and then
+#: immediately constructing another WebApiHandler in the same second
+#: reliably 429s otherwise.
+RATE_LIMIT_BACKOFF = 1.1
+
+
+def create_macos_ssl_context():
+    """Create an SSL context using macOS system certificates."""
+    import ssl
+    import subprocess
+
+    ctx = ssl.create_default_context()
+    macos_ca_certs = subprocess.run(
+        [
+            "security",
+            "find-certificate",
+            "-a",
+            "-p",
+            "/System/Library/Keychains/SystemRootCertificates.keychain",
+        ],
+        stdout=subprocess.PIPE,
+    ).stdout
+
+    with NamedTemporaryFile("w+b") as tmp_file:
+        tmp_file.write(macos_ca_certs)
+        ctx.load_verify_locations(tmp_file.name)
+
+    return ctx
+
+
+def decode_jwt_payload(jwt: str) -> dict[str, Any]:
+    """Decode and return the payload from a JWT."""
+    payload_part = jwt.split(".")[1]
+    padding = len(payload_part) % 4
+    if padding > 0:
+        payload_part += "=" * (4 - padding)
+    decoded_bytes = base64.urlsafe_b64decode(payload_part)
+    decoded_str = decoded_bytes.decode("utf-8")
+    return json.loads(decoded_str)
+
+
+def parse_api_key(api_key: str) -> tuple[str, str]:
+    """Split a GRAMPS_WEB_API_KEY value into ``(refresh_token, url)``."""
+    try:
+        token, encoded_url = api_key.split("*", 1)
+    except ValueError as exc:
+        raise ValueError(
+            "Malformed GRAMPS_WEB_API_KEY: expected '<TOKEN>*<ENCODED-URL>'"
+        ) from exc
+    padding = "=" * (-len(encoded_url) % 4)
+    try:
+        url = base64.urlsafe_b64decode(encoded_url + padding).decode("utf-8")
+    except (ValueError, UnicodeDecodeError) as exc:
+        raise ValueError("Malformed GRAMPS_WEB_API_KEY: bad URL encoding") from exc
+    if not token or not url:
+        raise ValueError("Malformed GRAMPS_WEB_API_KEY: empty token or URL")
+    return token, url
+
+
+def make_api_key(refresh_token: str, url: str) -> str:
+    """Build a GRAMPS_WEB_API_KEY value from a refresh token and URL."""
+    encoded_url = base64.urlsafe_b64encode(url.encode("utf-8")).decode("ascii")
+    return f"{refresh_token}*{encoded_url.rstrip('=')}"
+
+
+class WebApiHandler:
+    """Web API connection handler: token auth plus authenticated GET."""
+
+    def __init__(
+        self,
+        url: str,
+        username: str | None = None,
+        password: str | None = None,
+        refresh_token: str | None = None,
+    ) -> None:
+        """
+        Initialize given a server URL, plus either a username+password or
+        a non-expiring refresh token (exactly one of the two is expected).
+        """
+        self.url = url.rstrip("/")
+        self.username = username
+        self.password = password
+        self._refresh_token = refresh_token
+        self._access_token: str | None = None
+        self._ctx = (
+            create_macos_ssl_context() if platform.system() == "Darwin" else None
+        )
+        self._authenticate()
+
+    @classmethod
+    def from_api_key(cls, api_key: str) -> "WebApiHandler":
+        """Build a handler from a GRAMPS_WEB_API_KEY-shaped string."""
+        token, url = parse_api_key(api_key)
+        return cls(url, refresh_token=token)
+
+    @classmethod
+    def from_env(cls, env_var: str = API_KEY_ENV_VAR) -> "WebApiHandler":
+        """
+        Build a handler from an environment variable holding a
+        GRAMPS_WEB_API_KEY-shaped string. This is the SDK entry point:
+        ``client = WebApiHandler.from_env()``.
+        """
+        api_key = os.environ.get(env_var)
+        if not api_key:
+            raise ValueError(f"{env_var} is not set")
+        return cls.from_api_key(api_key)
+
+    @classmethod
+    def mint_api_key(cls, url: str, username: str, password: str) -> str:
+        """
+        One-time username+password login that returns a GRAMPS_WEB_API_KEY
+        value for all future non-interactive use. This is the client-side
+        half of what a future "Generate SDK Key" UI button would automate
+        server-side; until that exists, this is how a key gets created at
+        all.
+        """
+        handler = cls(url, username=username, password=password)
+        if not handler._refresh_token:
+            raise ValueError("Server did not return a refresh token")
+        return make_api_key(handler._refresh_token, handler.url)
+
+    def _open(self, req: Request):
+        """Open ``req`` with this handler's SSL context and timeout."""
+        return urlopen(req, context=self._ctx, timeout=TIMEOUT)
+
+    @property
+    def access_token(self) -> str:
+        """Get the access token. Cached after first call unless refresh needed."""
+        if not self._access_token:
+            self._authenticate()
+        remaining_time = self.get_access_token_remaining_time()
+        if remaining_time is not None and remaining_time < 60:
+            self._authenticate()
+        assert self._access_token  # for type checker
+        return self._access_token
+
+    def get_access_token_remaining_time(self) -> int | None:
+        """Get the remaining time of the access token in seconds."""
+        if self._access_token is None:
+            return None
+        payload = decode_jwt_payload(self._access_token)
+        if "exp" not in payload:
+            return None
+        expires = payload["exp"]
+        now = time.time()
+        return int(expires - now)
+
+    def _authenticate(self) -> None:
+        """Get a fresh access token, via whichever credential we hold."""
+        if self._refresh_token:
+            self._refresh_access_token()
+        else:
+            self.fetch_token()
+
+    def fetch_token(self, retry_on_rate_limit: bool = True) -> None:
+        """Fetch and store an access token via username+password."""
+        LOG.debug("Fetching an access token from the server")
+        data = json.dumps({"username": self.username, "password": self.password})
+        req = Request(
+            f"{self.url}/token/",
+            data=data.encode(),
+            headers={"Content-Type": "application/json", "User-Agent": "GrampsWebApiDb"},
+        )
+        try:
+            with self._open(req) as res:
+                res_json = json.load(res)
+        except HTTPError as exc:
+            if exc.code == 429 and retry_on_rate_limit:
+                sleep(RATE_LIMIT_BACKOFF)
+                return self.fetch_token(retry_on_rate_limit=False)
+            if "/api" not in self.url:
+                self.url = f"{self.url}/api"
+                return self.fetch_token(retry_on_rate_limit=retry_on_rate_limit)
+            raise
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            if "/api" not in self.url:
+                self.url = f"{self.url}/api"
+                return self.fetch_token(retry_on_rate_limit=retry_on_rate_limit)
+            raise
+        self._access_token = res_json["access_token"]
+        # /token/ with username+password always includes a refresh token
+        # (TokenResource.post() calls get_tokens(..., include_refresh=True)).
+        if "refresh_token" in res_json:
+            self._refresh_token = res_json["refresh_token"]
+
+    def _refresh_access_token(self, retry_on_rate_limit: bool = True) -> None:
+        """Trade the stored refresh token for a new access token."""
+        LOG.debug("Refreshing access token from stored refresh token")
+        req = Request(
+            f"{self.url}/token/refresh/",
+            method="POST",
+            headers={
+                "Authorization": f"Bearer {self._refresh_token}",
+                "User-Agent": "GrampsWebApiDb",
+            },
+        )
+        try:
+            with self._open(req) as res:
+                res_json = json.load(res)
+        except HTTPError as exc:
+            if exc.code == 429 and retry_on_rate_limit:
+                sleep(RATE_LIMIT_BACKOFF)
+                return self._refresh_access_token(retry_on_rate_limit=False)
+            if "/api" not in self.url:
+                self.url = f"{self.url}/api"
+                return self._refresh_access_token(retry_on_rate_limit=retry_on_rate_limit)
+            raise
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            if "/api" not in self.url:
+                self.url = f"{self.url}/api"
+                return self._refresh_access_token(retry_on_rate_limit=retry_on_rate_limit)
+            raise
+        self._access_token = res_json["access_token"]
+
+    def get_permissions(self) -> set[str]:
+        """Get the permissions of the current user."""
+        return decode_jwt_payload(self.access_token).get("permissions", set())
+
+    def _get_json(self, url: str, retry: bool = True) -> tuple[Any, dict]:
+        """GET ``url`` with the bearer token and return ``(body, headers)``."""
+        req = Request(
+            url,
+            headers={
+                "Authorization": f"Bearer {self.access_token}",
+                "User-Agent": "GrampsWebApiDb",
+            },
+        )
+        try:
+            with self._open(req) as res:
+                return json.load(res), dict(res.headers)
+        except HTTPError as exc:
+            if exc.code == 401 and retry:
+                # in case of 401, retry once with a new token
+                sleep(RATE_LIMIT_BACKOFF)  # avoid immediately re-tripping the rate limit
+                self._authenticate()
+                return self._get_json(url, retry=False)
+            if exc.code == 429 and retry:
+                sleep(RATE_LIMIT_BACKOFF)
+                return self._get_json(url, retry=False)
+            raise
+        except (URLError, socket.timeout):
+            if retry:
+                sleep(1)
+                return self._get_json(url, retry=False)
+            raise
+
+    def get_transaction_history(
+        self, after: float = 0, page: int = 1, pagesize: int = 100
+    ) -> tuple[list[dict[str, Any]], int]:
+        """
+        Fetch one page of the server's transaction history committed
+        after ``after`` (a Unix timestamp), ascending by transaction id,
+        including the post-change raw object data.
+
+        :returns: ``(transactions, total_count)``. ``total_count`` comes
+            from the ``X-Total-Count`` response header, so the caller can
+            tell whether more pages remain.
+        """
+        params = {
+            "after": after,
+            "new": "1",
+            "sort": "id",
+            "page": page,
+            "pagesize": pagesize,
+        }
+        url = f"{self.url}/transactions/history/?{urlencode(params)}"
+        body, headers = self._get_json(url)
+        total_count = int(headers.get("X-Total-Count", len(body)))
+        return body, total_count
+
+    def push_transaction(
+        self, payload: list[dict[str, Any]], retry: bool = True
+    ) -> None:
+        """
+        POST a batch of local changes to /transactions/. Uses force=1:
+        without it, the server compares each item's "old" snapshot
+        against its own current data and rejects the whole batch on any
+        mismatch (POST /transactions/?force=... semantics, see
+        gramps_webapi/api/tasks.py's process_transactions -> old_unchanged
+        check) -- real conflict detection/resolution is out of scope for
+        now (see grampswebapidb.py), so this is last-write-wins by design,
+        not an oversight.
+        """
+        if not payload:
+            return
+        data = json.dumps(payload).encode()
+        req = Request(
+            f"{self.url}/transactions/?force=1",
+            data=data,
+            method="POST",
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {self.access_token}",
+                "User-Agent": "GrampsWebApiDb",
+            },
+        )
+        try:
+            with self._open(req) as res:
+                res.read()
+        except HTTPError as exc:
+            if exc.code == 401 and retry:
+                sleep(RATE_LIMIT_BACKOFF)
+                self._authenticate()
+                return self.push_transaction(payload, retry=False)
+            if exc.code == 429 and retry:
+                sleep(RATE_LIMIT_BACKOFF)
+                return self.push_transaction(payload, retry=False)
+            raise
+        except (URLError, socket.timeout):
+            if retry:
+                sleep(RATE_LIMIT_BACKOFF)
+                return self.push_transaction(payload, retry=False)
+            raise

--- a/GrampsWebApiDb/webapi_client.py
+++ b/GrampsWebApiDb/webapi_client.py
@@ -386,7 +386,10 @@ class WebApiHandler:
         return body, total_count
 
     def push_transaction(
-        self, payload: list[dict[str, Any]], retry: bool = True
+        self,
+        payload: list[dict[str, Any]],
+        retry: bool = True,
+        undo: bool = False,
     ) -> None:
         """
         POST a batch of local changes to /transactions/ (no force=1): the
@@ -404,12 +407,24 @@ class WebApiHandler:
         a network/auth failure. Actual merge resolution is still out of
         scope -- the caller's response to a conflict is to resync from the
         server, not to retry the push.
+
+        ``undo=True`` sends the *same* payload a prior push_transaction()
+        call already sent, with ?undo=1: the server reverses it itself
+        (swaps old/new, add<->delete -- see
+        gramps_webapi/api/resources/util.py's reverse_transaction()) before
+        applying, so this is how grampswebapidb.py implements Undo without
+        having to compute the inverse payload locally. Redo is *not* a
+        variant of this -- it's just an ordinary push_transaction() call
+        with the original (forward) payload again.
         """
         if not payload:
             return
         data = json.dumps(payload).encode()
+        url = f"{self.url}/transactions/"
+        if undo:
+            url += "?undo=1"
         req = Request(
-            f"{self.url}/transactions/",
+            url,
             data=data,
             method="POST",
             headers={
@@ -425,15 +440,15 @@ class WebApiHandler:
             if exc.code == 401 and retry:
                 sleep(RATE_LIMIT_BACKOFF)
                 self._authenticate()
-                return self.push_transaction(payload, retry=False)
+                return self.push_transaction(payload, retry=False, undo=undo)
             if exc.code == 429 and retry:
                 sleep(RATE_LIMIT_BACKOFF)
-                return self.push_transaction(payload, retry=False)
+                return self.push_transaction(payload, retry=False, undo=undo)
             if exc.code == 400:
                 _raise_for_push_conflict(exc)
             raise
         except (URLError, socket.timeout):
             if retry:
                 sleep(RATE_LIMIT_BACKOFF)
-                return self.push_transaction(payload, retry=False)
+                return self.push_transaction(payload, retry=False, undo=undo)
             raise


### PR DESCRIPTION
## Summary

`GrampsWebApiDb` is a `DATABASE`-type addon that lets Gramps (desktop or
scripted) open a [gramps-web-api](https://github.com/gramps-project/gramps-web-api) server (e.g. a [gramps-connect](https://github.com/dsblank/gramps-connect) or Gramps
Web instance) as a regular family tree — read and write, no
export/import step, no separate sync tool to run by hand.

It's not fast (every write is a network round trip), but it means the
same tree hosted online is simultaneously usable from Gramps desktop and
from the web app, live.

## How it works

Rather than implementing `DbReadBase`/`DbWriteBase` from scratch (~175
methods), `WebApiDB` subclasses the stock `SQLite` DBAPI backend.
`DbGeneric` already implements every `get_*`/`iter_*`/`commit_*`/
`remove_*` method generically on top of a small SQL connection, so this
addon only needs to supply two things:

- **A local SQLite mirror** for fast reads, kept in sync via
  `GET /transactions/history/?after=<high-water-mark>` — the same
  per-object transaction log the server's own undo system uses. The
  high-water-mark is persisted in the mirror's own metadata table
  (`_get_metadata`/`_set_metadata`), so reopening an existing tree is
  incremental, not a full re-download.
- **Write-through**, hooked at `transaction_commit()` (the single point
  `DbTxn.__exit__` calls after any completed local transaction) rather
  than each individual `commit_person`/`commit_family`/etc. Local edits
  push to `POST /transactions/` automatically.

`webapi_client.py` is a small, self-contained HTTP client (stdlib
`urllib` only, no extra dependency) — trimmed from and crediting the
`WebApiHandler` class in the `GrampsWebSync` addon (same repo). It's now
a hand-synced vendored copy of a standalone `gramps-api-client`
package (not yet published; same code, class renamed `Client`) — the
addon keeps its own copy since Gramps addons can't declare a pip
dependency. That standalone package also ships a
`gramps-api-client generate-key` CLI as an alternative to the
`mint_api_key()` script-based flow described below.

## Credentials

A single environment variable, `GRAMPS_WEB_API_KEY`, shaped
`"<REFRESH_TOKEN>*<BASE64URL(URL)>"`. This is deliberately *not* a login
dialog: `requires_login()` returns `False`, and the same env var also
works as a bare SDK credential (`WebApiHandler.from_env()`) for scripts
that talk to the server directly, without Gramps involved at all — one
credential, two consumers.

The `TOKEN` half is a non-expiring JWT refresh token
(`gramps-web-api`'s `JWT_REFRESH_TOKEN_EXPIRES` is `False` by default),
obtained once via `WebApiHandler.mint_api_key(url, username, password)`
(or the `gramps-api-client generate-key` CLI mentioned above). This
is a **known, deliberate stopgap**, not a real personal-access-token:
`gramps-web-api` has scoped, revocable token infrastructure already
(`AccessToken`, hashed, per-scope) but it's currently hardcoded to a
single scope (`anniversaries_ics`) and not wired into general request
auth. Until that's generalized server-side, this key is exactly as
powerful as the account it was minted from, and — unlike a real
personal-access-token — isn't individually revocable (a password change
doesn't invalidate it). This tradeoff and the reasoning are documented
in `webapi_client.py`'s module docstring.

## Usage

1. Mint a `GRAMPS_WEB_API_KEY` -- it bakes in the host, and logs in as a
   particular user/database on that server. Via the CLI, for example:

```python
$ gramps-api-client generate-key --url "http://localhost:5003/api" --user "gramps"
Password:...
<the key>
```

2. `export GRAMPS_WEB_API_KEY="<the key>"`
3. Add the addon in Gramps 
4. Start Gramps; in Preferences, change the database backend to "Gramps
   Web API Database".

<img width="679" height="192" alt="image" src="https://github.com/user-attachments/assets/1e8024bc-8fc2-4373-9346-691fddf11397" />


5. Create a new family tree. The type just reflects what the `GRAMPS_WEB_API_KEY` points to at that time.

<img width="1451" height="886" alt="image" src="https://github.com/user-attachments/assets/90ed7da9-1242-40f1-98de-eb11902dd452" />

Gramps opens the tree already populated with the server's data (the
initial sync), and from there it behaves like any other family tree:
edit, delete, undo, and redo all work, with every change pushed back to
the server live.

## Status

- ✅ Read sync (`_sync_from_server`), incremental, verified against a
  live server
- ✅ Write-through (`transaction_commit` hook), verified add/update/delete
  round-trip against a live server, confirmed via an independent fresh
  mirror that pushes actually reach the server
- ✅ Verified live in Gramps desktop itself (not just scripts): backend
  selectable in the New Family Tree dialog, syncs and edits correctly
- ✅ Push conflict detection — pushes no longer go out with `force=1`;
  the server's optimistic-concurrency check (comparing each item's
  pre-edit snapshot against its current data) now actually runs, and a
  rejection raises `WebApiPushConflict`, which `transaction_commit()`
  catches to resync the local mirror from the server instead of
  silently overwriting. Real conflict *resolution* (merge, prompt the
  user) is still out of scope — the losing local edit is simply lost
  from the server's perspective.
- ✅ Undo/redo integration — `undo()`/`redo()` are overridden to push to
  the server too, not just the local mirror: undo sends the original
  transaction's payload to `POST /transactions/?undo=1` (the server
  reverses it itself), redo just re-pushes it forward, same as an
  ordinary commit. Both go through the same conflict-detection/resync
  path as a plain commit. Verified end-to-end against a live server
  (add a person, undo, confirm via a fresh mirror sync that the server
  no longer has it, redo, confirm it's back). Gramps' own undo history
  is in-memory/per-session, not persisted, so this only matters within
  a single running session.
- ❌ No media file sync

Registered `status=UNSTABLE` to reflect the remaining gaps. Targets
`gramps_target_version="6.0"`.

## Testing

- Automated: `python3 -m unittest GrampsWebApiDb.tests.test_webapi_client
  GrampsWebApiDb.tests.test_grampswebapidb -v` — 67 tests, covering
  `webapi_client.py`'s auth/retry/rate-limit/conflict logic and
  `grampswebapidb.py`'s sync/apply-change/transaction-commit/undo-redo
  logic, with `urlopen` and the SQLite base class mocked (no live server
  needed).
- Manual, end-to-end against a real gramps-web-api server: read sync,
  write-through, incremental re-sync, push-conflict detection + resync,
  undo/redo (round-tripped through independent fresh mirrors to confirm
  the server's state, not just the local one), and live use from Gramps
  desktop (New Family Tree dialog, backend selectable, syncs and edits
  correctly). Also verified `make_database("grampswebapidb")` loads the
  addon through Gramps's real plugin manager, not just via direct
  import.



