### PR TITLE
GrampsWebApiDb: add a tool to generate a GRAMPS_WEB_API_KEY and create its Family Tree

### DIFF
--- a/GrampsWebApiDb/README.md
+++ b/GrampsWebApiDb/README.md
@@ -21,9 +21,12 @@ settings.ini. Generate one once via username/password.
 
 The easiest way is the **Generate Gramps Web API key** tool (this addon
 also installs `mintapikeytool.py`/`mintapikeytool.gpr.py`): open it from
-Tools → Utilities → Generate Gramps Web API key (no Family Tree needs to
-be open), enter the server URL, username, and password, and click
-**Generate API Key**. On success it sets `GRAMPS_WEB_API_KEY` in the
+Tools → Utilities → Generate Gramps Web API key, enter the server URL,
+username, and password, and click **Generate API Key**. Gramps only shows
+the Tools menu once *some* Family Tree is open -- it doesn't have to be a
+WebApiDB one, even an empty local tree works, so open (or create) one
+first if you don't already have one open. On success the tool sets
+`GRAMPS_WEB_API_KEY` in the
 running Gramps process's environment, so a WebApiDB-backed Family Tree
 can be opened right away without restarting Gramps -- but that only lasts
 for this process; it is not written to a shell profile, settings.ini, or

--- a/GrampsWebApiDb/README.md
+++ b/GrampsWebApiDb/README.md
@@ -16,8 +16,29 @@ cursor.
 
 The addon takes a single credential, via the `GRAMPS_WEB_API_KEY`
 environment variable, shaped `<REFRESH_TOKEN>*<BASE64URL(URL)>`. There is
-deliberately no login dialog and no per-tree settings.ini. Mint one once
-via username/password, either from the command line with the standalone
+deliberately no login dialog wired into WebApiDB itself, and no per-tree
+settings.ini. Generate one once via username/password.
+
+The easiest way is the **Generate Gramps Web API key** tool (this addon
+also installs `mintapikeytool.py`/`mintapikeytool.gpr.py`): open it from
+Tools → Utilities → Generate Gramps Web API key (no Family Tree needs to
+be open), enter the server URL, username, and password, and click
+**Generate API Key**. On success it sets `GRAMPS_WEB_API_KEY` in the
+running Gramps process's environment, so a WebApiDB-backed Family Tree
+can be opened right away without restarting Gramps -- but that only lasts
+for this process; it is not written to a shell profile, settings.ini, or
+any open Family Tree. Copy the displayed key into your shell's startup
+file too if you want it set automatically next time.
+
+Click **Create Synced Family Tree for this key** to also create a new,
+empty Family Tree for that key's account, using the `grampswebapidb`
+database backend and already named correctly (see "Family Tree naming"
+below) -- equivalent to creating one by hand via Family Trees → Manage
+Family Trees, just with the name and backend filled in for you. It
+creates the tree but does not open it; open it from Family Trees →
+Manage Family Trees afterward to start syncing.
+
+Alternatively, generate one from the command line with the standalone
 `gramps-api-client` package (not yet published; pip-installable from
 its own repo, e.g. `pip install -e path/to/gramps-api-client`):
 

--- a/GrampsWebApiDb/grampswebapidb.py
+++ b/GrampsWebApiDb/grampswebapidb.py
@@ -248,6 +248,25 @@ POLL_INTERVAL_SECONDS = 10
 #: is an OSError subclass).
 _CONNECTION_ERRORS = (ValueError, KeyError, HTTPError, URLError, OSError)
 
+
+def _describe_connection_error(err):
+    """
+    Turn a _CONNECTION_ERRORS exception into DbConnectionError's message
+    body. A 403 means the account GRAMPS_WEB_API_KEY authenticates as was
+    correctly identified but isn't allowed to do this -- worth calling out
+    specifically, since the raw HTTPError text ("HTTP Error 403:
+    Forbidden") reads like an auth failure rather than a permissions one.
+    """
+    if isinstance(err, HTTPError) and err.code == 403:
+        return _(
+            "The account authenticating via GRAMPS_WEB_API_KEY does not "
+            "have permission on the server for this operation (HTTP 403 "
+            "Forbidden). Generate a key for an account with sufficient "
+            "permissions, or ask the server administrator to grant this "
+            "one access."
+        )
+    return str(err)
+
 #: Same substitution gramps.gui.dbman's Family Tree Manager applies to
 #: whatever a user types renaming a tree (dbman.py's __change_name(): "kill
 #: special characters so can use as file name in backup"). A hostname-
@@ -334,7 +353,7 @@ class WebApiDB(SQLite):
         try:
             self.web_client = WebApiHandler.from_env()
         except _CONNECTION_ERRORS as err:
-            raise DbConnectionError(str(err), directory) from err
+            raise DbConnectionError(_describe_connection_error(err), directory) from err
 
         # Local mirror: reuse SQLite's own _initialize for the on-disk
         # cache file, then sync from the server on load().
@@ -356,7 +375,12 @@ class WebApiDB(SQLite):
             callback = args[1]
         super().load(*args, **kwargs)
         self._check_identity()
-        self._sync_from_server(progress_callback=callback)
+        try:
+            self._sync_from_server(progress_callback=callback)
+        except _CONNECTION_ERRORS as err:
+            raise DbConnectionError(
+                _describe_connection_error(err), self._directory
+            ) from err
         self._poll_source_id = GLib.timeout_add_seconds(
             POLL_INTERVAL_SECONDS, self._poll_tick
         )
@@ -386,7 +410,9 @@ class WebApiDB(SQLite):
         try:
             expected = self.web_client.get_identity()
         except _CONNECTION_ERRORS as err:
-            raise DbConnectionError(str(err), self._directory) from err
+            raise DbConnectionError(
+                _describe_connection_error(err), self._directory
+            ) from err
         expected_typeable = _FAMILY_TREE_NAME_UNSAFE_CHARS.sub("_", expected)
         actual = self.get_dbname()
         actual_normalized = _FAMILY_TREE_NAME_UNSAFE_CHARS.sub("_", actual)

--- a/GrampsWebApiDb/mintapikeytool.gpr.py
+++ b/GrampsWebApiDb/mintapikeytool.gpr.py
@@ -1,0 +1,41 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026 Douglas S. Blank <doug.blank@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+register(
+    TOOL,
+    id="MintApiKeyTool",
+    name=_("Generate Gramps Web API key"),
+    description=_(
+        "Turn a Gramps Web API server URL, username, and password into a "
+        "GRAMPS_WEB_API_KEY value for GrampsWebApiDb, and optionally "
+        "create a matching, correctly-named GrampsWebApiDb Family Tree "
+        "for it."
+    ),
+    status=BETA,
+    version="0.1.0",
+    gramps_target_version="6.0",
+    fname="mintapikeytool.py",
+    authors=["Doug Blank"],
+    authors_email=["doug.blank@gmail.com"],
+    category=TOOL_UTILS,
+    toolclass="MintApiKeyTool",
+    optionclass="MintApiKeyToolOptions",
+    tool_modes=[TOOL_MODE_GUI],
+    help_url="Addon:GrampsWebApiDb",
+)

--- a/GrampsWebApiDb/mintapikeytool.py
+++ b/GrampsWebApiDb/mintapikeytool.py
@@ -1,0 +1,378 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026 Douglas S. Blank <doug.blank@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Tools/Utilities/Generate Gramps Web API key
+
+Dialog front end for WebApiHandler.mint_api_key() (webapi_client.py):
+username/password in, a GRAMPS_WEB_API_KEY value out. Exists because
+generating a key otherwise requires either a shell with the standalone
+gramps-api-client package installed, or hand-writing the three lines of
+Python from GrampsWebApiDb's own README -- this tool is that same call
+behind a form, for anyone who just wants the key string.
+
+A TOOL rather than a gramplet: generating a key is a one-off setup action,
+not something worth keeping permanently docked in a gramplet bar, and
+unlike a gramplet it doesn't need an open Family Tree at all -- see
+build_dialog() and the module's use of dbstate below.
+
+On success, it also sets GRAMPS_WEB_API_KEY in this running Gramps
+process's environment, so a WebApiDB-backed Family Tree can be opened in
+the same session without restarting Gramps -- but that lasts only for
+this process; it is not written to a shell profile, settings.ini, or any
+open Family Tree, matching the README's "Credentials" section on why
+persistence otherwise stays a manual step.
+
+"Create Synced Family Tree for this key" goes one step further: it
+creates (but does not open) a new, empty Family Tree using the
+"grampswebapidb" DATABASE plugin, named "<username>@<host>" for whoever
+the key authenticates as -- the exact name grampswebapidb.py's
+_check_identity() requires, via the same CLIDbManager.create_new_db_cli()
+Gramps' own Family Tree Manager uses for its "New" button, just with an
+explicit dbid instead of the configured default backend. See README.md's
+"Family Tree naming" section for why that name is required.
+"""
+
+# ------------------------------------------------------------------------
+#
+# Standard Python modules
+#
+# ------------------------------------------------------------------------
+import os
+import re
+import threading
+from urllib.error import HTTPError, URLError
+
+# ------------------------------------------------------------------------
+#
+# GTK/Gnome modules
+#
+# ------------------------------------------------------------------------
+from gi.repository import GLib, Gtk
+
+# ------------------------------------------------------------------------
+#
+# Gramps modules
+#
+# ------------------------------------------------------------------------
+from gramps.cli.clidbman import CLIDbManager
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+from gramps.gui.managedwindow import ManagedWindow
+from gramps.gui.plug import tool
+from gramps.gui.utils import text_to_clipboard
+
+from webapi_client import API_KEY_ENV_VAR, WebApiHandler
+
+try:
+    _trans = glocale.get_addon_translator(__file__)
+except ValueError:
+    _trans = glocale.translation
+_ = _trans.gettext
+
+#: Same failure modes WebApiHandler.from_env()/push_transaction() can
+#: raise elsewhere in this addon -- see grampswebapidb.py's
+#: _CONNECTION_ERRORS -- but here they mean "bad URL/credentials or an
+#: unreachable server" rather than "lost sync", so they're just reported
+#: in the status label rather than acted on.
+_MINT_ERRORS = (ValueError, HTTPError, URLError, OSError)
+
+#: Same substitution grampswebapidb.py's _check_identity() applies to a
+#: Family Tree's own name before comparing it against the server identity
+#: -- keep in sync if that changes. Applied here too so a tree created by
+#: this button already has the name _check_identity() will accept.
+_FAMILY_TREE_NAME_UNSAFE_CHARS = re.compile(r"[':<>|,;=\"\[\]\.\+\*\/\?\\]")
+
+#: The DATABASE plugin id grampswebapidb.gpr.py registers WebApiDB under.
+_WEBAPIDB_ID = "grampswebapidb"
+
+
+class MintApiKeyTool(tool.Tool, ManagedWindow):
+    """
+    Dialog that turns a server URL + username + password into a
+    GRAMPS_WEB_API_KEY value, via WebApiHandler.mint_api_key().
+    """
+
+    def __init__(self, dbstate, user, options_class, name, callback=None):
+        self.dbstate = dbstate
+        self.uistate = user.uistate
+        self.mint_thread = None
+        self.tree_thread = None
+        ManagedWindow.__init__(self, self.uistate, [], self.__class__)
+        self.set_window(Gtk.Window(), Gtk.Label(), "")
+        tool.Tool.__init__(self, dbstate, options_class, name)
+
+        dialog = self.build_dialog()
+        dialog.run()
+        dialog.destroy()
+        self.close()
+
+    def build_dialog(self):
+        dialog = Gtk.Dialog(
+            _("Generate Gramps Web API key"),
+            self.uistate.window if self.uistate else None,
+            Gtk.DialogFlags.MODAL | Gtk.DialogFlags.DESTROY_WITH_PARENT,
+            (Gtk.STOCK_CLOSE, Gtk.ResponseType.CLOSE),
+        )
+        dialog.set_default_size(420, -1)
+
+        vbox = dialog.get_content_area()
+        vbox.set_border_width(6)
+        vbox.set_spacing(6)
+
+        self.url_entry = self.__add_entry(
+            vbox, _("Server URL"), _("e.g. https://your-server/api")
+        )
+        self.username_entry = self.__add_entry(vbox, _("Username"))
+        self.password_entry = self.__add_entry(vbox, _("Password"))
+        self.password_entry.set_visibility(False)
+        self.password_entry.connect("activate", self.mint_clicked)
+
+        button_box = Gtk.ButtonBox()
+        button_box.set_layout(Gtk.ButtonBoxStyle.START)
+        button_box.set_spacing(6)
+        button_box.set_border_width(6)
+
+        self.mint_button = Gtk.Button(label=_("Generate API Key"))
+        self.mint_button.connect("clicked", self.mint_clicked)
+        button_box.add(self.mint_button)
+        vbox.pack_start(button_box, False, False, 0)
+
+        self.status_label = Gtk.Label(halign=Gtk.Align.START)
+        self.status_label.set_line_wrap(True)
+        self.status_label.set_text(
+            _(
+                "Enter your server URL, username, and password, then "
+                "click Generate API Key."
+            )
+        )
+        vbox.pack_start(self.status_label, False, False, 0)
+
+        self.key_entry = self.__add_entry(vbox, _("GRAMPS_WEB_API_KEY"))
+        self.key_entry.set_editable(False)
+
+        copy_box = Gtk.ButtonBox()
+        copy_box.set_layout(Gtk.ButtonBoxStyle.START)
+        copy_box.set_spacing(6)
+        copy_box.set_border_width(6)
+
+        copy_button = Gtk.Button(label=_("Copy"))
+        copy_button.connect("clicked", self.copy_clicked)
+        copy_box.add(copy_button)
+        vbox.pack_start(copy_box, False, False, 0)
+
+        self.create_tree_button = Gtk.Button(
+            label=_("Create Synced Family Tree for this key")
+        )
+        self.create_tree_button.set_sensitive(False)
+        self.create_tree_button.connect("clicked", self.create_tree_clicked)
+        vbox.pack_start(self.create_tree_button, False, False, 0)
+
+        self.tree_name_entry = self.__add_entry(vbox, _("Family Tree"))
+        self.tree_name_entry.set_editable(False)
+
+        existing_key = os.environ.get(API_KEY_ENV_VAR)
+        if existing_key:
+            self.key_entry.set_text(existing_key)
+            self.create_tree_button.set_sensitive(True)
+            self.status_label.set_text(
+                _(
+                    "Found an existing %s for this session. Click Create "
+                    "Synced Family Tree to use it directly, or fill in the "
+                    "form above to generate a different key."
+                )
+                % API_KEY_ENV_VAR
+            )
+
+        dialog.show_all()
+        return dialog
+
+    def __add_entry(self, vbox, name, tooltip=""):
+        label = Gtk.Label(halign=Gtk.Align.START)
+        label.set_markup("<b>%s</b>" % name)
+        vbox.pack_start(label, False, False, 0)
+        entry = Gtk.Entry()
+        entry.set_tooltip_text(tooltip)
+        vbox.pack_start(entry, False, False, 0)
+        return entry
+
+    def mint_clicked(self, obj):
+        url = self.url_entry.get_text().strip()
+        username = self.username_entry.get_text().strip()
+        password = self.password_entry.get_text()
+        if not url or not username or not password:
+            self.status_label.set_text(
+                _("Please fill in the server URL, username, and password.")
+            )
+            return
+
+        self.key_entry.set_text("")
+        self.tree_name_entry.set_text("")
+        self.password_entry.set_text("")
+        self.status_label.set_text(_("Generating API key…"))
+        self.mint_button.set_sensitive(False)
+        self.create_tree_button.set_sensitive(False)
+
+        if self.mint_thread and self.mint_thread.is_alive():
+            return
+        self.mint_thread = threading.Thread(
+            target=self._mint_api_key, args=(url, username, password)
+        )
+        self.mint_thread.daemon = True
+        self.mint_thread.start()
+
+    def _mint_api_key(self, url, username, password):
+        """Run off the GTK main thread; hands the result back via idle_add."""
+        try:
+            key = WebApiHandler.mint_api_key(url, username, password)
+        except _MINT_ERRORS as exc:
+            GLib.idle_add(self._mint_failed, self._describe_mint_error(exc))
+        else:
+            GLib.idle_add(self._mint_succeeded, key)
+
+    @staticmethod
+    def _describe_mint_error(exc):
+        """
+        Turn a mint_api_key() exception into a message that says which of
+        URL/username/password is the likely problem, instead of a raw
+        urllib exception the user has to decode themselves.
+        """
+        if isinstance(exc, HTTPError):
+            if exc.code in (401, 403):
+                return _(
+                    "Login failed (HTTP %d): check your username and password."
+                ) % exc.code
+            return _(
+                "Server returned an error (HTTP %d %s): check the Server URL."
+            ) % (exc.code, exc.reason)
+        if isinstance(exc, OSError):
+            # Covers URLError (DNS failure, connection refused, ...) and
+            # socket.timeout, both OSError subclasses -- the server at
+            # that URL could not be reached at all.
+            reason = getattr(exc, "reason", exc)
+            return (
+                _("Could not reach the server: check the Server URL. (%s)")
+                % reason
+            )
+        return _("Unexpected response from the server: %s") % exc
+
+    def _mint_failed(self, message):
+        self.status_label.set_text(_("Error: %s") % message)
+        self.mint_button.set_sensitive(True)
+        return False
+
+    def _mint_succeeded(self, key):
+        os.environ[API_KEY_ENV_VAR] = key
+        self.key_entry.set_text(key)
+        self.status_label.set_text(
+            _(
+                "Success. %s is now set for this Gramps session -- no "
+                "restart needed. Copy the key below to also set it in your "
+                "shell environment for next time."
+            )
+            % API_KEY_ENV_VAR
+        )
+        self.mint_button.set_sensitive(True)
+        self.create_tree_button.set_sensitive(True)
+        self.key_entry.grab_focus()
+        self.key_entry.select_region(0, -1)
+        return False
+
+    def copy_clicked(self, obj):
+        text_to_clipboard(self.key_entry.get_text())
+
+    def create_tree_clicked(self, obj):
+        key = self.key_entry.get_text().strip()
+        if not key:
+            return
+
+        self.tree_name_entry.set_text("")
+        self.status_label.set_text(_("Looking up account identity…"))
+        self.create_tree_button.set_sensitive(False)
+
+        if self.tree_thread and self.tree_thread.is_alive():
+            return
+        self.tree_thread = threading.Thread(target=self._lookup_identity, args=(key,))
+        self.tree_thread.daemon = True
+        self.tree_thread.start()
+
+    def _lookup_identity(self, key):
+        """Run off the GTK main thread; hands the result back via idle_add."""
+        try:
+            identity = WebApiHandler.from_api_key(key).get_identity()
+        except _MINT_ERRORS as exc:
+            GLib.idle_add(self._create_tree_failed, self._describe_mint_error(exc))
+        else:
+            GLib.idle_add(self._create_tree, identity)
+
+    def _create_tree(self, identity):
+        """
+        Create the local Family Tree entry (mkdir + name.txt +
+        database.txt) for `identity`, via the same CLIDbManager Gramps'
+        own Family Tree Manager uses -- see clidbman.py's
+        create_new_db_cli(). Runs on the GTK main thread (via idle_add):
+        it's local filesystem work, not network, and touches self.dbstate.
+        """
+        tree_name = _FAMILY_TREE_NAME_UNSAFE_CHARS.sub("_", identity)
+        dbman = CLIDbManager(self.dbstate)
+        if tree_name in [existing[0] for existing in dbman.current_names]:
+            self.tree_name_entry.set_text(tree_name)
+            self.status_label.set_text(
+                _(
+                    'A Family Tree named "%s" already exists. Open it from '
+                    "Family Trees -> Manage Family Trees instead of "
+                    "creating another one."
+                )
+                % tree_name
+            )
+            self.create_tree_button.set_sensitive(True)
+            return False
+        try:
+            new_path, title = dbman.create_new_db_cli(
+                title=tree_name, dbid=_WEBAPIDB_ID
+            )
+        except Exception as exc:
+            self.status_label.set_text(_("Error creating Family Tree: %s") % exc)
+            self.create_tree_button.set_sensitive(True)
+            return False
+        self.tree_name_entry.set_text(title)
+        self.status_label.set_text(
+            _(
+                'Created Family Tree "%s". Open it from Family Trees -> '
+                "Manage Family Trees to start syncing."
+            )
+            % title
+        )
+        self.create_tree_button.set_sensitive(True)
+        self.tree_name_entry.grab_focus()
+        self.tree_name_entry.select_region(0, -1)
+        return False
+
+    def _create_tree_failed(self, message):
+        self.status_label.set_text(_("Error: %s") % message)
+        self.create_tree_button.set_sensitive(True)
+        return False
+
+
+class MintApiKeyToolOptions(tool.ToolOptions):
+    """
+    Defines options and provides handling interface.
+    """
+
+    def __init__(self, name, person_id=None):
+        tool.ToolOptions.__init__(self, name, person_id)

--- a/GrampsWebApiDb/mintapikeytool.py
+++ b/GrampsWebApiDb/mintapikeytool.py
@@ -28,9 +28,11 @@ Python from GrampsWebApiDb's own README -- this tool is that same call
 behind a form, for anyone who just wants the key string.
 
 A TOOL rather than a gramplet: generating a key is a one-off setup action,
-not something worth keeping permanently docked in a gramplet bar, and
-unlike a gramplet it doesn't need an open Family Tree at all -- see
-build_dialog() and the module's use of dbstate below.
+not something worth keeping permanently docked in a gramplet bar. It
+doesn't read or write anything in dbstate's Family Tree -- see
+build_dialog() below -- but Gramps only populates the Tools menu once
+some Family Tree is open, so in practice the user still needs one open
+(any backend, even an empty local tree) to reach this tool at all.
 
 On success, it also sets GRAMPS_WEB_API_KEY in this running Gramps
 process's environment, so a WebApiDB-backed Family Tree can be opened in


### PR DESCRIPTION
This tool adds the ability to create key, set it, and even create the synced tree:

<img width="437" height="647" alt="image" src="https://github.com/user-attachments/assets/87fd0a09-1c59-4db5-a562-db61537e97d7" />


## Summary
- Adds Tools -> Utilities -> **Generate Gramps Web API key**, a small dialog that turns a server URL/username/password into a `GRAMPS_WEB_API_KEY` value via `WebApiHandler.mint_api_key()`, instead of requiring a shell with `gramps-api-client` installed or hand-writing the snippet from the README.
- On success it sets `GRAMPS_WEB_API_KEY` in the running Gramps process's environment, so a WebApiDB-backed Family Tree can be opened in the same session without restarting Gramps.
- Adds a **Create Synced Family Tree for this key** follow-up button that creates (but does not open) a correctly-named Family Tree using the `grampswebapidb` database backend, via the same `CLIDbManager.create_new_db_cli()` API Gramps' own Family Tree Manager uses — checking first that a tree with that name doesn't already exist.
- Tightens `grampswebapidb.py`'s own error handling: `load()`'s initial sync is now wrapped in `DbConnectionError` the same way `_check_identity()` already was, so a failure there shows the addon's own dialog instead of escaping as a raw `HTTPError` that Gramps' generic dbloader dialog renders unhelpfully (`Could not open file: ... HTTP Error 403: FORBIDDEN`). HTTP 403s specifically get a message calling out that it's a permissions problem with the authenticated account, not a URL/credentials one.

## Test plan
- [x] `python3 -m py_compile` on `mintapikeytool.py` and `grampswebapidb.py`
- [x] Both `.gpr.py` files parse and their `register(...)` blocks match the existing `TOOL`/`DATABASE` conventions used elsewhere in this repo
- [x] `mintapikeytool.py` imports cleanly against a local Gramps checkout (`gi.repository.Gtk`, `gramps.gui.plug.tool`, `gramps.cli.clidbman.CLIDbManager`, `gramps.gen.plug.Gramplet` base classes resolve)
- [x] `_describe_mint_error()`/`_describe_connection_error()` exercised directly against synthetic `HTTPError`/`URLError`/`ValueError` instances for the 401/403/unreachable-server/malformed-response branches
- [x] Manual GUI smoke test against a live gramps-web-api server (generate a key, confirm the dialog reflects success/failure correctly, confirm the created Family Tree opens and syncs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)