### PR TITLE
JSON: use .jsonl extension for export/import

### DIFF
--- a/JSON/JSON.gpr.py
+++ b/JSON/JSON.gpr.py
@@ -10,7 +10,7 @@ register(
     export_function="exportData",
     export_options="WriterOptionBox",
     export_options_title=_("JSON options"),
-    extension="json",
+    extension="jsonl",
     help_url="Addon:JSON_Export_Import#Export_JSON",
 )
 
@@ -24,6 +24,6 @@ register(
     status=STABLE,
     fname="JSONImport.py",
     import_function="importData",
-    extension="json",
+    extension="jsonl",
     help_url="Addon:JSON_Export_Import#Import_JSON",
 )


### PR DESCRIPTION
## Summary
- The JSON export writes one JSON object per line (JSON Lines format), via `write_line` appending `\n` after each `object_to_string(obj)` call — not a single JSON document.
- Updated `extension` in `JSON.gpr.py` from `json` to `jsonl` for both the EXPORT and IMPORT registrations so the produced/expected file extension matches the actual format.

## Test plan
- [x] Export a family tree via the JSON exporter in Gramps and confirm the file save dialog now defaults to `.jsonl`.
- [x] Re-import the resulting `.jsonl` file and confirm it round-trips correctly.