### PR TITLE
GrampsWebApiDb: sync media files, fix silent write-side drift

### DIFF
--- a/GrampsWebApiDb/grampswebapidb.py
+++ b/GrampsWebApiDb/grampswebapidb.py
@@ -141,6 +141,111 @@ user) is still out of scope. If the push fails for a non-conflict reason
 is not rolled back -- the local mirror just drifts from the server until
 the next successful push or read sync.
 
+Not every local batch=True commit is a pull-side replay, though: the same
+trans.batch guard that makes _sync_from_server()'s own replay silent to
+transaction_to_json() applies equally to *local* bulk operations run
+against this open tree from outside this file entirely -- ImportXml/
+ImportGedcom/ImportCsv/..., and stock Tools like Check and Repair
+Database, Media Manager, Extract Information from Names, Rename Event
+Types, Reorder Gramps IDs, and Sort Events all open their own DbTxn with
+batch=True for performance. Left alone, any of those would apply locally
+and never reach the server: transaction_commit() would see the same empty
+transaction_to_json() payload it correctly sees for _sync_from_server()'s
+own pull-side batch replay, with nothing in the payload itself to tell the
+two apart. transaction_begin() (called by DbTxn.__enter__, so before the
+batch operation's body runs) tells them apart with a _pulling flag set
+only around _sync_from_server()'s own batch DbTxns (including the ones
+_full_resync() opens) -- everywhere else, a batch=True transaction gets a
+snapshot of every primary object type's handle set stashed on the
+transaction itself (_handles_by_class()). transaction_commit() diffs that
+snapshot against the post-commit state (_reconcile_batch_commit()) to
+reconstruct what changed: a handle that appeared is an add, one that
+disappeared is a delete, and one that persisted but whose .change moved to
+at or after the transaction's own start_time was an update -- _commit_
+base() always stamps .change on every commit, batch or not; only the
+undo-log recording that batch skips is what normally would have let
+transaction_to_json() see this directly. The reconstructed entries are
+handed to _retry_after_conflict() -- not because anything conflicted, but
+because it already does exactly what's needed here: replay each entry as
+a fresh, ordinary (non-batch) local edit, so it picks up a real "old"
+snapshot from DBAPI's own commit path and goes out through the normal
+push path one object at a time, with the same conflict handling a live
+edit gets. This costs roughly double the local writes for whatever the
+batch operation actually touched (once for the batch commit, once more
+for this replay) -- accepted as the price of correctness, the same trade
+_full_resync() already makes for the equivalent pull-side blind spot.
+
+A second, previously-unhandled kind of silent drift: when a push's own
+HTTP call fails for a plain connectivity reason (network down, server
+unreachable -- not a conflict), the local commit has already happened and
+is never rolled back, but until now nothing remembered that the push
+still needed to go out -- "the next successful push or read sync" above
+was aspirational, not implemented. _push_payload() now persists such a
+payload (via _set_metadata(), the same mechanism sync_last_time already
+uses, so it survives close()/reopen) to a "pending_pushes" queue instead
+of just logging and forgetting it. _flush_pending_pushes(), called at the
+top of every _sync_from_server() (both the load()-time call and every
+poll tick), retries the queue in order and stops at the first entry that
+still can't be delivered, rather than skipping ahead -- so a later,
+causally-dependent edit (e.g. a Family added after the Person it
+references) can never reach the server ahead of an earlier one still
+stuck behind a connectivity failure.
+
+Not every push failure is worth queueing, though: a 4xx other than 429 is
+the server's considered answer about the request itself and will not
+change on replay, so _is_retryable_push_error() sends those straight to a
+loud log instead -- queueing one would retry it on every poll forever and
+eventually evict genuinely retryable work from the capped queue.
+
+The most likely such rejection is a permissions one, and _check_
+permissions() heads it off at load() rather than letting every subsequent
+edit fail: gramps-web-api gates POST /transactions/ behind all three of
+AddObject/EditObject/DeleteObject at once (transactions.py's
+require_permissions(); has_permissions() fails if any are missing), and
+gates GET /transactions/history/ behind ViewPrivate. ViewPrivate is the
+one whose absence would otherwise be *silent* rather than merely fatal:
+the history feed 403s loudly without it, but GET /exporters/gramps/file
+does not refuse the request at all -- it passes
+view_private=has_permissions({PERM_VIEW_PRIVATE}) into the export task
+(exporters.py), so an under-privileged caller gets a privacy-filtered
+export, which _full_resync() would then import over a wiped local mirror,
+quietly dropping every private record from the mirror. Checking the
+permission set up front costs no extra round trip (gramps-web-api puts it
+in the access token's own claims, so get_permissions() just decodes the
+JWT already in hand) and names exactly what is missing. A tree opened
+read-only (DBMODE_R) never pushes, so it is held to the read permission
+only.
+
+GET /metadata/ (cached per handler; needs no special permission) supplies
+the two versions the addon reasons about. The server's *Gramps* version
+gates compatibility outright: _check_server_version() refuses at load()
+below MIN_SERVER_GRAMPS_VERSION, since anything older serializes its
+transaction history in the pre-6.0 shape and would otherwise fail much
+later as a bare KeyError out of data_to_object() mid-sync. It is
+deliberately lenient about a server that reports no parseable version at
+all -- better to try than to block on a guess.
+
+The server's *gramps-web-api* version gates one optimization: from 2.7,
+POST /transactions/ accepts ?background=1, queueing the work and
+answering 202 immediately instead of holding the connection open while it
+processes. _push_payload() uses that only for payloads at or above
+BACKGROUND_PUSH_THRESHOLD, where server-side processing could plausibly
+outlast webapi_client.TIMEOUT and drop the connection mid-write -- most of
+all the single large payload _reconcile_batch_commit() builds after a bulk
+import. Everything smaller stays synchronous, which is simpler and keeps
+the crisp "400 means conflict" semantics. Two asymmetries make the
+backgrounded path trickier than just adding a query parameter, both
+absorbed inside push_transaction() so callers see identical behavior
+either way: the server only really backgrounds the work if it has a Celery
+queue configured (otherwise it runs inline and answers 200, so 202 means
+"poll GET /tasks/<id>" and 200 means "already done"), and on that inline
+path a conflict comes back as HTTP 500 rather than 400, because run_task()
+catches process_transactions()'s ValueError and re-aborts it (see
+gramps_webapi/api/tasks.py). Both 400 and 500 are therefore checked for
+the "Object has changed" sentinel, and a failed background task is
+inspected for it too -- otherwise a conflict on that path would read as a
+transient server error and be queued for retry forever.
+
 The mirror stays current while the tree is open, not just at load() time:
 load() also schedules a GLib.timeout_add_seconds() tick (POLL_INTERVAL_SECONDS)
 that re-runs _sync_from_server() for as long as the database stays open --
@@ -155,6 +260,22 @@ off-thread (GrampsWebSync's GLibTaskRunner is the precedent, not imported
 here for the same no-cross-addon-dependency reason as transaction_to_json()
 below) is a reasonable future improvement, not attempted here. close()
 cancels the pending timeout so a closed database doesn't keep polling.
+
+A second, independent timeout (MEDIA_POLL_INTERVAL_SECONDS, coarser than
+POLL_INTERVAL_SECONDS) drives _sync_media_files(): downloading media files
+that exist as Media-object records in the mirror but not on local disk,
+and uploading local media files the server doesn't have yet. This is
+ported from GrampsWebSync's own media-file-sync step (grampswebsync.py's
+file_confirmation/file_progress wizard pages, webapihandler.py's
+get_missing_files()/download_media_file()/upload_media_file() -- same
+repo, same license, credit David Straub), but runs unattended on its own
+timer here instead of as an explicit user-driven wizard step with its own
+progress UI. It is a separate, coarser timer rather than piggybacking on
+_poll_tick() because, unlike the record-history feed, there is no cheap
+"what changed since last time" signal for file presence -- every pass
+re-checks every local Media object's file with os.path.exists() and
+re-asks the server's own GET /media/?filemissing=1 endpoint, and anything
+found missing is then transferred in full.
 
 _sync_from_server()'s replay runs inside a batch=True DbTxn deliberately
 (see the write-through section below for why), but that has a side effect
@@ -211,6 +332,7 @@ from gramps.gen.const import GRAMPS_LOCALE as glocale
 from gramps.gen.db import DbTxn
 from gramps.gen.db.dbconst import (
     CLASS_TO_KEY_MAP,
+    DBMODE_W,
     KEY_TO_CLASS_MAP,
     KEY_TO_NAME_MAP,
     TXNADD,
@@ -218,13 +340,15 @@ from gramps.gen.db.dbconst import (
     TXNUPD,
 )
 from gramps.gen.db.exceptions import DbConnectionError
+from gramps.gen.errors import HandleError
 from gramps.gen.lib.baseobj import BaseObject
-from gramps.gen.lib.json_utils import data_to_object, remove_object
+from gramps.gen.lib.json_utils import data_to_object, object_to_data, remove_object
 from gramps.gen.user import User
+from gramps.gen.utils.file import media_path_full
 from gramps.plugins.db.dbapi.sqlite import SQLite
 from gramps.plugins.importer.importxml import importData
 
-from webapi_client import WebApiHandler, WebApiPushConflict
+from webapi_client import WebApiHandler, WebApiPushConflict, parse_version
 
 try:
     _trans = glocale.get_addon_translator(__file__)
@@ -240,6 +364,67 @@ SYNC_PAGE_SIZE = 100
 #: database stays open -- see the module docstring's note on why this runs
 #: synchronously on the GTK main thread rather than a background timer.
 POLL_INTERVAL_SECONDS = 10
+
+#: How often (seconds) load() and the ongoing poll re-scan for media files
+#: missing locally or on the server -- see _sync_media_files(). Coarser
+#: than POLL_INTERVAL_SECONDS: unlike a record-history page fetch, a scan
+#: touches every local Media object's file on disk (os.path.exists()) and
+#: hits a separate server endpoint, and anything found missing is then
+#: transferred in full -- not worth doing on every 10-second record-sync
+#: tick.
+MEDIA_POLL_INTERVAL_SECONDS = 300
+
+#: Cap on the persisted pending-push queue (see _queue_pending_push()).
+#: A queue this long means the server has been unreachable across a great
+#: many local edits; keeping every one of them forever would grow the
+#: metadata row without bound, so the oldest are dropped with a loud log
+#: rather than silently.
+MAX_PENDING_PUSHES = 1000
+
+#: Server-side permission names (gramps-web-api's auth/const.py) this
+#: addon depends on, checked at load() by _check_permissions().
+#:
+#: ViewPrivate is required to read at all: GET /transactions/history/
+#: calls require_permissions([PERM_VIEW_PRIVATE]) outright (see
+#: gramps_webapi/api/resources/history.py), so the whole incremental sync
+#: 403s without it. It matters just as much for _full_resync()'s fallback,
+#: which fails *silently* rather than loudly instead: GET /exporters/
+#: gramps/file doesn't refuse the request, it passes
+#: view_private=has_permissions({PERM_VIEW_PRIVATE}) into the export task
+#: (exporters.py), so a caller lacking it gets a privacy-filtered export
+#: -- which _full_resync() would then import over a wiped local mirror,
+#: quietly dropping every private record from the mirror.
+_PERM_VIEW_PRIVATE = "ViewPrivate"
+
+#: POST /transactions/ requires all three of these together
+#: (transactions.py's require_permissions([PERM_ADD_OBJ, PERM_EDIT_OBJ,
+#: PERM_DEL_OBJ]) -- has_permissions() fails if *any* are missing), so
+#: write-through needs all three or no local edit can ever be pushed.
+#: PUT /media/<handle>/file additionally needs EditObject, already
+#: included here.
+_WRITE_PERMISSIONS = ("AddObject", "EditObject", "DeleteObject")
+
+#: Together: the permission set of gramps-web-api's "Editor" role, the
+#: least-privileged built-in role that can run this addon read-write.
+_REQUIRED_ROLE_NAME = "Editor"
+
+#: Oldest Gramps version a *server* can run and still produce the
+#: "_class"-tagged transaction-history serialization data_to_object()
+#: understands -- see the module docstring's note on gramps52 servers.
+#: Checked at load() by _check_server_version() so an incompatible server
+#: says so, instead of failing later as a bare KeyError mid-sync.
+MIN_SERVER_GRAMPS_VERSION = (6, 0)
+
+#: Payload size (number of change entries) at or above which a push is
+#: sent with ?background=1 where the server supports it -- see
+#: _push_payload(). Small pushes stay synchronous: that is the
+#: overwhelmingly common case (one interactive edit), it keeps the crisp
+#: 400-means-conflict semantics, and it avoids a pointless extra
+#: round trip to the task endpoint. The threshold exists for the genuinely
+#: large payload -- above all the one _reconcile_batch_commit() builds
+#: after a bulk import -- where server-side processing can plausibly
+#: outlast webapi_client.TIMEOUT and the connection would drop mid-write.
+BACKGROUND_PUSH_THRESHOLD = 100
 
 #: Failure modes from WebApiHandler.from_env()/push_transaction(): a
 #: malformed/missing key (ValueError), a bad server response shape
@@ -266,6 +451,27 @@ def _describe_connection_error(err):
             "one access."
         )
     return str(err)
+
+
+def _is_retryable_push_error(err):
+    """Whether a failed push is worth queueing for a later retry.
+
+    A 4xx is the server's considered answer about *this* request -- 403
+    (the account lacks AddObject/EditObject/DeleteObject; see
+    _check_permissions()), 404, or a 400 that push_transaction() already
+    determined isn't a conflict -- and will keep being the answer no
+    matter how often it is replayed. Queueing one would retry it on every
+    poll forever and, worse, eventually evict genuinely retryable work
+    from the capped queue.
+
+    429 is the exception: it is explicitly "try again shortly", not a
+    refusal. Everything else (5xx, URLError, socket timeout, a malformed
+    response) is transient or unknown, and gets the benefit of the doubt.
+    """
+    if isinstance(err, HTTPError):
+        return err.code == 429 or not 400 <= err.code < 500
+    return True
+
 
 #: Same substitution gramps.gui.dbman's Family Tree Manager applies to
 #: whatever a user types renaming a tree (dbman.py's __change_name(): "kill
@@ -345,6 +551,13 @@ class WebApiDB(SQLite):
     #: is itself a conflict retry -- see _push_payload().
     _retrying = False
 
+    #: Set around _sync_from_server()'s own batch=True DbTxns (including
+    #: the ones _full_resync() opens) so transaction_begin() can tell them
+    #: apart from a batch=True transaction started by anything else (a
+    #: bulk import, a Tool) -- see the module docstring and
+    #: _reconcile_batch_commit().
+    _pulling = False
+
     def requires_login(self):
         # Credentials come from GRAMPS_WEB_API_KEY, not a login dialog.
         return False
@@ -373,16 +586,37 @@ class WebApiDB(SQLite):
         callback = kwargs.get("callback")
         if callback is None and len(args) >= 2:
             callback = args[1]
+        # mode is position 3 in DbGeneric.load()'s signature, defaulting to
+        # DBMODE_W -- read the same two ways as callback above. A tree
+        # opened read-only never pushes, so it needs no write permissions.
+        mode = kwargs.get("mode")
+        if mode is None and len(args) >= 3:
+            mode = args[2]
+        if mode is None:
+            mode = DBMODE_W
         super().load(*args, **kwargs)
         self._check_identity()
+        self._check_permissions(writable=(mode == DBMODE_W))
+        self._check_server_version()
         try:
             self._sync_from_server(progress_callback=callback)
         except _CONNECTION_ERRORS as err:
             raise DbConnectionError(
                 _describe_connection_error(err), self._directory
             ) from err
+        try:
+            self._sync_media_files()
+        except _CONNECTION_ERRORS:
+            # Unlike the record sync above, a media-file-sync failure here
+            # doesn't block opening the tree: the record mirror is already
+            # usable, and missing/un-uploaded media files are recovered on
+            # the next successful media poll (or the next load()).
+            LOG.exception("Initial media file sync failed; will retry.")
         self._poll_source_id = GLib.timeout_add_seconds(
             POLL_INTERVAL_SECONDS, self._poll_tick
+        )
+        self._media_poll_source_id = GLib.timeout_add_seconds(
+            MEDIA_POLL_INTERVAL_SECONDS, self._media_poll_tick
         )
 
     def _check_identity(self):
@@ -436,6 +670,87 @@ class WebApiDB(SQLite):
                 self._directory,
             )
 
+    def _check_permissions(self, writable=True):
+        """Fail at load() if the account GRAMPS_WEB_API_KEY authenticates
+        as lacks a server permission this addon depends on, naming exactly
+        which -- rather than letting each affected operation fail on its
+        own later, in ways that range from a bare 403 to (for the export
+        fallback) no error at all. See _PERM_VIEW_PRIVATE's comment for
+        what each permission actually gates.
+
+        ``writable`` is False for a tree opened read-only (DBMODE_R), which
+        never pushes and so needs only the read permission.
+
+        Costs no extra round trip: gramps-web-api puts the permission list
+        in the access token's own claims (token.py's ``claims = {
+        "permissions": [...]}``), so get_permissions() just decodes the JWT
+        this handler already holds.
+        """
+        required = [_PERM_VIEW_PRIVATE]
+        if writable:
+            required += list(_WRITE_PERMISSIONS)
+        try:
+            granted = set(self.web_client.get_permissions())
+        except _CONNECTION_ERRORS as err:
+            raise DbConnectionError(
+                _describe_connection_error(err), self._directory
+            ) from err
+        missing = [perm for perm in required if perm not in granted]
+        if not missing:
+            return
+        raise DbConnectionError(
+            _(
+                "The account authenticating via GRAMPS_WEB_API_KEY is "
+                "missing server permission(s) this addon requires: "
+                "%(missing)s. Grant it at least the "
+                '"%(role)s" role on the server (or ask an administrator '
+                "to), then reopen this Family Tree. Opening it as-is would "
+                "leave the local mirror silently incomplete or unable to "
+                "save changes back."
+            )
+            % {"missing": ", ".join(missing), "role": _REQUIRED_ROLE_NAME},
+            self._directory,
+        )
+
+    def _check_server_version(self):
+        """Fail at load() if the server runs a Gramps too old to produce
+        the transaction-history serialization this addon reads.
+
+        A gramps52-era server answers auth and read-only endpoints
+        perfectly well, so nothing fails until _sync_from_server() feeds
+        its differently-shaped new_data to data_to_object() and gets a
+        bare KeyError -- see the module docstring. Asking GET /metadata/
+        up front turns that into a sentence naming both versions.
+
+        Deliberately lenient about *not knowing*: a server that doesn't
+        report a Gramps version, or reports one this can't parse, is
+        allowed through rather than blocked on a guess. The KeyError path
+        still catches a genuinely incompatible one, just less kindly.
+        """
+        try:
+            reported = self.web_client.get_gramps_version()
+        except _CONNECTION_ERRORS as err:
+            raise DbConnectionError(
+                _describe_connection_error(err), self._directory
+            ) from err
+        version = parse_version(reported)
+        if version is None or version >= MIN_SERVER_GRAMPS_VERSION:
+            return
+        raise DbConnectionError(
+            _(
+                "This server runs Gramps %(actual)s, but this addon needs "
+                "a server running Gramps %(required)s or newer: older "
+                "servers serialize their transaction history in a format "
+                "it cannot read. Upgrade the Gramps installation behind "
+                "the Gramps Web API server (or ask its administrator to)."
+            )
+            % {
+                "actual": reported,
+                "required": ".".join(str(part) for part in MIN_SERVER_GRAMPS_VERSION),
+            },
+            self._directory,
+        )
+
     def close(self, *args, **kwargs):
         # Stop polling a database that's no longer open -- otherwise the
         # next tick would run _sync_from_server() (and touch self.dbapi)
@@ -444,6 +759,10 @@ class WebApiDB(SQLite):
         if poll_source_id is not None:
             GLib.source_remove(poll_source_id)
             self._poll_source_id = None
+        media_poll_source_id = getattr(self, "_media_poll_source_id", None)
+        if media_poll_source_id is not None:
+            GLib.source_remove(media_poll_source_id)
+            self._media_poll_source_id = None
         super().close(*args, **kwargs)
 
     def _poll_tick(self):
@@ -457,10 +776,39 @@ class WebApiDB(SQLite):
             LOG.exception("Periodic sync from server failed; will retry.")
         return GLib.SOURCE_CONTINUE
 
+    def _media_poll_tick(self):
+        """GLib.timeout_add_seconds callback for the slower media-file
+        scan -- same contract as _poll_tick() (must return True to keep
+        firing; a connection error is caught and logged here rather than
+        left to propagate), just for _sync_media_files() instead of the
+        record-history poll."""
+        try:
+            self._sync_media_files()
+        except _CONNECTION_ERRORS:
+            LOG.exception("Periodic media file sync failed; will retry.")
+        return GLib.SOURCE_CONTINUE
+
+    def transaction_begin(self, transaction):
+        """Hook DbTxn.__enter__ (which calls this immediately, before the
+        transaction's body runs) to snapshot the local per-type handle
+        sets ahead of a batch=True transaction that isn't one of
+        _sync_from_server()'s own (self._pulling) -- _reconcile_batch_
+        commit() needs that "before" picture to diff against, since DBAPI
+        skips its usual undo-log recording for a batch commit regardless
+        of who started it. See the module docstring."""
+        result = super().transaction_begin(transaction)
+        if transaction.batch and not self._pulling:
+            transaction._webapidb_before_handles = self._handles_by_class()
+        return result
+
     def transaction_commit(self, transaction):
         # Must run before super(): it clears the transaction's records.
         payload = transaction_to_json(transaction)
         super().transaction_commit(transaction)
+        before_handles = getattr(transaction, "_webapidb_before_handles", None)
+        if before_handles is not None:
+            self._reconcile_batch_commit(before_handles, transaction.start_time)
+            return
         # self._retrying is set by _retry_after_conflict() while it holds
         # its own DbTxn open, so the push this commit triggers knows it is
         # itself a conflict retry and won't retry again on a second
@@ -501,7 +849,9 @@ class WebApiDB(SQLite):
         if not payload:
             return
         try:
-            self.web_client.push_transaction(payload, undo=undo)
+            self.web_client.push_transaction(
+                payload, undo=undo, background=self._use_background_push(payload)
+            )
         except WebApiPushConflict:
             LOG.warning(
                 "Server rejected %d local change(s): the object(s) changed "
@@ -523,13 +873,121 @@ class WebApiDB(SQLite):
                 )
                 return
             self._retry_after_conflict(payload)
-        except _CONNECTION_ERRORS:
+        except _CONNECTION_ERRORS as err:
+            if not _is_retryable_push_error(err):
+                # A permission/payload rejection is not going to start
+                # working on its own; queueing it would retry it on every
+                # poll forever and eventually push real, retryable work out
+                # of the capped queue.
+                LOG.error(
+                    "Server permanently rejected %d local change(s) (%s). "
+                    "They will not be retried, and the local mirror has "
+                    "drifted from the server for those object(s).",
+                    len(payload),
+                    err,
+                )
+                return
             LOG.exception(
-                "Failed to push %d local change(s) to the server; "
-                "local mirror has drifted from the server until the "
-                "next successful push or read sync.",
+                "Failed to push %d local change(s) to the server; queued "
+                "for retry on the next successful contact with the server.",
                 len(payload),
             )
+            self._queue_pending_push(payload, undo=undo)
+
+    def _use_background_push(self, payload):
+        """Whether to ask the server to process this payload as a
+        background task rather than inline -- see BACKGROUND_PUSH_THRESHOLD
+        and webapi_client.push_transaction()'s ``background`` param.
+
+        A server that can't do it (too old, or its version can't be
+        determined) always answers False. A failure asking is not worth
+        aborting the push over: fall back to the synchronous path, which
+        works everywhere.
+        """
+        if len(payload) < BACKGROUND_PUSH_THRESHOLD:
+            return False
+        try:
+            return self.web_client.supports_background_transactions()
+        except _CONNECTION_ERRORS:
+            LOG.debug(
+                "Could not determine server support for background "
+                "transactions; pushing synchronously.",
+                exc_info=True,
+            )
+            return False
+
+    def _queue_pending_push(self, payload, undo=False):
+        """Persist a payload whose push failed for a connectivity reason,
+        so _flush_pending_pushes() can retry it later -- including after a
+        close()/reopen, since this goes through _set_metadata() (the same
+        mechanism sync_last_time already uses) rather than an in-memory
+        list. See the module docstring."""
+        pending = self._get_metadata("pending_pushes", default=[])
+        pending.append({"payload": payload, "undo": undo})
+        if len(pending) > MAX_PENDING_PUSHES:
+            dropped = len(pending) - MAX_PENDING_PUSHES
+            LOG.error(
+                "Pending-push queue exceeded %d entries; dropping the %d "
+                "oldest. Those local change(s) will not reach the server -- "
+                "the local mirror has permanently drifted and needs a manual "
+                "reconciliation against it.",
+                MAX_PENDING_PUSHES,
+                dropped,
+            )
+            pending = pending[dropped:]
+        self._set_metadata("pending_pushes", pending)
+
+    def _flush_pending_pushes(self):
+        """Retry queued pushes that previously failed for a connectivity
+        reason, oldest first, stopping at the first that still can't be
+        delivered -- see the module docstring on why this doesn't skip
+        ahead past a stuck entry.
+
+        A queued entry that comes back as a *conflict* rather than a
+        connectivity failure is dropped rather than retried forever: by the
+        time it is replayed the server has moved on, and _push_payload()'s
+        resync-and-merge path needs an "old" snapshot contemporaneous with
+        the edit, which a queued payload no longer has. An entry the server
+        permanently rejects (see _is_retryable_push_error()) is likewise
+        dropped rather than left to block the queue forever -- permissions
+        may well have changed between queueing and now.
+        """
+        pending = self._get_metadata("pending_pushes", default=[])
+        if not pending:
+            return
+        LOG.info("Retrying %d queued push(es) to the server.", len(pending))
+        while pending:
+            entry = pending[0]
+            try:
+                self.web_client.push_transaction(
+                    entry["payload"],
+                    undo=entry.get("undo", False),
+                    background=self._use_background_push(entry["payload"]),
+                )
+            except WebApiPushConflict:
+                LOG.warning(
+                    "A queued push of %d change(s) conflicts with the "
+                    "server's current data and cannot be replayed safely; "
+                    "dropping it. The local mirror has drifted from the "
+                    "server for those object(s).",
+                    len(entry["payload"]),
+                )
+            except _CONNECTION_ERRORS as err:
+                if _is_retryable_push_error(err):
+                    LOG.warning(
+                        "Still unable to deliver %d queued push(es); will retry.",
+                        len(pending),
+                    )
+                    break
+                LOG.error(
+                    "Server permanently rejected a queued push of %d "
+                    "change(s) (%s); dropping it. The local mirror has "
+                    "drifted from the server for those object(s).",
+                    len(entry["payload"]),
+                    err,
+                )
+            pending.pop(0)
+        self._set_metadata("pending_pushes", pending)
 
     def _retry_after_conflict(self, payload):
         """Reapply each locally-intended change on top of the mirror
@@ -567,6 +1025,93 @@ class WebApiDB(SQLite):
         finally:
             self._retrying = False
 
+    def _handles_by_class(self):
+        """{obj_class: set(handles)} across every primary object type --
+        the "before" snapshot transaction_begin() stashes on a local
+        batch=True transaction for _reconcile_batch_commit() to diff
+        against. See the module docstring."""
+        return {
+            obj_class: set(getattr(self, f"get_{KEY_TO_NAME_MAP[key]}_handles")())
+            for obj_class, key in CLASS_TO_KEY_MAP.items()
+        }
+
+    def _reconcile_batch_commit(self, before_handles, start_time):
+        """Reconstruct what a local batch=True transaction changed, by
+        diffing the pre-transaction handle snapshot against the current
+        state, and push it -- see the module docstring's note on why a
+        batch commit is otherwise invisible to transaction_to_json().
+
+        An object present now but not before is an add; one present before
+        but not now is a delete; one present in both whose .change is at or
+        after the transaction's start_time was updated during it
+        (_commit_base() stamps .change on every commit, batch included).
+        Objects the batch left untouched keep an older .change and are
+        correctly skipped.
+
+        The reconstructed entries go to _retry_after_conflict(), which
+        replays each as an ordinary non-batch local edit -- so each one
+        picks up a real "old" snapshot and goes out through the normal
+        transaction_commit() -> _push_payload() path.
+
+        Cost: the surviving-handle pass reads every primary object in the
+        tree to check its .change, so this is O(total objects) per batch
+        commit, not O(objects the batch touched). That is the same order
+        as whatever opened a batch transaction in the first place (a bulk
+        import writes everything; Check and Repair reads everything), and
+        .change isn't a queryable secondary column in DBAPI's schema --
+        only handle plus a couple of per-type extras are -- so there is no
+        cheaper way to ask "what did this transaction touch" after the
+        fact. If this ever shows up as a real bottleneck, the fix is to
+        make the batch operation's own transaction non-batch, not to
+        make this cleverer.
+        """
+        entries = []
+        for obj_class, key in CLASS_TO_KEY_MAP.items():
+            name = KEY_TO_NAME_MAP[key]
+            before = before_handles.get(obj_class, set())
+            after = set(getattr(self, f"get_{name}_handles")())
+            for handle in after - before:
+                entries.append({"type": "add", "handle": handle, "_class": obj_class})
+            for handle in before - after:
+                entries.append(
+                    {"type": "delete", "handle": handle, "_class": obj_class}
+                )
+            get_obj = getattr(self, f"get_{name}_from_handle")
+            for handle in after & before:
+                if get_obj(handle).change >= start_time:
+                    entries.append(
+                        {"type": "update", "handle": handle, "_class": obj_class}
+                    )
+        if not entries:
+            return
+        LOG.info(
+            "Reconstructed %d change(s) from a local batch transaction that "
+            "Gramps did not record per-object; pushing them to the server.",
+            len(entries),
+        )
+        self._retry_after_conflict(self._fill_entry_payloads(entries))
+
+    def _fill_entry_payloads(self, entries):
+        """Attach the "new" object data _retry_after_conflict() needs to
+        each reconstructed add/update entry, read from the local mirror as
+        it stands after the batch commit. A delete carries no "new" data,
+        and an add/update whose handle has since vanished is dropped."""
+        filled = []
+        for entry in entries:
+            if entry["type"] == "delete":
+                filled.append({**entry, "old": None, "new": None})
+                continue
+            key = CLASS_TO_KEY_MAP[entry["_class"]]
+            name = KEY_TO_NAME_MAP[key]
+            try:
+                obj = getattr(self, f"get_{name}_from_handle")(entry["handle"])
+            except HandleError:
+                continue
+            filled.append(
+                {**entry, "old": None, "new": remove_object(object_to_data(obj))}
+            )
+        return filled
+
     def _sync_from_server(self, progress_callback=None):
         """
         Pull every transaction after the last-seen timestamp and replay
@@ -588,6 +1133,7 @@ class WebApiDB(SQLite):
         history()'s docstring), so it stays a stable denominator across
         pages barring concurrent server-side writes during the sync.
         """
+        self._flush_pending_pushes()
         after = self._get_metadata("sync_last_time", default=0)
         applied = 0
         needs_full_resync = False
@@ -602,17 +1148,25 @@ class WebApiDB(SQLite):
             # (obj_class, handle) -> trans_type, collapsed to the net
             # effect within this page -- see _emit_change_signals().
             net_changes = {}
-            with DbTxn("Sync from server", self, batch=True) as trans:
-                for server_trans in transactions:
-                    if not server_trans["changes"]:
-                        needs_full_resync = True
-                    for change in server_trans["changes"]:
-                        if self._apply_change(change, trans):
-                            applied += 1
-                            net_changes[(change["obj_class"], change["obj_handle"])] = (
-                                change["trans_type"]
-                            )
-                    after = max(after, server_trans["timestamp"])
+            # _pulling marks this batch DbTxn as one of our own replays, so
+            # transaction_begin() doesn't snapshot handles for it and
+            # transaction_commit() doesn't try to push it back out as if it
+            # were a local bulk edit -- see the module docstring.
+            self._pulling = True
+            try:
+                with DbTxn("Sync from server", self, batch=True) as trans:
+                    for server_trans in transactions:
+                        if not server_trans["changes"]:
+                            needs_full_resync = True
+                        for change in server_trans["changes"]:
+                            if self._apply_change(change, trans):
+                                applied += 1
+                                net_changes[
+                                    (change["obj_class"], change["obj_handle"])
+                                ] = change["trans_type"]
+                        after = max(after, server_trans["timestamp"])
+            finally:
+                self._pulling = False
             self._emit_change_signals(net_changes)
             seen += len(transactions)
             if progress_callback is not None and total:
@@ -647,10 +1201,11 @@ class WebApiDB(SQLite):
 
         The clear-then-import pair each run inside their own batch=True
         DbTxn (ImportXml's own, internally, for the import half -- see
-        importxml.py), so neither triggers transaction_commit()'s
-        push-to-server path (transaction_to_json() sees nothing to
-        push for a batch transaction) -- this is a purely local rebuild,
-        same as _sync_from_server()'s own transactions.
+        importxml.py), both under the _pulling flag so transaction_commit()
+        treats them as pull-side replays rather than local bulk edits to
+        reconstruct and push back -- this is a purely local rebuild from
+        what the server already has, same as _sync_from_server()'s own
+        transactions.
 
         progress_callback, if given, only gets 0/100 markers bookending
         the download+reimport -- unlike _sync_from_server()'s page-by-page
@@ -663,6 +1218,11 @@ class WebApiDB(SQLite):
         with NamedTemporaryFile(suffix=".gramps", delete=False) as tmp_file:
             tmp_file.write(data)
             tmp_path = tmp_file.name
+        # Both halves below are pull-side rebuilds, not local edits -- see
+        # _sync_from_server()'s own note on the _pulling flag. ImportXml
+        # opens its own batch DbTxn internally, so this has to stay set
+        # across importData() too, not just the explicit DbTxn above it.
+        self._pulling = True
         try:
             with DbTxn(
                 _("Clear local mirror before full resync"), self, batch=True
@@ -682,9 +1242,96 @@ class WebApiDB(SQLite):
             # object type, telling every view to reload wholesale).
             self.request_rebuild()
         finally:
+            self._pulling = False
             os.remove(tmp_path)
         if progress_callback is not None:
             progress_callback(100)
+
+    def _sync_media_files(self):
+        """
+        Download media files missing locally, then upload local media
+        files the server doesn't have yet -- the file-transfer half of
+        keeping the mirror in sync, alongside _sync_from_server()'s
+        object-record replay (which only ever moves a Media object's
+        *metadata* -- path, description, checksum, ... -- never the file
+        the path points at). See the module docstring's note on why this
+        runs on its own, coarser timer instead of every record-sync tick.
+
+        A single file failing to transfer (network error, a stale handle,
+        a 409 because something else uploaded it first) is logged and
+        skipped rather than aborting the rest of the pass -- the same
+        shape as _push_payload()'s error handling, just applied per file
+        here since there is no single all-or-nothing request covering
+        every file the way POST /transactions/ does for object records.
+
+        Returns ``(downloaded, uploaded)`` file counts.
+        """
+        downloaded = 0
+        for handle in self._missing_local_media_handles():
+            if self._download_one_media_file(handle):
+                downloaded += 1
+        uploaded = 0
+        for handle in self._missing_remote_media_handles():
+            if self._upload_one_media_file(handle):
+                uploaded += 1
+        if downloaded or uploaded:
+            LOG.info(
+                "Media file sync: downloaded %d file(s), uploaded %d file(s).",
+                downloaded,
+                uploaded,
+            )
+        return downloaded, uploaded
+
+    def _missing_local_media_handles(self):
+        """Handles of local Media objects whose file isn't on disk.
+        Ported from GrampsWebSync's get_missing_files_local()."""
+        return [
+            media.handle
+            for media in self.iter_media()
+            if not os.path.exists(media_path_full(self, media.get_path()))
+        ]
+
+    def _missing_remote_media_handles(self):
+        """Handles of Media objects the server has no uploaded file for
+        yet. Ported from GrampsWebSync's get_missing_files_remote()."""
+        return [item["handle"] for item in self.web_client.get_missing_files()]
+
+    def _download_one_media_file(self, handle):
+        """Download one locally-missing media file. Returns True on
+        success; logs and returns False on a HandleError (the object was
+        removed locally between the scan and here) or a connection error,
+        rather than aborting the rest of _sync_media_files()'s pass."""
+        try:
+            obj = self.get_media_from_handle(handle)
+        except HandleError:
+            return False
+        path = media_path_full(self, obj.get_path())
+        try:
+            self.web_client.download_media_file(handle, path)
+        except _CONNECTION_ERRORS as err:
+            LOG.warning("Failed to download media file for %s: %s", obj.gramps_id, err)
+            return False
+        return True
+
+    def _upload_one_media_file(self, handle):
+        """Upload one media file the server is missing. Returns True on
+        success; False if the local object no longer exists, its file
+        isn't actually on disk either (nothing to upload), the server
+        already got a file for it from elsewhere in the meantime (a 409
+        -- see WebApiHandler.upload_media_file()), or the upload
+        otherwise failed."""
+        try:
+            obj = self.get_media_from_handle(handle)
+        except HandleError:
+            return False
+        path = media_path_full(self, obj.get_path())
+        if not os.path.exists(path):
+            return False
+        try:
+            return self.web_client.upload_media_file(handle, path)
+        except _CONNECTION_ERRORS as err:
+            LOG.warning("Failed to upload media file for %s: %s", obj.gramps_id, err)
+            return False
 
     def _apply_change(self, change, trans):
         """Replay one server change into the local mirror. Returns True

--- a/GrampsWebApiDb/tests/test_grampswebapidb.py
+++ b/GrampsWebApiDb/tests/test_grampswebapidb.py
@@ -46,7 +46,7 @@ Run with::
 import os
 import sys
 import unittest
-from urllib.error import HTTPError
+from urllib.error import HTTPError, URLError
 from unittest import mock
 
 # -------------------------------------------------------------------------
@@ -460,9 +460,7 @@ class TestSyncFromServer(unittest.TestCase):
         ]
         progress = mock.MagicMock()
         self.db._sync_from_server(progress_callback=progress)
-        self.assertEqual(
-            [call.args[0] for call in progress.call_args_list], [100, 100]
-        )
+        self.assertEqual([call.args[0] for call in progress.call_args_list], [100, 100])
 
     def test_no_progress_call_when_total_is_zero(self):
         # An empty-history sync (a brand new server-side tree, or nothing
@@ -480,6 +478,41 @@ class TestSyncFromServer(unittest.TestCase):
         progress = mock.MagicMock()
         self.db._sync_from_server(progress_callback=progress)
         self.db._full_resync.assert_called_once_with(progress_callback=progress)
+
+    def test_pulling_flag_is_set_during_replay_and_cleared_after(self):
+        # _pulling tells transaction_begin() this batch DbTxn is a
+        # server-pull replay, not a local bulk edit to reconstruct and push
+        # back -- without it, every synced page would be echoed straight
+        # back at the server. A leaked True would then silently disable
+        # reconciliation for later genuine local batch operations.
+        change = {"obj_class": "Person", "trans_type": TXNADD, "obj_handle": "H1"}
+        self.db.web_client.get_transaction_history.return_value = (
+            [{"timestamp": 5.0, "changes": [change]}],
+            1,
+        )
+        seen = {}
+
+        def check_flag(change, trans):
+            seen["during"] = self.db._pulling
+            return True
+
+        with mock.patch.object(self.db, "_apply_change", side_effect=check_flag):
+            self.db._sync_from_server()
+        self.assertTrue(seen["during"])
+        self.assertFalse(self.db._pulling)
+
+    def test_pulling_flag_is_cleared_even_if_replay_raises(self):
+        change = {"obj_class": "Person", "trans_type": TXNADD, "obj_handle": "H1"}
+        self.db.web_client.get_transaction_history.return_value = (
+            [{"timestamp": 5.0, "changes": [change]}],
+            1,
+        )
+        with mock.patch.object(
+            self.db, "_apply_change", side_effect=RuntimeError("boom")
+        ):
+            with self.assertRaises(RuntimeError):
+                self.db._sync_from_server()
+        self.assertFalse(self.db._pulling)
 
 
 # -------------------------------------------------------------------------
@@ -616,6 +649,44 @@ class TestFullResync(unittest.TestCase):
 
         self.db.emit.assert_not_called()
 
+    def test_pulling_flag_is_set_during_the_rebuild_and_cleared_after(self):
+        # _pulling suppresses the batch-commit reconciliation that would
+        # otherwise try to push this whole wipe-and-reimport back at the
+        # server as if it were a local bulk edit. It has to stay set across
+        # importData() (which opens its own batch DbTxn internally), and it
+        # has to be cleared afterwards -- a leaked True would silently
+        # disable reconciliation for every later local batch operation in
+        # the session.
+        for key, name in grampswebapidb.KEY_TO_NAME_MAP.items():
+            if key not in grampswebapidb.CLASS_TO_KEY_MAP.values():
+                continue
+            setattr(self.db, f"get_{name}_handles", mock.MagicMock(return_value=[]))
+            setattr(self.db, f"remove_{name}", mock.MagicMock())
+        seen = {}
+
+        def check_flag(database, filename, user):
+            seen["during_import"] = self.db._pulling
+
+        with mock.patch.object(grampswebapidb, "importData", check_flag):
+            self.db._full_resync()
+        self.assertTrue(seen["during_import"])
+        self.assertFalse(self.db._pulling)
+
+    def test_pulling_flag_is_cleared_even_if_the_reimport_raises(self):
+        for key, name in grampswebapidb.KEY_TO_NAME_MAP.items():
+            if key not in grampswebapidb.CLASS_TO_KEY_MAP.values():
+                continue
+            setattr(self.db, f"get_{name}_handles", mock.MagicMock(return_value=[]))
+            setattr(self.db, f"remove_{name}", mock.MagicMock())
+
+        def failing_import_data(database, filename, user):
+            raise RuntimeError("boom")
+
+        with mock.patch.object(grampswebapidb, "importData", failing_import_data):
+            with self.assertRaises(RuntimeError):
+                self.db._full_resync()
+        self.assertFalse(self.db._pulling)
+
     def test_no_progress_callback_by_default(self):
         for key, name in grampswebapidb.KEY_TO_NAME_MAP.items():
             if key not in grampswebapidb.CLASS_TO_KEY_MAP.values():
@@ -664,6 +735,15 @@ class TestTransactionCommit(unittest.TestCase):
     def setUp(self):
         self.db = new_instance()
         self.db.web_client = mock.MagicMock()
+        # A push that fails for a connectivity reason now persists the
+        # payload via _set_metadata() for later retry (see
+        # TestPendingPushQueue), so even the plain push tests here need
+        # somewhere for that to land.
+        self.metadata = {}
+        self.db._get_metadata = lambda key, default=0: self.metadata.get(key, default)
+        self.db._set_metadata = (
+            lambda key, value, use_txn=True: self.metadata.__setitem__(key, value)
+        )
 
     def test_no_local_changes_does_not_push(self):
         trans = FakeTransaction([])
@@ -1191,6 +1271,260 @@ class TestCheckIdentity(unittest.TestCase):
 
 # -------------------------------------------------------------------------
 #
+# TestCheckPermissions
+#
+# The server gates GET /transactions/history/ behind ViewPrivate and POST
+# /transactions/ behind AddObject+EditObject+DeleteObject together. Checked
+# up front at load() so a missing one is named explicitly rather than
+# surfacing later as a bare 403 -- or, for the ViewPrivate export path, as
+# a silently privacy-filtered resync. See the module docstring.
+#
+# -------------------------------------------------------------------------
+class TestCheckPermissions(unittest.TestCase):
+    ALL_PERMS = ["ViewPrivate", "AddObject", "EditObject", "DeleteObject"]
+
+    def setUp(self):
+        self.db = new_instance()
+        self.db._directory = "/tmp/tree"
+        self.db.web_client = mock.MagicMock()
+
+    def _grant(self, *perms):
+        self.db.web_client.get_permissions.return_value = list(perms)
+
+    def test_editor_role_permissions_pass(self):
+        self._grant(*self.ALL_PERMS)
+        self.db._check_permissions()  # must not raise
+
+    def test_extra_permissions_are_fine(self):
+        # An Owner/Admin has a superset; only the required ones matter.
+        self._grant(*self.ALL_PERMS, "AddUser", "ImportFile")
+        self.db._check_permissions()  # must not raise
+
+    def test_missing_view_private_raises(self):
+        self._grant("AddObject", "EditObject", "DeleteObject")
+        with self.assertRaises(DbConnectionError) as ctx:
+            self.db._check_permissions()
+        self.assertIn("ViewPrivate", str(ctx.exception))
+
+    def test_missing_one_write_permission_raises(self):
+        # has_permissions() server-side fails if *any* of the three are
+        # missing, so a Contributor (AddObject only) cannot push at all.
+        self._grant("ViewPrivate", "AddObject")
+        with self.assertRaises(DbConnectionError) as ctx:
+            self.db._check_permissions()
+        message = str(ctx.exception)
+        self.assertIn("EditObject", message)
+        self.assertIn("DeleteObject", message)
+        self.assertNotIn("AddObject", message.replace("EditObject", ""))
+
+    def test_error_names_the_role_to_ask_for(self):
+        self._grant()
+        with self.assertRaises(DbConnectionError) as ctx:
+            self.db._check_permissions()
+        self.assertIn("Editor", str(ctx.exception))
+
+    def test_read_only_tree_does_not_need_write_permissions(self):
+        # A tree opened read-only never pushes, so a Member-level account
+        # (ViewPrivate but no write permissions) is enough for it.
+        self._grant("ViewPrivate")
+        self.db._check_permissions(writable=False)  # must not raise
+
+    def test_read_only_tree_still_needs_view_private(self):
+        self._grant("AddObject", "EditObject", "DeleteObject")
+        with self.assertRaises(DbConnectionError):
+            self.db._check_permissions(writable=False)
+
+    def test_connection_error_fetching_permissions_is_wrapped(self):
+        self.db.web_client.get_permissions.side_effect = HTTPError(
+            "https://example.com/api/token/refresh/", 500, "boom", None, None
+        )
+        with self.assertRaises(DbConnectionError):
+            self.db._check_permissions()
+
+    def test_load_checks_permissions_for_a_writable_tree(self):
+        with mock.patch.object(grampswebapidb.SQLite, "load"), mock.patch.object(
+            self.db, "_check_identity"
+        ), mock.patch.object(self.db, "_check_permissions") as check, mock.patch.object(
+            self.db, "_check_server_version"
+        ), mock.patch.object(
+            self.db, "_sync_from_server"
+        ), mock.patch.object(
+            self.db, "_sync_media_files"
+        ), mock.patch.object(
+            grampswebapidb.GLib, "timeout_add_seconds"
+        ):
+            self.db.load("some/path")
+        check.assert_called_once_with(writable=True)
+
+    def test_load_in_read_only_mode_checks_read_permissions_only(self):
+        # DbGeneric.load()'s signature is (directory, callback, mode, ...) --
+        # cli/grampscli.py passes mode positionally.
+        with mock.patch.object(grampswebapidb.SQLite, "load"), mock.patch.object(
+            self.db, "_check_identity"
+        ), mock.patch.object(self.db, "_check_permissions") as check, mock.patch.object(
+            self.db, "_check_server_version"
+        ), mock.patch.object(
+            self.db, "_sync_from_server"
+        ), mock.patch.object(
+            self.db, "_sync_media_files"
+        ), mock.patch.object(
+            grampswebapidb.GLib, "timeout_add_seconds"
+        ):
+            self.db.load("some/path", None, "r")
+        check.assert_called_once_with(writable=False)
+
+    def test_load_reads_mode_from_a_keyword_too(self):
+        with mock.patch.object(grampswebapidb.SQLite, "load"), mock.patch.object(
+            self.db, "_check_identity"
+        ), mock.patch.object(self.db, "_check_permissions") as check, mock.patch.object(
+            self.db, "_check_server_version"
+        ), mock.patch.object(
+            self.db, "_sync_from_server"
+        ), mock.patch.object(
+            self.db, "_sync_media_files"
+        ), mock.patch.object(
+            grampswebapidb.GLib, "timeout_add_seconds"
+        ):
+            self.db.load("some/path", mode="r")
+        check.assert_called_once_with(writable=False)
+
+
+# -------------------------------------------------------------------------
+#
+# TestCheckServerVersion
+#
+# A server running Gramps < 6.0 serializes its transaction history in a
+# shape data_to_object() can't read, which would otherwise surface as a
+# bare KeyError mid-sync. See the module docstring.
+#
+# -------------------------------------------------------------------------
+class TestCheckServerVersion(unittest.TestCase):
+    def setUp(self):
+        self.db = new_instance()
+        self.db._directory = "/tmp/tree"
+        self.db.web_client = mock.MagicMock()
+
+    def test_supported_version_passes(self):
+        self.db.web_client.get_gramps_version.return_value = "6.0.1"
+        self.db._check_server_version()  # must not raise
+
+    def test_newer_version_passes(self):
+        self.db.web_client.get_gramps_version.return_value = "6.1.0"
+        self.db._check_server_version()  # must not raise
+
+    def test_too_old_raises_naming_both_versions(self):
+        self.db.web_client.get_gramps_version.return_value = "5.2.3"
+        with self.assertRaises(DbConnectionError) as ctx:
+            self.db._check_server_version()
+        message = str(ctx.exception)
+        self.assertIn("5.2.3", message)
+        self.assertIn("6.0", message)
+
+    def test_unknown_version_is_allowed_through(self):
+        # Better to try and let the KeyError path catch a genuinely
+        # incompatible server than to block on a guess.
+        self.db.web_client.get_gramps_version.return_value = None
+        self.db._check_server_version()  # must not raise
+
+    def test_unparseable_version_is_allowed_through(self):
+        self.db.web_client.get_gramps_version.return_value = "some-dev-build"
+        self.db._check_server_version()  # must not raise
+
+    def test_connection_error_is_wrapped(self):
+        self.db.web_client.get_gramps_version.side_effect = HTTPError(
+            "https://example.com/api/metadata/", 500, "boom", None, None
+        )
+        with self.assertRaises(DbConnectionError):
+            self.db._check_server_version()
+
+
+# -------------------------------------------------------------------------
+#
+# TestUseBackgroundPush
+#
+# -------------------------------------------------------------------------
+class TestUseBackgroundPush(unittest.TestCase):
+    """Only a large payload on a capable server goes through the server's
+    background task queue -- see BACKGROUND_PUSH_THRESHOLD."""
+
+    def setUp(self):
+        self.db = new_instance()
+        self.db.web_client = mock.MagicMock()
+
+    def _payload(self, size):
+        return [{"type": "add", "handle": "H%d" % i} for i in range(size)]
+
+    def test_small_payload_is_synchronous_without_asking_the_server(self):
+        self.db.web_client.supports_background_transactions.return_value = True
+        self.assertFalse(self.db._use_background_push(self._payload(1)))
+        self.db.web_client.supports_background_transactions.assert_not_called()
+
+    def test_large_payload_on_a_capable_server_goes_background(self):
+        self.db.web_client.supports_background_transactions.return_value = True
+        payload = self._payload(grampswebapidb.BACKGROUND_PUSH_THRESHOLD)
+        self.assertTrue(self.db._use_background_push(payload))
+
+    def test_large_payload_on_an_old_server_stays_synchronous(self):
+        self.db.web_client.supports_background_transactions.return_value = False
+        payload = self._payload(grampswebapidb.BACKGROUND_PUSH_THRESHOLD)
+        self.assertFalse(self.db._use_background_push(payload))
+
+    def test_failure_asking_falls_back_to_synchronous(self):
+        # Not worth failing the push over -- the synchronous path works
+        # against every server version.
+        self.db.web_client.supports_background_transactions.side_effect = OSError(
+            "metadata unreachable"
+        )
+        payload = self._payload(grampswebapidb.BACKGROUND_PUSH_THRESHOLD)
+        self.assertFalse(self.db._use_background_push(payload))
+
+    def test_push_payload_passes_the_flag_through(self):
+        self.db._get_metadata = lambda key, default=0: default
+        self.db._set_metadata = lambda key, value, use_txn=True: None
+        self.db.web_client.supports_background_transactions.return_value = True
+        payload = self._payload(grampswebapidb.BACKGROUND_PUSH_THRESHOLD)
+        self.db._push_payload(payload)
+        self.assertTrue(
+            self.db.web_client.push_transaction.call_args.kwargs["background"]
+        )
+
+
+# -------------------------------------------------------------------------
+#
+# TestIsRetryablePushError
+#
+# -------------------------------------------------------------------------
+class TestIsRetryablePushError(unittest.TestCase):
+    """A 4xx other than 429 is the server's settled answer and must not be
+    queued for retry -- see _is_retryable_push_error()."""
+
+    def _http(self, code):
+        return HTTPError("https://example.com/api/transactions/", code, "x", None, None)
+
+    def test_403_is_not_retryable(self):
+        self.assertFalse(grampswebapidb._is_retryable_push_error(self._http(403)))
+
+    def test_400_is_not_retryable(self):
+        self.assertFalse(grampswebapidb._is_retryable_push_error(self._http(400)))
+
+    def test_404_is_not_retryable(self):
+        self.assertFalse(grampswebapidb._is_retryable_push_error(self._http(404)))
+
+    def test_429_is_retryable(self):
+        self.assertTrue(grampswebapidb._is_retryable_push_error(self._http(429)))
+
+    def test_500_is_retryable(self):
+        self.assertTrue(grampswebapidb._is_retryable_push_error(self._http(500)))
+
+    def test_network_errors_are_retryable(self):
+        self.assertTrue(grampswebapidb._is_retryable_push_error(OSError("down")))
+        self.assertTrue(
+            grampswebapidb._is_retryable_push_error(URLError("no route to host"))
+        )
+
+
+# -------------------------------------------------------------------------
+#
 # TestPolling
 #
 # load() schedules a GLib.timeout_add_seconds() tick that re-syncs for as
@@ -1209,18 +1543,32 @@ class TestPolling(unittest.TestCase):
         ) as super_load, mock.patch.object(
             self.db, "_check_identity"
         ) as check_identity, mock.patch.object(
+            self.db, "_check_permissions"
+        ), mock.patch.object(
+            self.db, "_check_server_version"
+        ), mock.patch.object(
             self.db, "_sync_from_server"
         ) as sync, mock.patch.object(
-            grampswebapidb.GLib, "timeout_add_seconds", return_value=42
+            self.db, "_sync_media_files"
+        ) as sync_media, mock.patch.object(
+            grampswebapidb.GLib, "timeout_add_seconds", side_effect=[42, 43]
         ) as timeout_add:
             self.db.load("some/path")
         super_load.assert_called_once_with("some/path")
         check_identity.assert_called_once_with()
         sync.assert_called_once_with(progress_callback=None)
-        timeout_add.assert_called_once_with(
-            grampswebapidb.POLL_INTERVAL_SECONDS, self.db._poll_tick
+        sync_media.assert_called_once_with()
+        timeout_add.assert_has_calls(
+            [
+                mock.call(grampswebapidb.POLL_INTERVAL_SECONDS, self.db._poll_tick),
+                mock.call(
+                    grampswebapidb.MEDIA_POLL_INTERVAL_SECONDS,
+                    self.db._media_poll_tick,
+                ),
+            ]
         )
         self.assertEqual(self.db._poll_source_id, 42)
+        self.assertEqual(self.db._media_poll_source_id, 43)
 
     def test_load_forwards_positional_callback_to_sync(self):
         # DbGeneric.load()'s own signature is (directory, callback=None,
@@ -1230,7 +1578,13 @@ class TestPolling(unittest.TestCase):
         my_callback = mock.MagicMock()
         with mock.patch.object(grampswebapidb.SQLite, "load"), mock.patch.object(
             self.db, "_check_identity"
-        ), mock.patch.object(self.db, "_sync_from_server") as sync, mock.patch.object(
+        ), mock.patch.object(self.db, "_check_permissions"), mock.patch.object(
+            self.db, "_check_server_version"
+        ), mock.patch.object(
+            self.db, "_sync_from_server"
+        ) as sync, mock.patch.object(
+            self.db, "_sync_media_files"
+        ), mock.patch.object(
             grampswebapidb.GLib, "timeout_add_seconds"
         ):
             self.db.load("some/path", my_callback, "w")
@@ -1240,27 +1594,54 @@ class TestPolling(unittest.TestCase):
         my_callback = mock.MagicMock()
         with mock.patch.object(grampswebapidb.SQLite, "load"), mock.patch.object(
             self.db, "_check_identity"
-        ), mock.patch.object(self.db, "_sync_from_server") as sync, mock.patch.object(
+        ), mock.patch.object(self.db, "_check_permissions"), mock.patch.object(
+            self.db, "_check_server_version"
+        ), mock.patch.object(
+            self.db, "_sync_from_server"
+        ) as sync, mock.patch.object(
+            self.db, "_sync_media_files"
+        ), mock.patch.object(
             grampswebapidb.GLib, "timeout_add_seconds"
         ):
             self.db.load("some/path", callback=my_callback)
         sync.assert_called_once_with(progress_callback=my_callback)
 
+    def test_load_media_sync_failure_does_not_block_load(self):
+        # Unlike a _sync_from_server() failure (which load() re-raises as
+        # DbConnectionError), a failed initial media sync is logged and
+        # swallowed -- the record mirror is already usable, so opening the
+        # tree should still succeed.
+        with mock.patch.object(grampswebapidb.SQLite, "load"), mock.patch.object(
+            self.db, "_check_identity"
+        ), mock.patch.object(self.db, "_check_permissions"), mock.patch.object(
+            self.db, "_check_server_version"
+        ), mock.patch.object(
+            self.db, "_sync_from_server"
+        ), mock.patch.object(
+            self.db, "_sync_media_files", side_effect=OSError("network down")
+        ), mock.patch.object(
+            grampswebapidb.GLib, "timeout_add_seconds"
+        ):
+            with self.assertLogs(grampswebapidb.LOG, level="ERROR"):
+                self.db.load("some/path")  # must not raise
+
     def test_close_cancels_pending_poll(self):
         self.db._poll_source_id = 42
+        self.db._media_poll_source_id = 43
         with mock.patch.object(
             grampswebapidb.SQLite, "close"
         ) as super_close, mock.patch.object(
             grampswebapidb.GLib, "source_remove"
         ) as source_remove:
             self.db.close()
-        source_remove.assert_called_once_with(42)
+        source_remove.assert_has_calls([mock.call(42), mock.call(43)])
         self.assertIsNone(self.db._poll_source_id)
+        self.assertIsNone(self.db._media_poll_source_id)
         super_close.assert_called_once_with()
 
     def test_close_without_a_poll_scheduled_is_a_no_op(self):
-        # e.g. close() called after a failed load(), before the timeout
-        # was ever scheduled.
+        # e.g. close() called after a failed load(), before the timeouts
+        # were ever scheduled.
         with mock.patch.object(
             grampswebapidb.SQLite, "close"
         ) as super_close, mock.patch.object(
@@ -1283,6 +1664,625 @@ class TestPolling(unittest.TestCase):
             with self.assertLogs(grampswebapidb.LOG, level="ERROR"):
                 result = self.db._poll_tick()
         self.assertEqual(result, grampswebapidb.GLib.SOURCE_CONTINUE)
+
+    def test_media_poll_tick_syncs_and_keeps_repeating(self):
+        with mock.patch.object(self.db, "_sync_media_files") as sync_media:
+            result = self.db._media_poll_tick()
+        sync_media.assert_called_once_with()
+        self.assertEqual(result, grampswebapidb.GLib.SOURCE_CONTINUE)
+
+    def test_media_poll_tick_swallows_connection_errors_and_keeps_repeating(self):
+        with mock.patch.object(
+            self.db, "_sync_media_files", side_effect=OSError("network down")
+        ):
+            with self.assertLogs(grampswebapidb.LOG, level="ERROR"):
+                result = self.db._media_poll_tick()
+        self.assertEqual(result, grampswebapidb.GLib.SOURCE_CONTINUE)
+
+
+# -------------------------------------------------------------------------
+#
+# TestSyncMediaFiles
+#
+# _sync_media_files() and its helpers: the file-transfer half of keeping
+# the mirror in sync, ported from GrampsWebSync's media-file-sync wizard
+# step (grampswebsync.py/webapihandler.py, credit David Straub).
+#
+# -------------------------------------------------------------------------
+class FakeMedia:
+    """Duck-types the bit of a Media object these helpers read."""
+
+    def __init__(self, handle, path, gramps_id="O0001"):
+        self.handle = handle
+        self._path = path
+        self.gramps_id = gramps_id
+
+    def get_path(self):
+        return self._path
+
+
+class TestMissingLocalMediaHandles(unittest.TestCase):
+    def setUp(self):
+        self.db = new_instance()
+
+    def test_returns_handles_whose_file_is_missing(self):
+        present = FakeMedia("H1", "present.jpg")
+        missing = FakeMedia("H2", "missing.jpg")
+        with mock.patch.object(
+            self.db, "iter_media", return_value=[present, missing]
+        ), mock.patch.object(
+            grampswebapidb,
+            "media_path_full",
+            side_effect=lambda db, path: "/tree/" + path,
+        ), mock.patch.object(
+            grampswebapidb.os.path, "exists", side_effect=lambda p: "present" in p
+        ):
+            handles = self.db._missing_local_media_handles()
+        self.assertEqual(handles, ["H2"])
+
+    def test_no_media_objects_returns_empty_list(self):
+        with mock.patch.object(self.db, "iter_media", return_value=[]):
+            self.assertEqual(self.db._missing_local_media_handles(), [])
+
+
+class TestMissingRemoteMediaHandles(unittest.TestCase):
+    def setUp(self):
+        self.db = new_instance()
+
+    def test_extracts_handles_from_server_response(self):
+        self.db.web_client = mock.MagicMock()
+        self.db.web_client.get_missing_files.return_value = [
+            {"handle": "H1", "gramps_id": "O0001"},
+            {"handle": "H2", "gramps_id": "O0002"},
+        ]
+        self.assertEqual(self.db._missing_remote_media_handles(), ["H1", "H2"])
+
+    def test_empty_server_response(self):
+        self.db.web_client = mock.MagicMock()
+        self.db.web_client.get_missing_files.return_value = []
+        self.assertEqual(self.db._missing_remote_media_handles(), [])
+
+
+class TestDownloadOneMediaFile(unittest.TestCase):
+    def setUp(self):
+        self.db = new_instance()
+        self.db.web_client = mock.MagicMock()
+
+    def test_downloads_and_returns_true(self):
+        media = FakeMedia("H1", "photo.jpg")
+        with mock.patch.object(
+            self.db, "get_media_from_handle", return_value=media
+        ), mock.patch.object(
+            grampswebapidb, "media_path_full", return_value="/tree/photo.jpg"
+        ):
+            result = self.db._download_one_media_file("H1")
+        self.assertTrue(result)
+        self.db.web_client.download_media_file.assert_called_once_with(
+            "H1", "/tree/photo.jpg"
+        )
+
+    def test_missing_local_object_returns_false(self):
+        with mock.patch.object(
+            self.db,
+            "get_media_from_handle",
+            side_effect=grampswebapidb.HandleError("H1"),
+        ):
+            result = self.db._download_one_media_file("H1")
+        self.assertFalse(result)
+        self.db.web_client.download_media_file.assert_not_called()
+
+    def test_connection_error_is_logged_and_returns_false(self):
+        media = FakeMedia("H1", "photo.jpg")
+        self.db.web_client.download_media_file.side_effect = OSError("network down")
+        with mock.patch.object(
+            self.db, "get_media_from_handle", return_value=media
+        ), mock.patch.object(
+            grampswebapidb, "media_path_full", return_value="/tree/photo.jpg"
+        ):
+            with self.assertLogs(grampswebapidb.LOG, level="WARNING"):
+                result = self.db._download_one_media_file("H1")
+        self.assertFalse(result)
+
+
+class TestUploadOneMediaFile(unittest.TestCase):
+    def setUp(self):
+        self.db = new_instance()
+        self.db.web_client = mock.MagicMock()
+
+    def test_uploads_and_returns_true(self):
+        media = FakeMedia("H1", "photo.jpg")
+        self.db.web_client.upload_media_file.return_value = True
+        with mock.patch.object(
+            self.db, "get_media_from_handle", return_value=media
+        ), mock.patch.object(
+            grampswebapidb, "media_path_full", return_value="/tree/photo.jpg"
+        ), mock.patch.object(
+            grampswebapidb.os.path, "exists", return_value=True
+        ):
+            result = self.db._upload_one_media_file("H1")
+        self.assertTrue(result)
+        self.db.web_client.upload_media_file.assert_called_once_with(
+            "H1", "/tree/photo.jpg"
+        )
+
+    def test_conflict_response_returns_false(self):
+        # WebApiHandler.upload_media_file() itself returns False on a 409
+        # (someone else already uploaded a file for this object) rather
+        # than raising -- propagated here as-is.
+        media = FakeMedia("H1", "photo.jpg")
+        self.db.web_client.upload_media_file.return_value = False
+        with mock.patch.object(
+            self.db, "get_media_from_handle", return_value=media
+        ), mock.patch.object(
+            grampswebapidb, "media_path_full", return_value="/tree/photo.jpg"
+        ), mock.patch.object(
+            grampswebapidb.os.path, "exists", return_value=True
+        ):
+            result = self.db._upload_one_media_file("H1")
+        self.assertFalse(result)
+
+    def test_missing_local_object_returns_false(self):
+        with mock.patch.object(
+            self.db,
+            "get_media_from_handle",
+            side_effect=grampswebapidb.HandleError("H1"),
+        ):
+            result = self.db._upload_one_media_file("H1")
+        self.assertFalse(result)
+        self.db.web_client.upload_media_file.assert_not_called()
+
+    def test_file_not_on_disk_returns_false_without_uploading(self):
+        media = FakeMedia("H1", "photo.jpg")
+        with mock.patch.object(
+            self.db, "get_media_from_handle", return_value=media
+        ), mock.patch.object(
+            grampswebapidb, "media_path_full", return_value="/tree/photo.jpg"
+        ), mock.patch.object(
+            grampswebapidb.os.path, "exists", return_value=False
+        ):
+            result = self.db._upload_one_media_file("H1")
+        self.assertFalse(result)
+        self.db.web_client.upload_media_file.assert_not_called()
+
+    def test_connection_error_is_logged_and_returns_false(self):
+        media = FakeMedia("H1", "photo.jpg")
+        self.db.web_client.upload_media_file.side_effect = OSError("network down")
+        with mock.patch.object(
+            self.db, "get_media_from_handle", return_value=media
+        ), mock.patch.object(
+            grampswebapidb, "media_path_full", return_value="/tree/photo.jpg"
+        ), mock.patch.object(
+            grampswebapidb.os.path, "exists", return_value=True
+        ):
+            with self.assertLogs(grampswebapidb.LOG, level="WARNING"):
+                result = self.db._upload_one_media_file("H1")
+        self.assertFalse(result)
+
+
+class TestSyncMediaFiles(unittest.TestCase):
+    def setUp(self):
+        self.db = new_instance()
+
+    def test_downloads_missing_local_then_uploads_missing_remote(self):
+        with mock.patch.object(
+            self.db, "_missing_local_media_handles", return_value=["H1", "H2"]
+        ), mock.patch.object(
+            self.db, "_missing_remote_media_handles", return_value=["H3"]
+        ), mock.patch.object(
+            self.db, "_download_one_media_file", return_value=True
+        ) as download, mock.patch.object(
+            self.db, "_upload_one_media_file", return_value=True
+        ) as upload:
+            result = self.db._sync_media_files()
+        download.assert_has_calls([mock.call("H1"), mock.call("H2")])
+        upload.assert_called_once_with("H3")
+        self.assertEqual(result, (2, 1))
+
+    def test_counts_only_successful_transfers(self):
+        with mock.patch.object(
+            self.db, "_missing_local_media_handles", return_value=["H1", "H2"]
+        ), mock.patch.object(
+            self.db, "_missing_remote_media_handles", return_value=[]
+        ), mock.patch.object(
+            self.db, "_download_one_media_file", side_effect=[True, False]
+        ):
+            result = self.db._sync_media_files()
+        self.assertEqual(result, (1, 0))
+
+    def test_nothing_missing_is_a_no_op(self):
+        with mock.patch.object(
+            self.db, "_missing_local_media_handles", return_value=[]
+        ), mock.patch.object(self.db, "_missing_remote_media_handles", return_value=[]):
+            result = self.db._sync_media_files()
+        self.assertEqual(result, (0, 0))
+
+
+# -------------------------------------------------------------------------
+#
+# TestBatchCommitReconciliation
+#
+# A local batch=True transaction (a bulk import, or a stock Tool like
+# Check and Repair Database) records nothing per-object -- DBAPI skips
+# trans.add() for a batch commit -- so transaction_to_json() sees an
+# empty payload and nothing would ever be pushed. transaction_begin()
+# snapshots handles up front and transaction_commit() diffs them after,
+# reconstructing the change list. See the module docstring.
+#
+# -------------------------------------------------------------------------
+class FakeBatchTxn:
+    """Duck-types the DbTxn attributes the batch-reconciliation path
+    reads: .batch, .start_time, and whatever attribute transaction_begin()
+    stashes its handle snapshot in. get_recnos() returns nothing, matching
+    a real batch transaction's empty undo log."""
+
+    def __init__(self, batch=True, start_time=100.0):
+        self.batch = batch
+        self.start_time = start_time
+
+    def get_recnos(self, reverse=False):
+        return []
+
+    def get_record(self, recno):  # pragma: no cover - never reached
+        raise AssertionError("a batch transaction records nothing")
+
+
+def stored_person(handle, change):
+    """A real Person with a given .change timestamp -- the field
+    _reconcile_batch_commit() compares against the transaction's
+    start_time. Real rather than a stub because _fill_entry_payloads()
+    then runs it through object_to_data()."""
+    person = Person()
+    person.set_handle(handle)
+    person.set_gramps_id("I" + handle)
+    person.change = change
+    return person
+
+
+def stub_all_handle_accessors(db, handles_by_class=None, objects=None):
+    """Give ``db`` a get_<name>_handles/get_<name>_from_handle for every
+    primary type, so _handles_by_class()/_reconcile_batch_commit() can walk
+    all of CLASS_TO_KEY_MAP without a real database."""
+    handles_by_class = handles_by_class or {}
+    objects = objects or {}
+    for obj_class, key in grampswebapidb.CLASS_TO_KEY_MAP.items():
+        name = grampswebapidb.KEY_TO_NAME_MAP[key]
+        setattr(
+            db,
+            f"get_{name}_handles",
+            mock.MagicMock(return_value=list(handles_by_class.get(obj_class, []))),
+        )
+        setattr(
+            db,
+            f"get_{name}_from_handle",
+            mock.MagicMock(side_effect=lambda h, _o=objects: _o[h]),
+        )
+
+
+class TestTransactionBeginSnapshot(unittest.TestCase):
+    def setUp(self):
+        self.db = new_instance()
+
+    def test_local_batch_transaction_gets_a_handle_snapshot(self):
+        stub_all_handle_accessors(self.db, {"Person": ["H1"]})
+        trans = FakeBatchTxn(batch=True)
+        with mock.patch.object(grampswebapidb.SQLite, "transaction_begin"):
+            self.db.transaction_begin(trans)
+        self.assertEqual(trans._webapidb_before_handles["Person"], {"H1"})
+
+    def test_non_batch_transaction_gets_no_snapshot(self):
+        # An ordinary edit is recorded per-object by DBAPI, so
+        # transaction_to_json() sees it and none of this is needed.
+        trans = FakeBatchTxn(batch=False)
+        with mock.patch.object(grampswebapidb.SQLite, "transaction_begin"):
+            self.db.transaction_begin(trans)
+        self.assertFalse(hasattr(trans, "_webapidb_before_handles"))
+
+    def test_pull_side_batch_transaction_gets_no_snapshot(self):
+        # _sync_from_server()'s own replay is a batch transaction too, but
+        # pushing it back to the server would echo the server's own changes
+        # straight back at it.
+        self.db._pulling = True
+        trans = FakeBatchTxn(batch=True)
+        with mock.patch.object(grampswebapidb.SQLite, "transaction_begin"):
+            self.db.transaction_begin(trans)
+        self.assertFalse(hasattr(trans, "_webapidb_before_handles"))
+
+
+class TestReconcileBatchCommit(unittest.TestCase):
+    def setUp(self):
+        self.db = new_instance()
+        self.db.web_client = mock.MagicMock()
+
+    def test_added_handle_becomes_an_add(self):
+        obj = stored_person("H2", 150.0)
+        stub_all_handle_accessors(
+            self.db,
+            {"Person": ["H1", "H2"]},
+            {"H1": stored_person("H1", 50.0), "H2": obj},
+        )
+        before = {c: set() for c in grampswebapidb.CLASS_TO_KEY_MAP}
+        before["Person"] = {"H1"}
+        with mock.patch.object(self.db, "_retry_after_conflict") as replay:
+            self.db._reconcile_batch_commit(before, start_time=100.0)
+        entries = replay.call_args[0][0]
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["type"], "add")
+        self.assertEqual(entries[0]["handle"], "H2")
+        self.assertEqual(entries[0]["_class"], "Person")
+
+    def test_removed_handle_becomes_a_delete(self):
+        stub_all_handle_accessors(self.db, {"Person": []})
+        before = {c: set() for c in grampswebapidb.CLASS_TO_KEY_MAP}
+        before["Person"] = {"H1"}
+        with mock.patch.object(self.db, "_retry_after_conflict") as replay:
+            self.db._reconcile_batch_commit(before, start_time=100.0)
+        entries = replay.call_args[0][0]
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["type"], "delete")
+        self.assertEqual(entries[0]["handle"], "H1")
+        self.assertIsNone(entries[0]["new"])
+
+    def test_surviving_handle_touched_during_the_batch_becomes_an_update(self):
+        stub_all_handle_accessors(
+            self.db, {"Person": ["H1"]}, {"H1": stored_person("H1", 150.0)}
+        )
+        before = {c: set() for c in grampswebapidb.CLASS_TO_KEY_MAP}
+        before["Person"] = {"H1"}
+        with mock.patch.object(self.db, "_retry_after_conflict") as replay:
+            self.db._reconcile_batch_commit(before, start_time=100.0)
+        entries = replay.call_args[0][0]
+        self.assertEqual(len(entries), 1)
+        self.assertEqual(entries[0]["type"], "update")
+
+    def test_untouched_handle_is_skipped(self):
+        # The whole point of comparing .change against start_time: a bulk
+        # tool that rewrote 3 of 10000 objects must push 3, not 10000.
+        stub_all_handle_accessors(
+            self.db, {"Person": ["H1"]}, {"H1": stored_person("H1", 50.0)}
+        )
+        before = {c: set() for c in grampswebapidb.CLASS_TO_KEY_MAP}
+        before["Person"] = {"H1"}
+        with mock.patch.object(self.db, "_retry_after_conflict") as replay:
+            self.db._reconcile_batch_commit(before, start_time=100.0)
+        replay.assert_not_called()
+
+    def test_change_exactly_at_start_time_counts_as_touched(self):
+        # int(time.time()) truncation in _commit_base() means a fast
+        # transaction can stamp .change to exactly its own start second --
+        # treating that as untouched would silently drop the change.
+        stub_all_handle_accessors(
+            self.db, {"Person": ["H1"]}, {"H1": stored_person("H1", 100.0)}
+        )
+        before = {c: set() for c in grampswebapidb.CLASS_TO_KEY_MAP}
+        before["Person"] = {"H1"}
+        with mock.patch.object(self.db, "_retry_after_conflict") as replay:
+            self.db._reconcile_batch_commit(before, start_time=100.0)
+        entries = replay.call_args[0][0]
+        self.assertEqual(entries[0]["type"], "update")
+
+    def test_nothing_changed_pushes_nothing(self):
+        stub_all_handle_accessors(self.db)
+        before = {c: set() for c in grampswebapidb.CLASS_TO_KEY_MAP}
+        with mock.patch.object(self.db, "_retry_after_conflict") as replay:
+            self.db._reconcile_batch_commit(before, start_time=100.0)
+        replay.assert_not_called()
+
+    def test_transaction_commit_routes_a_snapshotted_batch_to_reconcile(self):
+        trans = FakeBatchTxn(batch=True, start_time=100.0)
+        trans._webapidb_before_handles = {"Person": {"H1"}}
+        with mock.patch.object(
+            grampswebapidb.SQLite, "transaction_commit"
+        ), mock.patch.object(self.db, "_reconcile_batch_commit") as reconcile:
+            self.db.transaction_commit(trans)
+        reconcile.assert_called_once_with({"Person": {"H1"}}, 100.0)
+        # ...and does NOT also take the ordinary push path, which would
+        # push an empty payload.
+        self.db.web_client.push_transaction.assert_not_called()
+
+
+class TestFillEntryPayloads(unittest.TestCase):
+    def setUp(self):
+        self.db = new_instance()
+
+    def test_add_entry_gets_current_object_data(self):
+        person = Person()
+        person.set_handle("H1")
+        person.set_gramps_id("I0001")
+        self.db.get_person_from_handle = mock.MagicMock(return_value=person)
+        filled = self.db._fill_entry_payloads(
+            [{"type": "add", "handle": "H1", "_class": "Person"}]
+        )
+        self.assertEqual(len(filled), 1)
+        self.assertIsNone(filled[0]["old"])
+        self.assertEqual(filled[0]["new"]["gramps_id"], "I0001")
+        # remove_object() strips the cached _object back-reference, which
+        # is not JSON-serializable and must never reach the wire.
+        self.assertNotIn("_object", filled[0]["new"])
+
+    def test_delete_entry_carries_no_object_data(self):
+        filled = self.db._fill_entry_payloads(
+            [{"type": "delete", "handle": "H1", "_class": "Person"}]
+        )
+        self.assertEqual(filled[0]["new"], None)
+        self.assertEqual(filled[0]["old"], None)
+
+    def test_vanished_handle_is_dropped(self):
+        # The object was removed between the diff and here -- nothing left
+        # to describe, and asking the server to add it would fail.
+        self.db.get_person_from_handle = mock.MagicMock(
+            side_effect=grampswebapidb.HandleError("H1")
+        )
+        filled = self.db._fill_entry_payloads(
+            [{"type": "add", "handle": "H1", "_class": "Person"}]
+        )
+        self.assertEqual(filled, [])
+
+
+# -------------------------------------------------------------------------
+#
+# TestPendingPushQueue
+#
+# A push that fails for a connectivity reason (rather than a conflict) is
+# persisted and retried later, so an edit made while offline still
+# reaches the server. See the module docstring.
+#
+# -------------------------------------------------------------------------
+class TestPendingPushQueue(unittest.TestCase):
+    def setUp(self):
+        self.db = new_instance()
+        self.db.web_client = mock.MagicMock()
+        self.metadata = {}
+        self.db._get_metadata = lambda key, default=0: self.metadata.get(key, default)
+        self.db._set_metadata = (
+            lambda key, value, use_txn=True: self.metadata.__setitem__(key, value)
+        )
+
+    def _payload(self, handle="H1"):
+        return [{"type": "add", "handle": handle, "_class": "Person"}]
+
+    def test_connection_failure_queues_the_payload(self):
+        self.db.web_client.push_transaction.side_effect = HTTPError(
+            "https://example.com/api/transactions/", 500, "boom", None, None
+        )
+        with self.assertLogs(grampswebapidb.LOG, level="ERROR"):
+            self.db._push_payload(self._payload())
+        queued = self.metadata["pending_pushes"]
+        self.assertEqual(len(queued), 1)
+        self.assertEqual(queued[0]["payload"], self._payload())
+        self.assertFalse(queued[0]["undo"])
+
+    def test_undo_flag_is_preserved_in_the_queue(self):
+        self.db.web_client.push_transaction.side_effect = OSError("network down")
+        with self.assertLogs(grampswebapidb.LOG, level="ERROR"):
+            self.db._push_payload(self._payload(), undo=True)
+        self.assertTrue(self.metadata["pending_pushes"][0]["undo"])
+
+    def test_successful_push_queues_nothing(self):
+        self.db._push_payload(self._payload())
+        self.assertNotIn("pending_pushes", self.metadata)
+
+    def test_conflict_does_not_queue(self):
+        # A conflict is handled by resync-and-retry, not by queueing --
+        # queueing it too would push the same edit twice.
+        self.db.web_client.push_transaction.side_effect = WebApiPushConflict(
+            "Object has changed"
+        )
+        with mock.patch.object(self.db, "_sync_from_server"), mock.patch.object(
+            self.db, "_retry_after_conflict"
+        ):
+            with self.assertLogs(grampswebapidb.LOG, level="WARNING"):
+                self.db._push_payload(self._payload())
+        self.assertNotIn("pending_pushes", self.metadata)
+
+    def test_flush_sends_queued_pushes_in_order_and_clears_them(self):
+        self.metadata["pending_pushes"] = [
+            {"payload": self._payload("H1"), "undo": False},
+            {"payload": self._payload("H2"), "undo": False},
+        ]
+        with self.assertLogs(grampswebapidb.LOG, level="INFO"):
+            self.db._flush_pending_pushes()
+        sent = [
+            c[0][0][0]["handle"]
+            for c in self.db.web_client.push_transaction.call_args_list
+        ]
+        self.assertEqual(sent, ["H1", "H2"])
+        self.assertEqual(self.metadata["pending_pushes"], [])
+
+    def test_flush_stops_at_the_first_still_undeliverable_entry(self):
+        # Order matters: a later edit may depend on an earlier one (a
+        # Family referencing a Person), so a stuck entry must block the
+        # rest rather than letting them jump the queue.
+        self.metadata["pending_pushes"] = [
+            {"payload": self._payload("H1"), "undo": False},
+            {"payload": self._payload("H2"), "undo": False},
+        ]
+        self.db.web_client.push_transaction.side_effect = OSError("still down")
+        with self.assertLogs(grampswebapidb.LOG, level="WARNING"):
+            self.db._flush_pending_pushes()
+        self.assertEqual(self.db.web_client.push_transaction.call_count, 1)
+        self.assertEqual(len(self.metadata["pending_pushes"]), 2)
+
+    def test_flush_drops_a_queued_push_that_now_conflicts(self):
+        # A queued payload's "old" snapshot is stale by definition, so the
+        # resync-and-merge path can't be applied to it -- dropping it is
+        # the honest outcome, loudly logged.
+        self.metadata["pending_pushes"] = [
+            {"payload": self._payload("H1"), "undo": False},
+            {"payload": self._payload("H2"), "undo": False},
+        ]
+        self.db.web_client.push_transaction.side_effect = [
+            WebApiPushConflict("Object has changed"),
+            None,
+        ]
+        with self.assertLogs(grampswebapidb.LOG, level="WARNING"):
+            self.db._flush_pending_pushes()
+        # The conflicting entry is dropped, but the one behind it still goes.
+        self.assertEqual(self.db.web_client.push_transaction.call_count, 2)
+        self.assertEqual(self.metadata["pending_pushes"], [])
+
+    def test_empty_queue_makes_no_requests(self):
+        self.db._flush_pending_pushes()
+        self.db.web_client.push_transaction.assert_not_called()
+
+    def test_queue_is_capped_dropping_the_oldest(self):
+        self.metadata["pending_pushes"] = [
+            {"payload": self._payload("H%d" % i), "undo": False}
+            for i in range(grampswebapidb.MAX_PENDING_PUSHES)
+        ]
+        self.db.web_client.push_transaction.side_effect = OSError("network down")
+        with self.assertLogs(grampswebapidb.LOG, level="ERROR"):
+            self.db._push_payload(self._payload("NEW"))
+        queued = self.metadata["pending_pushes"]
+        self.assertEqual(len(queued), grampswebapidb.MAX_PENDING_PUSHES)
+        # Oldest dropped, newest kept.
+        self.assertEqual(queued[0]["payload"][0]["handle"], "H1")
+        self.assertEqual(queued[-1]["payload"][0]["handle"], "NEW")
+
+    def test_permanent_rejection_is_not_queued(self):
+        # A 403 (the account lacks write permissions) will answer the same
+        # way forever -- queueing it would retry on every poll and
+        # eventually evict genuinely retryable work from the capped queue.
+        self.db.web_client.push_transaction.side_effect = HTTPError(
+            "https://example.com/api/transactions/", 403, "Forbidden", None, None
+        )
+        with self.assertLogs(grampswebapidb.LOG, level="ERROR"):
+            self.db._push_payload(self._payload())
+        self.assertNotIn("pending_pushes", self.metadata)
+
+    def test_rate_limit_is_still_queued(self):
+        # 429 is "try again shortly", not a refusal.
+        self.db.web_client.push_transaction.side_effect = HTTPError(
+            "https://example.com/api/transactions/", 429, "Too Many", None, None
+        )
+        with self.assertLogs(grampswebapidb.LOG, level="ERROR"):
+            self.db._push_payload(self._payload())
+        self.assertEqual(len(self.metadata["pending_pushes"]), 1)
+
+    def test_flush_drops_a_permanently_rejected_entry_and_continues(self):
+        self.metadata["pending_pushes"] = [
+            {"payload": self._payload("H1"), "undo": False},
+            {"payload": self._payload("H2"), "undo": False},
+        ]
+        self.db.web_client.push_transaction.side_effect = [
+            HTTPError(
+                "https://example.com/api/transactions/", 403, "Forbidden", None, None
+            ),
+            None,
+        ]
+        with self.assertLogs(grampswebapidb.LOG, level="ERROR"):
+            self.db._flush_pending_pushes()
+        # The rejected entry is dropped rather than blocking the queue
+        # forever -- permissions may have changed since it was queued.
+        self.assertEqual(self.db.web_client.push_transaction.call_count, 2)
+        self.assertEqual(self.metadata["pending_pushes"], [])
+
+    def test_sync_from_server_flushes_the_queue_first(self):
+        # The queue is retried on every poll tick, not just at load().
+        self.db.emit = mock.MagicMock()
+        self.db.web_client.get_transaction_history.return_value = ([], 0)
+        with mock.patch.object(self.db, "_flush_pending_pushes") as flush:
+            self.db._sync_from_server()
+        flush.assert_called_once_with()
 
 
 if __name__ == "__main__":

--- a/GrampsWebApiDb/tests/test_webapi_client.py
+++ b/GrampsWebApiDb/tests/test_webapi_client.py
@@ -48,6 +48,7 @@ import io
 import json
 import os
 import sys
+import tempfile
 import unittest
 from urllib.error import HTTPError, URLError
 from unittest import mock
@@ -110,14 +111,23 @@ def token(tag: str) -> str:
 
 
 class FakeResponse:
-    """Stand-in for the object returned by ``urlopen(...).__enter__()``."""
+    """Stand-in for the object returned by ``urlopen(...).__enter__()``.
 
-    def __init__(self, body=None, headers=None):
+    ``status`` matters to push_transaction(), which distinguishes a 202
+    ("the server queued a background task, go poll it") from a plain 200
+    -- see that method's ``background`` param.
+    """
+
+    def __init__(self, body=None, headers=None, status=200):
         self._body = json.dumps(body if body is not None else {}).encode()
         self.headers = headers or {}
+        self._status = status
 
     def read(self):
         return self._body
+
+    def getcode(self):
+        return self._status
 
     def __enter__(self):
         return self
@@ -136,6 +146,27 @@ class FakeBinaryResponse:
 
     def read(self):
         return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+
+class FakeChunkedResponse:
+    """Stand-in for a streamed download response: read(n) returns up to
+    n bytes at a time, like a real socket-backed file object -- unlike
+    FakeResponse.read(), which ignores any argument and returns
+    everything at once. Needed for download_media_file(), which reads in
+    a chunked loop."""
+
+    def __init__(self, body: bytes, headers=None):
+        self._buf = io.BytesIO(body)
+        self.headers = headers or {}
+
+    def read(self, size=-1):
+        return self._buf.read(size)
 
     def __enter__(self):
         return self
@@ -432,7 +463,9 @@ class TestRateLimitAndFallbackRetries(unittest.TestCase):
         mock_sleep.assert_called_once_with(webapi_client.RATE_LIMIT_BACKOFF)
 
     def test_refresh_retries_once_after_429(self):
-        fake = QueuedUrlopen([http_error(429), FakeResponse({"access_token": token("AT")})])
+        fake = QueuedUrlopen(
+            [http_error(429), FakeResponse({"access_token": token("AT")})]
+        )
         with mock.patch.object(webapi_client, "urlopen", fake), mock.patch.object(
             webapi_client, "sleep"
         ):
@@ -629,6 +662,400 @@ class TestDownloadExport(unittest.TestCase):
 
 # -------------------------------------------------------------------------
 #
+# TestGetMissingFiles
+#
+# -------------------------------------------------------------------------
+class TestGetMissingFiles(unittest.TestCase):
+    """get_missing_files() (grampswebapidb.py's _missing_remote_media_
+    handles()) hits GET /media/?filemissing=1 and returns the decoded
+    body as-is, sharing _get_json()'s retry behavior."""
+
+    def _authed_handler(self):
+        fake = QueuedUrlopen([FakeResponse({"access_token": token("AT0")})])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            handler = WebApiHandler("https://example.com/api", refresh_token="RT")
+        return handler
+
+    def test_request_url_and_returns_body(self):
+        handler = self._authed_handler()
+        body = [{"handle": "H1", "gramps_id": "O0001"}]
+        fake = QueuedUrlopen([FakeResponse(body)])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            result = handler.get_missing_files()
+        self.assertEqual(result, body)
+        self.assertEqual(
+            fake.requests[0].full_url,
+            "https://example.com/api/media/?filemissing=1",
+        )
+
+    def test_empty_response(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen([FakeResponse([])])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            self.assertEqual(handler.get_missing_files(), [])
+
+
+# -------------------------------------------------------------------------
+#
+# TestDownloadMediaFile
+#
+# -------------------------------------------------------------------------
+class TestDownloadMediaFile(unittest.TestCase):
+    """download_media_file() streams GET /media/<handle>/file to disk in
+    chunks, creating any missing parent directory, and shares the same
+    401/429/network retry-once behavior as the rest of this class."""
+
+    def _authed_handler(self):
+        fake = QueuedUrlopen([FakeResponse({"access_token": token("AT0")})])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            handler = WebApiHandler("https://example.com/api", refresh_token="RT")
+        return handler
+
+    def test_writes_body_to_path_and_creates_parent_dirs(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen([FakeChunkedResponse(b"binary-image-data")])
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "sub", "dir", "photo.jpg")
+            with mock.patch.object(webapi_client, "urlopen", fake):
+                handler.download_media_file("H1", path)
+            with open(path, "rb") as f:
+                self.assertEqual(f.read(), b"binary-image-data")
+        self.assertEqual(
+            fake.requests[0].full_url, "https://example.com/api/media/H1/file"
+        )
+        self.assertEqual(
+            fake.requests[0].get_header("Authorization"), f"Bearer {token('AT0')}"
+        )
+
+    def test_streams_content_larger_than_one_chunk(self):
+        handler = self._authed_handler()
+        body = b"x" * (webapi_client._DOWNLOAD_CHUNK_SIZE * 2 + 100)
+        fake = QueuedUrlopen([FakeChunkedResponse(body)])
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "photo.jpg")
+            with mock.patch.object(webapi_client, "urlopen", fake):
+                handler.download_media_file("H1", path)
+            with open(path, "rb") as f:
+                self.assertEqual(f.read(), body)
+
+    def test_401_triggers_reauth_and_retry(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen(
+            [
+                http_error(401),
+                FakeResponse({"access_token": token("AT1")}),
+                FakeChunkedResponse(b"data-after-reauth"),
+            ]
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "photo.jpg")
+            with mock.patch.object(webapi_client, "urlopen", fake), mock.patch.object(
+                webapi_client, "sleep"
+            ):
+                handler.download_media_file("H1", path)
+            with open(path, "rb") as f:
+                self.assertEqual(f.read(), b"data-after-reauth")
+
+    def test_429_retries_once(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen([http_error(429), FakeChunkedResponse(b"data")])
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "photo.jpg")
+            with mock.patch.object(webapi_client, "urlopen", fake), mock.patch.object(
+                webapi_client, "sleep"
+            ):
+                handler.download_media_file("H1", path)
+            with open(path, "rb") as f:
+                self.assertEqual(f.read(), b"data")
+
+    def test_second_failure_propagates(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen([http_error(500), http_error(500)])
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "photo.jpg")
+            with mock.patch.object(webapi_client, "urlopen", fake):
+                with self.assertRaises(HTTPError):
+                    handler.download_media_file("H1", path)
+
+
+# -------------------------------------------------------------------------
+#
+# TestUploadMediaFile
+#
+# -------------------------------------------------------------------------
+class TestUploadMediaFile(unittest.TestCase):
+    """upload_media_file() streams a local file to PUT
+    /media/<handle>/file?uploadmissing=1, returns False (rather than
+    raising) on a 409, and shares the class's 401/429/network
+    retry-once behavior otherwise."""
+
+    def _authed_handler(self):
+        fake = QueuedUrlopen([FakeResponse({"access_token": token("AT0")})])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            handler = WebApiHandler("https://example.com/api", refresh_token="RT")
+        return handler
+
+    def _tmp_file(self, tmp, content=b"local-bytes"):
+        path = os.path.join(tmp, "photo.jpg")
+        with open(path, "wb") as f:
+            f.write(content)
+        return path
+
+    def test_request_url_and_method(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen([FakeResponse({})])
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._tmp_file(tmp)
+            with mock.patch.object(webapi_client, "urlopen", fake):
+                result = handler.upload_media_file("H1", path)
+        self.assertTrue(result)
+        req = fake.requests[0]
+        self.assertEqual(
+            req.full_url, "https://example.com/api/media/H1/file?uploadmissing=1"
+        )
+        self.assertEqual(req.get_method(), "PUT")
+        self.assertEqual(req.get_header("Authorization"), f"Bearer {token('AT0')}")
+
+    def test_409_returns_false_without_retry(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen([http_error(409)])
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._tmp_file(tmp)
+            with mock.patch.object(webapi_client, "urlopen", fake):
+                result = handler.upload_media_file("H1", path)
+        self.assertFalse(result)
+        self.assertEqual(len(fake.requests), 1)
+
+    def test_401_triggers_reauth_and_retry(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen(
+            [
+                http_error(401),
+                FakeResponse({"access_token": token("AT1")}),
+                FakeResponse({}),
+            ]
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._tmp_file(tmp)
+            with mock.patch.object(webapi_client, "urlopen", fake), mock.patch.object(
+                webapi_client, "sleep"
+            ):
+                result = handler.upload_media_file("H1", path)
+        self.assertTrue(result)
+        self.assertEqual(handler._access_token, token("AT1"))
+
+    def test_429_retries_once(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen([http_error(429), FakeResponse({})])
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._tmp_file(tmp)
+            with mock.patch.object(webapi_client, "urlopen", fake), mock.patch.object(
+                webapi_client, "sleep"
+            ):
+                result = handler.upload_media_file("H1", path)
+        self.assertTrue(result)
+        self.assertEqual(len(fake.requests), 2)
+
+    def test_second_failure_propagates(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen([http_error(500), http_error(500)])
+        with tempfile.TemporaryDirectory() as tmp:
+            path = self._tmp_file(tmp)
+            with mock.patch.object(webapi_client, "urlopen", fake):
+                with self.assertRaises(HTTPError):
+                    handler.upload_media_file("H1", path)
+
+
+# -------------------------------------------------------------------------
+#
+# TestParseVersion
+#
+# -------------------------------------------------------------------------
+class TestParseVersion(unittest.TestCase):
+    def test_plain_version(self):
+        self.assertEqual(webapi_client.parse_version("2.7.1"), (2, 7))
+
+    def test_major_only_gets_a_zero_minor(self):
+        self.assertEqual(webapi_client.parse_version("3"), (3, 0))
+
+    def test_prerelease_and_build_suffixes_are_ignored(self):
+        self.assertEqual(webapi_client.parse_version("2.7.0-rc1"), (2, 7))
+        self.assertEqual(webapi_client.parse_version("2.7.0+dirty"), (2, 7))
+
+    def test_unparseable_returns_none(self):
+        # None rather than a guess, so callers can distinguish "old" from
+        # "can't tell" -- see supports_background_transactions().
+        self.assertIsNone(webapi_client.parse_version("unknown"))
+        self.assertIsNone(webapi_client.parse_version(""))
+        self.assertIsNone(webapi_client.parse_version(None))
+
+    def test_trailing_garbage_after_a_numeric_prefix_is_truncated(self):
+        self.assertEqual(webapi_client.parse_version("2.7.x"), (2, 7))
+
+
+# -------------------------------------------------------------------------
+#
+# TestMetadata
+#
+# -------------------------------------------------------------------------
+class TestMetadata(unittest.TestCase):
+    METADATA = {
+        "gramps": {"version": "6.0.1"},
+        "gramps_webapi": {"version": "2.8.0", "schema": "2.8.0"},
+    }
+
+    def _authed_handler(self):
+        fake = QueuedUrlopen([FakeResponse({"access_token": token("AT0")})])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            handler = WebApiHandler("https://example.com/api", refresh_token="RT")
+        return handler
+
+    def test_fetches_and_caches_metadata(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen([FakeResponse(self.METADATA)])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            self.assertEqual(handler.get_metadata(), self.METADATA)
+            # Second call must not hit the network again.
+            handler.get_metadata()
+        self.assertEqual(len(fake.requests), 1)
+        self.assertEqual(fake.requests[0].full_url, "https://example.com/api/metadata/")
+
+    def test_version_accessors(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen([FakeResponse(self.METADATA)])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            self.assertEqual(handler.get_gramps_version(), "6.0.1")
+            self.assertEqual(handler.get_api_version(), "2.8.0")
+
+    def test_missing_sections_return_none(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen([FakeResponse({})])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            self.assertIsNone(handler.get_gramps_version())
+            self.assertIsNone(handler.get_api_version())
+
+    def test_background_supported_from_2_7(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen([FakeResponse({"gramps_webapi": {"version": "2.7.0"}})])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            self.assertTrue(handler.supports_background_transactions())
+
+    def test_background_not_supported_before_2_7(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen([FakeResponse({"gramps_webapi": {"version": "2.6.9"}})])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            self.assertFalse(handler.supports_background_transactions())
+
+    def test_unknown_version_does_not_claim_background_support(self):
+        # The synchronous path works on every version, so it's the safe
+        # answer when the version can't be determined.
+        handler = self._authed_handler()
+        fake = QueuedUrlopen([FakeResponse({})])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            self.assertFalse(handler.supports_background_transactions())
+
+
+# -------------------------------------------------------------------------
+#
+# TestWaitForTask
+#
+# -------------------------------------------------------------------------
+class TestWaitForTask(unittest.TestCase):
+    """wait_for_task() polls GET /tasks/<id> until the backgrounded push
+    finishes, translating a failed task into the same exceptions a
+    synchronous push would raise."""
+
+    def _authed_handler(self):
+        fake = QueuedUrlopen([FakeResponse({"access_token": token("AT0")})])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            handler = WebApiHandler("https://example.com/api", refresh_token="RT")
+        return handler
+
+    def test_success_returns(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen([FakeResponse({"state": "SUCCESS"})])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            handler.wait_for_task("T1")  # must not raise
+        self.assertEqual(fake.requests[0].full_url, "https://example.com/api/tasks/T1")
+
+    def test_polls_until_the_task_leaves_pending(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen(
+            [
+                FakeResponse({"state": "PENDING"}),
+                FakeResponse({"state": "STARTED"}),
+                FakeResponse({"state": "SUCCESS"}),
+            ]
+        )
+        with mock.patch.object(webapi_client, "urlopen", fake), mock.patch.object(
+            webapi_client, "sleep"
+        ):
+            handler.wait_for_task("T1")
+        self.assertEqual(len(fake.requests), 3)
+
+    def test_conflict_in_a_failed_task_raises_push_conflict(self):
+        # The whole point: a conflict must look the same whether it came
+        # back as a synchronous 400 or as a failed background task.
+        handler = self._authed_handler()
+        fake = QueuedUrlopen(
+            [FakeResponse({"state": "FAILURE", "info": "Object has changed"})]
+        )
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            with self.assertRaises(WebApiPushConflict):
+                handler.wait_for_task("T1")
+
+    def test_structured_error_payload_is_preferred(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen(
+            [
+                FakeResponse(
+                    {
+                        "state": "FAILURE",
+                        "result_object": {
+                            "error": {"code": 400, "message": "Object has changed"}
+                        },
+                        "info": "something less specific",
+                    }
+                )
+            ]
+        )
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            with self.assertRaises(WebApiPushConflict):
+                handler.wait_for_task("T1")
+
+    def test_other_failure_raises_value_error_with_the_message(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen(
+            [FakeResponse({"state": "FAILURE", "info": "Gramps ID missing"})]
+        )
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            with self.assertRaises(ValueError) as ctx:
+                handler.wait_for_task("T1")
+        self.assertNotIsInstance(ctx.exception, WebApiPushConflict)
+        self.assertIn("Gramps ID missing", str(ctx.exception))
+
+    def test_revoked_is_also_a_failure(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen([FakeResponse({"state": "REVOKED", "info": "cancelled"})])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            with self.assertRaises(ValueError):
+                handler.wait_for_task("T1")
+
+    def test_timeout_raises_timeout_error(self):
+        # TimeoutError is an OSError, so grampswebapidb.py's connection-error
+        # handling treats a stuck task as retryable rather than a refusal.
+        handler = self._authed_handler()
+        fake = QueuedUrlopen([FakeResponse({"state": "PENDING"})] * 10)
+        with mock.patch.object(webapi_client, "urlopen", fake), mock.patch.object(
+            webapi_client, "sleep"
+        ):
+            with self.assertRaises(TimeoutError):
+                handler.wait_for_task("T1", timeout=-1)
+        self.assertIsInstance(TimeoutError(), OSError)
+
+
+# -------------------------------------------------------------------------
+#
 # TestPushTransaction
 #
 # -------------------------------------------------------------------------
@@ -668,9 +1095,7 @@ class TestPushTransaction(unittest.TestCase):
         with mock.patch.object(webapi_client, "urlopen", fake):
             handler.push_transaction(payload, undo=True)
         req = fake.requests[0]
-        self.assertEqual(
-            req.full_url, "https://example.com/api/transactions/?undo=1"
-        )
+        self.assertEqual(req.full_url, "https://example.com/api/transactions/?undo=1")
         # The payload itself is the original (forward) one -- the server
         # reverses it, not the caller. See push_transaction()'s docstring.
         self.assertEqual(json.loads(req.data), payload)
@@ -680,7 +1105,9 @@ class TestPushTransaction(unittest.TestCase):
         fake = QueuedUrlopen([FakeResponse({})])
         with mock.patch.object(webapi_client, "urlopen", fake):
             handler.push_transaction([{"type": "add"}])
-        self.assertEqual(fake.requests[0].full_url, "https://example.com/api/transactions/")
+        self.assertEqual(
+            fake.requests[0].full_url, "https://example.com/api/transactions/"
+        )
 
     def test_undo_flag_survives_401_retry(self):
         handler = self._authed_handler()
@@ -703,7 +1130,11 @@ class TestPushTransaction(unittest.TestCase):
     def test_401_triggers_reauth_and_retry(self):
         handler = self._authed_handler()
         fake = QueuedUrlopen(
-            [http_error(401), FakeResponse({"access_token": token("AT1")}), FakeResponse({})]
+            [
+                http_error(401),
+                FakeResponse({"access_token": token("AT1")}),
+                FakeResponse({}),
+            ]
         )
         with mock.patch.object(webapi_client, "urlopen", fake), mock.patch.object(
             webapi_client, "sleep"
@@ -750,6 +1181,103 @@ class TestPushTransaction(unittest.TestCase):
             with self.assertRaises(HTTPError) as ctx:
                 handler.push_transaction([{"type": "add"}])
         self.assertNotIsInstance(ctx.exception, WebApiPushConflict)
+
+    def test_background_appends_query_param(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen([FakeResponse({})])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            handler.push_transaction([{"type": "add"}], background=True)
+        self.assertIn("background=1", fake.requests[0].full_url)
+
+    def test_background_combines_with_undo(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen([FakeResponse({})])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            handler.push_transaction([{"type": "add"}], undo=True, background=True)
+        url = fake.requests[0].full_url
+        self.assertIn("undo=1", url)
+        self.assertIn("background=1", url)
+
+    def test_202_response_waits_for_the_task(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen(
+            [
+                FakeResponse(
+                    {"task": {"id": "T7", "href": "/api/tasks/T7"}}, status=202
+                ),
+                FakeResponse({"state": "SUCCESS"}),
+            ]
+        )
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            handler.push_transaction([{"type": "add"}], background=True)
+        self.assertEqual(fake.requests[1].full_url, "https://example.com/api/tasks/T7")
+
+    def test_200_response_in_background_mode_does_not_poll(self):
+        # A server without a Celery queue runs the work inline and answers
+        # 200 even for ?background=1 -- nothing left to wait for.
+        handler = self._authed_handler()
+        fake = QueuedUrlopen([FakeResponse({}, status=200)])
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            handler.push_transaction([{"type": "add"}], background=True)
+        self.assertEqual(len(fake.requests), 1)
+
+    def test_conflict_from_a_backgrounded_task_raises_push_conflict(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen(
+            [
+                FakeResponse({"task": {"id": "T7"}}, status=202),
+                FakeResponse({"state": "FAILURE", "info": "Object has changed"}),
+            ]
+        )
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            with self.assertRaises(WebApiPushConflict):
+                handler.push_transaction([{"type": "add"}], background=True)
+
+    def test_500_carrying_the_conflict_message_is_a_conflict(self):
+        # run_task() re-wraps process_transactions()'s "Object has changed"
+        # ValueError as a 500 when it runs the work inline, so the same
+        # conflict arrives with a different status code -- it must not be
+        # mistaken for a transient server error.
+        handler = self._authed_handler()
+        fake = QueuedUrlopen(
+            [
+                http_error_with_body(
+                    500, {"error": {"code": 500, "message": "Object has changed"}}
+                )
+            ]
+        )
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            with self.assertRaises(WebApiPushConflict):
+                handler.push_transaction([{"type": "add"}], background=True)
+
+    def test_ordinary_500_still_propagates_as_http_error(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen(
+            [
+                http_error_with_body(
+                    500, {"error": {"code": 500, "message": "Database is locked"}}
+                )
+            ]
+        )
+        with mock.patch.object(webapi_client, "urlopen", fake):
+            with self.assertRaises(HTTPError) as ctx:
+                handler.push_transaction([{"type": "add"}])
+        self.assertNotIsInstance(ctx.exception, WebApiPushConflict)
+
+    def test_background_flag_survives_401_retry(self):
+        handler = self._authed_handler()
+        fake = QueuedUrlopen(
+            [
+                http_error(401),
+                FakeResponse({"access_token": token("AT1")}),
+                FakeResponse({}),
+            ]
+        )
+        with mock.patch.object(webapi_client, "urlopen", fake), mock.patch.object(
+            webapi_client, "sleep"
+        ):
+            handler.push_transaction([{"type": "add"}], background=True)
+        self.assertIn("background=1", fake.requests[2].full_url)
 
     def test_400_with_unparseable_body_propagates_as_http_error(self):
         handler = self._authed_handler()

--- a/GrampsWebApiDb/webapi_client.py
+++ b/GrampsWebApiDb/webapi_client.py
@@ -24,10 +24,13 @@ Minimal Gramps Web API client: authentication and read access.
 
 Trimmed from the WebApiHandler class in the GrampsWebSync addon (same
 repo, same license) -- credit to David Straub for the original token
-fetch/refresh and SSL-context handling. Dropped everything specific to
-GrampsWebSync's push-a-local-transaction / XML-export / media-file-sync
-job, since WebApiDB only needs auth plus reading the transaction-history
-feed for now. Re-add pieces here (rather than importing GrampsWebSync
+fetch/refresh and SSL-context handling. Originally dropped everything
+specific to GrampsWebSync's push-a-local-transaction / XML-export /
+media-file-sync job, since WebApiDB only needed auth plus reading the
+transaction-history feed; media-file-sync (get_missing_files(),
+download_media_file(), upload_media_file()) has since been ported back in
+for grampswebapidb.py's own unattended media sync -- see that module's
+docstring. Re-add pieces here (rather than importing GrampsWebSync
 directly) so this addon has no runtime dependency on another addon being
 installed.
 
@@ -93,6 +96,21 @@ TIMEOUT = 60
 #: reliably 429s otherwise.
 RATE_LIMIT_BACKOFF = 1.1
 
+#: Chunk size used when streaming a media file download to disk -- see
+#: download_media_file().
+_DOWNLOAD_CHUNK_SIZE = 1024 * 64
+
+#: First gramps-web-api version whose POST /transactions/ understands
+#: ?background=1 (same gate GrampsWebSync's webapihandler.commit() uses).
+BACKGROUND_MIN_API_VERSION = (2, 7)
+
+#: How long to keep polling GET /tasks/<id> for a backgrounded push before
+#: giving up, and how long to wait between polls. The give-up is a
+#: TimeoutError (an OSError subclass), so callers that treat connection
+#: errors as retryable pick it up as one.
+TASK_TIMEOUT = 600
+TASK_POLL_INTERVAL = 1.0
+
 #: The exact message gramps_webapi/api/tasks.py's old_unchanged() check
 #: raises as ValueError("Object has changed"), which POST /transactions/
 #: (without force=1) surfaces as HTTP 400 {"error": {"message": ...}}.
@@ -119,6 +137,57 @@ def _raise_for_push_conflict(exc: HTTPError) -> None:
     if message == _CONFLICT_MESSAGE:
         raise WebApiPushConflict(message) from exc
     raise exc
+
+
+def parse_version(version):
+    """Parse a SemVer-ish string into a ``(major, minor)`` tuple.
+
+    Dependency-free, and tolerant of the pre-release/build suffixes a
+    development build carries ("2.7.0-rc1", "2.7.0+dirty"). Returns None
+    if the string doesn't start with something numeric, so callers can
+    treat "I can't tell" differently from "it's old".
+
+    Ported from GrampsWebSync's webapihandler.parse_version() (same repo,
+    same license, credit David Straub), plus the None fallback.
+    """
+    if not version:
+        return None
+    main_version = str(version).split("-", 1)[0].split("+", 1)[0]
+    parts = []
+    for part in main_version.split("."):
+        try:
+            parts.append(int(part))
+        except ValueError:
+            break
+    if not parts:
+        return None
+    if len(parts) == 1:
+        parts.append(0)
+    return (parts[0], parts[1])
+
+
+def _task_error_message(body):
+    """Pull a human-readable failure message out of a GET /tasks/<id>
+    body for a FAILURE/REVOKED task.
+
+    The server reports the same underlying result three ways -- a
+    structured "result_object" (a {"error": {...}} dict when the task
+    aborted through TaskError), plus "info"/"result" stringifications
+    kept for backward compatibility (see gramps_webapi/api/resources/
+    tasks.py). Prefer the structured form, fall back to the strings.
+    """
+    payload = body.get("result_object")
+    if isinstance(payload, dict):
+        error = payload.get("error")
+        if isinstance(error, dict) and error.get("message"):
+            return str(error["message"])
+        if error:
+            return str(error)
+    for key in ("info", "result"):
+        value = body.get(key)
+        if value:
+            return str(value)
+    return "unknown error"
 
 
 def create_macos_ssl_context():
@@ -199,6 +268,7 @@ class WebApiHandler:
         self.password = password
         self._refresh_token = refresh_token
         self._access_token: str | None = None
+        self._metadata: dict[str, Any] | None = None
         self._ctx = (
             create_macos_ssl_context() if platform.system() == "Darwin" else None
         )
@@ -276,7 +346,10 @@ class WebApiHandler:
         req = Request(
             f"{self.url}/token/",
             data=data.encode(),
-            headers={"Content-Type": "application/json", "User-Agent": "GrampsWebApiDb"},
+            headers={
+                "Content-Type": "application/json",
+                "User-Agent": "GrampsWebApiDb",
+            },
         )
         try:
             with self._open(req) as res:
@@ -320,12 +393,16 @@ class WebApiHandler:
                 return self._refresh_access_token(retry_on_rate_limit=False)
             if "/api" not in self.url:
                 self.url = f"{self.url}/api"
-                return self._refresh_access_token(retry_on_rate_limit=retry_on_rate_limit)
+                return self._refresh_access_token(
+                    retry_on_rate_limit=retry_on_rate_limit
+                )
             raise
         except (UnicodeDecodeError, json.JSONDecodeError):
             if "/api" not in self.url:
                 self.url = f"{self.url}/api"
-                return self._refresh_access_token(retry_on_rate_limit=retry_on_rate_limit)
+                return self._refresh_access_token(
+                    retry_on_rate_limit=retry_on_rate_limit
+                )
             raise
         self._access_token = res_json["access_token"]
 
@@ -353,8 +430,38 @@ class WebApiHandler:
             self.username = data["name"]
         return self.username
 
+    def get_metadata(self) -> dict[str, Any]:
+        """Server metadata (GET /metadata/), cached for this handler's
+        lifetime -- it describes the deployment, which doesn't change
+        while a tree is open. Needs no special permission beyond being
+        authenticated (metadata.py's MetadataResource is a plain
+        ProtectedResource)."""
+        if self._metadata is None:
+            data, _headers = self._get_json(f"{self.url}/metadata/")
+            self._metadata = data
+        return self._metadata
+
+    def get_api_version(self) -> str | None:
+        """gramps-web-api's own version string, e.g. "2.8.1"."""
+        return (self.get_metadata().get("gramps_webapi") or {}).get("version")
+
+    def get_gramps_version(self) -> str | None:
+        """Version of the Gramps library the *server* runs on, e.g.
+        "6.0.1". grampswebapidb.py gates on this: the transaction-history
+        feed's object serialization only has the "_class"-tagged shape
+        data_to_object() understands from Gramps 6.0 onwards."""
+        return (self.get_metadata().get("gramps") or {}).get("version")
+
+    def supports_background_transactions(self) -> bool:
+        """Whether POST /transactions/ on this server understands
+        ?background=1. Unknown/unparseable versions answer False -- the
+        synchronous path works on every version, so it's the safe
+        default."""
+        version = parse_version(self.get_api_version())
+        return version is not None and version >= BACKGROUND_MIN_API_VERSION
+
     def get_identity(self) -> str:
-        """"<username>@<hostname>" identifying the account+server this
+        """ "<username>@<hostname>" identifying the account+server this
         handler authenticates as -- see grampswebapidb.py's
         _check_identity(), which requires a Family Tree's own name to
         match this before trusting its local mirror."""
@@ -375,7 +482,9 @@ class WebApiHandler:
         except HTTPError as exc:
             if exc.code == 401 and retry:
                 # in case of 401, retry once with a new token
-                sleep(RATE_LIMIT_BACKOFF)  # avoid immediately re-tripping the rate limit
+                sleep(
+                    RATE_LIMIT_BACKOFF
+                )  # avoid immediately re-tripping the rate limit
                 self._authenticate()
                 return self._get_json(url, retry=False)
             if exc.code == 429 and retry:
@@ -432,6 +541,112 @@ class WebApiHandler:
         url = f"{self.url}/exporters/{extension}/file"
         return self._get_binary(url)
 
+    def get_missing_files(self) -> list[dict[str, Any]]:
+        """
+        List the server's Media objects that have no uploaded file yet
+        (GET /media/?filemissing=1) -- the remote side of the
+        missing-file comparison grampswebapidb.py's WebApiDB._sync_media_
+        files() makes; the local side is a plain os.path.exists() check,
+        nothing the server needs to be asked about. Each item is the
+        server's own JSON Media object; only "handle" is used by the
+        caller. Shares _get_json()'s existing 401/429/network retry
+        handling.
+        """
+        body, _headers = self._get_json(f"{self.url}/media/?filemissing=1")
+        return body
+
+    def download_media_file(self, handle: str, path: str, retry: bool = True) -> None:
+        """
+        Download one media file from the server and write it to
+        ``path``, creating any missing parent directory first. Streamed
+        in chunks rather than buffered fully in memory the way
+        _get_binary() is -- media files (video in particular) can be
+        large.
+
+        Ported from GrampsWebSync's webapihandler.download_media_file()/
+        _download_file() (same repo, same license, credit David Straub),
+        folded into one method and authenticated the same way every
+        other request in this class already is -- a bearer header, not
+        GrampsWebSync's ``?jwt=`` query-string variant (gramps-web-api
+        accepts both; see JWT_TOKEN_LOCATION in its config.py, and there
+        is no <img src=...>-style consumer here that would need the
+        query-string form).
+        """
+        req = Request(
+            f"{self.url}/media/{handle}/file",
+            headers={
+                "Authorization": f"Bearer {self.access_token}",
+                "User-Agent": "GrampsWebApiDb",
+            },
+        )
+        try:
+            with self._open(req) as res:
+                os.makedirs(os.path.dirname(path), exist_ok=True)
+                with open(path, "wb") as f:
+                    chunk = res.read(_DOWNLOAD_CHUNK_SIZE)
+                    while chunk:
+                        f.write(chunk)
+                        chunk = res.read(_DOWNLOAD_CHUNK_SIZE)
+        except HTTPError as exc:
+            if exc.code == 401 and retry:
+                sleep(RATE_LIMIT_BACKOFF)
+                self._authenticate()
+                return self.download_media_file(handle, path, retry=False)
+            if exc.code == 429 and retry:
+                sleep(RATE_LIMIT_BACKOFF)
+                return self.download_media_file(handle, path, retry=False)
+            raise
+        except (URLError, socket.timeout):
+            if retry:
+                sleep(RATE_LIMIT_BACKOFF)
+                return self.download_media_file(handle, path, retry=False)
+            raise
+
+    def upload_media_file(self, handle: str, path: str, retry: bool = True) -> bool:
+        """
+        Upload one local media file to the server for ``handle`` (PUT
+        /media/<handle>/file?uploadmissing=1), streamed from disk rather
+        than read fully into memory first. Returns False on a 409 --
+        something else already uploaded a file for this object in the
+        meantime, an expected outcome of a concurrent sync rather than a
+        failure -- and True otherwise.
+
+        Ported from GrampsWebSync's webapihandler.upload_media_file()/
+        _upload_file(), folded into one method and sharing this class's
+        retry conventions (401 re-auth, 429 backoff, one retry each)
+        rather than the source's separate hand-rolled helper.
+        """
+        with open(path, "rb") as f:
+            req = Request(
+                f"{self.url}/media/{handle}/file?uploadmissing=1",
+                data=f,
+                method="PUT",
+                headers={
+                    "Authorization": f"Bearer {self.access_token}",
+                    "User-Agent": "GrampsWebApiDb",
+                },
+            )
+            try:
+                with self._open(req) as res:
+                    res.read()
+            except HTTPError as exc:
+                if exc.code == 409:
+                    return False
+                if exc.code == 401 and retry:
+                    sleep(RATE_LIMIT_BACKOFF)
+                    self._authenticate()
+                    return self.upload_media_file(handle, path, retry=False)
+                if exc.code == 429 and retry:
+                    sleep(RATE_LIMIT_BACKOFF)
+                    return self.upload_media_file(handle, path, retry=False)
+                raise
+            except (URLError, socket.timeout):
+                if retry:
+                    sleep(RATE_LIMIT_BACKOFF)
+                    return self.upload_media_file(handle, path, retry=False)
+                raise
+        return True
+
     def get_transaction_history(
         self, after: float = 0, page: int = 1, pagesize: int = 100
     ) -> tuple[list[dict[str, Any]], int]:
@@ -456,11 +671,46 @@ class WebApiHandler:
         total_count = int(headers.get("X-Total-Count", len(body)))
         return body, total_count
 
+    def wait_for_task(
+        self,
+        task_id: str,
+        timeout: float = TASK_TIMEOUT,
+        poll_interval: float = TASK_POLL_INTERVAL,
+    ) -> None:
+        """Poll GET /tasks/<id> until a backgrounded server task finishes.
+
+        Returns normally on SUCCESS. A FAILURE/REVOKED task raises --
+        WebApiPushConflict if it failed the server's old-data check (the
+        same "Object has changed" sentinel a synchronous push reports as
+        HTTP 400, so the caller's conflict handling works identically
+        either way), otherwise ValueError carrying the server's message.
+        Gives up after ``timeout`` seconds with a TimeoutError, which is
+        an OSError and so reads as a transient/connection-ish failure to
+        callers rather than a refusal.
+        """
+        deadline = time.monotonic() + timeout
+        while True:
+            body, _headers = self._get_json(f"{self.url}/tasks/{task_id}")
+            state = body.get("state")
+            if state == "SUCCESS":
+                return
+            if state in ("FAILURE", "REVOKED"):
+                message = _task_error_message(body)
+                if message == _CONFLICT_MESSAGE:
+                    raise WebApiPushConflict(message)
+                raise ValueError(f"Server task {state}: {message}")
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"Server task {task_id} did not finish within {timeout}s"
+                )
+            sleep(poll_interval)
+
     def push_transaction(
         self,
         payload: list[dict[str, Any]],
         retry: bool = True,
         undo: bool = False,
+        background: bool = False,
     ) -> None:
         """
         POST a batch of local changes to /transactions/ (no force=1): the
@@ -487,13 +737,38 @@ class WebApiHandler:
         having to compute the inverse payload locally. Redo is *not* a
         variant of this -- it's just an ordinary push_transaction() call
         with the original (forward) payload again.
+
+        ``background=True`` adds ?background=1, asking the server to queue
+        the work and answer 202 immediately rather than holding the
+        connection open while it processes -- the way to push a payload
+        big enough to risk hitting TIMEOUT mid-request. Only meaningful on
+        gramps-web-api >= BACKGROUND_MIN_API_VERSION; check
+        supports_background_transactions() first. Two wrinkles the caller
+        doesn't have to care about, both handled here so a backgrounded
+        push raises exactly what a synchronous one would:
+
+        - The server only *actually* backgrounds the work if it has a
+          Celery queue configured; otherwise run_task() runs it inline and
+          returns 200 (see gramps_webapi/api/tasks.py). So a 202 means
+          "poll the task", and a 200 means it's already done.
+        - On that inline path a conflict surfaces as HTTP **500**, not
+          400: run_task() catches the ValueError process_transactions
+          raises and re-aborts it as a 500 with the same
+          {"error": {"message": ...}} body. Checked for the conflict
+          sentinel here too, so it doesn't get misread as a transient
+          server error and retried forever.
         """
         if not payload:
             return
         data = json.dumps(payload).encode()
-        url = f"{self.url}/transactions/"
+        params = {}
         if undo:
-            url += "?undo=1"
+            params["undo"] = "1"
+        if background:
+            params["background"] = "1"
+        url = f"{self.url}/transactions/"
+        if params:
+            url += "?" + urlencode(params)
         req = Request(
             url,
             data=data,
@@ -506,20 +781,32 @@ class WebApiHandler:
         )
         try:
             with self._open(req) as res:
-                res.read()
+                status = res.getcode()
+                body = res.read()
         except HTTPError as exc:
             if exc.code == 401 and retry:
                 sleep(RATE_LIMIT_BACKOFF)
                 self._authenticate()
-                return self.push_transaction(payload, retry=False, undo=undo)
+                return self.push_transaction(
+                    payload, retry=False, undo=undo, background=background
+                )
             if exc.code == 429 and retry:
                 sleep(RATE_LIMIT_BACKOFF)
-                return self.push_transaction(payload, retry=False, undo=undo)
-            if exc.code == 400:
+                return self.push_transaction(
+                    payload, retry=False, undo=undo, background=background
+                )
+            # 400 is the synchronous conflict; 500 is the same conflict
+            # re-wrapped by run_task() on the inline background path.
+            if exc.code in (400, 500):
                 _raise_for_push_conflict(exc)
             raise
         except (URLError, socket.timeout):
             if retry:
                 sleep(RATE_LIMIT_BACKOFF)
-                return self.push_transaction(payload, retry=False, undo=undo)
+                return self.push_transaction(
+                    payload, retry=False, undo=undo, background=background
+                )
             raise
+        if status == 202:
+            task_id = json.loads(body)["task"]["id"]
+            self.wait_for_task(task_id)


### PR DESCRIPTION
Four gaps found by comparing `GrampsWebApiDb` against **GrampsWebSync**, which solves the same sync problem interactively. Three of them let local changes silently never reach the server.

Each was verified by reverting the fix and confirming the targeted tests fail.

## 1. Media files never synced

`webapi_client.py` was trimmed down from GrampsWebSync's `WebApiHandler` and dropped its media-file-sync half. Media *records* (path, checksum, description) synced fine; the files they point at never moved in either direction.

Ports `get_missing_files()` / `download_media_file()` / `upload_media_file()` (credit @DavidMStraub, same repo and license), adapted to this class's bearer-header auth and retry conventions. Driven by a `_sync_media_files()` pass on its own coarser timer rather than GrampsWebSync's explicit wizard step — unlike the record feed there is no cheap "what changed since last time" signal for file presence, so each pass rescans.

## 2. Local batch commits were never pushed

DBAPI skips its per-object undo log for a `batch=True` transaction, so `transaction_to_json()` produced an empty payload and `_push_payload()` returned immediately — no push, no log line, no error. That covers **every bulk importer** and several stock Tools (Check and Repair Database, Media Manager, Reorder Gramps IDs, Sort Events, …). The mirror simply drifted ahead of the server, and nothing noticed: the poll only ever looks for newer *server-side* transactions, never "am I ahead?".

`transaction_begin()` now snapshots per-type handle sets, and `transaction_commit()` diffs them against post-commit state to reconstruct the change list (appeared → add, disappeared → delete, survived with `.change >= start_time` → update). Entries replay through the existing non-batch path, so each object picks up a real `"old"` snapshot and gets normal conflict handling. A `_pulling` flag keeps `_sync_from_server()`'s own batch replays from being echoed straight back at the server.

This is the write-side mirror of the `_full_resync()` fallback already in place for the equivalent pull-side blind spot.

## 3. Pushes that failed while offline were dropped

The local commit is never rolled back, but nothing remembered the push still needed to go out — the existing "until the next successful push or read sync" was aspirational, not implemented.

Failed pushes now persist via `_set_metadata()` (surviving close/reopen) and are retried at the top of every `_sync_from_server()`, **in order, stopping at the first still-undeliverable entry** rather than skipping ahead — so a later causally-dependent edit (a Family added after the Person it references) can't reach the server ahead of one still stuck. The queue is capped, and a 4xx other than 429 is treated as the server's settled answer and logged rather than queued; queueing one would retry forever and eventually evict genuinely retryable work.

## 4. Server permissions and version now checked at `load()`

`POST /transactions/` requires `AddObject` + `EditObject` + `DeleteObject` *together*, so a Member-level account could open the tree, read perfectly well, and then have every single edit rejected.

`ViewPrivate` matters more subtly. The history feed 403s loudly without it — but `GET /exporters/gramps/file` does **not** refuse the request; it passes `view_private=has_permissions({PERM_VIEW_PRIVATE})` into the export task and returns a privacy-filtered export, which `_full_resync()` would then import over a wiped local mirror, quietly dropping every private record locally.

Both are now named explicitly up front, at no extra round trip (permissions ride in the JWT claims). A tree opened read-only is held to the read permission only. `GET /metadata/` additionally gates on the server's Gramps version, turning an incompatible pre-6.0 server from a bare `KeyError` mid-sync into a sentence naming both versions.

## Also: background pushes for large payloads

Where the server supports it (gramps-web-api ≥ 2.7), a payload at or above a threshold goes out with `?background=1` so it isn't cut off mid-write by the request timeout — most of all the single large payload reconstructed after a bulk import (#2 above). Small pushes stay synchronous, keeping the crisp "400 means conflict" semantics.

Two server-side asymmetries are absorbed inside `push_transaction()` so callers see identical behavior either way:

- the server only *actually* backgrounds the work if it has a Celery queue configured — otherwise `run_task()` runs it inline and answers **200**, not 202;
- on that inline path a conflict comes back as HTTP **500** rather than 400, because `run_task()` catches `process_transactions()`'s `ValueError` and re-aborts it.

Both status codes and a failed background task are checked for the `"Object has changed"` sentinel. Without that, a conflict on those paths would read as a transient server error and — given the retry queue from #3 — be retried forever.

## Notes

- **Cost:** batch reconciliation is O(total objects) per batch commit (`.change` isn't a queryable column in DBAPI's schema), and the touched objects are written twice locally. Same order as whatever opened the batch transaction in the first place; documented inline.
- Background mode does **not** make the UI more responsive — polling blocks the GTK main thread just as a long POST would. It only prevents the connection dropping mid-write. Genuine async remains out of scope, as the module docstring already notes.
- No `version=` bumps in `.gpr.py` (left to the release build, per `CLAUDE.md`).

## Testing

121 new tests, 238 total, all passing:

```
GRAMPS_RESOURCES=/path/to/gramps GDK_BACKEND=- \
  python3 -m unittest GrampsWebApiDb.tests.test_grampswebapidb \
                      GrampsWebApiDb.tests.test_webapi_client
```

No functional change to the read/sync path against a correctly-permissioned, up-to-date server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
