### PR TITLE
GrampsWebApiDb: sync hardening and read-only-account support

### DIFF
--- a/GrampsWebApiDb/grampswebapidb.py
+++ b/GrampsWebApiDb/grampswebapidb.py
@@ -794,6 +794,87 @@ _WRITE_PERMISSIONS = ("AddObject", "EditObject", "DeleteObject")
 _REQUIRED_ROLE_NAME = "Editor"
 
 
+class _MissingWritePermissionError(DbWriteFailure):
+    """DbWriteFailure raised specifically by _missing_write_permission_
+    error() -- a distinct subclass purely so _install_quiet_popup_
+    filter()'s logging.Filter can recognize this one, already-explained,
+    expected condition and single it out from any other DbWriteFailure
+    (e.g. exportxml.py's backup-write failures), which must keep
+    reaching Gramps' generic crash dialog unchanged.
+    """
+
+
+def _notify_missing_write_permission(message):
+    """Show a calm, native dialog carrying the same explanation as the
+    DbWriteFailure _missing_write_permission_error() is about to raise.
+
+    Neither a friendlier exception message nor a custom dialog title can
+    change what Gramps' own top-level crash dialog says -- ErrorView
+    (gui/logger/_errorview.py) hardcodes "Gramps has experienced an
+    unexpected error" and "it would be advisable to restart Gramps
+    immediately" regardless of exception type or message, which is
+    needlessly alarming for something as ordinary and recoverable as a
+    read-only account attempting an edit. This dialog is the actually
+    useful one; _install_quiet_popup_filter() (below) keeps the alarming
+    one from also popping up right after it. has_display()-gated the
+    same best-effort way _notify_fatal_poll_error() already is, since
+    this DATABASE plugin must stay importable and usable without a
+    display (CLI use) or gi/Gtk installed at all -- headless just skips
+    the dialog, same as _notify_fatal_poll_error().
+    """
+    if not has_display():
+        return
+    try:
+        from gramps.gui.user import User as GuiUser
+    except ImportError:
+        return
+    GuiUser().notify_error(_("Can't save this change"), message)
+
+
+def _install_quiet_popup_filter():
+    """Add a logging.Filter to the root logger's GtkHandler, if one is
+    attached, so that a _MissingWritePermissionError reaching Gramps'
+    top-level sys.excepthook (grampsapp.py's exc_hook, which LOG.error()s
+    every uncaught exception unconditionally -- there is no narrower
+    extension point in Gramps core to hook instead) still gets its full
+    traceback recorded to the log file/console exactly as any other
+    uncaught exception would, but does not also trigger GtkHandler's own
+    modal "Gramps has experienced an unexpected error" popup on top of
+    the calmer, already-shown _notify_missing_write_permission() dialog.
+    Filtering on the log record (rather than wrapping sys.excepthook
+    itself) leaves grampsapp.exc_hook's own special-casing (Ctrl-C,
+    IOError, HandleError's runcheck flag) completely untouched, and
+    affects only this one exception subclass -- any other DbWriteFailure,
+    or any other exception at all, still pops the generic dialog exactly
+    as before.
+
+    Idempotent (checked via the filter instance's class, not identity)
+    and a no-op wherever GtkHandler isn't attached at all: no display
+    (has_display() gates the import, same reasoning as
+    _notify_missing_write_permission()), a CLI session, or simply not
+    having reached gui.grampsgui.py's do_startup() yet.
+    """
+    if not has_display():
+        return
+    try:
+        from gramps.gui.logger import GtkHandler
+    except ImportError:
+        return
+    for handler in logging.getLogger().handlers:
+        if isinstance(handler, GtkHandler) and not any(
+            isinstance(f, _QuietMissingWritePermissionFilter) for f in handler.filters
+        ):
+            handler.addFilter(_QuietMissingWritePermissionFilter())
+
+
+class _QuietMissingWritePermissionFilter(logging.Filter):
+    """See _install_quiet_popup_filter()."""
+
+    def filter(self, record):
+        exc_info = record.exc_info
+        return not (exc_info and isinstance(exc_info[1], _MissingWritePermissionError))
+
+
 def _missing_write_permission_error(missing_write_permissions):
     """Build the DbWriteFailure raised by transaction_commit()/undo()/
     redo() when self._missing_write_permissions (set once, at load(), by
@@ -802,27 +883,30 @@ def _missing_write_permission_error(missing_write_permissions):
     can reject *before* anything commits locally instead of only after a
     doomed push comes back 403.
 
-    DbWriteFailure's own __str__ returns only its first argument (see
-    gramps.gen.db.exceptions), and nothing in Gramps core catches this
-    exception type around an ordinary editor's own DbTxn -- it reaches
-    the user via Gramps' top-level sys.excepthook bug-report dialog, the
-    same as any other uncaught exception from a GTK callback (see
-    grampsapp.py) -- so the actually useful explanation belongs in that
-    first argument, not the second.
+    Also shows the user a calm explanation immediately, via
+    _notify_missing_write_permission(), and makes sure Gramps' own
+    generic crash dialog won't pop up right after it, via
+    _install_quiet_popup_filter() -- see both for why. The raised
+    exception itself is still required: nothing in Gramps core catches
+    this exception type around an ordinary editor's own DbTxn, but that
+    propagation is exactly what stops the editor from treating the save
+    as having succeeded (e.g. closing itself and discarding the reason
+    why), so it has to keep happening even though the user has already
+    been told what went wrong by the time it does.
     """
-    return DbWriteFailure(
-        _(
-            "This local edit was not saved: the account authenticating "
-            "via GRAMPS_WEB_API_KEY is missing server permission(s) "
-            "needed to push changes to this Family Tree: %(missing)s. "
-            'Grant it the "%(role)s" role on the server (or ask an '
-            "administrator to) to enable editing."
-        )
-        % {
-            "missing": ", ".join(missing_write_permissions),
-            "role": _REQUIRED_ROLE_NAME,
-        }
-    )
+    message = _(
+        "This local edit was not saved: the account authenticating "
+        "via GRAMPS_WEB_API_KEY is missing server permission(s) "
+        "needed to push changes to this Family Tree: %(missing)s. "
+        'Grant it the "%(role)s" role on the server (or ask an '
+        "administrator to) to enable editing."
+    ) % {
+        "missing": ", ".join(missing_write_permissions),
+        "role": _REQUIRED_ROLE_NAME,
+    }
+    _install_quiet_popup_filter()
+    _notify_missing_write_permission(message)
+    return _MissingWritePermissionError(message)
 
 
 #: Oldest Gramps version a *server* can run and still produce the

--- a/GrampsWebApiDb/grampswebapidb.py
+++ b/GrampsWebApiDb/grampswebapidb.py
@@ -379,14 +379,27 @@ gates POST /transactions/ behind all three at once (transactions.py's
 require_permissions(); has_permissions() fails if any are missing) -- does
 *not* fail load(): the mirror still opens and keeps polling and staying
 current for reading, and self._missing_write_permissions names the
-shortfall in one loud log line so the user finds out before hitting a
-surprise 403, without being blocked from reading. Only an actual write
-is refused, and only when one is actually attempted: it reaches the
-server and comes back a 403, which _push_payload_async() already treats
-as a non-retryable rejection (see below) -- logged, and recorded as a
-note on the affected object(s), the same path a permission *revoked*
-mid-session (rather than missing from the start) already went through.
-Checking the permission set up front costs no extra round trip
+shortfall in one loud log line so the user finds out before ever
+attempting an edit. An actual write is refused synchronously, at the
+point of the attempt: transaction_commit() checks
+self._missing_write_permissions itself and, for a genuine local edit
+(not self._pulling's server-to-local replays, or self._recording_note's
+own bookkeeping -- see both flags' own comments), calls
+transaction_abort() and raises DbWriteFailure before anything reaches
+self.dbapi as committed, rather than letting it commit locally and
+finding out only when the resulting push comes back 403. undo()/redo()
+do the same, before even calling super() -- Gramps core's own undo/redo
+machinery (DbGenericUndo) commits directly, bypassing
+transaction_commit() entirely, so there is no later point at which
+either could still be intercepted. This is strictly better than the
+push-time rejection below where it is possible (no wasted round trip, no
+local/server divergence to explain after the fact -- see
+_missing_write_permission_error()), but it can only ever catch what is
+already known at load() time: a permission *revoked* mid-session is
+still invisible until the next push actually goes out and comes back
+403, handled by _push_payload_async()'s existing non-retryable-rejection
+path (logged, and recorded as a note on the affected object(s) -- see
+below). Checking the permission set up front costs no extra round trip
 (gramps-web-api puts it in the access token's own claims, so
 get_permissions() just decodes the JWT already in hand) and names
 exactly what is missing either way.
@@ -616,7 +629,7 @@ from gramps.gen.db.dbconst import (
     TXNDEL,
     TXNUPD,
 )
-from gramps.gen.db.exceptions import DbConnectionError
+from gramps.gen.db.exceptions import DbConnectionError, DbWriteFailure
 from gramps.gen.errors import HandleError
 from gramps.gen.lib import Note, NoteType, Tag
 from gramps.gen.lib.baseobj import BaseObject
@@ -779,6 +792,38 @@ _WRITE_PERMISSIONS = ("AddObject", "EditObject", "DeleteObject")
 #: Together: the permission set of gramps-web-api's "Editor" role, the
 #: least-privileged built-in role that can run this addon read-write.
 _REQUIRED_ROLE_NAME = "Editor"
+
+
+def _missing_write_permission_error(missing_write_permissions):
+    """Build the DbWriteFailure raised by transaction_commit()/undo()/
+    redo() when self._missing_write_permissions (set once, at load(), by
+    _check_permissions_async()) says this account cannot push edits at
+    all -- see transaction_commit()'s own docstring for why that check
+    can reject *before* anything commits locally instead of only after a
+    doomed push comes back 403.
+
+    DbWriteFailure's own __str__ returns only its first argument (see
+    gramps.gen.db.exceptions), and nothing in Gramps core catches this
+    exception type around an ordinary editor's own DbTxn -- it reaches
+    the user via Gramps' top-level sys.excepthook bug-report dialog, the
+    same as any other uncaught exception from a GTK callback (see
+    grampsapp.py) -- so the actually useful explanation belongs in that
+    first argument, not the second.
+    """
+    return DbWriteFailure(
+        _(
+            "This local edit was not saved: the account authenticating "
+            "via GRAMPS_WEB_API_KEY is missing server permission(s) "
+            "needed to push changes to this Family Tree: %(missing)s. "
+            'Grant it the "%(role)s" role on the server (or ask an '
+            "administrator to) to enable editing."
+        )
+        % {
+            "missing": ", ".join(missing_write_permissions),
+            "role": _REQUIRED_ROLE_NAME,
+        }
+    )
+
 
 #: Oldest Gramps version a *server* can run and still produce the
 #: "_class"-tagged transaction-history serialization data_to_object()
@@ -1812,6 +1857,15 @@ class WebApiDB(SQLite):
     #: _reconcile_batch_commit().
     _pulling = False
 
+    #: Set around _record_conflict_notes()'s own DbTxns (including the
+    #: tag-creation ones _get_or_create_tag() opens on its behalf) so
+    #: transaction_commit()'s own missing-write-permission rejection (see
+    #: its docstring) doesn't reject the very note it is itself recording
+    #: -- the addon's own bookkeeping, not a fresh local edit, and one
+    #: that must go on being allowed to commit locally regardless of
+    #: self._missing_write_permissions, the same as _pulling.
+    _recording_note = False
+
     #: Set for the duration of any async operation that owns the mirror
     #: -- a record/media sync, or (since the move off reentrant pumping)
     #: a push -- so a second one can't start concurrently and land an
@@ -1822,11 +1876,12 @@ class WebApiDB(SQLite):
     #: authenticating via GRAMPS_WEB_API_KEY was found missing at load()'s
     #: _check_permissions_async() -- empty for a fully-privileged account,
     #: for a tree opened read-only (never checked), or before load() has
-    #: run its checks. Does not by itself block anything: it is purely
-    #: informational (logged once at load()) and left for
-    #: _push_payload_async()'s own per-push 403 handling to actually
-    #: reject an edit when one is attempted -- see
-    #: _check_permissions_async()'s docstring.
+    #: run its checks. When non-empty, transaction_commit()/undo()/redo()
+    #: reject a genuine local edit with it, synchronously and before
+    #: anything commits locally -- see transaction_commit()'s own
+    #: docstring. Never updated after load(): a permission revoked
+    #: mid-session is not reflected here, and still only surfaces from an
+    #: actual push's own 403 -- see _push_payload_async().
     _missing_write_permissions = ()
 
     #: The chain a conflict retry's nested re-push belongs to, stashed by
@@ -2154,16 +2209,12 @@ class WebApiDB(SQLite):
         (AddObject/EditObject/DeleteObject) does *not* block load(): a
         viewer- or contributor-level account can still open the tree, and
         the mirror still polls and stays current for reading -- only
-        pushing a local edit back to the server is unavailable to it, and
-        gets rejected when it is actually attempted, via
-        _push_payload_async()'s existing handling of a non-retryable 4xx
-        (_is_retryable_push_error()): the server answers 403, the push is
-        logged loudly as permanently rejected, and a note recording why is
-        attached to the affected object(s) -- see
-        _record_undelivered_push_notes(). self._missing_write_permissions
-        is stashed here and logged once, at load() time, so a user who
-        never even attempts an edit still finds out why before hitting a
-        surprise 403 later.
+        editing it is unavailable. self._missing_write_permissions,
+        stashed here, is what transaction_commit()/undo()/redo() check to
+        reject a local edit synchronously, before it ever reaches
+        self.dbapi as committed -- see transaction_commit()'s own
+        docstring. Logged once here too, at load() time, so a user who
+        never even attempts an edit still finds out why up front.
 
         ``writable`` is False for a tree opened read-only (DBMODE_R), which
         never pushes and so is not checked for write permissions at all.
@@ -2699,6 +2750,37 @@ class WebApiDB(SQLite):
         return result
 
     def transaction_commit(self, transaction):
+        # Reject before anything is committed locally -- not just before
+        # the push -- when the account is *known*, from load()'s own
+        # _check_permissions_async(), to lack write access altogether:
+        # self._missing_write_permissions is set once there and never
+        # updated mid-session, so this only ever catches the load-time-
+        # known case, not a permission revoked after load() (that one is
+        # still only discoverable from a live 403 -- see
+        # _push_payload_async()'s on_push_error and the module
+        # docstring). transaction_begin() already called self.dbapi.begin()
+        # for this transaction and whatever the caller's DbTxn body did
+        # (commit_person(), etc.) is only staged in that still-open SQL
+        # transaction, not yet durable -- transaction_abort() (self.dbapi.
+        # rollback()) unwinds it cleanly instead of leaving it half-open,
+        # which simply calling super().transaction_commit() at some later
+        # point would not: DbTxn.__exit__() only calls transaction_abort()
+        # for an exception raised *inside* the `with` block, not one
+        # raised by transaction_commit() itself, so this method has to do
+        # that part itself before raising. Exempted: self._pulling (a
+        # server-to-local replay, which must always be allowed so a
+        # read-only account can still poll and stay current -- see the
+        # module docstring) and self._recording_note (the addon's own
+        # note/tag bookkeeping, which must go on committing locally and
+        # attempting its own push exactly as before -- see
+        # _record_conflict_notes()'s docstring).
+        if (
+            self._missing_write_permissions
+            and not self._pulling
+            and not self._recording_note
+        ):
+            self.transaction_abort(transaction)
+            raise _missing_write_permission_error(self._missing_write_permissions)
         # Must run before super(): it clears the transaction's records.
         payload = transaction_to_json(transaction)
         # The same description Gramps desktop's own editors set on this
@@ -2721,6 +2803,18 @@ class WebApiDB(SQLite):
         self._start_push(payload, is_retry=self._retrying, message=message)
 
     def undo(self, update_history=True):
+        # Unlike transaction_commit(), there is no way to let the local
+        # change happen and then reject just the push: DbGenericUndo._undo()
+        # (Gramps core) commits directly via self.db._txn_begin()/
+        # _txn_commit(), never through transaction_commit(), so by the
+        # time control would return here the local mirror has already
+        # changed regardless of what this method does. Reject before even
+        # calling super() instead -- nothing has touched self.dbapi yet,
+        # so there is nothing to unwind, unlike transaction_commit()'s own
+        # transaction_abort() call. See that method's docstring for what
+        # self._missing_write_permissions does and does not catch.
+        if self._missing_write_permissions:
+            raise _missing_write_permission_error(self._missing_write_permissions)
         # Peek before super(): DbGenericUndo._undo() pops this DbTxn off
         # undoq. The DbTxn's own backing data isn't touched by that (it
         # just moves queues), so building its JSON payload could happen
@@ -2737,6 +2831,11 @@ class WebApiDB(SQLite):
         return result
 
     def redo(self, update_history=True):
+        # See undo()'s own comment: DbGenericUndo._redo() commits directly,
+        # bypassing transaction_commit(), so this has to reject before
+        # calling super() too.
+        if self._missing_write_permissions:
+            raise _missing_write_permission_error(self._missing_write_permissions)
         transaction = self.undodb.redoq[-1] if self.undodb.redo_count else None
         result = super().redo(update_history)
         if result and transaction is not None:
@@ -3405,36 +3504,42 @@ class WebApiDB(SQLite):
         stays exactly what it always was: one object per conflicting
         entry, nothing else (see that method's docstring). This one goes
         through the completely ordinary transaction_commit() ->
-        _start_push() path like any other local edit -- no special-
-        casing needed, and safe even if *this* push itself hits a
+        _start_push() path like any other local edit, under
+        self._recording_note so transaction_commit()'s own missing-
+        write-permission rejection (see its docstring) lets it through
+        regardless -- and safe even if *this* push itself hits a
         conflict, since attaching a note is a list-valued change
         merge() already unions correctly (unlike the scalar edit this
         note exists to record in the first place).
         """
-        message_tag = self._get_or_create_tag(MESSAGE_TAG_NAME)
-        todo_tag = self._get_or_create_tag(MESSAGE_TODO_OPEN_TAG_NAME)
-        with DbTxn(_message_note_description(), self) as trans:
-            for obj_class, name, handle, lines in conflicts:
-                get_from_handle = getattr(self, f"get_{name}_from_handle", None)
-                if get_from_handle is None:
-                    continue
-                try:
-                    obj = get_from_handle(handle)
-                except HandleError:
-                    continue  # gone locally by the time this runs
-                if not hasattr(obj, "add_note"):
-                    continue  # e.g. Tag -- nothing to attach a note to
-                summary = "; ".join(lines)
-                note = Note()
-                note.set_handle(create_id())
-                note.set_gramps_id(self.find_next_note_gramps_id())
-                note.set_type(NoteType.GENERAL)
-                note.set(f"{MESSAGE_NOTE_AUTHOR}: {obj_class} -- {summary}")
-                note.add_tag(message_tag.handle)
-                note.add_tag(todo_tag.handle)
-                self.commit_note(note, trans)
-                obj.add_note(note.handle)
-                getattr(self, f"commit_{name}")(obj, trans)
+        self._recording_note = True
+        try:
+            message_tag = self._get_or_create_tag(MESSAGE_TAG_NAME)
+            todo_tag = self._get_or_create_tag(MESSAGE_TODO_OPEN_TAG_NAME)
+            with DbTxn(_message_note_description(), self) as trans:
+                for obj_class, name, handle, lines in conflicts:
+                    get_from_handle = getattr(self, f"get_{name}_from_handle", None)
+                    if get_from_handle is None:
+                        continue
+                    try:
+                        obj = get_from_handle(handle)
+                    except HandleError:
+                        continue  # gone locally by the time this runs
+                    if not hasattr(obj, "add_note"):
+                        continue  # e.g. Tag -- nothing to attach a note to
+                    summary = "; ".join(lines)
+                    note = Note()
+                    note.set_handle(create_id())
+                    note.set_gramps_id(self.find_next_note_gramps_id())
+                    note.set_type(NoteType.GENERAL)
+                    note.set(f"{MESSAGE_NOTE_AUTHOR}: {obj_class} -- {summary}")
+                    note.add_tag(message_tag.handle)
+                    note.add_tag(todo_tag.handle)
+                    self.commit_note(note, trans)
+                    obj.add_note(note.handle)
+                    getattr(self, f"commit_{name}")(obj, trans)
+        finally:
+            self._recording_note = False
 
     def _record_undelivered_push_notes(self, payload, reason):
         """Attach a gramps-connect-style "message" Note to every add/

--- a/GrampsWebApiDb/grampswebapidb.py
+++ b/GrampsWebApiDb/grampswebapidb.py
@@ -364,23 +364,32 @@ whole nested chain synchronously and would hang or blow the stack
 otherwise, not just log an extra line.
 
 The most likely such rejection is a permissions one, and _check_
-permissions() heads it off at load() rather than letting every subsequent
-edit fail: gramps-web-api gates POST /transactions/ behind all three of
-AddObject/EditObject/DeleteObject at once (transactions.py's
-require_permissions(); has_permissions() fails if any are missing), and
-gates GET /transactions/history/ behind ViewPrivate. ViewPrivate is the
-one whose absence would otherwise be *silent* rather than merely fatal:
-the history feed 403s loudly without it, but GET /exporters/gramps/file
-does not refuse the request at all -- it passes
+permissions() checks for it up front at load() -- but only ViewPrivate is
+fatal to opening the tree at all: gates GET /transactions/history/, and its
+absence would otherwise be *silent* rather than merely loud, since GET
+/exporters/gramps/file does not refuse a request lacking it -- it passes
 view_private=has_permissions({PERM_VIEW_PRIVATE}) into the export task
 (exporters.py), so an under-privileged caller gets a privacy-filtered
 export, which _full_resync_async() would then import over a wiped local mirror,
-quietly dropping every private record from the mirror. Checking the
-permission set up front costs no extra round trip (gramps-web-api puts it
-in the access token's own claims, so get_permissions() just decodes the
-JWT already in hand) and names exactly what is missing. A tree opened
-read-only (DBMODE_R) never pushes, so it is held to the read permission
-only.
+quietly dropping every private record from the mirror. A tree opened
+read-only (DBMODE_R) never pushes, so it is checked for ViewPrivate only.
+
+A writable tree missing AddObject/EditObject/DeleteObject -- gramps-web-api
+gates POST /transactions/ behind all three at once (transactions.py's
+require_permissions(); has_permissions() fails if any are missing) -- does
+*not* fail load(): the mirror still opens and keeps polling and staying
+current for reading, and self._missing_write_permissions names the
+shortfall in one loud log line so the user finds out before hitting a
+surprise 403, without being blocked from reading. Only an actual write
+is refused, and only when one is actually attempted: it reaches the
+server and comes back a 403, which _push_payload_async() already treats
+as a non-retryable rejection (see below) -- logged, and recorded as a
+note on the affected object(s), the same path a permission *revoked*
+mid-session (rather than missing from the start) already went through.
+Checking the permission set up front costs no extra round trip
+(gramps-web-api puts it in the access token's own claims, so
+get_permissions() just decodes the JWT already in hand) and names
+exactly what is missing either way.
 
 GET /metadata/ (cached per handler; needs no special permission) supplies
 the two versions the addon reasons about. The server's *Gramps* version
@@ -1594,7 +1603,24 @@ def _discarded_scalar_fields(old_data, current, local_obj, result):
     ever actually disputed, so checking it here the same way would flag
     a plain uncontested edit as a discarded conflict; see TODO.md's
     "Only do for CONFLICTS" note.
+
+    Also returns [] without a real old_data, same as
+    _apply_uncontested_scalar_edits() and _demoted_field_conflicts(): a
+    caller with no genuine pre-edit baseline is always a fresh add (see
+    transaction_to_json()'s "old": None convention) being retried against
+    an object that -- since has_handle() is what routes _retry_after_
+    conflict() into this merge path at all -- already exists locally with
+    exactly local_obj's own values, from the original commit this retry
+    is replaying. Treating a missing old_data as {} used to compare every
+    field against that fictitious empty baseline instead of skipping the
+    check, so every field local_obj actually set (its own real content,
+    not an edit relative to anything) read as "touched," and then as
+    "discarded" the moment current happened to already hold the identical
+    value -- a spurious conflict note, its "kept" and "discarded" values
+    always identical, on every retried add.
     """
+    if old_data is None:
+        return []
     if type(current).merge is BaseObject.merge:
         return []
     if not isinstance(result, type(current)):
@@ -1602,7 +1628,6 @@ def _discarded_scalar_fields(old_data, current, local_obj, result):
         # raise into that path over a result shape this couldn't parse.
         return []
     locked = _SCALAR_MERGE_LOCKED_FIELDS.get(type(current).__name__, frozenset())
-    old_data = old_data or {}
     current_data = object_to_dict(current)
     local_data = object_to_dict(local_obj)
     result_data = object_to_dict(result)
@@ -1792,6 +1817,17 @@ class WebApiDB(SQLite):
     #: a push -- so a second one can't start concurrently and land an
     #: overlapping DB-apply callback. See _start_push()/_finish_async_op().
     _syncing = False
+
+    #: Write permission(s) (of _WRITE_PERMISSIONS) the account
+    #: authenticating via GRAMPS_WEB_API_KEY was found missing at load()'s
+    #: _check_permissions_async() -- empty for a fully-privileged account,
+    #: for a tree opened read-only (never checked), or before load() has
+    #: run its checks. Does not by itself block anything: it is purely
+    #: informational (logged once at load()) and left for
+    #: _push_payload_async()'s own per-push 403 handling to actually
+    #: reject an edit when one is attempted -- see
+    #: _check_permissions_async()'s docstring.
+    _missing_write_permissions = ()
 
     #: The chain a conflict retry's nested re-push belongs to, stashed by
     #: _after_conflict_resync() so _start_push()'s recursive
@@ -2110,15 +2146,27 @@ class WebApiDB(SQLite):
         )
 
     def _check_permissions_async(self, on_done, on_error, writable=True):
-        """Fail at load() if the account GRAMPS_WEB_API_KEY authenticates
-        as lacks a server permission this addon depends on, naming exactly
-        which -- rather than letting each affected operation fail on its
-        own later, in ways that range from a bare 403 to (for the export
-        fallback) no error at all. See _PERM_VIEW_PRIVATE's comment for
-        what each permission actually gates.
+        """Fail at load() only if the account GRAMPS_WEB_API_KEY
+        authenticates as lacks ViewPrivate -- the one permission whose
+        absence is either loudly fatal (the history feed 403s outright) or
+        worse, silent (the export fallback just drops private records; see
+        _PERM_VIEW_PRIVATE's comment). A missing write permission
+        (AddObject/EditObject/DeleteObject) does *not* block load(): a
+        viewer- or contributor-level account can still open the tree, and
+        the mirror still polls and stays current for reading -- only
+        pushing a local edit back to the server is unavailable to it, and
+        gets rejected when it is actually attempted, via
+        _push_payload_async()'s existing handling of a non-retryable 4xx
+        (_is_retryable_push_error()): the server answers 403, the push is
+        logged loudly as permanently rejected, and a note recording why is
+        attached to the affected object(s) -- see
+        _record_undelivered_push_notes(). self._missing_write_permissions
+        is stashed here and logged once, at load() time, so a user who
+        never even attempts an edit still finds out why before hitting a
+        surprise 403 later.
 
         ``writable`` is False for a tree opened read-only (DBMODE_R), which
-        never pushes and so needs only the read permission.
+        never pushes and so is not checked for write permissions at all.
 
         Costs no extra round trip: gramps-web-api puts the permission list
         in the access token's own claims (token.py's ``claims = {
@@ -2127,34 +2175,49 @@ class WebApiDB(SQLite):
 
         Runs on io_runner for the same reason _check_identity_async() does.
         """
-        required = [_PERM_VIEW_PRIVATE]
-        if writable:
-            required += list(_WRITE_PERMISSIONS)
 
         def fetch():
             return self.web_client.get_permissions()
 
         def on_fetched(permissions):
             granted = set(permissions)
-            missing = [perm for perm in required if perm not in granted]
-            if not missing:
-                on_done(True)
-                return
-            on_error(
-                DbConnectionError(
-                    _(
-                        "The account authenticating via GRAMPS_WEB_API_KEY is "
-                        "missing server permission(s) this addon requires: "
-                        "%(missing)s. Grant it at least the "
-                        '"%(role)s" role on the server (or ask an '
-                        "administrator to), then reopen this Family Tree. "
-                        "Opening it as-is would leave the local mirror "
-                        "silently incomplete or unable to save changes back."
+            if _PERM_VIEW_PRIVATE not in granted:
+                on_error(
+                    DbConnectionError(
+                        _(
+                            "The account authenticating via GRAMPS_WEB_API_KEY is "
+                            "missing server permission(s) this addon requires: "
+                            "%(missing)s. Grant it at least the "
+                            '"%(role)s" role on the server (or ask an '
+                            "administrator to), then reopen this Family Tree. "
+                            "Opening it as-is would leave the local mirror "
+                            "silently incomplete or unable to save changes back."
+                        )
+                        % {"missing": _PERM_VIEW_PRIVATE, "role": _REQUIRED_ROLE_NAME},
+                        self._directory,
                     )
-                    % {"missing": ", ".join(missing), "role": _REQUIRED_ROLE_NAME},
-                    self._directory,
                 )
+                return
+            missing_write = (
+                [perm for perm in _WRITE_PERMISSIONS if perm not in granted]
+                if writable
+                else []
             )
+            self._missing_write_permissions = missing_write
+            if missing_write:
+                LOG.warning(
+                    "The account authenticating via GRAMPS_WEB_API_KEY is "
+                    'missing server permission(s) ("%s") this addon needs '
+                    "to push local changes back to the server; grant it "
+                    'the "%s" role (or ask an administrator to) to enable '
+                    "editing. Opening this Family Tree read-only against "
+                    "the server: the local mirror will keep polling and "
+                    "staying current, but any local edit will be rejected "
+                    "when it tries to push.",
+                    ", ".join(missing_write),
+                    _REQUIRED_ROLE_NAME,
+                )
+            on_done(True)
 
         def on_fetch_error(exc):
             if isinstance(exc, _CONNECTION_ERRORS):

--- a/GrampsWebApiDb/grampswebapidb.py
+++ b/GrampsWebApiDb/grampswebapidb.py
@@ -121,7 +121,12 @@ via _sync_from_server_async()'s verify_totals) and routes a shortfall to the
 same _full_resync_async(). Comparing totals rather than watching for an empty
 feed is what makes the case detectable: one API edit against such a
 server is enough for the feed to hand back a transaction and for the
-sync to look like it worked.
+sync to look like it worked. The ongoing poll (_poll_tick(), see
+VERIFY_TOTALS_POLL_INTERVAL_SECONDS) asks for the same check too, just on
+an hourly cadence rather than every tick, so this blind spot opening up
+while a tree is already sitting open -- not just at the moment it's
+opened -- gets caught within the hour instead of only at the next
+load().
 
 Pushes go out without force=1, so the server compares each item's "old"
 snapshot against its own current data and rejects the whole batch with
@@ -179,8 +184,12 @@ those two fields as ordinary content, a Person whose true index doesn't
 match that heuristic would otherwise disagree with the server after
 every single resync, forever, for reasons unrelated to anything actually
 edited. _snapshot_birth_death_indices()/_restore_birth_death_indices()
-carry the pre-resync value back across the reimport for any Person whose
-event_ref_list didn't itself change, closing that gap.
+carry the pre-resync value back across the reimport, closing that gap --
+by relocating the specific EventRef each index actually identifies
+(_relocate_birth_death_index()), not a bare integer position, so an
+unrelated addition/removal/reorder elsewhere in that Person's
+event_ref_list no longer forfeits the restore the way an earlier,
+whole-list-signature version of this mechanism did.
 
 For an add/update whose object still exists server-side (i.e. the
 conflicting edit changed the same object rather than deleting it),
@@ -192,19 +201,77 @@ clobber whatever the other side changed. merge(current, acquisition) is
 called as current.merge(acquisition) with current the server's post-
 resync copy and acquisition the local edit, so a *list*-valued field
 (notes, citations, media, urls, event/family refs, tags, ...) is
-unioned -- both sides' items survive -- and any other field merge()
-doesn't specially handle is simply left as current's own value, with
-acquisition's silently discarded (confirmed empirically:
-merge(FEMALE-current, MALE-local) keeps FEMALE) -- the *opposite* of
-"local overwrites remote". Two fields do get their own special-cased
-merge instead of either of those: privacy is OR'd
-(PrivacyBase._merge_privacy(): ``self.private = self.private or
-other.private``, so the merged object is private if either side marked
-it private -- confirmed the same way), and Person.merge() keeps
+unioned -- both sides' items survive. Two fields get their own special-
+cased merge beyond that: privacy is OR'd (PrivacyBase._merge_privacy():
+``self.private = self.private or other.private``, so the merged object
+is private if either side marked it private), and Person.merge() keeps
 current's own primary name but demotes acquisition's into current's
-alternate_names list rather than discarding it. Real field-level
-conflict *resolution* for the plain-scalar case (diff, prompt the user)
-is still out of scope. If the push fails for a non-conflict reason
+alternate_names list rather than discarding it.
+
+Any *other* field -- a plain scalar (date, place, description, gender,
+...) merge() has no handling for at all -- is left at current's own
+value by merge() itself (confirmed empirically: merge(FEMALE-current,
+MALE-local) keeps FEMALE), which would silently discard acquisition's
+edit to it even when nothing about that field actually collided.
+_apply_uncontested_scalar_edits() below layers a real per-field 3-way
+merge on top to fix exactly that: using entry["old"] (the payload's own
+pre-edit snapshot, threaded through as _merge_or_overwrite()'s optional
+old_data) as the true merge base, any such field acquisition is the
+*only* side to have touched gets applied on top of merge()'s result --
+so a conflict on one field of an object no longer costs an unrelated
+edit to a different field on that same object. Genuine field-level
+conflict *resolution* -- both sides touching the identical field to
+different values -- has no algorithmic answer (there is no "more
+correct" of two different birth dates) and is deliberately left at
+current's value, same as before, with _SCALAR_MERGE_LOCKED_FIELDS
+excluding the handful of fields (currently just Person.primary_name)
+whose merge() already has real special-cased handling that this generic
+layer would otherwise fight rather than complement.
+
+For that remaining, truly irreconcilable case, silently losing the
+discarded value is not acceptable either: _discarded_scalar_fields()
+below re-diffs current/acquisition/merged-result field by field (reusing
+gramps.gen.merge.diff.diff_items(), the same function the server's own
+old_unchanged() check uses) to find exactly which top-level fields
+acquisition touched that the merged result still doesn't reflect.
+
+Three more genuine-conflict shapes get the same treatment, each unable
+to reuse that same current-vs-merged-result comparison for its own
+reason: _demoted_field_conflicts() covers a _SCALAR_MERGE_LOCKED_FIELDS
+field (Person.primary_name) -- current.primary_name never changes value
+regardless of whether local_obj's edit to it collided with anything, so
+"touched" has to be checked directly against old_data instead;
+_actively_resolved_conflicts() covers a _SCALAR_MERGE_ACTIVELY_RESOLVED_
+FIELDS field (Citation.confidence, whose level_priority rule reassigns
+it on *every* merge() call, collision or not, so "merge() changed it"
+can't mean "there was a conflict" the way it does for every other
+field); and _prune_dangling_references()'s own pruned list (threaded
+through as _merge_or_overwrite()'s optional pruned parameter) covers a
+Tag/Note/Citation reference the other side deleted entirely -- a
+delete-vs-reference conflict, not a same-field value disagreement, but
+a genuine one whenever it fires. _conflict_summary_lines() below
+combines all four into the lines one Note records. Deliberately never
+triggered by an uncontested edit (only one side touched the field) or a
+successful list union (two different Tags/Notes/... both added --
+merge()'s equivalence-checked unioning, gen/lib/*base.py's various
+_merge_*_list() methods, means this is never itself a source of
+duplicate entries either) -- only a real, two-sided disagreement is
+worth a human's attention; see TODO.md's "Only do for CONFLICTS" note.
+
+There is deliberately no synchronous "pick a winner" prompt anywhere in
+this addon (no login dialog, no settings.ini, no wizard -- a background
+poll tick can't demand a decision mid-session), so automatic resolution
+stays automatic; what changes is that it is no longer silent. That Note
+is tagged the way gramps-connect's own message-note convention already
+is -- a plain Note
+(NoteType untouched) tagged "message" plus "todo-open" (see
+../gramps-connect/app/src/store/notesApi.ts) -- so the record shows up
+as a review-worthy message in gramps-connect's Messages view for free,
+and degrades to an ordinary tagged note anywhere that doesn't know the
+convention (gramps-web, desktop Gramps). It runs as its own, separate
+local transaction, committed only after _retry_after_conflict()'s own
+DbTxn has already landed -- see that
+method's docstring for why. If the push fails for a non-conflict reason
 (network error, auth failure), the local commit has already happened and
 is not rolled back -- the local mirror just drifts from the server until
 the next successful push or read sync.
@@ -278,7 +345,23 @@ Not every push failure is worth queueing, though: a 4xx other than 429 is
 the server's considered answer about the request itself and will not
 change on replay, so _is_retryable_push_error() sends those straight to a
 loud log instead -- queueing one would retry it on every poll forever and
-eventually evict genuinely retryable work from the capped queue.
+eventually evict genuinely retryable work from the capped queue. That log
+line alone used to be the end of it, silently: local and server diverge
+for that edit's object(s) with nothing else to show for it. Every point
+that gives up on a payload this way -- a fresh push's own non-retryable
+rejection, a queued push that comes back a conflict or non-retryable on
+replay, or an entry evicted from the queue outright -- now also calls
+_record_undelivered_push_notes(), reusing _record_conflict_notes()'s own
+message-note machinery (same tags, same author, same separate-
+transaction timing) to attach a note to each affected object explaining
+why. _is_message_note_push() guards every one of those call sites: it
+checks a failing payload's own "message" (forwarded from its local
+DbTxn's description) against _message_note_description(), so a message
+note that itself fails to sync the same way doesn't recursively spawn
+another note about that failure -- confirmed against a real database,
+not just reasoned about, since InlineTaskRunner-driven tests resolve the
+whole nested chain synchronously and would hang or blow the stack
+otherwise, not just log an extra line.
 
 The most likely such rejection is a permissions one, and _check_
 permissions() heads it off at load() rather than letting every subsequent
@@ -526,11 +609,13 @@ from gramps.gen.db.dbconst import (
 )
 from gramps.gen.db.exceptions import DbConnectionError
 from gramps.gen.errors import HandleError
+from gramps.gen.lib import Note, NoteType, Tag
 from gramps.gen.lib.baseobj import BaseObject
-from gramps.gen.lib.json_utils import data_to_object, remove_object
+from gramps.gen.lib.json_utils import data_to_object, object_to_dict, remove_object
 from gramps.gen.merge.diff import diff_items
 from gramps.gen.user import User
 from gramps.gen.utils.file import media_path_full
+from gramps.gen.utils.id import create_id
 from gramps.plugins.db.dbapi.sqlite import SQLite
 from gramps.plugins.importer.importxml import importData
 
@@ -561,6 +646,19 @@ POLL_INTERVAL_SECONDS = 10
 #: tick.
 MEDIA_POLL_INTERVAL_SECONDS = 300
 
+#: How often (seconds) the ongoing poll also asks _sync_from_server_async()
+#: for a totals check (verify_totals=True) -- the same mirror-completeness
+#: safety net load() always runs (see _mirror_is_short_of_the_server_async()),
+#: just far less often here: every 10-second tick would mean an extra
+#: GET /metadata/ request forever, for a blind spot (a server populated
+#: out-of-band -- a restored dump, a truncated history table -- with no
+#: transaction trail to describe it) that only matters if it happens while
+#: a tree is already open; load() already covers every other case, since
+#: it always runs one. _poll_tick() derives how many ticks that is from
+#: POLL_INTERVAL_SECONDS, so this stays an hour in wall-clock terms even
+#: if that changes.
+VERIFY_TOTALS_POLL_INTERVAL_SECONDS = 3600
+
 #: Ceiling (seconds) on the record poll's backoff while the server is
 #: unreachable -- see _poll_tick(). Every consecutive failure doubles the
 #: interval from POLL_INTERVAL_SECONDS up to this cap, and the first
@@ -580,6 +678,52 @@ POLL_BACKOFF_MAX_SECONDS = 300
 #: metadata row without bound, so the oldest are dropped with a loud log
 #: rather than silently.
 MAX_PENDING_PUSHES = 1000
+
+#: Tag names gramps-connect's own message-note convention uses to mark a
+#: Note as a reviewable message rather than an ordinary research note (see
+#: ../gramps-connect/app/src/store/notesApi.ts's MESSAGE_TAG/TODO_OPEN_TAG).
+#: Reused as-is here -- both sides converge on the same Tag object via
+#: get_tag_from_name(), and a recorded conflict or undelivered-push
+#: notice shows up in gramps-connect's Messages view with no new
+#: client-side code needed.
+MESSAGE_TAG_NAME = "message"
+MESSAGE_TODO_OPEN_TAG_NAME = "todo-open"
+
+#: "Author" name for the "<author>: <message>" plain-text convention
+#: gramps-connect's authoredText.ts parses (see notesApi.ts). Shared by
+#: every message note this addon writes -- conflict records
+#: (_record_conflict_notes()) and undelivered-push notices
+#: (_record_undelivered_push_notes()) alike.
+MESSAGE_NOTE_AUTHOR = "GrampsWebApiDb"
+
+
+def _message_note_description():
+    """The DbTxn description _record_conflict_notes() uses -- also
+    becomes that commit's own pushed transaction "message"
+    (transaction_commit() forwards transaction.get_description()
+    through as-is; see its own comment). A function, not a module-level
+    constant, so a locale switched mid-session doesn't leave a stale
+    translation baked into later comparisons -- recomputed fresh every
+    time, same as every other translated DbTxn description in this
+    file.
+
+    _is_message_note_push() checks a push's own message against this to
+    tell whether that payload *is* a message-note commit, wherever this
+    file is about to record another undelivered-push note about a
+    payload that failed to reach the server -- so a message note that
+    itself fails to sync doesn't recursively spawn another note about
+    that failure, forever. See _record_undelivered_push_notes()'s
+    docstring.
+    """
+    return _("Record a discarded sync conflict")
+
+
+def _is_message_note_push(message):
+    """True if message (a push's own "message" field) is one this
+    addon's own message-note machinery produced -- see
+    _message_note_description()."""
+    return message == _message_note_description()
+
 
 #: Net change count at or below which _full_resync_async()/
 #: _bootstrap_full_resync() describe a reimport with granular per-object
@@ -877,15 +1021,22 @@ def _describe_connection_error(err):
 
 
 def _is_retryable_push_error(err):
-    """Whether a failed push is worth queueing for a later retry.
+    """Whether a failed request is worth retrying -- named for its
+    original use (a failed push, see _push_payload_async()) but equally
+    applicable to a failed poll read (_on_poll_error()/
+    _on_media_poll_error()): the same 4xx-is-a-considered-answer logic
+    holds regardless of which kind of request it was.
 
     A 4xx is the server's considered answer about *this* request -- 403
     (the account lacks AddObject/EditObject/DeleteObject; see
-    _check_permissions_async()), 404, or a 400 that push_transaction() already
-    determined isn't a conflict -- and will keep being the answer no
-    matter how often it is replayed. Queueing one would retry it on every
-    poll forever and, worse, eventually evict genuinely retryable work
-    from the capped queue.
+    _check_permissions_async() -- or, on a poll's read path, ViewPrivate,
+    or the account behind GRAMPS_WEB_API_KEY no longer existing at all,
+    e.g. the server having been reset), 404, or a 400 that
+    push_transaction() already determined isn't a conflict -- and will
+    keep being the answer no matter how often it is replayed. Retrying
+    one forever would just repeat the same rejection on every poll (and,
+    for a push, eventually evict genuinely retryable work from the
+    capped queue).
 
     429 is the exception: it is explicitly "try again shortly", not a
     refusal. Everything else (5xx, URLError, socket timeout, a malformed
@@ -894,6 +1045,40 @@ def _is_retryable_push_error(err):
     if isinstance(err, HTTPError):
         return err.code == 429 or not 400 <= err.code < 500
     return True
+
+
+def _notify_fatal_poll_error(detail):
+    """Show a native error dialog for _give_up_polling() -- the GUI
+    equivalent of load()'s own DbConnectionError path, reached directly
+    instead of by raising: a poll tick fires long after load() has
+    already returned, so there is no load() call left for a raised
+    exception to propagate out of and no dbstate/viewmanager code
+    waiting to catch one.
+
+    gramps.gui.user.User.notify_db_error() drives the same DBErrorDialog
+    load()'s own DbConnectionError shows -- imported the same has_display()-
+    gated, best-effort way _import_progress_user() already does, since
+    this DATABASE plugin must stay importable and usable without a
+    display (CLI use) or gi/Gtk installed at all. Headless or import
+    failure just leaves _give_up_polling()'s own LOG.error() call as the
+    only record -- there is no dialog to show either way.
+    """
+    if not has_display():
+        return
+    try:
+        from gramps.gui.user import User as GuiUser
+    except ImportError:
+        return
+    GuiUser().notify_db_error(
+        _(
+            "GrampsWebApiDb: this Family Tree's server credentials are no "
+            "longer valid, so periodic syncing has stopped:\n\n%(detail)s\n\n"
+            "Local edits will keep working, but will not reach the server "
+            "until this tree is closed and reopened with a valid "
+            "GRAMPS_WEB_API_KEY."
+        )
+        % {"detail": detail}
+    )
 
 
 #: Same substitution gramps.gui.dbman's Family Tree Manager applies to
@@ -970,7 +1155,7 @@ def _iter_referents(obj):
         yield from _iter_referents(child)
 
 
-def _prune_dangling_references(obj, db):
+def _prune_dangling_references(obj, db, pruned=None):
     """Strip any Tag/Note/Citation handle obj (or any nested child object
     -- see _iter_referents()) carries that no longer resolves in db.
 
@@ -993,6 +1178,15 @@ def _prune_dangling_references(obj, db):
     just the merge() branch's output -- the type(current).merge is
     BaseObject.merge fallback (e.g. Tag) returns local_obj outright with
     no merge() call at all to have caught this otherwise.
+
+    pruned, if given a list, gets one (attr, handle) tuple appended for
+    every handle actually stripped -- always a genuine two-sided
+    disagreement when it fires at all (local's edit still points at
+    something; db, reflecting the post-resync server state, says it no
+    longer exists), unlike an uncontested edit. How
+    _merge_or_overwrite() surfaces this to _retry_after_conflict() as a
+    conflict worth a message, without changing this function's own
+    in-place-mutation contract for existing callers that don't pass it.
     """
     for node in _iter_referents(obj):
         for attr, has_handle_name in _DANGLING_REFERENCE_CHECKS:
@@ -1000,23 +1194,77 @@ def _prune_dangling_references(obj, db):
             if not handles:
                 continue
             has_handle = getattr(db, has_handle_name)
-            handles[:] = [h for h in handles if has_handle(h)]
+            kept = []
+            for handle in handles:
+                if has_handle(handle):
+                    kept.append(handle)
+                elif pruned is not None:
+                    pruned.append((attr, handle))
+            handles[:] = kept
 
 
-def _event_ref_signature(person):
-    """A (handle, role) tuple per entry of person's event_ref_list --
-    enough to tell whether the list itself was untouched across a resync
-    (see _snapshot_birth_death_indices()), without pulling in the full
-    equality check EventRef.is_equivalent() does (citations, notes, ...
-    are irrelevant here)."""
-    return tuple((ref.ref, ref.role.serialize()) for ref in person.get_event_ref_list())
+def _birth_death_ref_identity(person):
+    """The (handle, role) identity -- (ref.ref, ref.role.serialize()) --
+    of whichever EventRef person's birth_ref_index/death_ref_index
+    currently points to, or None for an index that's -1 (nothing marked
+    primary) or out of range. What _restore_birth_death_indices() uses
+    to relocate the *same* ref after a resync by what it actually is,
+    not by trusting a bare integer position to still mean the same thing
+    once the list itself has changed around it -- see
+    _relocate_birth_death_index()."""
+    refs = person.get_event_ref_list()
+
+    def identity(index):
+        if index < 0 or index >= len(refs):
+            return None
+        ref = refs[index]
+        return (ref.ref, ref.role.serialize())
+
+    return identity(person.birth_ref_index), identity(person.death_ref_index)
+
+
+def _relocate_birth_death_index(event_ref_list, identity):
+    """Where identity (see _birth_death_ref_identity()) sits in
+    event_ref_list now, tolerating unrelated additions, removals, or
+    reordering elsewhere in the list -- unlike an earlier version of
+    this mechanism, which trusted a restore only if the person's whole
+    event_ref_list matched an exact pre-resync signature, forfeiting the
+    restore over any concurrent event-ref edit at all, even one entirely
+    unrelated to birth/death.
+
+    identity of None means "nothing was marked primary before" (the
+    original index was -1) -- restorable unconditionally as -1
+    regardless of what else in the list changed: birth_ref_index/
+    death_ref_index has no representation in a Gramps XML export at all
+    (see _snapshot_birth_death_indices()'s docstring), so nothing a
+    resync pulls in could ever correctly tell this addon to change its
+    own memory of this field from any other client. That memory --
+    including "nothing was marked" -- is the best available answer
+    regardless of what else about the person changed, for exactly the
+    same reason a real index is worth relocating rather than discarding
+    below.
+
+    Returns None (leave whatever ImportXml's own document-order
+    heuristic already computed alone) if identity names a specific ref
+    that is no longer present at all: unlike an unrelated list change,
+    losing the actual referenced event/role pair leaves nothing to
+    relocate to, and the freshly-recomputed guess is at least as
+    trustworthy as a now-dangling position would be.
+    """
+    if identity is None:
+        return -1
+    for position, ref in enumerate(event_ref_list):
+        if (ref.ref, ref.role.serialize()) == identity:
+            return position
+    return None
 
 
 def _snapshot_birth_death_indices(db):
-    """Capture birth_ref_index/death_ref_index (plus an event_ref_list
-    signature to tell whether it's still safe to trust that capture
-    afterwards) for every Person, keyed by handle -- taken right before
-    _full_resync_async()'s rebuild() clears the mirror.
+    """Capture birth_ref_index/death_ref_index -- as the specific
+    EventRef each currently identifies, not the bare integer position,
+    see _birth_death_ref_identity() -- for every Person, keyed by
+    handle, taken right before _full_resync_async()'s rebuild() clears
+    the mirror.
 
     Gramps XML has no element for either index (confirmed against
     exportxml.py's write_person(): only the event_ref_list itself is
@@ -1045,44 +1293,44 @@ def _snapshot_birth_death_indices(db):
     round trip, with no edit involved).
 
     _restore_birth_death_indices() undoes the damage for whatever this
-    captured, once the reimport is done -- but only for a Person whose
-    event_ref_list (see _event_ref_signature()) still matches signature
-    for signature afterwards: if it doesn't, something legitimately
-    changed that Person server-side and the freshly-recomputed index is
-    at least as trustworthy as blindly replaying a now-stale one.
+    captured, once the reimport is done.
     """
     snapshot = {}
     for handle in db.get_person_handles():
         person = db.get_person_from_handle(handle)
-        snapshot[handle] = (
-            person.birth_ref_index,
-            person.death_ref_index,
-            _event_ref_signature(person),
-        )
+        snapshot[handle] = _birth_death_ref_identity(person)
     return snapshot
 
 
 def _restore_birth_death_indices(db, snapshot, trans):
     """_snapshot_birth_death_indices()'s other half -- see that
-    function's docstring. Called under the same self._pulling context
-    _full_resync_async()'s rebuild() already holds around the reimport
-    itself, so this local-only correction does not get mistaken for an
-    edit to push back to the server (see transaction_begin()'s
-    self._pulling check). Returns the number of Person objects
-    corrected, purely for the caller's own debug log."""
+    function's docstring and _relocate_birth_death_index()'s for how
+    each index is relocated independently, tolerating an unrelated
+    change elsewhere in the person's event_ref_list. Called under the
+    same self._pulling context _full_resync_async()'s rebuild() already
+    holds around the reimport itself, so this local-only correction does
+    not get mistaken for an edit to push back to the server (see
+    transaction_begin()'s self._pulling check). Returns the number of
+    Person objects corrected, purely for the caller's own debug log.
+    """
     restored = 0
-    for handle, (birth_idx, death_idx, signature) in snapshot.items():
+    for handle, (birth_identity, death_identity) in snapshot.items():
         if not db.has_person_handle(handle):
             continue
         person = db.get_person_from_handle(handle)
-        if _event_ref_signature(person) != signature:
-            continue
-        if person.birth_ref_index == birth_idx and person.death_ref_index == death_idx:
-            continue
-        person.birth_ref_index = birth_idx
-        person.death_ref_index = death_idx
-        db.commit_person(person, trans)
-        restored += 1
+        event_ref_list = person.get_event_ref_list()
+        new_birth = _relocate_birth_death_index(event_ref_list, birth_identity)
+        new_death = _relocate_birth_death_index(event_ref_list, death_identity)
+        changed = False
+        if new_birth is not None and new_birth != person.birth_ref_index:
+            person.birth_ref_index = new_birth
+            changed = True
+        if new_death is not None and new_death != person.death_ref_index:
+            person.death_ref_index = new_death
+            changed = True
+        if changed:
+            db.commit_person(person, trans)
+            restored += 1
     return restored
 
 
@@ -1142,11 +1390,119 @@ def _diff_snapshots(before, after):
     return entries
 
 
-def _merge_or_overwrite(current, local_obj, db):
+#: object_to_dict() keys that never represent a real field edit: "change"
+#: is a commit timestamp, "handle"/"_class" identify the object rather
+#: than describe it, and "gramps_id" is deliberately cleared on local_obj
+#: before merge() runs (see _merge_or_overwrite() below), so it always
+#: "differs" from current without representing an actual local edit.
+_DISCARD_CHECK_IGNORED_FIELDS = frozenset({"_class", "handle", "change", "gramps_id"})
+
+#: Fields a primary type's own merge() deliberately preserves through a
+#: substitute mechanism, rather than simply leaving unhandled -- applying
+#: _apply_uncontested_scalar_edits() to these would fight that mechanism
+#: instead of complementing it. Currently just Person.primary_name:
+#: Person.merge() (gramps/gen/lib/person.py) always keeps current's own
+#: primary name and demotes acquisition's into current's alternate_names
+#: instead (already unioned in by the time _apply_uncontested_scalar_
+#: edits() runs) -- current.primary_name genuinely never changes value,
+#: structurally indistinguishable from "merge() never touched this
+#: field" the way every other special-cased field is (see that
+#: function's docstring), so it has to be named here explicitly instead.
+_SCALAR_MERGE_LOCKED_FIELDS = {"Person": frozenset({"primary_name"})}
+
+#: Fields a primary type's own merge() actively resolves via real
+#: business logic when both sides genuinely disagree, rather than either
+#: leaving a plain scalar at current's unchanged value or unioning a
+#: list. Currently just Citation.confidence: Citation.merge()
+#: (gramps/gen/lib/citation.py) always takes the more cautious of the
+#: two confidence levels, via a level_priority lookup -- a real,
+#: deliberate decision between two explicit values, worth a human
+#: knowing happened even though nothing was lost (the result is one of
+#: the two original values, just not left to chance which). Checked by
+#: _actively_resolved_conflicts() the same way _SCALAR_MERGE_LOCKED_
+#: FIELDS's Person.primary_name is checked by _demoted_field_
+#: conflicts() -- both need to be named explicitly, since in each case
+#: merge() already produced a definite value, so _discarded_scalar_
+#: fields() correctly has nothing left to flag for them.
+_SCALAR_MERGE_ACTIVELY_RESOLVED_FIELDS = {"Citation": frozenset({"confidence"})}
+
+
+def _is_genuine_collision(field, old_value, current_value, local_value):
+    """True only for the one shape of disagreement with no algorithmic
+    "correct" answer: current *and* local_obj both actually touched
+    field (each differs from old_value, the payload's own pre-edit
+    snapshot -- the true 3-way merge base), landing on genuinely
+    different values. An edit only one side made is not a conflict --
+    see TODO.md's "Only do for CONFLICTS" note -- so every function in
+    this file that has to tell the two apart shares this one check.
+    """
+    return (
+        diff_items(field, old_value, local_value)
+        and diff_items(field, old_value, current_value)
+        and diff_items(field, current_value, local_value)
+    )
+
+
+def _apply_uncontested_scalar_edits(old_data, current, local_obj, merged):
+    """Layered on top of merge()'s own field-specific handling (list
+    union, privacy-OR, ...): for any *other* field -- one merge() leaves
+    at current's unchanged value, a plain scalar it has no handling for
+    at all -- apply local_obj's edit if local_obj is the only side that
+    actually touched it, relative to old_data (the payload's own
+    pre-edit snapshot, entry["old"]) -- the true 3-way merge base; see
+    _discarded_scalar_fields()'s docstring for why old_data, not
+    current, decides "touched". A field both sides touched to
+    genuinely different values is a true collision and is deliberately
+    left alone here, at current's value -- see the module docstring's
+    "silently losing the discarded value is not" paragraph;
+    _discarded_scalar_fields(), called after this, records what's still
+    left to record once this has done what it safely can.
+
+    Mutates and returns merged in place, via plain setattr()/getattr():
+    every object_to_dict() top-level key names a real property on the
+    object (confirmed against Person's "gender", Event's "date"/"place"/
+    "description"/"type", ...), so this needs no per-class field list of
+    its own -- it discovers which fields merge() already handled by
+    asking what merge() actually changed (comparing current against
+    merged), the same technique _discarded_scalar_fields() uses, with
+    one necessary exception: _SCALAR_MERGE_LOCKED_FIELDS above.
+
+    A no-op if old_data is None: a caller with no real pre-edit baseline
+    (nothing in this file calls _merge_or_overwrite() without one except
+    tests exercising it directly) gets exactly the previous whole-
+    object-scalar behavior, not a guess at what "touched" means without
+    one.
+    """
+    if old_data is None or type(current).merge is BaseObject.merge:
+        return merged
+    locked = _SCALAR_MERGE_LOCKED_FIELDS.get(type(current).__name__, frozenset())
+    current_data = object_to_dict(current)
+    local_data = object_to_dict(local_obj)
+    merged_data = object_to_dict(merged)
+    for field, local_value in local_data.items():
+        if field in _DISCARD_CHECK_IGNORED_FIELDS or field in locked:
+            continue
+        if diff_items(field, current_data.get(field), merged_data.get(field)):
+            continue  # merge() already gave this field its own handling
+        old_value = old_data.get(field)
+        if not diff_items(field, old_value, local_value):
+            continue  # local_obj never touched this field
+        current_value = current_data.get(field)
+        if _is_genuine_collision(field, old_value, current_value, local_value):
+            continue  # a true conflict -- leave it for the note, not here
+        setattr(merged, field, getattr(local_obj, field))
+    return merged
+
+
+def _merge_or_overwrite(current, local_obj, db, old_data=None, pruned=None):
     """Combine local_obj's content into current via the object's own
     merge() -- the same list-unioning logic behind Gramps' Merge People/
     Family/... tools (ported from GrampsWebSync's diffhandler.py, credit
-    David Straub, same license) -- when the type actually implements it.
+    David Straub, same license) -- when the type actually implements it,
+    then _apply_uncontested_scalar_edits() layers a real per-field 3-way
+    merge on top for whatever merge() leaves untouched: a field only
+    local_obj touched (old_data provided) survives too, not just the
+    fields merge() itself knows how to combine.
 
     Falls back to local_obj outright for a type (e.g. Tag) that only
     inherits BaseObject's no-op merge(): "merging" into a no-op would
@@ -1158,8 +1514,17 @@ def _merge_or_overwrite(current, local_obj, db):
     merge() is for) and tag on a spurious "Merged Gramps ID" attribute --
     this is the same object, edited twice, not two objects becoming one.
 
+    old_data is entry["old"] -- the payload's own pre-edit snapshot, the
+    3-way merge base _apply_uncontested_scalar_edits() needs. Optional
+    (defaults to None, a no-op there) so every existing caller that
+    doesn't have one keeps the previous whole-object-scalar behavior
+    unchanged.
+
     db is required so the result can be checked for dangling references
-    before it's returned -- see _prune_dangling_references().
+    before it's returned -- see _prune_dangling_references(). pruned, if
+    given a list, is forwarded to it to collect what got stripped -- a
+    genuine conflict in its own right (the module docstring's "silently
+    losing the discarded value is not" section covers this too).
     """
     if type(current).merge is BaseObject.merge:
         result = local_obj
@@ -1168,9 +1533,239 @@ def _merge_or_overwrite(current, local_obj, db):
         local_copy = deepcopy(local_obj)
         local_copy.gramps_id = None
         merged.merge(local_copy)
+        _apply_uncontested_scalar_edits(old_data, current, local_obj, merged)
         result = merged
-    _prune_dangling_references(result, db)
+    _prune_dangling_references(result, db, pruned=pruned)
     return result
+
+
+def _readable_field_value(value):
+    """Render one object_to_dict() field value as a short, human-readable
+    string for a conflict note -- not a full pretty-printer, just enough
+    for a reader to tell what the kept/discarded value actually was.
+    """
+    if value is None or value == "":
+        return "(empty)"
+    if isinstance(value, dict):
+        if "string" in value:
+            # GrampsType-shaped (EventType, NameType, ...): its own
+            # custom string if set, else the type's standard name.
+            return value["string"] or str(value.get("value", value))
+        if "dateval" in value:
+            # Date-shaped: the user's own text if they set one, else the
+            # raw (day, month, year, slash) tuple.
+            return value.get("text") or str(value["dateval"])
+        return json.dumps(value, default=str)[:80]
+    if isinstance(value, list):
+        return f"{len(value)} item(s)"
+    return str(value)[:80]
+
+
+def _discarded_scalar_fields(old_data, current, local_obj, result):
+    """Return [(field, kept, discarded), ...] for every top-level field
+    local_obj's edit actually touched (differs from old_data, the
+    payload's own pre-edit snapshot -- entry["old"], the true 3-way merge
+    base) where result -- what _merge_or_overwrite() actually committed
+    -- still matches current unchanged, i.e. that edit did not survive.
+
+    old_data, not current, is what decides whether local_obj "touched" a
+    field: current is the server's post-resync state, which can itself
+    differ from old_data on fields local_obj never edited at all --
+    Person.merge()'s privacy-OR is exactly this shape (current.private
+    can be True from someone else's edit while local_obj.private is
+    still whatever it always was), and comparing against current there
+    would misreport an untouched field as a discarded local edit.
+
+    Deliberately does not need to know which fields merge() unions versus
+    leaves at current's value (see the module docstring's conflict-
+    handling section): comparing result against current directly catches
+    either shape of "local's edit didn't make it in" -- a plain scalar
+    merge() has no special handling for, or (structurally, though not
+    expected in practice for merge()'s own list/privacy/name handling) a
+    list-valued field for some reason not reflecting local's addition.
+
+    Returns [] for a type without a real merge() (BaseObject.merge --
+    result is local_obj outright, so nothing was discarded). Skips
+    _SCALAR_MERGE_LOCKED_FIELDS: those are handled exclusively by
+    _demoted_field_conflicts() instead, which (unlike this function)
+    requires a genuine collision -- merge() demotes a locked field like
+    Person.primary_name into a substitute unconditionally, on *every*
+    conflict-retry for that type, whether or not the field itself was
+    ever actually disputed, so checking it here the same way would flag
+    a plain uncontested edit as a discarded conflict; see TODO.md's
+    "Only do for CONFLICTS" note.
+    """
+    if type(current).merge is BaseObject.merge:
+        return []
+    if not isinstance(result, type(current)):
+        # Best-effort bookkeeping, not the retry's actual commit -- never
+        # raise into that path over a result shape this couldn't parse.
+        return []
+    locked = _SCALAR_MERGE_LOCKED_FIELDS.get(type(current).__name__, frozenset())
+    old_data = old_data or {}
+    current_data = object_to_dict(current)
+    local_data = object_to_dict(local_obj)
+    result_data = object_to_dict(result)
+    discarded = []
+    for field, local_value in local_data.items():
+        if field in _DISCARD_CHECK_IGNORED_FIELDS or field in locked:
+            continue
+        old_value = old_data.get(field)
+        if not diff_items(field, old_value, local_value):
+            continue  # local_obj didn't actually touch this field
+        current_value = current_data.get(field)
+        result_value = result_data.get(field)
+        if diff_items(field, current_value, result_value):
+            continue  # the result does reflect a real change -- not discarded
+        discarded.append(
+            (
+                field,
+                _readable_field_value(current_value),
+                _readable_field_value(local_value),
+            )
+        )
+    return discarded
+
+
+def _demoted_field_conflicts(old_data, current, local_obj, merged):
+    """Return [(field, kept, discarded), ...] for a _SCALAR_MERGE_LOCKED_
+    FIELDS field (currently just Person.primary_name) where old_data
+    shows a genuine collision -- current *and* local_obj both actually
+    touched it, to different values (see _is_genuine_collision()).
+
+    A locked field structurally never shows as "touched" by comparing
+    current against merged the way _discarded_scalar_fields() and
+    _apply_uncontested_scalar_edits() both detect every other field's
+    handling -- merge() demotes it into a substitute field entirely
+    (e.g. Person.merge() -> alternate_names) rather than declining to
+    change it the ordinary way, so current.primary_name genuinely never
+    changes value whether or not local_obj's edit to it collided with
+    anything. Requiring a real collision here, explicitly, is what
+    keeps this from flagging an ordinary, uncontested name edit that
+    happens to land on a locked field -- see TODO.md's "Only do for
+    CONFLICTS" note; nothing is actually lost in either case (merge()
+    always preserves the demoted value as an alternate), but only a
+    genuine conflict is worth a human's attention.
+
+    Returns [] without old_data, or for a type with no locked fields.
+    """
+    if old_data is None:
+        return []
+    locked = _SCALAR_MERGE_LOCKED_FIELDS.get(type(current).__name__)
+    if not locked:
+        return []
+    old_data = old_data or {}
+    current_data = object_to_dict(current)
+    local_data = object_to_dict(local_obj)
+    conflicts = []
+    for field in locked:
+        old_value = old_data.get(field)
+        current_value = current_data.get(field)
+        local_value = local_data.get(field)
+        if not _is_genuine_collision(field, old_value, current_value, local_value):
+            continue
+        conflicts.append(
+            (
+                field,
+                _readable_field_value(current_value),
+                _readable_field_value(local_value),
+            )
+        )
+    return conflicts
+
+
+def _actively_resolved_conflicts(old_data, current, local_obj, merged):
+    """Return [(field, kept, other), ...] for a _SCALAR_MERGE_ACTIVELY_
+    RESOLVED_FIELDS field (currently just Citation.confidence) where
+    old_data shows a genuine collision -- current *and* local_obj both
+    actually touched it, to different values (see
+    _is_genuine_collision()) -- that merge()'s own business logic (the
+    level_priority rule) then resolved to a definite answer, one of the
+    two original values.
+
+    Unlike _discarded_scalar_fields(), does not require merged to still
+    match current: merge() actively reassigns one of these fields on
+    every call regardless of whether a real collision occurred, so
+    "merged differs from current" doesn't by itself mean anything --
+    only a genuine collision (checked directly here, the same way
+    _demoted_field_conflicts() has to) does. kept is whichever of
+    current/local_obj's values merge() actually kept; other is whichever
+    it didn't -- both worth showing, since a human can't otherwise tell
+    a resolved conflict happened at all.
+
+    Returns [] without old_data, or for a type with no actively-resolved
+    fields.
+    """
+    if old_data is None:
+        return []
+    fields = _SCALAR_MERGE_ACTIVELY_RESOLVED_FIELDS.get(type(current).__name__)
+    if not fields:
+        return []
+    old_data = old_data or {}
+    current_data = object_to_dict(current)
+    local_data = object_to_dict(local_obj)
+    merged_data = object_to_dict(merged)
+    conflicts = []
+    for field in fields:
+        old_value = old_data.get(field)
+        current_value = current_data.get(field)
+        local_value = local_data.get(field)
+        if not _is_genuine_collision(field, old_value, current_value, local_value):
+            continue
+        merged_value = merged_data.get(field)
+        other_value = (
+            local_value
+            if diff_items(field, merged_value, current_value)
+            else current_value
+        )
+        conflicts.append(
+            (
+                field,
+                _readable_field_value(merged_value),
+                _readable_field_value(other_value),
+            )
+        )
+    return conflicts
+
+
+def _conflict_summary_lines(old_data, current, local_obj, merged, pruned):
+    """Build the human-readable lines _record_conflict_notes() writes
+    into one Note per conflicted object. Every source here only fires
+    for a genuine two-sided disagreement -- see each function's own
+    docstring, and TODO.md's "Only do for CONFLICTS" note -- so an
+    uncontested edit, or two different items both surviving a list
+    union, never produces a line.
+
+    pruned is _merge_or_overwrite()'s own pruned list (a dangling Tag/
+    Note/Citation reference _prune_dangling_references() had to strip):
+    always a genuine conflict when non-empty -- local's edit still
+    pointed at something that db, reflecting the post-resync server
+    state, says no longer exists, a real two-sided disagreement about
+    whether that referenced object should still exist at all.
+    """
+    lines = []
+    for field, kept, discarded in _discarded_scalar_fields(
+        old_data, current, local_obj, merged
+    ):
+        lines.append(f"kept {field} ({kept}), discarded local edit ({discarded})")
+    for field, kept, discarded in _demoted_field_conflicts(
+        old_data, current, local_obj, merged
+    ):
+        lines.append(
+            f"{field} conflict: kept ({kept}); local's conflicting edit "
+            f"({discarded}) was preserved separately rather than applied directly"
+        )
+    for field, kept, other in _actively_resolved_conflicts(
+        old_data, current, local_obj, merged
+    ):
+        lines.append(
+            f"{field} conflict: automatically resolved to ({kept}) over ({other})"
+        )
+    for attr, handle in pruned:
+        lines.append(
+            f"removed a {attr} reference ({handle}) that no longer exists on the server"
+        )
+    return lines
 
 
 class WebApiDB(SQLite):
@@ -1227,6 +1822,22 @@ class WebApiDB(SQLite):
     _poll_failures = 0
     _media_poll_failures = 0
     _poll_interval = POLL_INTERVAL_SECONDS
+
+    #: Ticks since _poll_tick() last asked for a totals check -- see
+    #: VERIFY_TOTALS_POLL_INTERVAL_SECONDS. Reset to 0 both by load()
+    #: (fresh state for a freshly opened tree, same as the outage
+    #: counters above) and by _poll_tick() itself every time it actually
+    #: fires one.
+    _polls_since_verify_totals = 0
+
+    #: Set by _give_up_polling() the first time either poller hits a
+    #: permanently-rejected request (see that method) -- both timers
+    #: share the one credential, so a rejection on either means neither
+    #: can succeed again, and this keeps the second poller's own arrival
+    #: at the same conclusion from showing a second dialog for the same
+    #: underlying problem. Reset by load() like every other outage-state
+    #: flag above.
+    _polling_abandoned = False
 
     def requires_login(self):
         # Credentials come from GRAMPS_WEB_API_KEY, not a login dialog.
@@ -1386,6 +1997,8 @@ class WebApiDB(SQLite):
         self._poll_failures = 0
         self._media_poll_failures = 0
         self._poll_interval = POLL_INTERVAL_SECONDS
+        self._polls_since_verify_totals = 0
+        self._polling_abandoned = False
         # _sync_media_files_async() runs its network legs on a worker
         # thread; _run_async_to_completion() blocks this call (pumping the
         # main loop so that worker thread's result can actually be
@@ -1775,16 +2388,34 @@ class WebApiDB(SQLite):
         once per tick, and the timer backs off while it lasts (see
         _record_poll_failure()) -- a 10-second traceback loop for as long
         as a server stays down buries anything else in the log and makes a
-        routine outage look like a crash."""
+        routine outage look like a crash.
+
+        Also asks for a totals check (verify_totals=True) once every
+        VERIFY_TOTALS_POLL_INTERVAL_SECONDS worth of ticks -- see that
+        constant and _mirror_is_short_of_the_server_async(). Tick-counted
+        (self._polls_since_verify_totals), not wall-clock-timed: this
+        still lands roughly on schedule during ordinary polling, and
+        stretches out for free during a backoff (_record_poll_failure())
+        without any extra bookkeeping, which is the right direction to
+        drift -- there is nothing useful to verify totals against while
+        the server is unreachable anyway. Reset to 0 both here and by
+        load(), which always runs its own check regardless."""
         if self._syncing:
             # Reached from inside a still-running chain this tick would
             # otherwise start again underneath.
             LOG.debug("poll: a sync is already running; skipping this tick")
             return GLib.SOURCE_CONTINUE
         self._syncing = True
+        self._polls_since_verify_totals += 1
+        verify_totals = self._polls_since_verify_totals >= (
+            VERIFY_TOTALS_POLL_INTERVAL_SECONDS // POLL_INTERVAL_SECONDS
+        )
+        if verify_totals:
+            self._polls_since_verify_totals = 0
         self._sync_from_server_async(
             on_done=self._finish_async_op(self._on_poll_success),
             on_error=self._finish_async_op(self._on_poll_error),
+            verify_totals=verify_totals,
         )
         return GLib.SOURCE_CONTINUE
 
@@ -1808,7 +2439,67 @@ class WebApiDB(SQLite):
                 "Unexpected error during periodic sync from server.", exc_info=exc
             )
             return
+        if not _is_retryable_push_error(exc):
+            # A permanent rejection (a revoked/expired token, an account
+            # the server no longer has -- see _give_up_polling()), not a
+            # connectivity blip: backing this off and retrying forever
+            # would just repeat the identical rejection every
+            # POLL_BACKOFF_MAX_SECONDS, silently, with nothing durable to
+            # tell the user their session is permanently stuck.
+            self._give_up_polling(exc)
+            return
         self._record_poll_failure(exc)
+
+    def _give_up_polling(self, exc):
+        """Reached from either _on_poll_error() or _on_media_poll_error()
+        once _is_retryable_push_error() says a poll's own request was
+        permanently rejected, not merely unreachable -- most plausibly
+        the account GRAMPS_WEB_API_KEY authenticates as no longer being
+        valid (a revoked/expired refresh token, or the server itself
+        having been reset: a fresh database behind the same URL, the old
+        account simply gone). Both timers share the one credential, so a
+        rejection on either means neither can succeed again -- this
+        stops both, not just whichever poller noticed first.
+
+        Deliberately does not call self.close(): nothing here can tell
+        dbstate/viewmanager a tree closed -- that direction only ever
+        runs the other way (viewmanager.py calls db.close(), never the
+        reverse; confirmed against gui/viewmanager.py) -- so doing that
+        would leave Gramps' own UI still showing the tree as open while
+        the connection underneath is actually gone, silently broken
+        rather than visibly stopped. What this leaves instead: sync
+        stopped, but the tree stays open and usable, local edits keep
+        working against the mirror and queuing (same as any other
+        unreachable-server state -- they simply never drain), and the
+        user has a clear, undismissable answer for why nothing is
+        syncing, via _notify_fatal_poll_error()'s dialog -- the nearest
+        equivalent reachable from here to load()'s own DbConnectionError
+        path, which isn't itself reachable once load() has already
+        returned.
+
+        Idempotent via self._polling_abandoned: both pollers can hit
+        this around the same moment (they share the one credential), and
+        the second call here stops its own timer quietly rather than
+        show a second dialog for the same underlying problem.
+        """
+        for attr in ("_poll_source_id", "_media_poll_source_id"):
+            source_id = getattr(self, attr, None)
+            if source_id is not None:
+                GLib.source_remove(source_id)
+                setattr(self, attr, None)
+        if self._polling_abandoned:
+            return
+        self._polling_abandoned = True
+        detail = _describe_connection_error(exc)
+        LOG.error(
+            "Periodic sync from the server was permanently rejected (%s); "
+            "this tree's credentials appear to no longer be valid. "
+            "Polling has stopped -- local edits will keep working but "
+            "will not sync until this tree is closed and reopened with a "
+            "valid GRAMPS_WEB_API_KEY.",
+            detail,
+        )
+        _notify_fatal_poll_error(detail)
 
     def _record_poll_failure(self, err):
         """Handle a failed _poll_tick() sync: report it (once per outage,
@@ -1907,6 +2598,11 @@ class WebApiDB(SQLite):
             # such caller for an async on_error, so log it loudly here
             # instead of silently losing it.
             LOG.error("Unexpected error during periodic media file sync.", exc_info=exc)
+            return
+        if not _is_retryable_push_error(exc):
+            # Same permanent-rejection reasoning as _on_poll_error() --
+            # see _give_up_polling().
+            self._give_up_polling(exc)
             return
         if self._media_poll_failures == 0:
             LOG.warning(
@@ -2180,7 +2876,19 @@ class WebApiDB(SQLite):
                     len(payload),
                     exc,
                 )
+                # on_error() first, not after: it's what releases
+                # self._syncing (via _finish_async_op(), the top-level
+                # caller's wrapped completion handler) -- calling it
+                # before the note's own local commit means that commit's
+                # own push (transaction_commit() -> _start_push()) finds
+                # self._syncing already clear and can go out right away,
+                # instead of finding it still held by this very chain and
+                # being deferred to _queue_pending_push() for no reason.
                 on_error(exc)
+                if not _is_message_note_push(message):
+                    self._record_undelivered_push_notes(
+                        payload, f"server permanently rejected it ({exc})"
+                    )
                 return
             # LOG.exception() (used by the old synchronous _push_payload())
             # relies on sys.exc_info(), which has nothing to show from
@@ -2349,9 +3057,20 @@ class WebApiDB(SQLite):
         alongside the payload so a queued push, once retried, still shows
         up in the server's history under its original description rather
         than falling back to "Raw transaction".
+
+        Recording a note for an evicted entry (see
+        _record_undelivered_push_notes()) is its own local edit, which
+        can itself land right back here if its push fails for a
+        connectivity reason too -- so the trimmed queue is persisted
+        *before* any of that runs, not after. Recording first would let
+        that nested call read this method's not-yet-persisted ``pending``
+        via its own _get_metadata() call, then overwrite it with a stale
+        copy missing whatever the nested call just queued, once this
+        call's own _set_metadata() finally runs.
         """
         pending = self._get_metadata("pending_pushes", default=[])
         pending.append({"payload": payload, "undo": undo, "message": message})
+        evicted_entries = []
         if len(pending) > MAX_PENDING_PUSHES:
             dropped = len(pending) - MAX_PENDING_PUSHES
             LOG.error(
@@ -2362,8 +3081,16 @@ class WebApiDB(SQLite):
                 MAX_PENDING_PUSHES,
                 dropped,
             )
+            evicted_entries = pending[:dropped]
             pending = pending[dropped:]
         self._set_metadata("pending_pushes", pending)
+        for evicted in evicted_entries:
+            if not _is_message_note_push(evicted.get("message")):
+                self._record_undelivered_push_notes(
+                    evicted["payload"],
+                    "it was evicted from the local retry queue after too "
+                    "many undelivered changes accumulated",
+                )
 
     def _flush_pending_pushes_async(self, on_done, on_error):
         """Retry queued pushes that previously failed for a connectivity
@@ -2404,7 +3131,26 @@ class WebApiDB(SQLite):
         mutated in place (entries popped off the front as they're
         delivered or dropped) and persisted once this recursion bottoms
         out, exactly the way the old synchronous while-loop this
-        replaces did with its own local variable."""
+        replaces did with its own local variable.
+
+        Recording a note for a dropped entry below (see
+        _record_undelivered_push_notes()) is its own local edit, which
+        could in principle land right back in _queue_pending_push() if
+        its own push fails for a connectivity reason -- and because this
+        method only persists ``pending`` once the whole recursion
+        bottoms out, not after every pop (see above), that nested call's
+        own _set_metadata() could be overwritten by this one's once it
+        finally runs, losing the note-push's own queued retry. Unlike
+        the same risk in _queue_pending_push() itself (persist-before-
+        record there, since it has one write to reorder around), fixing
+        it here would mean persisting after every single pop instead of
+        once at the end -- a real behavior change to well-tested
+        existing logic for what is, worst case, one best-effort
+        diagnostic note lost to a narrow double-failure race, not the
+        original edit itself (that loss is already logged unconditionally
+        either way). Left as a known, acceptable gap rather than
+        rearchitected for it.
+        """
         if not pending:
             self._set_metadata("pending_pushes", pending)
             LOG.debug("queue: %d push(es) still pending after the flush", len(pending))
@@ -2440,6 +3186,12 @@ class WebApiDB(SQLite):
                     "server for those object(s).",
                     len(entry["payload"]),
                 )
+                if not _is_message_note_push(entry.get("message")):
+                    self._record_undelivered_push_notes(
+                        entry["payload"],
+                        "it conflicted with the server's current data and "
+                        "could not be replayed safely",
+                    )
                 pop_and_continue()
                 return
             if _is_retryable_push_error(exc):
@@ -2460,6 +3212,10 @@ class WebApiDB(SQLite):
                 len(entry["payload"]),
                 exc,
             )
+            if not _is_message_note_push(entry.get("message")):
+                self._record_undelivered_push_notes(
+                    entry["payload"], f"server permanently rejected it ({exc})"
+                )
             pop_and_continue()
 
         self.io_runner.run(
@@ -2496,8 +3252,21 @@ class WebApiDB(SQLite):
         in the brief window since then. _after_conflict_resync() runs
         this as one runner (main-thread) step, since it's 100% local DB
         work with no network of its own.
+
+        Any genuine conflict _merge_or_overwrite() had to resolve
+        automatically -- a discarded scalar field, a demoted primary
+        name, an actively-resolved field like Citation confidence, or a
+        pruned dangling reference (see _conflict_summary_lines()) -- is
+        collected here and handed to _record_conflict_notes()
+        afterwards, as its own separate transaction -- not inside the
+        ``with DbTxn`` below, so this retry's own commit stays exactly
+        what it was before: one object per conflicting entry, nothing
+        else. An uncontested edit, or two different items both
+        surviving a list union, produces no lines and is never recorded
+        -- see TODO.md's "Only do for CONFLICTS" note.
         """
         self._retrying = True
+        conflicts = []
         try:
             with DbTxn(_("Retry local change after server conflict"), self) as trans:
                 for entry in payload:
@@ -2514,10 +3283,139 @@ class WebApiDB(SQLite):
                         obj = data_to_object(entry["new"])
                         if has_handle(handle):
                             current = getattr(self, f"get_{name}_from_handle")(handle)
-                            obj = _merge_or_overwrite(current, obj, self)
+                            old_data = entry.get("old")
+                            pruned = []
+                            merged = _merge_or_overwrite(
+                                current, obj, self, old_data=old_data, pruned=pruned
+                            )
+                            lines = _conflict_summary_lines(
+                                old_data, current, obj, merged, pruned
+                            )
+                            if lines:
+                                conflicts.append((entry["_class"], name, handle, lines))
+                            obj = merged
                         getattr(self, f"commit_{name}")(obj, trans)
         finally:
             self._retrying = False
+        if conflicts:
+            self._record_conflict_notes(conflicts)
+
+    def _get_or_create_tag(self, name):
+        """Look up a Tag by name, creating it if this is the first time
+        it's needed here -- the same lookup-or-create gramps-connect's
+        own notesApi.ts does for its "message"/"todo-open" tags, so both
+        sides converge on the same Tag object regardless of which one
+        creates it first.
+
+        Runs its own DbTxn rather than sharing the caller's: tag
+        creation is a one-time, idempotent event (a second call finds it
+        via get_tag_from_name() and never reaches the create branch
+        again), not part of what any particular conflict recording is
+        "about".
+        """
+        tag = self.get_tag_from_name(name)
+        if tag is not None:
+            return tag
+        tag = Tag()
+        tag.set_handle(create_id())
+        tag.set_name(name)
+        with DbTxn(_("Create tag"), self) as trans:
+            self.commit_tag(tag, trans)
+        return tag
+
+    def _record_conflict_notes(self, conflicts):
+        """Attach one gramps-connect-style "message" Note per conflicted
+        object, recording exactly what _retry_after_conflict() had to
+        resolve automatically -- see the module docstring's "silently
+        losing the discarded value is not" paragraph and
+        _conflict_summary_lines()'s own docstring for what counts.
+
+        ``conflicts`` is a list of (obj_class, name, handle, lines) from
+        _retry_after_conflict(), where lines is
+        _conflict_summary_lines()'s own list of ready-made, human-
+        readable strings -- already filtered to genuine conflicts only,
+        nothing left for this method to decide.
+
+        Runs as its own, separate local transaction, called only after
+        _retry_after_conflict()'s own DbTxn has already committed --
+        deliberately not folded into that one, so the retry's own commit
+        stays exactly what it always was: one object per conflicting
+        entry, nothing else (see that method's docstring). This one goes
+        through the completely ordinary transaction_commit() ->
+        _start_push() path like any other local edit -- no special-
+        casing needed, and safe even if *this* push itself hits a
+        conflict, since attaching a note is a list-valued change
+        merge() already unions correctly (unlike the scalar edit this
+        note exists to record in the first place).
+        """
+        message_tag = self._get_or_create_tag(MESSAGE_TAG_NAME)
+        todo_tag = self._get_or_create_tag(MESSAGE_TODO_OPEN_TAG_NAME)
+        with DbTxn(_message_note_description(), self) as trans:
+            for obj_class, name, handle, lines in conflicts:
+                get_from_handle = getattr(self, f"get_{name}_from_handle", None)
+                if get_from_handle is None:
+                    continue
+                try:
+                    obj = get_from_handle(handle)
+                except HandleError:
+                    continue  # gone locally by the time this runs
+                if not hasattr(obj, "add_note"):
+                    continue  # e.g. Tag -- nothing to attach a note to
+                summary = "; ".join(lines)
+                note = Note()
+                note.set_handle(create_id())
+                note.set_gramps_id(self.find_next_note_gramps_id())
+                note.set_type(NoteType.GENERAL)
+                note.set(f"{MESSAGE_NOTE_AUTHOR}: {obj_class} -- {summary}")
+                note.add_tag(message_tag.handle)
+                note.add_tag(todo_tag.handle)
+                self.commit_note(note, trans)
+                obj.add_note(note.handle)
+                getattr(self, f"commit_{name}")(obj, trans)
+
+    def _record_undelivered_push_notes(self, payload, reason):
+        """Attach a gramps-connect-style "message" Note to every add/
+        update entry in payload whose object still exists locally,
+        recording that this local edit will never reach the server, and
+        why -- reusing _record_conflict_notes()'s own Note-attachment
+        machinery (same tags, same separate-transaction timing, same
+        reasoning) rather than a second implementation of it. See
+        TODO.md gap #2/#3: local and server permanently diverge for
+        that object the moment this runs, exactly the kind of silent
+        loss the "never silent, never blocking" design principle exists
+        to close, just from a delivery failure rather than a merge
+        conflict.
+
+        Called from every point elsewhere in this file that gives up on
+        a local edit ever reaching the server: a non-retryable
+        rejection (_push_payload_async()'s on_push_error), a queued
+        push that now conflicts or is itself non-retryable on replay
+        (_flush_one_pending_push()'s on_push_error), and a pending-push
+        queue eviction (_queue_pending_push()).
+
+        A delete entry has no local object left to attach a note to --
+        skipped here, same as _record_conflict_notes() skips a handle
+        that's gone by the time it runs; only the caller's own log line
+        records that one.
+        """
+        conflicts = []
+        for entry in payload:
+            if entry["type"] == "delete":
+                continue  # nothing local left to attach a note to
+            key = CLASS_TO_KEY_MAP.get(entry["_class"])
+            if key is None:
+                continue
+            name = KEY_TO_NAME_MAP[key]
+            conflicts.append(
+                (
+                    entry["_class"],
+                    name,
+                    entry["handle"],
+                    [f"local edit could not be synced to the server: {reason}"],
+                )
+            )
+        if conflicts:
+            self._record_conflict_notes(conflicts)
 
     def _resync_after_conflict_async(self, on_done, on_error):
         """Rebuild the local mirror from a fresh server export
@@ -3083,7 +3981,8 @@ class WebApiDB(SQLite):
         is empty *altogether*, or too sparse to account for what the
         server holds, is the same kind of gap and gets the same
         fallback -- see _mirror_is_short_of_the_server_async(), which
-        ``verify_totals`` asks for (load() does; the poll doesn't).
+        ``verify_totals`` asks for (load() always does; the poll does
+        too, but only once every VERIFY_TOTALS_POLL_INTERVAL_SECONDS).
 
         progress_callback, if given, is called with an int 0-100 after
         each page -- see load()'s callback param. "total" comes from the
@@ -3364,10 +4263,13 @@ class WebApiDB(SQLite):
         already there.
 
         Only run where _sync_from_server_async()'s caller asks for it --
-        load(), not the 10-second poll (see POLL_INTERVAL_SECONDS): an
-        outdated mirror is repaired when the tree is opened, not on a
-        timer, so the extra GET /metadata/ costs one request per open and
-        a rebuild can never land in the middle of a working session.
+        load() every time, and _poll_tick() once every
+        VERIFY_TOTALS_POLL_INTERVAL_SECONDS rather than every 10-second
+        tick (see that constant): the extra GET /metadata/ request is
+        cheap enough for that cadence, but not for every tick forever,
+        and a shortfall discovered mid-session still routes to the same
+        _full_resync_async() a shortfall at load() would -- no longer
+        only repaired when the tree happens to be reopened.
 
         Skipped outright while pushes are queued (see
         _queue_pending_push()): those are local edits the server has not

--- a/GrampsWebApiDb/tests/test_grampswebapidb.py
+++ b/GrampsWebApiDb/tests/test_grampswebapidb.py
@@ -3274,6 +3274,28 @@ class TestDiscardedScalarFields(unittest.TestCase):
         )
         self.assertEqual(discarded, [])
 
+    def test_no_old_data_reports_nothing(self):
+        # A fresh add (transaction_to_json()'s "old": None convention)
+        # replayed by _retry_after_conflict(): has_handle() is what routes
+        # it into the merge path at all, so current already holds exactly
+        # local's own values from the original commit -- comparing against
+        # a fictitious {} baseline instead of skipping used to flag every
+        # field local set as both "touched" and "discarded" even though
+        # kept and discarded were identical (nothing actually happened).
+        current = Person()
+        current.set_handle("H1")
+        current.set_gender(Person.MALE)
+
+        local = Person()
+        local.set_handle("H1")
+        local.set_gender(Person.MALE)
+
+        merged = grampswebapidb._merge_or_overwrite(current, local, FakeHandleDb())
+        discarded = grampswebapidb._discarded_scalar_fields(
+            None, current, local, merged
+        )
+        self.assertEqual(discarded, [])
+
     def test_locked_field_is_never_reported_here_even_on_a_genuine_collision(self):
         # primary_name is handled exclusively by _demoted_field_conflicts()
         # -- reporting it here too would double-report the same conflict,
@@ -3963,16 +3985,29 @@ class TestCheckPermissions(unittest.TestCase):
             run_check(self.db, "_check_permissions_async")
         self.assertIn("ViewPrivate", str(ctx.exception))
 
-    def test_missing_one_write_permission_raises(self):
+    def test_missing_one_write_permission_does_not_block_load(self):
         # has_permissions() server-side fails if *any* of the three are
-        # missing, so a Contributor (AddObject only) cannot push at all.
+        # missing, so a Contributor (AddObject only) cannot push at all --
+        # but that no longer keeps the tree from opening: it still needs
+        # to poll and stay current for reading. Only an actual push is
+        # rejected, later, when one is attempted (see
+        # TestPushPermanentRejection / the module docstring).
         self._grant("ViewPrivate", "AddObject")
-        with self.assertRaises(DbConnectionError) as ctx:
-            run_check(self.db, "_check_permissions_async")
-        message = str(ctx.exception)
+        with self.assertLogs(grampswebapidb.LOG, level="WARNING") as ctx:
+            run_check(self.db, "_check_permissions_async")  # must not raise
+        message = "\n".join(ctx.output)
         self.assertIn("EditObject", message)
         self.assertIn("DeleteObject", message)
         self.assertNotIn("AddObject", message.replace("EditObject", ""))
+        self.assertEqual(
+            sorted(self.db._missing_write_permissions), ["DeleteObject", "EditObject"]
+        )
+
+    def test_missing_write_permissions_names_the_role_to_ask_for(self):
+        self._grant("ViewPrivate")
+        with self.assertLogs(grampswebapidb.LOG, level="WARNING") as ctx:
+            run_check(self.db, "_check_permissions_async")  # must not raise
+        self.assertIn("Editor", "\n".join(ctx.output))
 
     def test_error_names_the_role_to_ask_for(self):
         self._grant()
@@ -3980,11 +4015,18 @@ class TestCheckPermissions(unittest.TestCase):
             run_check(self.db, "_check_permissions_async")
         self.assertIn("Editor", str(ctx.exception))
 
+    def test_full_permissions_leave_no_missing_write_permissions(self):
+        self._grant(*self.ALL_PERMS)
+        run_check(self.db, "_check_permissions_async")
+        self.assertEqual(self.db._missing_write_permissions, [])
+
     def test_read_only_tree_does_not_need_write_permissions(self):
         # A tree opened read-only never pushes, so a Member-level account
-        # (ViewPrivate but no write permissions) is enough for it.
+        # (ViewPrivate but no write permissions) is enough for it, and it
+        # is never even checked for write permissions.
         self._grant("ViewPrivate")
         run_check(self.db, "_check_permissions_async", writable=False)  # must not raise
+        self.assertEqual(self.db._missing_write_permissions, [])
 
     def test_read_only_tree_still_needs_view_private(self):
         self._grant("AddObject", "EditObject", "DeleteObject")

--- a/GrampsWebApiDb/tests/test_grampswebapidb.py
+++ b/GrampsWebApiDb/tests/test_grampswebapidb.py
@@ -78,6 +78,7 @@ from gramps.gen.db.exceptions import DbConnectionError
 from gramps.gen.db.utils import make_database
 from gramps.gen.lib import (
     Attribute,
+    Citation,
     Event,
     EventRef,
     EventRoleType,
@@ -1930,6 +1931,525 @@ class TestConflictRetryAgainstARealDatabase(unittest.TestCase):
         self.assertEqual(len(final.get_attribute_list()), 1)
 
 
+class TestConflictNoteRecording(unittest.TestCase):
+    """_retry_after_conflict() -> _record_conflict_notes(): a genuine
+    scalar-field conflict (both sides changed the same field to
+    different values) must leave a gramps-connect-style "message" Note
+    behind recording what was kept and what was discarded, not just
+    silently keep the server's value -- see the module docstring's
+    "silently losing the discarded value is not" paragraph and TODO.md's
+    "never silent, never blocking" design principle. Same real-DBAPI
+    setup as TestConflictRetryAgainstARealDatabase."""
+
+    def setUp(self):
+        tmpdir = tempfile.mkdtemp(prefix="grampswebapidb_test_")
+        self.addCleanup(shutil.rmtree, tmpdir, ignore_errors=True)
+        db = make_database("sqlite")
+        db.load(tmpdir)
+        with DbTxn("seed", db) as trans:
+            person = Person()
+            person.set_gramps_id("I0001")
+            person.set_gender(Person.FEMALE)
+            db.add_person(person, trans)
+            self.handle = person.handle
+        db.__class__ = WebApiDB
+        db.web_client = mock.MagicMock()
+        db.runner = InlineTaskRunner()
+        db.io_runner = InlineTaskRunner()
+        db._syncing = False
+        db._retrying = False
+        db._pulling = False
+        db._get_metadata = lambda key, default=0: default
+        db._set_metadata = lambda key, value, use_txn=True: None
+        db.web_client.get_transaction_history.return_value = ([], 0)
+        db.web_client.get_object_count.return_value = 1
+        db.web_client.supports_background_transactions.return_value = False
+        self.db = db
+        self.addCleanup(self.db.close)
+
+    def _current_data(self):
+        return remove_object(
+            object_to_data(self.db.get_person_from_handle(self.handle))
+        )
+
+    def _stub_full_resync_to(self, server_fresh):
+        def fake_full_resync_async(on_done, on_error, progress_callback=None):
+            self.db._pulling = True
+            try:
+                with DbTxn("fake resync", self.db, batch=True) as trans:
+                    self.db.commit_person(data_to_object(server_fresh), trans)
+            finally:
+                self.db._pulling = False
+            on_done(None)
+
+        return mock.patch.object(
+            self.db, "_full_resync_async", side_effect=fake_full_resync_async
+        )
+
+    def _push_conflicts_once_then_succeeds(self):
+        calls = []
+
+        def fake_push(payload, undo=False, background=False, message=None):
+            calls.append(copy.deepcopy(payload))
+            if len(calls) == 1:
+                raise WebApiPushConflict("Object has changed")
+
+        self.db.web_client.push_transaction.side_effect = fake_push
+        return calls
+
+    def test_genuine_conflict_leaves_a_tagged_message_note(self):
+        server_fresh = self._current_data()
+        server_fresh["gender"] = Person.MALE
+        calls = self._push_conflicts_once_then_succeeds()
+
+        with self._stub_full_resync_to(server_fresh):
+            with DbTxn("edit", self.db) as trans:
+                person = self.db.get_person_from_handle(self.handle)
+                person.set_gender(Person.UNKNOWN)
+                self.db.commit_person(person, trans)
+
+        # The original push, the retry, then the note-recording side
+        # effects (creating the two tags and attaching the note each
+        # push through the normal transaction_commit() path in turn) --
+        # more than the plain retry case, since _record_conflict_notes()
+        # is real local edits, not free bookkeeping.
+        self.assertGreaterEqual(len(calls), 2)
+        final = self.db.get_person_from_handle(self.handle)
+        # The server's post-resync value won -- merge() has no special
+        # handling for gender, so it's left at current's value.
+        self.assertEqual(final.get_gender(), Person.MALE)
+
+        note_handles = final.get_note_list()
+        self.assertEqual(len(note_handles), 1)
+        note = self.db.get_note_from_handle(note_handles[0])
+        self.assertIn("gender", note.get())
+        self.assertTrue(
+            note.get().startswith(f"{grampswebapidb.MESSAGE_NOTE_AUTHOR}: ")
+        )
+
+        message_tag = self.db.get_tag_from_name(grampswebapidb.MESSAGE_TAG_NAME)
+        todo_tag = self.db.get_tag_from_name(grampswebapidb.MESSAGE_TODO_OPEN_TAG_NAME)
+        self.assertIsNotNone(message_tag)
+        self.assertIsNotNone(todo_tag)
+        self.assertIn(message_tag.handle, note.get_tag_list())
+        self.assertIn(todo_tag.handle, note.get_tag_list())
+
+    def test_a_conflict_resolved_entirely_by_merge_leaves_no_note(self):
+        # Same shape as TestConflictRetryAgainstARealDatabase's own
+        # privacy-OR/attribute-union case: nothing is actually discarded
+        # (privacy is OR'd, the attribute list is unioned), so no
+        # conflict note should be created at all.
+        server_fresh = self._current_data()
+        server_fresh["private"] = True
+        calls = self._push_conflicts_once_then_succeeds()
+
+        with self._stub_full_resync_to(server_fresh):
+            with DbTxn("edit", self.db) as trans:
+                person = self.db.get_person_from_handle(self.handle)
+                attr = Attribute()
+                attr.set_type("Occupation")
+                attr.set_value("Tester")
+                person.add_attribute(attr)
+                self.db.commit_person(person, trans)
+
+        self.assertEqual(len(calls), 2)
+        final = self.db.get_person_from_handle(self.handle)
+        self.assertEqual(final.get_note_list(), [])
+        self.assertIsNone(self.db.get_tag_from_name(grampswebapidb.MESSAGE_TAG_NAME))
+
+    def test_genuine_primary_name_collision_leaves_a_note(self):
+        server_fresh = self._current_data()
+        server_fresh["primary_name"]["first_name"] = "FromServer"
+        calls = self._push_conflicts_once_then_succeeds()
+
+        with self._stub_full_resync_to(server_fresh):
+            with DbTxn("edit", self.db) as trans:
+                person = self.db.get_person_from_handle(self.handle)
+                person.get_primary_name().set_first_name("FromLocal")
+                self.db.commit_person(person, trans)
+
+        self.assertGreaterEqual(len(calls), 2)
+        final = self.db.get_person_from_handle(self.handle)
+        # Server's name wins as primary; local's is demoted, not lost.
+        self.assertEqual(final.get_primary_name().get_first_name(), "FromServer")
+        self.assertEqual(
+            [n.get_first_name() for n in final.get_alternate_names()], ["FromLocal"]
+        )
+        note_handles = final.get_note_list()
+        self.assertEqual(len(note_handles), 1)
+        note = self.db.get_note_from_handle(note_handles[0])
+        self.assertIn("primary_name", note.get())
+
+    def test_uncontested_primary_name_edit_beside_a_real_conflict_is_not_named_in_the_note(
+        self,
+    ):
+        # The regression this guards against: local's primary-name edit
+        # was never disputed (the server never touched the name), but
+        # this Person also has a genuine gender conflict -- the note
+        # must mention gender, not primary_name, even though
+        # Person.merge() demotes the name into alternate_names on every
+        # retry regardless of whether it was ever actually contested.
+        server_fresh = self._current_data()
+        server_fresh["gender"] = Person.MALE  # server's real conflict
+        calls = self._push_conflicts_once_then_succeeds()
+
+        with self._stub_full_resync_to(server_fresh):
+            with DbTxn("edit", self.db) as trans:
+                person = self.db.get_person_from_handle(self.handle)
+                person.get_primary_name().set_first_name("Corrected")  # uncontested
+                person.set_gender(Person.UNKNOWN)  # local's real conflict
+                self.db.commit_person(person, trans)
+
+        self.assertGreaterEqual(len(calls), 2)
+        final = self.db.get_person_from_handle(self.handle)
+        note_handles = final.get_note_list()
+        self.assertEqual(len(note_handles), 1)
+        note = self.db.get_note_from_handle(note_handles[0])
+        self.assertIn("gender", note.get())
+        self.assertNotIn("primary_name", note.get())
+
+    def test_a_reference_the_other_side_deleted_is_pruned_and_leaves_a_note(self):
+        # Local's edit still references a Tag that, by the time the
+        # resync catches up, no longer exists at all -- the other side
+        # deleted it. Always a genuine conflict when it fires (see
+        # _prune_dangling_references()'s docstring): local implicitly
+        # wants to keep the reference, reality says it's gone.
+        with DbTxn("seed tag", self.db) as trans:
+            tag = Tag()
+            tag.set_name("SomeTag")
+            self.db.add_tag(tag, trans)
+            tag_handle = tag.handle
+            person = self.db.get_person_from_handle(self.handle)
+            person.add_tag(tag_handle)
+            self.db.commit_person(person, trans)
+
+        server_fresh = self._current_data()  # still carries the tag reference
+        calls = self._push_conflicts_once_then_succeeds()
+
+        def fake_resync_with_tag_deleted(on_done, on_error, progress_callback=None):
+            self.db._pulling = True
+            try:
+                with DbTxn("fake resync", self.db, batch=True) as trans:
+                    self.db.commit_person(data_to_object(server_fresh), trans)
+                    self.db.remove_tag(tag_handle, trans)  # the other side's delete
+            finally:
+                self.db._pulling = False
+            on_done(None)
+
+        with mock.patch.object(
+            self.db, "_full_resync_async", side_effect=fake_resync_with_tag_deleted
+        ):
+            with DbTxn("edit", self.db) as trans:
+                person = self.db.get_person_from_handle(self.handle)
+                person.set_gender(Person.UNKNOWN)  # any local edit; still tags H1
+                self.db.commit_person(person, trans)
+
+        self.assertGreaterEqual(len(calls), 2)
+        final = self.db.get_person_from_handle(self.handle)
+        self.assertEqual(final.get_tag_list(), [])  # dangling reference pruned
+        note_handles = final.get_note_list()
+        self.assertEqual(len(note_handles), 1)
+        note = self.db.get_note_from_handle(note_handles[0])
+        self.assertIn("tag_list", note.get())
+        self.assertIn(tag_handle, note.get())
+
+
+class TestFieldLevelMergeAgainstARealDatabase(unittest.TestCase):
+    """_retry_after_conflict() end-to-end with _apply_uncontested_scalar_
+    edits() wired in: two *different* fields edited concurrently on the
+    same object must both survive, and no conflict note should be
+    created for that -- there was never a genuine collision, just a
+    whole-object conflict response covering an object where only one
+    field actually collided. Same real-DBAPI setup as
+    TestConflictRetryAgainstARealDatabase, seeding an Event instead of a
+    Person for clean, independent scalar fields (date/place/description,
+    none of them special-cased by Event.merge() beyond privacy)."""
+
+    def setUp(self):
+        tmpdir = tempfile.mkdtemp(prefix="grampswebapidb_test_")
+        self.addCleanup(shutil.rmtree, tmpdir, ignore_errors=True)
+        db = make_database("sqlite")
+        db.load(tmpdir)
+        with DbTxn("seed", db) as trans:
+            event = Event()
+            event.set_description("Original")
+            db.add_event(event, trans)
+            self.handle = event.handle
+        db.__class__ = WebApiDB
+        db.web_client = mock.MagicMock()
+        db.runner = InlineTaskRunner()
+        db.io_runner = InlineTaskRunner()
+        db._syncing = False
+        db._retrying = False
+        db._pulling = False
+        db._get_metadata = lambda key, default=0: default
+        db._set_metadata = lambda key, value, use_txn=True: None
+        db.web_client.get_transaction_history.return_value = ([], 0)
+        db.web_client.get_object_count.return_value = 1
+        db.web_client.supports_background_transactions.return_value = False
+        self.db = db
+        self.addCleanup(self.db.close)
+
+    def _current_data(self):
+        return remove_object(object_to_data(self.db.get_event_from_handle(self.handle)))
+
+    def _stub_full_resync_to(self, server_fresh):
+        def fake_full_resync_async(on_done, on_error, progress_callback=None):
+            self.db._pulling = True
+            try:
+                with DbTxn("fake resync", self.db, batch=True) as trans:
+                    self.db.commit_event(data_to_object(server_fresh), trans)
+            finally:
+                self.db._pulling = False
+            on_done(None)
+
+        return mock.patch.object(
+            self.db, "_full_resync_async", side_effect=fake_full_resync_async
+        )
+
+    def _push_conflicts_once_then_succeeds(self):
+        calls = []
+
+        def fake_push(payload, undo=False, background=False, message=None):
+            calls.append(copy.deepcopy(payload))
+            if len(calls) == 1:
+                raise WebApiPushConflict("Object has changed")
+
+        self.db.web_client.push_transaction.side_effect = fake_push
+        return calls
+
+    def test_non_overlapping_field_edits_both_survive_with_no_note(self):
+        server_fresh = self._current_data()
+        server_fresh["place"] = "PLACE-1"  # server touched the place ref only
+        calls = self._push_conflicts_once_then_succeeds()
+
+        with self._stub_full_resync_to(server_fresh):
+            with DbTxn("edit", self.db) as trans:
+                event = self.db.get_event_from_handle(self.handle)
+                event.set_description("Updated by local")  # local: description only
+                self.db.commit_event(event, trans)
+
+        self.assertEqual(len(calls), 2)
+        final = self.db.get_event_from_handle(self.handle)
+        self.assertEqual(final.get_description(), "Updated by local")
+        self.assertEqual(final.get_place_handle(), "PLACE-1")
+        self.assertEqual(final.get_note_list(), [])
+        self.assertIsNone(self.db.get_tag_from_name(grampswebapidb.MESSAGE_TAG_NAME))
+
+    def test_a_genuine_same_field_collision_still_leaves_a_note(self):
+        server_fresh = self._current_data()
+        server_fresh["description"] = "Changed on server"
+        calls = self._push_conflicts_once_then_succeeds()
+
+        with self._stub_full_resync_to(server_fresh):
+            with DbTxn("edit", self.db) as trans:
+                event = self.db.get_event_from_handle(self.handle)
+                event.set_description("Changed locally")
+                self.db.commit_event(event, trans)
+
+        self.assertGreaterEqual(len(calls), 2)
+        final = self.db.get_event_from_handle(self.handle)
+        self.assertEqual(final.get_description(), "Changed on server")
+        note_handles = final.get_note_list()
+        self.assertEqual(len(note_handles), 1)
+        note = self.db.get_note_from_handle(note_handles[0])
+        self.assertIn("description", note.get())
+
+
+class TestUndeliveredPushNotes(unittest.TestCase):
+    """_record_undelivered_push_notes(): a local edit that will never
+    reach the server -- a fresh non-retryable rejection, a queued push
+    that now conflicts or is itself non-retryable on replay, or a queue
+    eviction -- leaves the same kind of message note
+    _record_conflict_notes() does, via the same machinery (see TODO.md
+    gap #2/#3). Also confirms the recursion guard
+    (_is_message_note_push()): a message note that itself fails to sync
+    must not spawn another note about that failure."""
+
+    def setUp(self):
+        tmpdir = tempfile.mkdtemp(prefix="grampswebapidb_test_")
+        self.addCleanup(shutil.rmtree, tmpdir, ignore_errors=True)
+        db = make_database("sqlite")
+        db.load(tmpdir)
+        with DbTxn("seed", db) as trans:
+            person = Person()
+            person.set_gramps_id("I0001")
+            db.add_person(person, trans)
+            self.handle = person.handle
+        db.__class__ = WebApiDB
+        db.web_client = mock.MagicMock()
+        db.runner = InlineTaskRunner()
+        db.io_runner = InlineTaskRunner()
+        db._syncing = False
+        db._retrying = False
+        db._pulling = False
+        db._get_metadata = lambda key, default=0: default
+        db._set_metadata = lambda key, value, use_txn=True: None
+        db.web_client.get_transaction_history.return_value = ([], 0)
+        db.web_client.get_object_count.return_value = 1
+        db.web_client.supports_background_transactions.return_value = False
+        self.db = db
+        self.addCleanup(self.db.close)
+
+    def _forbidden(self):
+        return HTTPError(
+            "https://example.com/api/transactions/", 403, "forbidden", None, None
+        )
+
+    def _queued_entry(self):
+        data = remove_object(
+            object_to_data(self.db.get_person_from_handle(self.handle))
+        )
+        payload = [
+            {
+                "type": "update",
+                "handle": self.handle,
+                "_class": "Person",
+                "old": data,
+                "new": data,
+            }
+        ]
+        return {"payload": payload, "undo": False, "message": None}
+
+    def _fake_pending_entry(self):
+        """A queued entry for a handle that doesn't exist locally --
+        used to pad the queue in the eviction test so any *additional*
+        eviction the test's own note-recording causes (its tag/note
+        commits queue too -- see _use_persisted_metadata()) lands on
+        padding, not the one real entry under test:
+        get_person_from_handle() raises HandleError for it, caught and
+        skipped by _record_conflict_notes(), so no note results."""
+        payload = [
+            {
+                "type": "add",
+                "handle": "NONEXISTENT",
+                "_class": "Person",
+                "old": None,
+                "new": {},
+            }
+        ]
+        return {"payload": payload, "undo": False, "message": None}
+
+    def test_a_fresh_non_retryable_rejection_leaves_a_note(self):
+        calls = []
+
+        def fake_push(payload, undo=False, background=False, message=None):
+            calls.append(message)
+            if len(calls) == 1:
+                raise self._forbidden()
+            # Every subsequent push (the note-recording side effects)
+            # succeeds.
+
+        self.db.web_client.push_transaction.side_effect = fake_push
+
+        with self.assertLogs(grampswebapidb.LOG, level="ERROR"):
+            with DbTxn("edit", self.db) as trans:
+                person = self.db.get_person_from_handle(self.handle)
+                person.set_privacy(True)
+                self.db.commit_person(person, trans)
+
+        # The original edit's push, then the note-recording side effects
+        # (creating the two tags and attaching the note each push in
+        # turn, same as TestConflictNoteRecording's own genuine-conflict
+        # case) -- more than a bare "record one note" would suggest.
+        self.assertGreaterEqual(len(calls), 2)
+        final = self.db.get_person_from_handle(self.handle)
+        note_handles = final.get_note_list()
+        self.assertEqual(len(note_handles), 1)
+        note = self.db.get_note_from_handle(note_handles[0])
+        self.assertIn("permanently rejected", note.get())
+
+    def test_the_notes_own_failed_push_does_not_recurse(self):
+        # Every push -- the original edit's, and the note-commit's own
+        # -- is rejected identically (permissions revoked mid-session,
+        # say). Confirms _is_message_note_push() stops this at one
+        # note, not an unbounded chain of notes about notes.
+        self.db.web_client.push_transaction.side_effect = self._forbidden()
+
+        with self.assertLogs(grampswebapidb.LOG, level="ERROR"):
+            with DbTxn("edit", self.db) as trans:
+                person = self.db.get_person_from_handle(self.handle)
+                person.set_privacy(True)
+                self.db.commit_person(person, trans)
+
+        final = self.db.get_person_from_handle(self.handle)
+        self.assertEqual(len(final.get_note_list()), 1)
+
+    def _use_persisted_metadata(self, pending_pushes):
+        # A real dict-backed store, not a single shared list handed back
+        # by every call -- _record_undelivered_push_notes()'s own nested
+        # commits (the two tags, the note) can themselves queue via
+        # _queue_pending_push() during these tests, and that needs a
+        # real read-modify-write round trip through _get_metadata()/
+        # _set_metadata() to behave correctly, the same as
+        # TestPendingPushQueue's own mocking.
+        self.metadata = {"pending_pushes": pending_pushes}
+        self.db._get_metadata = lambda key, default=0: self.metadata.get(key, default)
+        self.db._set_metadata = (
+            lambda key, value, use_txn=True: self.metadata.__setitem__(key, value)
+        )
+        # Both call sites under test here (_flush_pending_pushes_async(),
+        # _queue_pending_push()) are, in production, only ever reached
+        # while something else already holds self._syncing (a poll tick,
+        # load()'s own sync, or the push that's queueing in the first
+        # place) -- matching that here is what makes the note-commit's
+        # own nested push defer to the queue instead of going out for
+        # real against this test's mocked web_client.
+        self.db._syncing = True
+
+    def test_a_queued_push_that_now_conflicts_leaves_a_note(self):
+        self._use_persisted_metadata([self._queued_entry()])
+        self.db.web_client.push_transaction.side_effect = WebApiPushConflict(
+            "Object has changed"
+        )
+
+        with self.assertLogs(grampswebapidb.LOG, level="WARNING"):
+            self.db._flush_pending_pushes_async(
+                on_done=lambda _: None, on_error=lambda _: None
+            )
+
+        final = self.db.get_person_from_handle(self.handle)
+        note_handles = final.get_note_list()
+        self.assertEqual(len(note_handles), 1)
+        note = self.db.get_note_from_handle(note_handles[0])
+        self.assertIn("conflicted", note.get())
+
+    def test_a_queued_push_permanently_rejected_leaves_a_note(self):
+        self._use_persisted_metadata([self._queued_entry()])
+        self.db.web_client.push_transaction.side_effect = self._forbidden()
+
+        with self.assertLogs(grampswebapidb.LOG, level="ERROR"):
+            self.db._flush_pending_pushes_async(
+                on_done=lambda _: None, on_error=lambda _: None
+            )
+
+        final = self.db.get_person_from_handle(self.handle)
+        note_handles = final.get_note_list()
+        self.assertEqual(len(note_handles), 1)
+        note = self.db.get_note_from_handle(note_handles[0])
+        self.assertIn("permanently rejected", note.get())
+
+    def test_queue_eviction_leaves_a_note_for_each_evicted_entry(self):
+        # The real entry is oldest (index 0), so it's the one evicted;
+        # the padding gives the note-commit's own cascading queue
+        # pressure somewhere harmless to land -- see
+        # _fake_pending_entry()'s own docstring.
+        padding = [self._fake_pending_entry() for _ in range(4)]
+        self._use_persisted_metadata([self._queued_entry()] + padding)
+
+        with mock.patch.object(grampswebapidb, "MAX_PENDING_PUSHES", 5):
+            with self.assertLogs(grampswebapidb.LOG, level="ERROR"):
+                self.db._queue_pending_push(
+                    self._fake_pending_entry()["payload"], undo=False, message=None
+                )
+
+        final = self.db.get_person_from_handle(self.handle)
+        note_handles = final.get_note_list()
+        self.assertEqual(len(note_handles), 1)
+        note = self.db.get_note_from_handle(note_handles[0])
+        self.assertIn("evicted", note.get())
+
+
 class TestBirthDeathIndexPreservedAcrossResync(unittest.TestCase):
     """Gramps XML has no element for Person.birth_ref_index/
     death_ref_index (see exportxml.py's write_person()) -- ImportXml
@@ -2001,28 +2521,97 @@ class TestBirthDeathIndexPreservedAcrossResync(unittest.TestCase):
             self.db.get_person_from_handle(self.handle).birth_ref_index, -1
         )
 
-    def test_does_not_restore_when_the_event_ref_list_itself_changed(self):
-        # A real edit landed on this Person's event refs between the
-        # snapshot and the resync (e.g. someone added an event through
-        # the API) -- restoring the stale pre-resync index would be
-        # wrong here, so this must leave the freshly-recomputed value
-        # alone rather than clobber it.
+    def test_minus_one_is_restored_even_when_the_event_ref_list_changed(self):
+        # A concurrent, unrelated edit landed on this Person's event
+        # refs between the snapshot and the resync (e.g. someone added
+        # an event through the API) -- but birth_ref_index/
+        # death_ref_index has no representation in a Gramps XML export
+        # at all, so nothing about that edit could have told this addon
+        # anything new about it. The pre-resync -1 (nothing marked
+        # primary) is still the best available answer, so it must win
+        # over whatever ImportXml's document-order heuristic guessed --
+        # unlike an earlier, whole-list-signature version of this
+        # mechanism, which forfeited the restore over any event-ref
+        # change at all, even one unrelated to birth/death.
         snapshot = _snapshot_birth_death_indices(self.db)
 
-        with DbTxn("real edit", self.db, batch=True) as trans:
+        with DbTxn("unrelated edit", self.db, batch=True) as trans:
             person = self.db.get_person_from_handle(self.handle)
             other_ref = EventRef()
             other_ref.set_reference_handle(self.event_handle)
             other_ref.set_role(EventRoleType.WITNESS)
             person.add_event_ref(other_ref)
+            person.birth_ref_index = 0  # ImportXml-style recompute
+            self.db.commit_person(person, trans)
+
+        with DbTxn("restore", self.db, batch=True) as trans:
+            restored = _restore_birth_death_indices(self.db, snapshot, trans)
+
+        self.assertEqual(restored, 1)
+        self.assertEqual(
+            self.db.get_person_from_handle(self.handle).birth_ref_index, -1
+        )
+
+    def test_a_real_index_relocates_across_an_unrelated_list_change(self):
+        # The literal fix this mechanism exists for: birth_ref_index
+        # correctly points at the real primary birth ref (index 0)
+        # before the resync. A concurrent, unrelated edit inserts a
+        # *different* ref ahead of it, shifting the birth ref to index
+        # 1 -- an earlier, whole-list-signature version of this
+        # mechanism would have forfeited the restore entirely here, even
+        # though the referenced ref itself is untouched, just moved.
+        with DbTxn("mark as birth", self.db, batch=True) as trans:
+            person = self.db.get_person_from_handle(self.handle)
             person.birth_ref_index = 0
+            self.db.commit_person(person, trans)
+
+        snapshot = _snapshot_birth_death_indices(self.db)
+
+        with DbTxn("unrelated edit", self.db, batch=True) as trans:
+            other_event = Event()
+            other_event.set_type(EventType.OCCUPATION)
+            self.db.add_event(other_event, trans)
+            person = self.db.get_person_from_handle(self.handle)
+            new_ref = EventRef()
+            new_ref.set_reference_handle(other_event.handle)
+            new_ref.set_role(EventRoleType.PRIMARY)
+            person.get_event_ref_list().insert(0, new_ref)
+            person.birth_ref_index = 0  # ImportXml now (wrongly) points at new_ref
+            self.db.commit_person(person, trans)
+
+        with DbTxn("restore", self.db, batch=True) as trans:
+            restored = _restore_birth_death_indices(self.db, snapshot, trans)
+
+        self.assertEqual(restored, 1)
+        final = self.db.get_person_from_handle(self.handle)
+        self.assertEqual(final.birth_ref_index, 1)
+        self.assertEqual(final.get_event_ref_list()[1].ref, self.event_handle)
+
+    def test_a_real_index_is_not_restored_if_its_own_ref_was_removed(self):
+        # Unlike an unrelated list change, losing the *actual* referenced
+        # event/role pair leaves nothing to relocate to -- ImportXml's
+        # own freshly-recomputed guess is kept rather than pointing at a
+        # now-dangling position.
+        with DbTxn("mark as birth", self.db, batch=True) as trans:
+            person = self.db.get_person_from_handle(self.handle)
+            person.birth_ref_index = 0
+            self.db.commit_person(person, trans)
+
+        snapshot = _snapshot_birth_death_indices(self.db)
+
+        with DbTxn("removes the birth ref", self.db, batch=True) as trans:
+            person = self.db.get_person_from_handle(self.handle)
+            person.set_event_ref_list([])
+            person.birth_ref_index = -1  # ImportXml's own recompute: nothing left
             self.db.commit_person(person, trans)
 
         with DbTxn("restore", self.db, batch=True) as trans:
             restored = _restore_birth_death_indices(self.db, snapshot, trans)
 
         self.assertEqual(restored, 0)
-        self.assertEqual(self.db.get_person_from_handle(self.handle).birth_ref_index, 0)
+        self.assertEqual(
+            self.db.get_person_from_handle(self.handle).birth_ref_index, -1
+        )
 
     def test_a_person_deleted_since_the_snapshot_is_skipped_not_erred(self):
         snapshot = _snapshot_birth_death_indices(self.db)
@@ -2445,6 +3034,500 @@ class TestPruneDanglingReferences(unittest.TestCase):
 
 # -------------------------------------------------------------------------
 #
+# TestApplyUncontestedScalarEdits
+#
+# -------------------------------------------------------------------------
+class TestApplyUncontestedScalarEdits(unittest.TestCase):
+    """_apply_uncontested_scalar_edits() is _merge_or_overwrite()'s real
+    per-field 3-way merge, layered on top of merge()'s own list-union/
+    privacy-OR/... handling: a field only local_obj touched (relative to
+    old_data, the payload's real pre-edit snapshot) survives even though
+    merge() itself has no idea what to do with it. Real Person/Event/Tag
+    objects, same as TestMergeOrOverwrite."""
+
+    def test_a_local_only_edit_survives(self):
+        # Server never touched gender (current == old); local did.
+        old = Event()
+        old.set_handle("H1")
+        old.set_description("Original")
+        old_data = remove_object(object_to_data(old))
+
+        current = Event()
+        current.set_handle("H1")
+        current.set_description("Original")
+
+        local = Event()
+        local.set_handle("H1")
+        local.set_description("Updated by local")
+
+        merged = grampswebapidb._merge_or_overwrite(
+            current, local, FakeHandleDb(), old_data=old_data
+        )
+        self.assertEqual(merged.get_description(), "Updated by local")
+
+    def test_a_genuine_collision_is_not_applied(self):
+        # Both sides touched description, to different values -- current's
+        # (the server's post-resync value) must survive, matching the
+        # whole-object behavior this layers on top of.
+        old = Event()
+        old.set_handle("H1")
+        old.set_description("Original")
+        old_data = remove_object(object_to_data(old))
+
+        current = Event()
+        current.set_handle("H1")
+        current.set_description("Changed on server")
+
+        local = Event()
+        local.set_handle("H1")
+        local.set_description("Changed locally")
+
+        merged = grampswebapidb._merge_or_overwrite(
+            current, local, FakeHandleDb(), old_data=old_data
+        )
+        self.assertEqual(merged.get_description(), "Changed on server")
+
+    def test_two_different_fields_edited_concurrently_both_survive(self):
+        # The actual point of this layer: a conflict on *one* field must
+        # not cost an edit to a completely different field on the same
+        # object -- see the module docstring and TODO.md's gap #1.
+        old = Event()
+        old.set_handle("H1")
+        old.set_description("Original")
+        old_data = remove_object(object_to_data(old))
+
+        current = Event()  # server touched the place ref, not description
+        current.set_handle("H1")
+        current.set_description("Original")
+        current.set_place_handle("PLACE-1")
+
+        local = Event()  # local touched description, not the place ref
+        local.set_handle("H1")
+        local.set_description("Updated by local")
+
+        merged = grampswebapidb._merge_or_overwrite(
+            current, local, FakeHandleDb(), old_data=old_data
+        )
+        self.assertEqual(merged.get_description(), "Updated by local")
+        self.assertEqual(merged.get_place_handle(), "PLACE-1")
+
+    def test_persons_primary_name_is_never_overridden(self):
+        # Locked field (see _SCALAR_MERGE_LOCKED_FIELDS): Person.merge()
+        # deliberately keeps current's own primary name and demotes
+        # local's into alternate_names instead -- applying this layer's
+        # generic rule here would fight that, not complement it, even
+        # though local is the only side that touched it.
+        old = Person()
+        old.set_handle("H1")
+        old.get_primary_name().set_first_name("Old")
+        old_data = remove_object(object_to_data(old))
+
+        current = Person()
+        current.set_handle("H1")
+        current.get_primary_name().set_first_name("Old")
+
+        local = Person()
+        local.set_handle("H1")
+        local.get_primary_name().set_first_name("New")
+
+        merged = grampswebapidb._merge_or_overwrite(
+            current, local, FakeHandleDb(), old_data=old_data
+        )
+        self.assertEqual(merged.get_primary_name().get_first_name(), "Old")
+        # Demoted into alternate_names by Person.merge() itself, not lost.
+        self.assertEqual(
+            [n.get_first_name() for n in merged.get_alternate_names()], ["New"]
+        )
+
+    def test_no_old_data_is_a_no_op(self):
+        # Callers that don't pass old_data (every existing caller before
+        # this layer existed) get exactly the previous whole-object-
+        # scalar behavior -- see _merge_or_overwrite()'s own docstring.
+        current = Event()
+        current.set_handle("H1")
+        current.set_description("Current")
+
+        local = Event()
+        local.set_handle("H1")
+        local.set_description("Local")
+
+        merged = grampswebapidb._merge_or_overwrite(current, local, FakeHandleDb())
+        self.assertEqual(merged.get_description(), "Current")
+
+    def test_type_without_a_real_merge_is_unaffected(self):
+        # Tag falls back to local_obj outright -- nothing for this layer
+        # to add on top of that.
+        current = Tag()
+        current.set_handle("H1")
+        current.set_name("Remote name")
+
+        local = Tag()
+        local.set_handle("H1")
+        local.set_name("Local name")
+
+        old_data = remove_object(object_to_data(current))
+        merged = grampswebapidb._merge_or_overwrite(
+            current, local, FakeHandleDb(), old_data=old_data
+        )
+        self.assertEqual(merged.get_name(), "Local name")
+
+
+# -------------------------------------------------------------------------
+#
+# TestDiscardedScalarFields
+#
+# -------------------------------------------------------------------------
+class TestDiscardedScalarFields(unittest.TestCase):
+    """_discarded_scalar_fields() feeds _record_conflict_notes() -- see
+    the module docstring's "silently losing the discarded value is not"
+    paragraph. old_data (entry["old"], the payload's own pre-edit
+    snapshot) is the 3-way merge base that decides whether local_obj
+    "touched" a field at all; current/result are only used to decide
+    whether that touch survived. Real Person/Tag objects, same as
+    TestMergeOrOverwrite."""
+
+    def test_a_genuine_scalar_conflict_is_reported(self):
+        old = Person()
+        old.set_handle("H1")
+        old.set_gender(Person.FEMALE)
+        old_data = remove_object(object_to_data(old))
+
+        current = Person()  # the server's post-resync state
+        current.set_handle("H1")
+        current.set_gender(Person.UNKNOWN)
+
+        local = Person()  # what the local edit actually intended
+        local.set_handle("H1")
+        local.set_gender(Person.MALE)
+
+        merged = grampswebapidb._merge_or_overwrite(current, local, FakeHandleDb())
+        discarded = grampswebapidb._discarded_scalar_fields(
+            old_data, current, local, merged
+        )
+
+        fields = {field for field, kept, lost in discarded}
+        self.assertIn("gender", fields)
+
+    def test_a_field_local_never_touched_is_not_reported(self):
+        # current's privacy differs from local's, but only because
+        # current changed server-side -- local's own value is identical
+        # to what it was before local's edit (old), so this must not be
+        # reported as a discarded local edit even though
+        # _merge_or_overwrite() does apply its own special-cased OR here.
+        old = Person()
+        old.set_handle("H1")
+        old.set_privacy(False)
+        old_data = remove_object(object_to_data(old))
+
+        current = Person()
+        current.set_handle("H1")
+        current.set_privacy(True)
+
+        local = Person()
+        local.set_handle("H1")
+        local.set_privacy(False)
+
+        merged = grampswebapidb._merge_or_overwrite(current, local, FakeHandleDb())
+        discarded = grampswebapidb._discarded_scalar_fields(
+            old_data, current, local, merged
+        )
+        self.assertEqual(discarded, [])
+
+    def test_a_successfully_unioned_list_field_is_not_reported(self):
+        old = Person()
+        old.set_handle("H1")
+        old_data = remove_object(object_to_data(old))
+
+        current = Person()
+        current.set_handle("H1")
+        current.add_note("N-remote")
+
+        local = Person()
+        local.set_handle("H1")
+        local.add_note("N-local")
+
+        merged = grampswebapidb._merge_or_overwrite(current, local, FakeHandleDb())
+        discarded = grampswebapidb._discarded_scalar_fields(
+            old_data, current, local, merged
+        )
+        self.assertEqual(discarded, [])
+
+    def test_type_without_a_real_merge_reports_nothing(self):
+        # Tag falls back to local_obj outright (see _merge_or_overwrite())
+        # -- nothing was actually discarded, regardless of what changed.
+        old = Tag()
+        old.set_handle("H1")
+        old.set_name("Old name")
+        old_data = remove_object(object_to_data(old))
+
+        current = Tag()
+        current.set_handle("H1")
+        current.set_name("Remote name")
+
+        local = Tag()
+        local.set_handle("H1")
+        local.set_name("Local name")
+
+        merged = grampswebapidb._merge_or_overwrite(current, local, FakeHandleDb())
+        discarded = grampswebapidb._discarded_scalar_fields(
+            old_data, current, local, merged
+        )
+        self.assertEqual(discarded, [])
+
+    def test_locked_field_is_never_reported_here_even_on_a_genuine_collision(self):
+        # primary_name is handled exclusively by _demoted_field_conflicts()
+        # -- reporting it here too would double-report the same conflict,
+        # and with the wrong framing ("discarded" when it's actually
+        # preserved as an alternate name, not lost).
+        old = Person()
+        old.set_handle("H1")
+        old.get_primary_name().set_first_name("Old")
+        old_data = remove_object(object_to_data(old))
+
+        current = Person()
+        current.set_handle("H1")
+        current.get_primary_name().set_first_name("FromServer")
+
+        local = Person()
+        local.set_handle("H1")
+        local.get_primary_name().set_first_name("FromLocal")
+
+        merged = grampswebapidb._merge_or_overwrite(
+            current, local, FakeHandleDb(), old_data=old_data
+        )
+        discarded = grampswebapidb._discarded_scalar_fields(
+            old_data, current, local, merged
+        )
+        fields = {field for field, kept, lost in discarded}
+        self.assertNotIn("primary_name", fields)
+
+
+# -------------------------------------------------------------------------
+#
+# TestDemotedFieldConflicts
+#
+# -------------------------------------------------------------------------
+class TestDemotedFieldConflicts(unittest.TestCase):
+    """_demoted_field_conflicts() feeds _conflict_summary_lines() for
+    _SCALAR_MERGE_LOCKED_FIELDS (currently just Person.primary_name) --
+    the one case where a genuine collision has to be detected directly
+    (via _is_genuine_collision()) rather than by comparing merge()'s
+    result against current, since a locked field never shows as
+    "touched" that way at all -- see the function's own docstring."""
+
+    def test_a_genuine_collision_is_reported(self):
+        old = Person()
+        old.set_handle("H1")
+        old.get_primary_name().set_first_name("Old")
+        old_data = remove_object(object_to_data(old))
+
+        current = Person()
+        current.set_handle("H1")
+        current.get_primary_name().set_first_name("FromServer")
+
+        local = Person()
+        local.set_handle("H1")
+        local.get_primary_name().set_first_name("FromLocal")
+
+        merged = grampswebapidb._merge_or_overwrite(
+            current, local, FakeHandleDb(), old_data=old_data
+        )
+        conflicts = grampswebapidb._demoted_field_conflicts(
+            old_data, current, local, merged
+        )
+        fields = {field for field, kept, lost in conflicts}
+        self.assertIn("primary_name", fields)
+
+    def test_an_uncontested_local_edit_is_not_reported(self):
+        # THE regression this exists to guard: local edited its primary
+        # name and the server never touched it at all (current == old)
+        # -- Person.merge() demotes it into alternate_names on *every*
+        # conflict-retry regardless, but that demotion is not a
+        # conflict, so this must report nothing -- see TODO.md's "Only
+        # do for CONFLICTS" note.
+        old = Person()
+        old.set_handle("H1")
+        old.get_primary_name().set_first_name("Same")
+        old_data = remove_object(object_to_data(old))
+
+        current = Person()
+        current.set_handle("H1")
+        current.get_primary_name().set_first_name("Same")  # server never touched it
+
+        local = Person()
+        local.set_handle("H1")
+        local.get_primary_name().set_first_name("Corrected")  # local's only edit
+
+        merged = grampswebapidb._merge_or_overwrite(
+            current, local, FakeHandleDb(), old_data=old_data
+        )
+        conflicts = grampswebapidb._demoted_field_conflicts(
+            old_data, current, local, merged
+        )
+        self.assertEqual(conflicts, [])
+
+    def test_no_old_data_reports_nothing(self):
+        current = Person()
+        current.set_handle("H1")
+        current.get_primary_name().set_first_name("FromServer")
+
+        local = Person()
+        local.set_handle("H1")
+        local.get_primary_name().set_first_name("FromLocal")
+
+        merged = grampswebapidb._merge_or_overwrite(current, local, FakeHandleDb())
+        conflicts = grampswebapidb._demoted_field_conflicts(
+            None, current, local, merged
+        )
+        self.assertEqual(conflicts, [])
+
+    def test_a_type_with_no_locked_fields_reports_nothing(self):
+        old = Tag()
+        old.set_handle("H1")
+        old.set_name("Old")
+        old_data = remove_object(object_to_data(old))
+
+        current = Tag()
+        current.set_handle("H1")
+        current.set_name("FromServer")
+
+        local = Tag()
+        local.set_handle("H1")
+        local.set_name("FromLocal")
+
+        merged = grampswebapidb._merge_or_overwrite(
+            current, local, FakeHandleDb(), old_data=old_data
+        )
+        conflicts = grampswebapidb._demoted_field_conflicts(
+            old_data, current, local, merged
+        )
+        self.assertEqual(conflicts, [])
+
+
+# -------------------------------------------------------------------------
+#
+# TestActivelyResolvedConflicts
+#
+# -------------------------------------------------------------------------
+class TestActivelyResolvedConflicts(unittest.TestCase):
+    """_actively_resolved_conflicts() feeds _conflict_summary_lines() for
+    _SCALAR_MERGE_ACTIVELY_RESOLVED_FIELDS (currently just
+    Citation.confidence) -- like TestDemotedFieldConflicts, a genuine
+    collision has to be detected directly, since merge() reassigns this
+    field on every call whether or not a real collision occurred."""
+
+    def test_a_genuine_collision_is_reported(self):
+        old = Citation()
+        old.set_handle("H1")
+        old.set_confidence_level(Citation.CONF_NORMAL)
+        old_data = remove_object(object_to_data(old))
+
+        current = Citation()  # server lowered it
+        current.set_handle("H1")
+        current.set_confidence_level(Citation.CONF_LOW)
+
+        local = Citation()  # local raised it
+        local.set_handle("H1")
+        local.set_confidence_level(Citation.CONF_HIGH)
+
+        merged = grampswebapidb._merge_or_overwrite(
+            current, local, FakeHandleDb(), old_data=old_data
+        )
+        # Citation.merge()'s level_priority rule actually keeps current's
+        # (LOW) here -- confirms this test's own premise before checking
+        # that the conflict got reported at all.
+        self.assertEqual(merged.get_confidence_level(), Citation.CONF_LOW)
+
+        conflicts = grampswebapidb._actively_resolved_conflicts(
+            old_data, current, local, merged
+        )
+        fields = {field for field, kept, other in conflicts}
+        self.assertIn("confidence", fields)
+
+    def test_an_uncontested_local_edit_is_not_reported(self):
+        old = Citation()
+        old.set_handle("H1")
+        old.set_confidence_level(Citation.CONF_NORMAL)
+        old_data = remove_object(object_to_data(old))
+
+        current = Citation()
+        current.set_handle("H1")
+        current.set_confidence_level(Citation.CONF_NORMAL)  # server never touched it
+
+        local = Citation()
+        local.set_handle("H1")
+        local.set_confidence_level(Citation.CONF_HIGH)  # local's only edit
+
+        merged = grampswebapidb._merge_or_overwrite(
+            current, local, FakeHandleDb(), old_data=old_data
+        )
+        conflicts = grampswebapidb._actively_resolved_conflicts(
+            old_data, current, local, merged
+        )
+        self.assertEqual(conflicts, [])
+
+    def test_no_old_data_reports_nothing(self):
+        current = Citation()
+        current.set_handle("H1")
+        current.set_confidence_level(Citation.CONF_LOW)
+
+        local = Citation()
+        local.set_handle("H1")
+        local.set_confidence_level(Citation.CONF_HIGH)
+
+        merged = grampswebapidb._merge_or_overwrite(current, local, FakeHandleDb())
+        conflicts = grampswebapidb._actively_resolved_conflicts(
+            None, current, local, merged
+        )
+        self.assertEqual(conflicts, [])
+
+
+# -------------------------------------------------------------------------
+#
+# TestPruneDanglingReferencesPruned
+#
+# -------------------------------------------------------------------------
+class TestPruneDanglingReferencesPruned(unittest.TestCase):
+    """_prune_dangling_references()'s optional pruned list -- how
+    _merge_or_overwrite() surfaces a dangling-reference removal to
+    _retry_after_conflict() as a genuine conflict (see
+    _conflict_summary_lines()'s docstring)."""
+
+    def test_a_pruned_handle_is_collected(self):
+        person = Person()
+        person.set_handle("H1")
+        person.add_tag("deleted-tag-handle")
+        person.add_note("live-note-handle")
+
+        db = FakeHandleDb(known_handles={"live-note-handle"})
+        pruned = []
+        grampswebapidb._prune_dangling_references(person, db, pruned=pruned)
+        self.assertEqual(pruned, [("tag_list", "deleted-tag-handle")])
+
+    def test_nothing_pruned_is_an_empty_list_not_none(self):
+        person = Person()
+        person.set_handle("H1")
+        person.add_note("live-note-handle")
+
+        db = FakeHandleDb(known_handles={"live-note-handle"})
+        pruned = []
+        grampswebapidb._prune_dangling_references(person, db, pruned=pruned)
+        self.assertEqual(pruned, [])
+
+    def test_pruned_defaults_to_none_and_is_not_required(self):
+        # Existing callers that don't care (e.g. _merge_or_overwrite()'s
+        # own default) must keep working unchanged.
+        person = Person()
+        person.set_handle("H1")
+        person.add_tag("deleted-tag-handle")
+
+        db = FakeHandleDb(known_handles=set())
+        grampswebapidb._prune_dangling_references(person, db)  # must not raise
+        self.assertEqual(person.get_tag_list(), [])
+
+
+# -------------------------------------------------------------------------
+#
 # TestUndoRedo
 #
 # -------------------------------------------------------------------------
@@ -2685,6 +3768,42 @@ class TestImportProgressUser(unittest.TestCase):
         ), mock.patch.dict(sys.modules, {"gramps.gui.user": None}):
             user = grampswebapidb._import_progress_user(callback)
         self.assertIsInstance(user, grampswebapidb.User)
+
+
+# -------------------------------------------------------------------------
+#
+# TestNotifyFatalPollError
+#
+# -------------------------------------------------------------------------
+class TestNotifyFatalPollError(unittest.TestCase):
+    """_notify_fatal_poll_error() -- _give_up_polling()'s dialog, the
+    nearest reachable equivalent to load()'s own DbConnectionError path
+    once load() has already returned. Same has_display()-gated,
+    best-effort construction as _import_progress_user(); see
+    TestImportProgressUser above."""
+
+    def test_shows_a_db_error_dialog_with_a_display(self):
+        with mock.patch.object(
+            grampswebapidb, "has_display", return_value=True
+        ), mock.patch("gramps.gui.user.User") as gui_user_cls:
+            grampswebapidb._notify_fatal_poll_error("HTTP Error 401: Unauthorized")
+        gui_user_cls.assert_called_once_with()
+        notify = gui_user_cls.return_value.notify_db_error
+        notify.assert_called_once()
+        self.assertIn("HTTP Error 401", notify.call_args[0][0])
+
+    def test_does_nothing_without_a_display(self):
+        with mock.patch.object(
+            grampswebapidb, "has_display", return_value=False
+        ), mock.patch("gramps.gui.user.User") as gui_user_cls:
+            grampswebapidb._notify_fatal_poll_error("detail")
+        gui_user_cls.assert_not_called()
+
+    def test_does_nothing_if_gui_user_is_not_importable(self):
+        with mock.patch.object(
+            grampswebapidb, "has_display", return_value=True
+        ), mock.patch.dict(sys.modules, {"gramps.gui.user": None}):
+            grampswebapidb._notify_fatal_poll_error("detail")  # must not raise
 
 
 # -------------------------------------------------------------------------
@@ -3287,6 +4406,8 @@ class TestPolling(unittest.TestCase):
         self.db._poll_failures = 4
         self.db._media_poll_failures = 4
         self.db._poll_interval = grampswebapidb.POLL_BACKOFF_MAX_SECONDS
+        self.db._polls_since_verify_totals = 200
+        self.db._polling_abandoned = True
         with mock.patch.object(grampswebapidb.SQLite, "load"), mock.patch.object(
             self.db, "_check_identity_async", side_effect=stub_async_done(True)
         ), mock.patch.object(
@@ -3304,6 +4425,8 @@ class TestPolling(unittest.TestCase):
         self.assertEqual(self.db._poll_failures, 0)
         self.assertEqual(self.db._media_poll_failures, 0)
         self.assertEqual(self.db._poll_interval, grampswebapidb.POLL_INTERVAL_SECONDS)
+        self.assertEqual(self.db._polls_since_verify_totals, 0)
+        self.assertFalse(self.db._polling_abandoned)
 
     def test_close_cancels_pending_poll(self):
         self.db._poll_source_id = 42
@@ -3371,6 +4494,38 @@ class TestPolling(unittest.TestCase):
         sync.assert_not_called()
         self.assertEqual(result, grampswebapidb.GLib.SOURCE_CONTINUE)
 
+    def test_poll_tick_does_not_verify_totals_before_the_interval_elapses(self):
+        with mock.patch.object(
+            self.db, "_sync_from_server_async", side_effect=stub_async_done(0)
+        ) as sync:
+            self.db._poll_tick()
+        self.assertFalse(sync.call_args.kwargs["verify_totals"])
+        self.assertEqual(self.db._polls_since_verify_totals, 1)
+
+    def test_poll_tick_verifies_totals_once_the_interval_elapses(self):
+        ticks_per_check = (
+            grampswebapidb.VERIFY_TOTALS_POLL_INTERVAL_SECONDS
+            // grampswebapidb.POLL_INTERVAL_SECONDS
+        )
+        self.db._polls_since_verify_totals = ticks_per_check - 1
+        with mock.patch.object(
+            self.db, "_sync_from_server_async", side_effect=stub_async_done(0)
+        ) as sync:
+            self.db._poll_tick()
+        self.assertTrue(sync.call_args.kwargs["verify_totals"])
+        # Reset immediately, not left to grow past the threshold forever.
+        self.assertEqual(self.db._polls_since_verify_totals, 0)
+
+    def test_poll_tick_skipped_underneath_a_running_sync_does_not_advance_the_counter(
+        self,
+    ):
+        self.db._syncing = True
+        self.db._polls_since_verify_totals = 5
+        with mock.patch.object(self.db, "_sync_from_server_async") as sync:
+            self.db._poll_tick()
+        sync.assert_not_called()
+        self.assertEqual(self.db._polls_since_verify_totals, 5)
+
     def test_media_poll_tick_does_not_start_a_sync_underneath_a_running_one(self):
         self.db._syncing = True
         with mock.patch.object(self.db, "_sync_media_files_async") as sync_media:
@@ -3407,6 +4562,83 @@ class TestPolling(unittest.TestCase):
             self.db._poll_interval, grampswebapidb.POLL_INTERVAL_SECONDS * 2
         )
         self.assertEqual(self.db._poll_failures, 1)
+
+    def test_poll_tick_stops_and_notifies_on_a_permanently_rejected_request(self):
+        # A server reset invalidates GRAMPS_WEB_API_KEY (the refresh
+        # token's account is simply gone) -- this reads as a permanent
+        # 401/403, not a connectivity blip, so it must not be backed off
+        # and retried forever the way test_poll_tick_swallows_connection_
+        # errors_and_keeps_polling()'s OSError is.
+        err = HTTPError("https://example.com/api/transactions/", 401, "x", None, None)
+        with mock.patch.object(
+            self.db, "_sync_from_server_async", side_effect=stub_async_error(err)
+        ), mock.patch.object(
+            grampswebapidb, "_notify_fatal_poll_error"
+        ) as notify, mock.patch.object(
+            grampswebapidb.GLib, "source_remove"
+        ) as source_remove, mock.patch.object(
+            grampswebapidb.GLib, "timeout_add_seconds"
+        ) as timeout_add:
+            with self.assertLogs(grampswebapidb.LOG, level="ERROR"):
+                result = self.db._poll_tick()
+        self.assertEqual(result, grampswebapidb.GLib.SOURCE_CONTINUE)
+        # Stopped, not rescheduled: no backoff timer replaces this one.
+        source_remove.assert_called_once_with(1)  # setUp()'s placeholder id
+        timeout_add.assert_not_called()
+        self.assertIsNone(self.db._poll_source_id)
+        self.assertEqual(self.db._poll_failures, 0)
+        self.assertTrue(self.db._polling_abandoned)
+        notify.assert_called_once()
+
+    def test_media_poll_tick_stops_and_notifies_on_a_permanently_rejected_request(
+        self,
+    ):
+        self.db._media_poll_source_id = 2
+        err = HTTPError("https://example.com/api/media/", 403, "x", None, None)
+        with mock.patch.object(
+            self.db, "_sync_media_files_async", side_effect=stub_async_error(err)
+        ), mock.patch.object(
+            grampswebapidb, "_notify_fatal_poll_error"
+        ) as notify, mock.patch.object(
+            grampswebapidb.GLib, "source_remove"
+        ) as source_remove:
+            with self.assertLogs(grampswebapidb.LOG, level="ERROR"):
+                result = self.db._media_poll_tick()
+        self.assertEqual(result, grampswebapidb.GLib.SOURCE_CONTINUE)
+        source_remove.assert_any_call(2)
+        self.assertIsNone(self.db._media_poll_source_id)
+        self.assertEqual(self.db._media_poll_failures, 0)
+        self.assertTrue(self.db._polling_abandoned)
+        notify.assert_called_once()
+
+    def test_give_up_polling_stops_both_timers_and_notifies_once(self):
+        self.db._poll_source_id = 1
+        self.db._media_poll_source_id = 2
+        err = HTTPError("https://example.com/api/transactions/", 401, "x", None, None)
+        with mock.patch.object(
+            grampswebapidb, "_notify_fatal_poll_error"
+        ) as notify, mock.patch.object(
+            grampswebapidb.GLib, "source_remove"
+        ) as source_remove:
+            self.db._give_up_polling(err)
+        self.assertEqual(source_remove.call_args_list, [mock.call(1), mock.call(2)])
+        self.assertIsNone(self.db._poll_source_id)
+        self.assertIsNone(self.db._media_poll_source_id)
+        notify.assert_called_once()
+
+    def test_give_up_polling_is_idempotent_across_both_pollers(self):
+        # Both pollers share the one credential and can hit this around
+        # the same tick -- the second arrival must stop its own timer
+        # quietly, not show a second dialog for the same problem.
+        self.db._poll_source_id = 1
+        self.db._media_poll_source_id = 2
+        err = HTTPError("https://example.com/api/transactions/", 401, "x", None, None)
+        with mock.patch.object(
+            grampswebapidb, "_notify_fatal_poll_error"
+        ) as notify, mock.patch.object(grampswebapidb.GLib, "source_remove"):
+            self.db._give_up_polling(err)
+            self.db._give_up_polling(err)
+        notify.assert_called_once()
 
     def test_poll_tick_reports_a_lasting_outage_only_once(self):
         # A server that stays down must not log a warning (let alone a
@@ -4128,6 +5360,11 @@ class TestPendingPushQueue(unittest.TestCase):
         self.db._set_metadata = (
             lambda key, value, use_txn=True: self.metadata.__setitem__(key, value)
         )
+        # This class is about queue/flush mechanics, not note content --
+        # TestUndeliveredPushNotes covers _record_undelivered_push_notes()
+        # itself, against a real database; new_instance() here has no
+        # real self.dbapi for it to touch.
+        self.db._record_undelivered_push_notes = mock.MagicMock()
 
     def _payload(self, handle="H1"):
         return [{"type": "add", "handle": handle, "_class": "Person"}]

--- a/GrampsWebApiDb/tests/test_grampswebapidb.py
+++ b/GrampsWebApiDb/tests/test_grampswebapidb.py
@@ -74,7 +74,7 @@ except ImportError as _err:
 
 from gramps.gen.db import DbTxn
 from gramps.gen.db.dbconst import REFERENCE_KEY, TXNADD, TXNDEL, TXNUPD
-from gramps.gen.db.exceptions import DbConnectionError
+from gramps.gen.db.exceptions import DbConnectionError, DbWriteFailure
 from gramps.gen.db.utils import make_database
 from gramps.gen.lib import (
     Attribute,
@@ -1589,6 +1589,72 @@ class TestTransactionCommit(unittest.TestCase):
         self.assertEqual(resync.call_count, 1)
         retry.assert_not_called()
 
+    def test_missing_write_permissions_rejects_before_local_commit(self):
+        # self._missing_write_permissions is set once at load() by
+        # _check_permissions_async() -- see the module docstring's
+        # section on it. A genuine local edit must be rejected before
+        # anything commits, not merely before the (doomed) push.
+        self.db._missing_write_permissions = ["EditObject"]
+        trans = FakeTransaction([(0, TXNADD, "H1", None, person_data("H1"))])
+        with mock.patch.object(
+            grampswebapidb.SQLite, "transaction_commit"
+        ) as super_commit, mock.patch.object(
+            grampswebapidb.SQLite, "transaction_abort"
+        ) as abort:
+            with self.assertRaises(DbWriteFailure) as ctx:
+                self.db.transaction_commit(trans)
+        super_commit.assert_not_called()
+        abort.assert_called_once_with(trans)
+        self.assertIn("EditObject", str(ctx.exception))
+        self.db.web_client.push_transaction.assert_not_called()
+
+    def test_missing_write_permissions_names_the_role_to_ask_for(self):
+        self.db._missing_write_permissions = ["AddObject", "EditObject"]
+        trans = FakeTransaction([(0, TXNADD, "H1", None, person_data("H1"))])
+        with mock.patch.object(
+            grampswebapidb.SQLite, "transaction_commit"
+        ), mock.patch.object(grampswebapidb.SQLite, "transaction_abort"):
+            with self.assertRaises(DbWriteFailure) as ctx:
+                self.db.transaction_commit(trans)
+        self.assertIn("Editor", str(ctx.exception))
+
+    def test_pulling_is_exempt_from_the_permission_rejection(self):
+        # A server-to-local replay (poll/resync) must go on committing
+        # locally regardless of self._missing_write_permissions -- this
+        # is what lets a read-only account still poll and stay current.
+        self.db._missing_write_permissions = ["EditObject"]
+        self.db._pulling = True
+        trans = FakeTransaction([(0, TXNADD, "H1", None, person_data("H1"))])
+        with mock.patch.object(
+            grampswebapidb.SQLite, "transaction_commit"
+        ) as super_commit:
+            self.db.transaction_commit(trans)  # must not raise
+        super_commit.assert_called_once_with(trans)
+
+    def test_recording_note_is_exempt_from_the_permission_rejection(self):
+        # The addon's own note/tag bookkeeping (_record_conflict_notes())
+        # must go on committing locally (and attempting its own push)
+        # exactly as before -- see that method's docstring.
+        self.db._missing_write_permissions = ["EditObject"]
+        self.db._recording_note = True
+        trans = FakeTransaction([(0, TXNADD, "H1", None, person_data("H1"))])
+        with mock.patch.object(
+            grampswebapidb.SQLite, "transaction_commit"
+        ) as super_commit:
+            self.db.transaction_commit(trans)  # must not raise
+        super_commit.assert_called_once_with(trans)
+        self.db.web_client.push_transaction.assert_called_once()
+
+    def test_no_missing_permissions_is_unaffected(self):
+        self.db._missing_write_permissions = []
+        trans = FakeTransaction([(0, TXNADD, "H1", None, person_data("H1"))])
+        with mock.patch.object(
+            grampswebapidb.SQLite, "transaction_commit"
+        ) as super_commit:
+            self.db.transaction_commit(trans)  # must not raise
+        super_commit.assert_called_once_with(trans)
+        self.db.web_client.push_transaction.assert_called_once()
+
 
 # -------------------------------------------------------------------------
 #
@@ -1929,6 +1995,98 @@ class TestConflictRetryAgainstARealDatabase(unittest.TestCase):
         final = self.db.get_person_from_handle(self.handle)
         self.assertTrue(final.get_privacy())
         self.assertEqual(len(final.get_attribute_list()), 1)
+
+
+# -------------------------------------------------------------------------
+#
+# TestMissingWritePermissionsAgainstARealDatabase
+#
+# transaction_commit()'s missing-write-permission rejection calls
+# transaction_abort() (self.dbapi.rollback()) instead of letting
+# super().transaction_commit() run -- confirmed here against a real
+# DBAPI-backed connection, not just a mocked one, that the rejected
+# edit's local writes genuinely never land, and that the connection is
+# left clean enough for a later, permitted commit to succeed (nothing
+# left half-open the way skipping transaction_abort() would).
+#
+# -------------------------------------------------------------------------
+class TestMissingWritePermissionsAgainstARealDatabase(unittest.TestCase):
+    def setUp(self):
+        tmpdir = tempfile.mkdtemp(prefix="grampswebapidb_test_")
+        self.addCleanup(shutil.rmtree, tmpdir, ignore_errors=True)
+        db = make_database("sqlite")
+        db.load(tmpdir)
+        with DbTxn("seed", db) as trans:
+            person = Person()
+            person.set_gramps_id("I0001")
+            db.add_person(person, trans)
+            self.handle = person.handle
+        db.__class__ = WebApiDB
+        db.web_client = mock.MagicMock()
+        db.runner = InlineTaskRunner()
+        db.io_runner = InlineTaskRunner()
+        db._syncing = False
+        db._retrying = False
+        db._pulling = False
+        db._recording_note = False
+        db._get_metadata = lambda key, default=0: default
+        db._set_metadata = lambda key, value, use_txn=True: None
+        self.db = db
+        self.addCleanup(self.db.close)
+
+    def test_rejected_add_never_lands_locally(self):
+        self.db._missing_write_permissions = ["AddObject"]
+        person = Person()
+        person.set_gramps_id("I0002")
+        with self.assertRaises(DbWriteFailure):
+            with DbTxn("add", self.db) as trans:
+                self.db.add_person(person, trans)
+        self.assertFalse(self.db.has_person_handle(person.handle))
+        self.db.web_client.push_transaction.assert_not_called()
+
+    def test_rejected_edit_leaves_the_object_unchanged(self):
+        self.db._missing_write_permissions = ["EditObject"]
+        with self.assertRaises(DbWriteFailure):
+            with DbTxn("edit", self.db) as trans:
+                person = self.db.get_person_from_handle(self.handle)
+                person.set_privacy(True)
+                self.db.commit_person(person, trans)
+        self.assertFalse(self.db.get_person_from_handle(self.handle).get_privacy())
+        self.db.web_client.push_transaction.assert_not_called()
+
+    def test_connection_still_usable_for_a_later_permitted_commit(self):
+        # The whole point of calling transaction_abort() rather than
+        # simply not calling super().transaction_commit(): a rejected
+        # transaction must not leave the underlying SQL connection with a
+        # transaction still open, which would make the very next
+        # transaction_begin() (a real "BEGIN TRANSACTION" while one is
+        # already active) fail. Simulates permissions being fixed and the
+        # tree reopened by clearing the flag on the same instance.
+        self.db._missing_write_permissions = ["EditObject"]
+        with self.assertRaises(DbWriteFailure):
+            with DbTxn("edit", self.db) as trans:
+                person = self.db.get_person_from_handle(self.handle)
+                person.set_privacy(True)
+                self.db.commit_person(person, trans)
+
+        self.db._missing_write_permissions = []
+        with DbTxn("edit", self.db) as trans:
+            person = self.db.get_person_from_handle(self.handle)
+            person.set_privacy(True)
+            self.db.commit_person(person, trans)
+        self.assertTrue(self.db.get_person_from_handle(self.handle).get_privacy())
+
+    def test_pulling_replay_still_commits_locally(self):
+        # A poll/resync-driven replay must go on updating the mirror even
+        # though this account cannot push -- that's the entire point of
+        # not blocking load() over a missing write permission.
+        self.db._missing_write_permissions = ["EditObject"]
+        self.db._pulling = True
+        with DbTxn("pulled update", self.db) as trans:
+            person = self.db.get_person_from_handle(self.handle)
+            person.set_privacy(True)
+            self.db.commit_person(person, trans)
+        self.assertTrue(self.db.get_person_from_handle(self.handle).get_privacy())
 
 
 class TestConflictNoteRecording(unittest.TestCase):
@@ -3665,6 +3823,33 @@ class TestUndoRedo(unittest.TestCase):
             self.db.undo()
         payload = push.call_args[0][0]
         self.assertEqual(payload[0]["handle"], "H1")
+
+    def test_missing_write_permissions_rejects_undo_before_super(self):
+        # Unlike transaction_commit(), there is no hook that can catch
+        # this after the fact: DbGenericUndo._undo() (what super().undo()
+        # delegates to) commits directly, bypassing transaction_commit()
+        # entirely -- see undo()'s own docstring. So this must reject
+        # before ever calling super(), and self.undodb.undo() must never
+        # be reached.
+        self.db._missing_write_permissions = ["EditObject"]
+        self.db.undodb.undo_count = 1
+        self.db.undodb.undoq = [FakeTransaction([(0, TXNADD, "H1", None, {})])]
+        with mock.patch.object(self.db, "_start_push") as push:
+            with self.assertRaises(DbWriteFailure) as ctx:
+                self.db.undo()
+        self.db.undodb.undo.assert_not_called()
+        push.assert_not_called()
+        self.assertIn("EditObject", str(ctx.exception))
+
+    def test_missing_write_permissions_rejects_redo_before_super(self):
+        self.db._missing_write_permissions = ["EditObject"]
+        self.db.undodb.redo_count = 1
+        self.db.undodb.redoq = [FakeTransaction([(0, TXNADD, "H1", None, {})])]
+        with mock.patch.object(self.db, "_start_push") as push:
+            with self.assertRaises(DbWriteFailure):
+                self.db.redo()
+        self.db.undodb.redo.assert_not_called()
+        push.assert_not_called()
 
 
 # -------------------------------------------------------------------------

--- a/GrampsWebApiDb/tests/test_grampswebapidb.py
+++ b/GrampsWebApiDb/tests/test_grampswebapidb.py
@@ -46,6 +46,7 @@ Run with::
 import copy
 import io
 import json
+import logging
 import os
 import shutil
 import sys
@@ -4011,6 +4012,103 @@ class TestNotifyFatalPollError(unittest.TestCase):
             grampswebapidb, "has_display", return_value=True
         ), mock.patch.dict(sys.modules, {"gramps.gui.user": None}):
             grampswebapidb._notify_fatal_poll_error("detail")  # must not raise
+
+
+# -------------------------------------------------------------------------
+#
+# TestNotifyMissingWritePermission / TestInstallQuietPopupFilter /
+# TestMissingWritePermissionErrorBuilder
+#
+# _missing_write_permission_error() (the exception transaction_commit()/
+# undo()/redo() raise -- see its own docstring) now also shows the user a
+# calm, native dialog immediately (_notify_missing_write_permission(),
+# same has_display()-gated construction as _notify_fatal_poll_error()
+# above) and makes sure that dialog isn't immediately followed by
+# Gramps' own generic "Gramps has experienced an unexpected error...
+# restart Gramps immediately" crash dialog, which nothing in Gramps core
+# catches this exception type before reaching (_install_quiet_popup_
+# filter(), which tags the root logger's GtkHandler, if any, with a
+# logging.Filter that recognizes only this one exception subclass,
+# _MissingWritePermissionError -- any other DbWriteFailure, or any other
+# exception at all, still pops that dialog exactly as before).
+#
+# -------------------------------------------------------------------------
+class TestNotifyMissingWritePermission(unittest.TestCase):
+    def test_shows_an_error_dialog_with_a_display(self):
+        with mock.patch.object(
+            grampswebapidb, "has_display", return_value=True
+        ), mock.patch("gramps.gui.user.User") as gui_user_cls:
+            grampswebapidb._notify_missing_write_permission("detail text")
+        gui_user_cls.assert_called_once_with()
+        notify = gui_user_cls.return_value.notify_error
+        notify.assert_called_once()
+        self.assertIn("detail text", notify.call_args[0][1])
+
+    def test_does_nothing_without_a_display(self):
+        with mock.patch.object(
+            grampswebapidb, "has_display", return_value=False
+        ), mock.patch("gramps.gui.user.User") as gui_user_cls:
+            grampswebapidb._notify_missing_write_permission("detail")
+        gui_user_cls.assert_not_called()
+
+    def test_does_nothing_if_gui_user_is_not_importable(self):
+        with mock.patch.object(
+            grampswebapidb, "has_display", return_value=True
+        ), mock.patch.dict(sys.modules, {"gramps.gui.user": None}):
+            grampswebapidb._notify_missing_write_permission("detail")  # must not raise
+
+
+class TestInstallQuietPopupFilter(unittest.TestCase):
+    def setUp(self):
+        from gramps.gui.logger import GtkHandler
+
+        self.gtk_handler = GtkHandler()
+        self.root_logger = logging.getLogger()
+        self.root_logger.addHandler(self.gtk_handler)
+        self.addCleanup(self.root_logger.removeHandler, self.gtk_handler)
+
+    def _record_for(self, exc):
+        try:
+            raise exc
+        except Exception:
+            return logging.LogRecord(
+                "x", logging.ERROR, __file__, 1, "msg", None, sys.exc_info()
+            )
+
+    def test_does_nothing_without_a_display(self):
+        with mock.patch.object(grampswebapidb, "has_display", return_value=False):
+            grampswebapidb._install_quiet_popup_filter()
+        self.assertEqual(self.gtk_handler.filters, [])
+
+    def test_blocks_only_the_missing_write_permission_exception(self):
+        with mock.patch.object(grampswebapidb, "has_display", return_value=True):
+            grampswebapidb._install_quiet_popup_filter()
+        blocked = self._record_for(grampswebapidb._MissingWritePermissionError("boom"))
+        allowed = self._record_for(DbWriteFailure("some other failure"))
+        self.assertFalse(self.gtk_handler.filter(blocked))
+        self.assertTrue(self.gtk_handler.filter(allowed))
+
+    def test_is_idempotent(self):
+        with mock.patch.object(grampswebapidb, "has_display", return_value=True):
+            grampswebapidb._install_quiet_popup_filter()
+            grampswebapidb._install_quiet_popup_filter()
+        self.assertEqual(len(self.gtk_handler.filters), 1)
+
+
+class TestMissingWritePermissionErrorBuilder(unittest.TestCase):
+    def test_notifies_and_installs_the_quiet_filter_and_returns_a_dbwritefailure(
+        self,
+    ):
+        with mock.patch.object(
+            grampswebapidb, "_notify_missing_write_permission"
+        ) as notify, mock.patch.object(
+            grampswebapidb, "_install_quiet_popup_filter"
+        ) as install:
+            err = grampswebapidb._missing_write_permission_error(["EditObject"])
+        notify.assert_called_once()
+        install.assert_called_once_with()
+        self.assertIsInstance(err, grampswebapidb._MissingWritePermissionError)
+        self.assertIsInstance(err, DbWriteFailure)
 
 
 # -------------------------------------------------------------------------

--- a/GrampsWebApiDb/tests/test_reconcile_batch_commit_real_db.py
+++ b/GrampsWebApiDb/tests/test_reconcile_batch_commit_real_db.py
@@ -192,7 +192,7 @@ class TestReconcileBatchCommitAgainstARealDatabase(unittest.TestCase):
         self.addCleanup(self.db.close)
         self.pushes = []
 
-        def fake_push(payload, undo=False, background=False):
+        def fake_push(payload, undo=False, background=False, message=None):
             self.pushes.append(copy.deepcopy(payload))
 
         self.db.web_client.push_transaction.side_effect = fake_push
@@ -401,7 +401,7 @@ class TestReconcileBatchCommitAgainstARealDatabase(unittest.TestCase):
 
         calls = []
 
-        def fake_push(payload, undo=False, background=False):
+        def fake_push(payload, undo=False, background=False, message=None):
             calls.append(copy.deepcopy(payload))
             if len(calls) == 1:
                 raise WebApiPushConflict("Object has changed")


### PR DESCRIPTION
## Highlight

This continues hardening how the local mirror stays in sync with a Gramps Web API server, and adds support for accounts that don't have full edit rights on the server. An account limited to read-only (or partial) access can now open a Family Tree and keep it up to date, instead of being refused outright; any edit it isn't actually allowed to make is now rejected clearly and immediately, rather than appearing to save and then silently never reaching the server.

This continues an underlying philosophy for this addon: merging between the local copy and the server always happens automatically — there's no interactive "resolve this conflict" prompt to get in the way — and every conflict does get resolved one way or another. When that automatic resolution has to make a judgment call (or an edit couldn't be delivered to the server at all, as with the permission case above), a "message" note is attached to the affected record so a person can review it later, on their own schedule, rather than being interrupted in the moment.

## Details

**Read-only / permission-limited accounts**
- Opening a Family Tree no longer requires full edit rights on the server. An account that can only read is still checked for the one permission reading truly depends on, but is otherwise let in — the mirror opens, and keeps polling and staying current.
- If that account then tries to make an edit (add, change, delete, undo, redo) it isn't allowed to make, the edit is refused right away, with a message naming what's missing, instead of quietly succeeding locally and only failing (silently, later) when it tries to reach the server.
- A permission that changes *after* a tree is already open still surfaces the old way (a rejected sync attempt with a note left on the affected record) — this only changes the case where the limitation is already known when the tree is opened.

**Prior review-pass fixes also included in this branch**
- More accurate automatic conflict resolution when the same field is edited both locally and on the server, with a note left behind explaining what was kept versus discarded whenever that happens.
- That same note-leaving behavior now also covers an edit that permanently fails to reach the server for any other reason.
- A couple of mirror-resync edge cases (birth/death event ordering, and detecting a stalled poll) are more robust.

## How to test

For the permission-related change, `https://demo.grampsweb.org` is a convenient place to test since it's a public server you likely already have (or can create) an account on with a role short of full Editor access. Mint an API key from an account like that (this addon's own "Mint API Key" tool works fine for this), point `GRAMPS_WEB_API_KEY` at it, and open a tree:
- Confirm the tree opens normally and stays in sync with the server (make a change from another account/browser and confirm it shows up here).
- Try making a local edit (e.g. add a note or change a field) and confirm you get a clear rejection message instead of the edit silently disappearing or the app behaving oddly.
- As a sanity check, repeat with a full-Editor-role account and confirm normal editing still works exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
