### PR TITLE
Fix Hebrew display bugs in PlaceCompletion addon

### DIFF
--- a/PlaceCompletion/PlaceCompletion.py
+++ b/PlaceCompletion/PlaceCompletion.py
@@ -405,9 +405,14 @@ class PlaceCompletion(Tool.Tool, ManagedWindow):
                 latlongroup = ['lat', 'lon']
                 for group in latlongroup :
                     if findregex.find(r'(?P<'+group+r'>') == -1 :
+                        from gramps.gen.const import GRAMPS_LOCALE as glocale
+                        from gramps.plugins.lib.libnarrate import fix_hebrew_connectors
                         WarningDialog(_('Missing regex groups in match lat/lon'),
-                    _('Regex groups %(lat)s and %(lon)s must be present in lat/lon match. Quiting')
+                    fix_hebrew_connectors(
+                        _('Regex groups %(lat)s and %(lon)s must be present in lat/lon match. Quiting')
                                 % {'lat' : latlongroup[0], 'lon' : latlongroup[1]},
+                        glocale,
+                    ),
                             self.window)
                         return
                 #check if extra data can be extracted from file

--- a/PlaceCompletion/placecompletion.glade
+++ b/PlaceCompletion/placecompletion.glade
@@ -722,10 +722,19 @@ title format:</property>
                       </packing>
                     </child>
                     <child>
+                      <!-- NOTE: xalign auto-reverses for RTL locales (0.0 =
+                           left in LTR but RIGHT in RTL; 1.0 = right in LTR but
+                           LEFT in RTL) - unlike GtkLabel:justify, which does
+                           NOT reverse for RTL. xalign=0 here renders correctly
+                           right-aligned in Hebrew/Arabic. If you ever switch
+                           this to justify=LEFT/RIGHT instead, remember that
+                           "right" must be written literally as "right", not
+                           inferred from xalign logic. See:
+                           https://docs.gtk.org/gtk3/property.Label.xalign.html -->
                       <object class="GtkLabel" id="label3">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="xalign">1</property>
+                        <property name="xalign">0</property>
                         <property name="xpad">6</property>
                         <property name="label" translatable="yes">Available variables: city, street, locality, parish, county, state, country, postal_code</property>
                         <property name="selectable">False</property>


### PR DESCRIPTION
Summary
Two separate Hebrew-specific display bugs in the PlaceCompletion gramplet: a missing maqaf (Hebrew hyphen) in a warning dialog, and a left-aligned label that should read right-aligned in RTL locales.

Root cause
- The regex-validation warning message ("Regex groups %(lat)s and %(lon)s must be present...") joins two placeholders with the English word "and", which Hebrew translations render as a single-letter connector ("ו") glued directly to the following value with no separating maqaf when that value starts with a non-Hebrew character.
- The "Available variables" label in placecompletion.glade used xalign="1" intending right-alignment, but GtkLabel:xalign auto-reverses for RTL locales (0.0 becomes right, 1.0 becomes left), so the label rendered flush-left in Hebrew instead of right, the opposite of what was intended.

Fix
- Wrap the warning message with the same locale-guarded fix_hebrew_connectors() helper already used throughout Gramps core (gramps/plugins/lib/libnarrate.py) for this exact class of bug: it operates on the fully-assembled string rather than a specific variable, so it stays correct regardless of translation wording or variable order.
- Change xalign from 1 to 0 for the "Available variables" label, so it renders right-aligned in RTL locales as originally intended.
- Added an XML comment next to the fix explaining the RTL-reversal behavior of xalign (documented, but easy to get backwards) versus GtkLabel:justify, which does not auto-reverse, to prevent this from silently regressing if a future change swaps between the two properties.

Scope
PlaceCompletion/PlaceCompletion.py and
PlaceCompletion/placecompletion.glade only. No translation files touched - both fixes operate on already-translated strings/UI properties at runtime, not translation content.

Testing
Verified against a real he_IL Gramps installation: reproduced the broken-regex warning dialog and the left-aligned label before the fix, confirmed both render correctly after.