### PR TITLE
Complete Hebrew translation for ToDoReport addon

### DIFF
--- a/ToDoReport/po/he-local.po
+++ b/ToDoReport/po/he-local.po
@@ -1,34 +1,193 @@
+# Hebrew translation for Gramps
+# This file is distributed under the same license as the Gramps package.
+# Copyright (C) 2009
+# First Translator: Igal Shapira <igal.shapira@gmail.com>, 2009, 2010, 2011.
+# Last-Translator: Avi Markovitz <avi.markovitz@gmail.com>, 2019, 2021, 2022, 2023, 2024, 2025, 2026.
+# Nick Hall <nick-h@gramps-project.org>, 2021, 2023, 2024.
+# Omer I.S. <omeritzicschwartz@gmail.com>, 2021, 2022, 2023.
+# Yaron Shahrabani <sh.yaron@gmail.com>, 2023, 2024, 2025, 2026.
 msgid ""
 msgstr ""
-"Project-Id-Version: Gramps 5.2.0 – mediamerge\n"
+"Project-Id-Version: Gramps 5.1.2\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-02-16 15:10-0800\n"
-"PO-Revision-Date: 2025-03-08 15:16+0000\n"
-"Last-Translator: Avi Markovitz <avi.markovitz@gmail.com>\n"
+"PO-Revision-Date: 2026-03-17 06:09+0000\n"
+"Last-Translator: Yaron Shahrabani <sh.yaron@gmail.com>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/gramps-project/"
-"addons/he/>\n"
+"gramps/he/>\n"
 "Language: he\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=(n == 1) ? 0 : ((n == 2) ? 1 : ((n > 10 && "
-"n % 10 == 0) ? 2 : 3));\n"
-"X-Generator: Weblate 5.10.3-dev\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Weblate 5.17-dev\n"
+"X-Poedit-Bookmarks: 1508,-1,-1,-1,-1,-1,-1,-1,-1,-1\n"
 
+#: ToDoReport/TodoReport.py:107 ToDoReport/TodoReport.py:904
+msgid "TR-Title"
+msgstr "תואר TR"
+
+#: ToDoReport/TodoReport.py:111
+#, python-format
+msgid "Report on Notes Tagged '%s'"
+msgstr "דוח על הערות מתויגות '%s'"
+
+#: ToDoReport/TodoReport.py:237 ToDoReport/TodoReport.py:914
 msgid "TR-Heading"
 msgstr "כותרת TR"
 
+#: ToDoReport/TodoReport.py:243
+msgid "NoteTable"
+msgstr "טבלת הערות"
+
+#: ToDoReport/TodoReport.py:243 ToDoReport/TodoReport.py:962
+msgid "TR-Table"
+msgstr "טבלה TR"
+
+#: ToDoReport/TodoReport.py:247 ToDoReport/TodoReport.py:253
+#: ToDoReport/TodoReport.py:267 ToDoReport/TodoReport.py:273
+#: ToDoReport/TodoReport.py:302 ToDoReport/TodoReport.py:310
+#: ToDoReport/TodoReport.py:323 ToDoReport/TodoReport.py:329
+#: ToDoReport/TodoReport.py:347 ToDoReport/TodoReport.py:353
+#: ToDoReport/TodoReport.py:363 ToDoReport/TodoReport.py:373
+#: ToDoReport/TodoReport.py:392 ToDoReport/TodoReport.py:398
+#: ToDoReport/TodoReport.py:410 ToDoReport/TodoReport.py:421
+#: ToDoReport/TodoReport.py:437 ToDoReport/TodoReport.py:444
+#: ToDoReport/TodoReport.py:458 ToDoReport/TodoReport.py:469
+#: ToDoReport/TodoReport.py:474 ToDoReport/TodoReport.py:480
+#: ToDoReport/TodoReport.py:490 ToDoReport/TodoReport.py:512
+#: ToDoReport/TodoReport.py:518 ToDoReport/TodoReport.py:535
+#: ToDoReport/TodoReport.py:541 ToDoReport/TodoReport.py:547
+#: ToDoReport/TodoReport.py:564 ToDoReport/TodoReport.py:570
+#: ToDoReport/TodoReport.py:576 ToDoReport/TodoReport.py:582
+#: ToDoReport/TodoReport.py:599 ToDoReport/TodoReport.py:607
+#: ToDoReport/TodoReport.py:613 ToDoReport/TodoReport.py:619
+#: ToDoReport/TodoReport.py:636 ToDoReport/TodoReport.py:642
+#: ToDoReport/TodoReport.py:648 ToDoReport/TodoReport.py:654
+#: ToDoReport/TodoReport.py:678 ToDoReport/TodoReport.py:683
+#: ToDoReport/TodoReport.py:689 ToDoReport/TodoReport.py:947
+msgid "TR-TableCell"
+msgstr "תא-טבלה TR"
+
+#: ToDoReport/TodoReport.py:248 ToDoReport/TodoReport.py:254
+#: ToDoReport/TodoReport.py:935
+msgid "TR-Normal-Bold"
+msgstr "רגיל-מודגש TR"
+
+#: ToDoReport/TodoReport.py:249
+msgid "Id"
+msgstr "מזהה"
+
+#: ToDoReport/TodoReport.py:255
+msgid "Text"
+msgstr "מלל"
+
+#: ToDoReport/TodoReport.py:268 ToDoReport/TodoReport.py:285
+#: ToDoReport/TodoReport.py:303 ToDoReport/TodoReport.py:311
+#: ToDoReport/TodoReport.py:324 ToDoReport/TodoReport.py:330
+#: ToDoReport/TodoReport.py:348 ToDoReport/TodoReport.py:354
+#: ToDoReport/TodoReport.py:364 ToDoReport/TodoReport.py:374
+#: ToDoReport/TodoReport.py:393 ToDoReport/TodoReport.py:399
+#: ToDoReport/TodoReport.py:411 ToDoReport/TodoReport.py:422
+#: ToDoReport/TodoReport.py:438 ToDoReport/TodoReport.py:445
+#: ToDoReport/TodoReport.py:459 ToDoReport/TodoReport.py:470
+#: ToDoReport/TodoReport.py:475 ToDoReport/TodoReport.py:481
+#: ToDoReport/TodoReport.py:491 ToDoReport/TodoReport.py:513
+#: ToDoReport/TodoReport.py:519 ToDoReport/TodoReport.py:536
+#: ToDoReport/TodoReport.py:542 ToDoReport/TodoReport.py:548
+#: ToDoReport/TodoReport.py:565 ToDoReport/TodoReport.py:571
+#: ToDoReport/TodoReport.py:577 ToDoReport/TodoReport.py:583
+#: ToDoReport/TodoReport.py:600 ToDoReport/TodoReport.py:608
+#: ToDoReport/TodoReport.py:614 ToDoReport/TodoReport.py:620
+#: ToDoReport/TodoReport.py:637 ToDoReport/TodoReport.py:643
+#: ToDoReport/TodoReport.py:649 ToDoReport/TodoReport.py:679
+#: ToDoReport/TodoReport.py:684 ToDoReport/TodoReport.py:690
+#: ToDoReport/TodoReport.py:924
+msgid "TR-Normal"
+msgstr "רגיל TR"
+
+#: ToDoReport/TodoReport.py:275 ToDoReport/TodoReport.py:942
+msgid "TR-Note"
+msgstr "הערה TR"
+
+#: ToDoReport/TodoReport.py:284 ToDoReport/TodoReport.py:952
+msgid "TR-BorderCell"
+msgstr "תא-מסגרת TR"
+
+#: ToDoReport/TodoReport.py:405
+msgid "date: "
+msgstr "תאריך: "
+
+#: ToDoReport/TodoReport.py:417
 msgid "place: "
 msgstr "מקום: "
 
+#: ToDoReport/TodoReport.py:855
+msgid "Report Options"
+msgstr "אפשרויות דוח"
+
+#: ToDoReport/TodoReport.py:857
+msgid "Title"
+msgstr "תואר"
+
+#: ToDoReport/TodoReport.py:867 ToDoReport/TodoReport.py:871
+msgid "Tag"
+msgstr "תג"
+
+#: ToDoReport/TodoReport.py:874
+msgid "The tag to use for the report"
+msgstr "התג שישמש בדוח"
+
+#: ToDoReport/TodoReport.py:877
+msgid "Note Type"
+msgstr "סוג הערה"
+
+#: ToDoReport/TodoReport.py:885
+msgid "Group by reference type"
+msgstr "קיבוץ לפי סוג הפניה"
+
+#: ToDoReport/TodoReport.py:886
+msgid "Group notes by Family, Person, Place, etc."
+msgstr "קיבוץ הערות לפי משפחה, אדם, מקום וכו׳."
+
+#: ToDoReport/TodoReport.py:903
 msgid "The style used for the title of the page."
 msgstr "הסגנון שמשמש בכותרת העמוד."
 
+#: ToDoReport/TodoReport.py:913
+msgid "The style used for the section headers."
+msgstr "הסגנון שמשמש לכותרת המקטע."
+
+#: ToDoReport/TodoReport.py:923
+msgid "The basic style used for the text display."
+msgstr "הסגנון הבסיסי המשמש להצגת המלל."
+
+#: ToDoReport/TodoReport.py:934
+msgid "The basic style used for table headings."
+msgstr "הסגנון הבסיסי עבור טבלת הכותרות."
+
+#: ToDoReport/TodoReport.py:941
+msgid "The basic style used for the note display."
+msgstr "הסגנון הבסיסי שמשמש להצגת ההערה."
+
+#: ToDoReport/TodoReport.py:946
 msgid "The basic style used for the table cell display."
 msgstr "הסגנון הבסיסי שמשמש את מצג התא בטבלה."
 
+#: ToDoReport/TodoReport.py:951
+msgid "The basic style used for the table border cell display."
+msgstr "הסגנון הבסיסי שמשמש את מצג תא-המסגרת בטבלה."
+
+#: ToDoReport/TodoReport.py:961
 msgid "The basic style used for the table display."
 msgstr "הסגנון הבסיסי שמשמש את מצג הטבלה."
 
+#: ToDoReport/TodoReport.gpr.py:25
 msgid "Todo Report"
 msgstr "דוח משימות לביצוע"
+
+#: ToDoReport/TodoReport.gpr.py:27
+msgid ""
+"Produces a list of all the notes with a given tag along with the records "
+"that it references, the Person, Family, Event, etc."
+msgstr "מפיק רשימה של כל ההערות עם תג נתון, יחד עם הרשומות שאליהן הן מפנות - אדם, משפחה, אירוע וכו׳."


### PR DESCRIPTION
Hebrew translation was ~20% complete (7 of 32 strings). Completed the remaining 25 strings.