### PR TITLE
Gramps Web Sync: trust private CAs from all macOS keychains

### DIFF
--- a/GrampsWebSync/tests/test_ssl_context.py
+++ b/GrampsWebSync/tests/test_ssl_context.py
@@ -1,0 +1,155 @@
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Florian J. Breunig
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+"""The macOS trust store is assembled from every keychain, not just Apple's.
+
+``security`` is stubbed throughout, so these run on any platform and never
+touch the host's real keychains.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import unittest
+import unittest.mock
+
+from webapihandler import (
+    MACOS_ADMIN_KEYCHAIN,
+    MACOS_ROOT_KEYCHAIN,
+    _macos_keychains,
+    create_macos_ssl_context,
+)
+
+LOGIN_KEYCHAIN = "/Users/someone/Library/Keychains/login.keychain-db"
+
+#: What ``security list-keychains`` prints: indented and quoted.
+LIST_OUTPUT = f'    "{LOGIN_KEYCHAIN}"\n    "{MACOS_ADMIN_KEYCHAIN}"\n'
+
+
+def fake_security(list_output: str = LIST_OUTPUT, certs: dict | None = None):
+    """Return a ``subprocess.run`` stub answering the two ``security`` calls.
+
+    ``certs`` maps a keychain path to the PEM bytes it should yield; a path
+    mapped to an exception has that exception raised instead, standing in for
+    a keychain that cannot be read.
+    """
+    certs = {} if certs is None else certs
+
+    def run(cmd, **kwargs):
+        if cmd[1] == "list-keychains":
+            return subprocess.CompletedProcess(cmd, 0, stdout=list_output.encode())
+        keychain = cmd[-1]
+        result = certs.get(keychain, b"")
+        if isinstance(result, Exception):
+            raise result
+        return subprocess.CompletedProcess(cmd, 0, stdout=result)
+
+    return run
+
+
+class KeychainListTest(unittest.TestCase):
+    """Which keychains are searched, and in what order."""
+
+    def test_apple_roots_and_admin_keychain_come_first(self):
+        with unittest.mock.patch("subprocess.run", fake_security()):
+            keychains = _macos_keychains()
+        self.assertEqual(keychains[:2], [MACOS_ROOT_KEYCHAIN, MACOS_ADMIN_KEYCHAIN])
+
+    def test_search_list_is_appended(self):
+        """A CA in the login keychain is reachable — the point of the fix."""
+        with unittest.mock.patch("subprocess.run", fake_security()):
+            keychains = _macos_keychains()
+        self.assertIn(LOGIN_KEYCHAIN, keychains)
+
+    def test_no_duplicates(self):
+        """The admin keychain is usually in the search list as well."""
+        with unittest.mock.patch("subprocess.run", fake_security()):
+            keychains = _macos_keychains()
+        self.assertEqual(len(keychains), len(set(keychains)))
+
+    def test_survives_security_failing(self):
+        """Without a usable search list, the two known keychains still stand."""
+
+        def boom(cmd, **kwargs):
+            raise OSError("security not found")
+
+        with unittest.mock.patch("subprocess.run", boom):
+            keychains = _macos_keychains()
+        self.assertEqual(keychains, [MACOS_ROOT_KEYCHAIN, MACOS_ADMIN_KEYCHAIN])
+
+
+class SSLContextTest(unittest.TestCase):
+    """What ends up in the file handed to OpenSSL."""
+
+    def load_verify_calls(self, certs):
+        """Collect the PEM bytes ``create_macos_ssl_context`` loads."""
+        loaded: list[bytes] = []
+
+        def load_verify_locations(path):
+            with open(path, "rb") as handle:
+                loaded.append(handle.read())
+
+        ctx = unittest.mock.Mock()
+        ctx.load_verify_locations.side_effect = load_verify_locations
+        with unittest.mock.patch("subprocess.run", fake_security(certs=certs)):
+            with unittest.mock.patch("ssl.create_default_context", return_value=ctx):
+                create_macos_ssl_context()
+        return loaded
+
+    def test_certificates_from_every_keychain_are_loaded(self):
+        loaded = self.load_verify_calls(
+            {
+                MACOS_ROOT_KEYCHAIN: b"-----BEGIN CERTIFICATE-----\napple\n",
+                MACOS_ADMIN_KEYCHAIN: b"-----BEGIN CERTIFICATE-----\nprivate-ca\n",
+                LOGIN_KEYCHAIN: b"-----BEGIN CERTIFICATE-----\nuser-ca\n",
+            }
+        )
+        self.assertEqual(len(loaded), 1)
+        self.assertIn(b"apple", loaded[0])
+        self.assertIn(b"private-ca", loaded[0])
+        self.assertIn(b"user-ca", loaded[0])
+
+    def test_written_file_is_flushed_before_openssl_reads_it(self):
+        """A buffered write would truncate a realistically sized anchor list."""
+        bulk = b"".join(
+            b"-----BEGIN CERTIFICATE-----\n%d\n" % index for index in range(4000)
+        )
+        loaded = self.load_verify_calls(
+            {MACOS_ROOT_KEYCHAIN: bulk, MACOS_ADMIN_KEYCHAIN: b"tail-marker\n"}
+        )
+        self.assertIn(b"tail-marker", loaded[0])
+        self.assertEqual(len(loaded[0]), len(bulk) + len(b"\ntail-marker\n"))
+
+    def test_unreadable_keychain_does_not_lose_the_others(self):
+        loaded = self.load_verify_calls(
+            {
+                MACOS_ROOT_KEYCHAIN: b"apple\n",
+                MACOS_ADMIN_KEYCHAIN: subprocess.TimeoutExpired("security", 30),
+                LOGIN_KEYCHAIN: b"user-ca\n",
+            }
+        )
+        self.assertIn(b"apple", loaded[0])
+        self.assertIn(b"user-ca", loaded[0])
+
+    def test_no_certificates_at_all_is_not_fatal(self):
+        """An empty store still returns a context rather than raising."""
+        self.assertEqual(self.load_verify_calls({}), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/GrampsWebSync/webapihandler.py
+++ b/GrampsWebSync/webapihandler.py
@@ -126,13 +126,9 @@ def _macos_keychains() -> list[str]:
 def create_macos_ssl_context() -> ssl.SSLContext:
     """Create an SSL context trusting the CAs in the user's macOS keychains.
 
-    A privately issued CA — a corporate root, or one made for a self-hosted
-    Gramps Web instance — lands in the admin or login keychain, never in the
-    read-only ``SystemRootCertificates`` list. Reading that list alone fails
-    with ``CERTIFICATE_VERIFY_FAILED`` on a server Safari opens happily.
-
-    There is no fallback: the bundled OpenSSL's ``OPENSSLDIR`` points into the
-    build machine's tree, so the default store is empty on a user's Mac.
+    Searches the hard-coded system keychains and the user keychains reported
+    by ``security list-keychains``, so that a privately issued CA installed in
+    the admin or login keychain is trusted alongside Apple's public roots.
     """
     ctx = ssl.create_default_context()
     pem_blocks: list[bytes] = []

--- a/GrampsWebSync/webapihandler.py
+++ b/GrampsWebSync/webapihandler.py
@@ -28,6 +28,8 @@ import logging
 import os
 import platform
 import socket
+import ssl
+import subprocess
 import time
 from collections.abc import Callable
 from pathlib import Path
@@ -91,25 +93,75 @@ def parse_version(version) -> tuple[int, int]:
     return (parts[0], parts[1])
 
 
-def create_macos_ssl_context():
-    import ssl
-    import subprocess
+#: Apple's public roots — absent from the ``security list-keychains`` list.
+MACOS_ROOT_KEYCHAIN = "/System/Library/Keychains/SystemRootCertificates.keychain"
 
-    """Creates an SSL context using macOS system certificates."""
+#: The machine-wide keychain, where an administrator installs a private CA.
+MACOS_ADMIN_KEYCHAIN = "/Library/Keychains/System.keychain"
+
+KEYCHAIN_TIMEOUT = 30
+
+
+def _macos_keychains() -> list[str]:
+    """Return the keychains to read trust anchors from, in search order."""
+    keychains = [MACOS_ROOT_KEYCHAIN, MACOS_ADMIN_KEYCHAIN]
+    try:
+        listed = subprocess.run(
+            ["security", "list-keychains"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=KEYCHAIN_TIMEOUT,
+        ).stdout.decode("utf-8", "replace")
+    except (OSError, subprocess.SubprocessError) as exc:
+        LOG.warning("Could not list macOS keychains: %s", exc)
+        listed = ""
+    # Each entry is quoted and indented on its own line.
+    for line in listed.splitlines():
+        path = line.strip().strip('"')
+        if path and path not in keychains:
+            keychains.append(path)
+    return keychains
+
+
+def create_macos_ssl_context() -> ssl.SSLContext:
+    """Create an SSL context trusting the CAs in the user's macOS keychains.
+
+    A privately issued CA — a corporate root, or one made for a self-hosted
+    Gramps Web instance — lands in the admin or login keychain, never in the
+    read-only ``SystemRootCertificates`` list. Reading that list alone fails
+    with ``CERTIFICATE_VERIFY_FAILED`` on a server Safari opens happily.
+
+    There is no fallback: the bundled OpenSSL's ``OPENSSLDIR`` points into the
+    build machine's tree, so the default store is empty on a user's Mac.
+    """
     ctx = ssl.create_default_context()
-    macos_ca_certs = subprocess.run(
-        [
-            "security",
-            "find-certificate",
-            "-a",
-            "-p",
-            "/System/Library/Keychains/SystemRootCertificates.keychain",
-        ],
-        stdout=subprocess.PIPE,
-    ).stdout
+    pem_blocks: list[bytes] = []
+    for keychain in _macos_keychains():
+        try:
+            result = subprocess.run(
+                ["security", "find-certificate", "-a", "-p", keychain],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                timeout=KEYCHAIN_TIMEOUT,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            LOG.warning("Could not read certificates from %s: %s", keychain, exc)
+            continue
+        if result.stdout:
+            pem_blocks.append(result.stdout)
 
-    with NamedTemporaryFile("w+b") as tmp_file:
-        tmp_file.write(macos_ca_certs)
+    if not pem_blocks:
+        LOG.warning(
+            "No certificates found in the macOS keychains; TLS verification "
+            "will fail for every server."
+        )
+        return ctx
+
+    with NamedTemporaryFile("w+b", suffix=".pem") as tmp_file:
+        tmp_file.write(b"\n".join(pem_blocks))
+        # Without the flush, the tail of the buffer is still unwritten when
+        # OpenSSL opens the file by name, silently truncating the anchors.
+        tmp_file.flush()
         ctx.load_verify_locations(tmp_file.name)
 
     return ctx


### PR DESCRIPTION
## Problem

On macOS, Gramps Web Sync cannot connect to a Gramps Web instance served with a
privately issued certificate — one signed by a company root pushed via MDM, or by a
local CA generated for a self-hosted instance. The sync fails at connect time with:

```
URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED]
certificate verify failed: unable to get local issuer certificate>
```

The same URL loads without complaint in Safari and `curl`, and the same username and
password work in the web UI. That mismatch makes the failure easy to misread as a
credentials or server problem.

## Cause

`create_macos_ssl_context()` harvests certificates from exactly one keychain:

```python
"/System/Library/Keychains/SystemRootCertificates.keychain"
```

That is Apple's **read-only** list of public root CAs. A privately issued CA is never
installed there — it goes into the admin keychain (`/Library/Keychains/System.keychain`)
or the user's login keychain. Safari and `curl` consult the full keychain search list,
which is why they succeed where the addon fails.

There is no fallback either. The context is seeded from `ssl.create_default_context()`,
which normally loads OpenSSL's default CA store — but the OpenSSL shipped inside the
Gramps macOS bundle has its `OPENSSLDIR` baked in at build time:

```
$ strings Gramps.app/Contents/Resources/lib/libcrypto.3.dylib | grep etc/ssl
/Users/john/Development/gramps-tarball-11.0-arm64/inst/etc/ssl
```

That path exists only on the build machine, so on a user's Mac the default store
resolves to nothing and the context starts out **empty**. Every trust anchor has to be
supplied explicitly from the keychains — which makes the single-keychain read the sole
source of trust, not merely a supplement to it.

## Note for reviewers

The change reads the admin keychain and the `security list-keychains` search list in
addition to Apple's roots. That promotes every certificate in those keychains to a
trust anchor, without consulting per-certificate **trust settings** — so a certificate
a user has stored but explicitly marked *untrusted* would still be honoured. That
limitation is inherited from the existing implementation, not introduced here, and it
keeps the change small and dependency-free.

Reading trust settings properly means going through the Security framework rather than
parsing `security(1)` output — [`truststore`](https://pypi.org/project/truststore/)
does exactly that and would let this whole function be deleted. I've kept that out of
this PR since adding a runtime dependency to an addon is a separate decision, but I'm
happy to follow up if maintainers would prefer that direction.

No `version` bump in `.gpr.py`, per `AGENTS.md`.
