### PR TITLE
Port GOQLFilter to gramps60 by vendoring gramps-object-query-language

### DIFF
--- a/GOQLFilter/MANIFEST
+++ b/GOQLFilter/MANIFEST
@@ -1,0 +1,7 @@
+GOQLFilter/gramps_object_query_language_copy/__init__.py
+GOQLFilter/gramps_object_query_language_copy/evaluator.py
+GOQLFilter/gramps_object_query_language_copy/proxied_query.py
+GOQLFilter/gramps_object_query_language_copy/query.py
+GOQLFilter/gramps_object_query_language_copy/query_lang.py
+GOQLFilter/gramps_object_query_language_copy/py.typed
+GOQLFilter/gramps_object_query_language_copy/LICENSE

--- a/GOQLFilter/goql.gpr.py
+++ b/GOQLFilter/goql.gpr.py
@@ -1,0 +1,190 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Gramplets providing a gramps-object-query-language filter for each
+primary object view."""
+
+_HELP = "Addon:GrampsObjectQueryLanguage"
+_AUTHORS = ["Douglas Blank"]
+_AUTHORS_EMAIL = ["doug.blank@gmail.com"]
+
+register(
+    GRAMPLET,
+    id="Person GOQL Filter",
+    name=_("Person GOQL Filter"),
+    description=_("Gramplet providing a gramps-object-query-language person filter"),
+    version = '1.0.1',
+    gramps_target_version="6.0",
+    status=STABLE,
+    fname="goql.py",
+    height=260,
+    gramplet="PersonQueryFilter",
+    gramplet_title=_("GOQL Filter"),
+    navtypes=["Person"],
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+)
+
+register(
+    GRAMPLET,
+    id="Family GOQL Filter",
+    name=_("Family GOQL Filter"),
+    description=_("Gramplet providing a gramps-object-query-language family filter"),
+    version = '1.0.1',
+    gramps_target_version="6.0",
+    status=STABLE,
+    fname="goql.py",
+    height=260,
+    gramplet="FamilyQueryFilter",
+    gramplet_title=_("GOQL Filter"),
+    navtypes=["Family"],
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+)
+
+register(
+    GRAMPLET,
+    id="Event GOQL Filter",
+    name=_("Event GOQL Filter"),
+    description=_("Gramplet providing a gramps-object-query-language event filter"),
+    version = '1.0.1',
+    gramps_target_version="6.0",
+    status=STABLE,
+    fname="goql.py",
+    height=260,
+    gramplet="EventQueryFilter",
+    gramplet_title=_("GOQL Filter"),
+    navtypes=["Event"],
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+)
+
+register(
+    GRAMPLET,
+    id="Place GOQL Filter",
+    name=_("Place GOQL Filter"),
+    description=_("Gramplet providing a gramps-object-query-language place filter"),
+    version = '1.0.1',
+    gramps_target_version="6.0",
+    status=STABLE,
+    fname="goql.py",
+    height=260,
+    gramplet="PlaceQueryFilter",
+    gramplet_title=_("GOQL Filter"),
+    navtypes=["Place"],
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+)
+
+register(
+    GRAMPLET,
+    id="Repository GOQL Filter",
+    name=_("Repository GOQL Filter"),
+    description=_(
+        "Gramplet providing a gramps-object-query-language repository filter"
+    ),
+    version = '1.0.1',
+    gramps_target_version="6.0",
+    status=STABLE,
+    fname="goql.py",
+    height=260,
+    gramplet="RepositoryQueryFilter",
+    gramplet_title=_("GOQL Filter"),
+    navtypes=["Repository"],
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+)
+
+register(
+    GRAMPLET,
+    id="Source GOQL Filter",
+    name=_("Source GOQL Filter"),
+    description=_("Gramplet providing a gramps-object-query-language source filter"),
+    version = '1.0.1',
+    gramps_target_version="6.0",
+    status=STABLE,
+    fname="goql.py",
+    height=260,
+    gramplet="SourceQueryFilter",
+    gramplet_title=_("GOQL Filter"),
+    navtypes=["Source"],
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+)
+
+register(
+    GRAMPLET,
+    id="Citation GOQL Filter",
+    name=_("Citation GOQL Filter"),
+    description=_("Gramplet providing a gramps-object-query-language citation filter"),
+    version = '1.0.1',
+    gramps_target_version="6.0",
+    status=STABLE,
+    fname="goql.py",
+    height=260,
+    gramplet="CitationQueryFilter",
+    gramplet_title=_("GOQL Filter"),
+    navtypes=["Citation"],
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+)
+
+register(
+    GRAMPLET,
+    id="Media GOQL Filter",
+    name=_("Media GOQL Filter"),
+    description=_("Gramplet providing a gramps-object-query-language media filter"),
+    version = '1.0.1',
+    gramps_target_version="6.0",
+    status=STABLE,
+    fname="goql.py",
+    height=260,
+    gramplet="MediaQueryFilter",
+    gramplet_title=_("GOQL Filter"),
+    navtypes=["Media"],
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+)
+
+register(
+    GRAMPLET,
+    id="Note GOQL Filter",
+    name=_("Note GOQL Filter"),
+    description=_("Gramplet providing a gramps-object-query-language note filter"),
+    version = '1.0.1',
+    gramps_target_version="6.0",
+    status=STABLE,
+    fname="goql.py",
+    height=260,
+    gramplet="NoteQueryFilter",
+    gramplet_title=_("GOQL Filter"),
+    navtypes=["Note"],
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+)

--- a/GOQLFilter/goql.py
+++ b/GOQLFilter/goql.py
@@ -1,0 +1,646 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Gramplets providing a gramps-object-query-language (GOQL) filter for each
+primary object view: a multi-line text area for a where-expression plus
+Find / Reset / Define filter buttons, the same shape as core's sidebar
+filters.
+
+"Find" compiles the expression, wraps it in a real ``GenericFilter`` (a
+one-rule filter whose rule evaluates the compiled GOQL ``where`` AST via
+``evaluate_where``), and drops it straight into ``view.generic_filter`` --
+the exact mechanism ``plugins/gramplet/filter.py`` uses for the built-in
+rule-based sidebar filters, just fed from a compiled expression instead of a
+rule-picker widget. "Define filter" hands the same expression to Gramps'
+own ``EditFilter`` dialog as a single ``MatchesExpression`` rule (see
+``whereexprrule.py``), so it can be named and saved as an ordinary Custom
+Filter -- reusable anywhere a Custom Filter is, not just in this gramplet.
+
+The text area is a plain ``Enter``-inserts-a-newline ``Gtk.TextView`` (not a
+``Gtk.Entry``) since where-expressions with ``and``/``or`` read better over
+several lines; ``Ctrl+Return`` runs Find instead. Up/Down at the first/last
+line of the buffer recall previous expressions from an in-memory,
+per-gramplet-instance history (session-scoped -- not persisted to disk),
+the same first/last-line-aware convention multiline REPL inputs use so
+plain cursor movement inside a multi-line expression still works.
+"""
+
+# -------------------------------------------------------------------------
+#
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import logging
+import time
+from typing import Any
+
+# -------------------------------------------------------------------------
+#
+# GTK/Gnome modules
+#
+# -------------------------------------------------------------------------
+import warnings
+
+with warnings.catch_warnings():
+    # PyGObject warns on *import* of GLib -- not on use -- when the
+    # underlying GLib build has moved unix_signal_add_full() to GLibUnix
+    # (GLib >= 2.88). This addon never calls that function; the warning is
+    # just noise from gi's override machinery. See
+    # https://gitlab.gnome.org/GNOME/pygobject/-/work_items/757
+    warnings.filterwarnings(
+        "ignore", message=".*unix_signal_add_full.*", category=DeprecationWarning
+    )
+    from gi.repository import Gdk, GLib, Gtk
+
+# -------------------------------------------------------------------------
+#
+# Gramps modules
+#
+# -------------------------------------------------------------------------
+from gramps.gen.plug import Gramplet
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+from gramps.gen.filters import (
+    CustomFilters,
+    GenericFilterFactory,
+    reload_custom_filters,
+)
+from gramps.gui.display import display_help, display_url
+from gramps.gui.editors import EditFilter
+
+# -------------------------------------------------------------------------
+#
+# gramps-object-query-language modules (vendored -- see
+# gramps_object_query_language_copy/, a bundled copy of the
+# gramps-object-query-language PyPI package. This gramps60 branch of the
+# addon vendors it rather than relying on `pip install
+# gramps-object-query-language` -- see gramps_object_query_language_copy/
+# for why (pip installs of pure-Python addon dependencies are unreliable
+# across the various AIO installers on Gramps 6.0).
+#
+# -------------------------------------------------------------------------
+from gramps_object_query_language_copy.query_lang import QueryLangError, compile_expr
+
+from whereexprrule import (
+    CitationMatchesExpression,
+    EventMatchesExpression,
+    FamilyMatchesExpression,
+    MediaMatchesExpression,
+    NoteMatchesExpression,
+    PersonMatchesExpression,
+    PlaceMatchesExpression,
+    RepositoryMatchesExpression,
+    SourceMatchesExpression,
+)
+from goql_completion_popup import CompletionController
+from goql_highlight import classify_tokens
+
+try:
+    _trans = glocale.get_addon_translator(__file__)
+except ValueError:
+    _trans = glocale.translation
+_ = _trans.gettext
+
+LOG = logging.getLogger(".GOQLFilter")
+
+# Minimum pixel height for the text area's scrolled window -- a floor, not
+# the actual displayed size (the Paned in init() splits editor/buttons ~50%
+# of whatever space is actually available; this just keeps the editor from
+# collapsing to something unreadable if the user drags the divider all the
+# way down). Not computed from font metrics (needs a realized widget), just
+# a reasonable fixed default.
+TEXT_AREA_HEIGHT = 90
+
+# Cap on saved history entries -- self.gui.data round-trips through the
+# gramplet's saved placement config (an .ini file) on every save, so an
+# unbounded history would keep growing that file forever.
+HISTORY_MAX_ENTRIES = 50
+
+# Foreground colors for goql_highlight.classify_tokens' categories -- muted,
+# mid-tone hex values chosen to stay legible on both light and dark GTK
+# themes, since a plain Gtk.TextView has no adaptive-theme color mechanism
+# to hook into (no runtime dark/light detection here).
+HIGHLIGHT_COLORS = {
+    "keyword": "#7C3AED",
+    "string": "#15803D",
+    "number": "#B45309",
+    "constant-class": "#BE185D",
+    "operator": "#6B7280",
+}
+
+
+def _icon_button(icon_name, label_text):
+    """A ``Gtk.Button`` with an icon beside its label.
+
+    Same construction ``_sidebarfilter.py``'s ``_init_interface`` uses for
+    its own "Reset" button (``edit-undo`` + label in an ``Gtk.Box``) --
+    matched here for a consistent look, and reused for "Help".
+    """
+    button = Gtk.Button()
+    box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=4)
+    image = Gtk.Image()
+    image.set_from_icon_name(icon_name, Gtk.IconSize.BUTTON)
+    box.pack_start(image, False, False, 0)
+    box.pack_start(Gtk.Label(label=label_text), False, True, 0)
+    button.add(box)
+    return button
+
+
+# -------------------------------------------------------------------------
+#
+# QueryFilter
+#
+# -------------------------------------------------------------------------
+class QueryFilter(Gramplet):
+    """Base class for all GOQL filter gramplets."""
+
+    NAMESPACE: str = ""  # e.g. "Person"; set by subclass
+    RULE_CLASS: Any = None  # e.g. PersonMatchesExpression; set by subclass
+
+    def init(self):
+        self.history = []
+        self.history_index = None  # None == live/current input, not browsing
+        self.history_draft = ""  # the not-yet-submitted text, saved on history-back
+
+        self.text_view = Gtk.TextView()
+        self.text_view.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
+        self.text_view.set_monospace(True)
+        self.text_buffer = self.text_view.get_buffer()
+        self.text_view.set_tooltip_text(
+            _("A gramps-object-query-language where-expression, e.g.\n")
+            + "gender == Person.MALE and 'Anderson' in primary_name.surname\n\n"
+            + _("Enter inserts a newline; Ctrl+Enter runs Find.\n")
+            + _("Up/Down at the first/last line recalls previous expressions.\n")
+            + _("Tab always completes -- it never inserts a tab character.")
+        )
+        for tag_name, color in HIGHLIGHT_COLORS.items():
+            self.text_buffer.create_tag(tag_name, foreground=color)
+
+        self.completion = CompletionController(
+            self.text_view, get_namespace=lambda: self.NAMESPACE
+        )
+        self.text_view.connect("key-press-event", self._on_key_press)
+        self.text_buffer.connect("changed", self._on_text_changed)
+        self.text_view.connect("button-press-event", self._on_textview_defocus)
+        self.text_view.connect("focus-out-event", self._on_textview_defocus)
+
+        scroller = Gtk.ScrolledWindow()
+        scroller.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        scroller.set_shadow_type(Gtk.ShadowType.IN)
+        scroller.set_min_content_height(TEXT_AREA_HEIGHT)
+        scroller.add(self.text_view)
+
+        # Reminds the user this expression's fields are specific to this
+        # view -- e.g. "gender" compiles here but not in the Family filter.
+        namespace_label = Gtk.Label()
+        namespace_label.set_markup(
+            "<b>%s</b>" % GLib.markup_escape_text(_("%s filter") % _(self.NAMESPACE))
+        )
+        namespace_label.set_xalign(0)
+
+        editor_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=3)
+        editor_box.pack_start(namespace_label, False, False, 0)
+        editor_box.pack_start(scroller, True, True, 0)
+
+        # Same button shapes/icons as the built-in rule-based sidebar filter
+        # (`gui/filters/sidebar/_sidebarfilter.py`'s `_init_interface`): a
+        # plain mnemonic "Find" button, an icon+label "Reset", plain-text
+        # "Define filter", grouped into two ButtonBox rows the same way.
+        find_button = Gtk.Button.new_with_mnemonic(_("_Find"))
+        find_button.set_tooltip_text(
+            _("This updates the view with the current filter parameters.")
+        )
+        find_button.connect("clicked", self.find_clicked)
+
+        reset_button = _icon_button("edit-undo", _("Reset"))
+        reset_button.set_tooltip_text(
+            _("This resets the filter parameters to empty state.")
+        )
+        reset_button.connect("clicked", self.reset_clicked)
+
+        define_button = Gtk.Button(label=_("Define filter"))
+        define_button.set_tooltip_text(
+            _("This opens a dialog to save the current expression as a named filter.")
+        )
+        define_button.connect("clicked", self.define_clicked)
+
+        help_button = _icon_button("help-browser", _("Help"))
+        help_button.set_tooltip_text(_("Open this gramplet's help page in a browser."))
+        help_button.connect("clicked", self.help_clicked)
+
+        self.msg_label = Gtk.Label(label="")
+        self.msg_label.set_line_wrap(True)
+        self.msg_label.set_xalign(0)
+
+        action_row = Gtk.ButtonBox()
+        action_row.set_layout(Gtk.ButtonBoxStyle.START)
+        action_row.set_spacing(6)
+        action_row.add(find_button)
+        action_row.add(reset_button)
+
+        secondary_row = Gtk.ButtonBox()
+        secondary_row.set_layout(Gtk.ButtonBoxStyle.START)
+        secondary_row.set_spacing(6)
+        secondary_row.add(define_button)
+        secondary_row.add(help_button)
+
+        bottom_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+        bottom_box.pack_start(action_row, False, False, 0)
+        bottom_box.pack_start(secondary_row, False, False, 0)
+        bottom_box.pack_start(self.msg_label, False, False, 0)
+
+        # A Paned (same widget core's own gui/views/pageview.py uses for its
+        # sidebar/main-content split) rather than a plain Box with
+        # expand=True on the scroller: a Box has no notion of "50% of
+        # whatever's available," only "give the expanding child all
+        # leftover space" -- the text area would end up taller than half
+        # the gramplet on any reasonably tall placement. A Paned's handle
+        # is also user-draggable afterward, which a fixed split wouldn't be.
+        self.paned = Gtk.Paned(orientation=Gtk.Orientation.VERTICAL)
+        self.paned.set_border_width(6)
+        self.paned.pack1(editor_box, True, True)
+        self.paned.pack2(bottom_box, False, True)
+        self._paned_position_set = False
+        self.paned.connect("size-allocate", self._init_paned_position)
+
+        self.gui.get_container_widget().remove(self.gui.textview)
+        self.gui.get_container_widget().add(self.paned)
+        self.paned.show_all()
+
+    def _init_paned_position(self, widget, allocation):
+        """Split the editor/buttons area ~50/50 the first time this pane is
+        actually sized.
+
+        ``Gtk.Paned`` has no percentage-based position, only pixels, and
+        the real allocated height isn't known until the widget is
+        realized -- so this can't just be set once up front in ``init()``.
+        Runs exactly once (``self._paned_position_set``): after that, the
+        divider is the user's own drag to keep, not something to keep
+        resetting back to 50% on every later resize.
+        """
+        if self._paned_position_set or allocation.height <= 1:
+            return
+        widget.set_position(allocation.height // 2)
+        self._paned_position_set = True
+
+    def on_load(self):
+        """Restore history saved by a previous session.
+
+        Called once, right after ``init()``, with ``self.gui.data`` already
+        populated from this gramplet's saved placement config (an .ini
+        file) -- the same mechanism core gramplets like
+        ``pedigreegramplet.py`` use for their own persisted options. Each
+        gramplet *instance* (Person filter, Family filter, ...) has its own
+        ``self.gui.data``, so histories stay independent automatically.
+        """
+        self.history = [str(item) for item in self.gui.data]
+
+    def on_save(self):
+        """Called on app/view shutdown, before ``self.gui.data`` is written
+        to disk -- see ``GrampletBar.on_delete``.
+        """
+        self.gui.data = list(self.history)
+
+    def _on_text_changed(self, _buffer):
+        self._apply_highlighting()
+        self.completion.on_buffer_changed()
+
+    def _on_textview_defocus(self, _widget, _event):
+        """Close the completion popover on a click or focus-out -- shared
+        handler for both signals (``button-press-event``,
+        ``focus-out-event``), matching ``GrampyScript.py``'s
+        ``on_textview_click``/``on_editor_focus_out``. Never consumes the
+        event: a click still needs to move the cursor normally.
+        """
+        self.completion.close()
+        return False
+
+    def _apply_highlighting(self):
+        start, end = self.text_buffer.get_bounds()
+        for tag_name in HIGHLIGHT_COLORS:
+            self.text_buffer.remove_tag_by_name(tag_name, start, end)
+        source = self.text_buffer.get_text(start, end, False)
+        for start_line, start_col, end_line, end_col, category in classify_tokens(
+            source
+        ):
+            start_iter = self.text_buffer.get_iter_at_line_offset(start_line, start_col)
+            end_iter = self.text_buffer.get_iter_at_line_offset(end_line, end_col)
+            self.text_buffer.apply_tag_by_name(category, start_iter, end_iter)
+
+    def _get_expr_text(self):
+        start, end = self.text_buffer.get_bounds()
+        return self.text_buffer.get_text(start, end, False).strip()
+
+    def _set_expr_text(self, text):
+        self.text_buffer.set_text(text)
+        self.text_buffer.place_cursor(self.text_buffer.get_end_iter())
+
+    def _set_message(self, text):
+        self.msg_label.set_text(text)
+
+    def _run_with_filter_progress(self, action):
+        """Run ``action()`` with Gramps' own filter-application phase
+        timings routed into this gramplet's message area, mirroring
+        ``gui/filters/sidebar/_sidebarfilter.py``'s ``clicked()``.
+
+        ``GenericFilter.apply()`` (``gen/filters/_genericfilter.py``)
+        already reports "Prepare time: Xs" / "Apply time: Ys" via
+        ``user.notify(...)`` on every call -- but ``User._gui_print``
+        (``gui/user.py``) only routes that to a widget if
+        ``uistate.filter_print_func`` is set; otherwise it falls through to
+        stdout, which is exactly why those lines showed up in a terminal
+        instead of this gramplet. Returns the collected phase messages.
+        """
+        phase_msgs = []
+
+        def pump_events():
+            while Gtk.events_pending():
+                Gtk.main_iteration()
+
+        def live_print(msg):
+            phase_msgs.append(msg)
+            self._set_message("\n".join(phase_msgs))
+            pump_events()
+
+        def live_step():
+            pump_events()
+
+        self.uistate.filter_print_func = live_print
+        self.uistate.filter_step_func = live_step
+        self.uistate.set_busy_cursor(True)
+        try:
+            action()
+        finally:
+            self.uistate.filter_print_func = None
+            self.uistate.filter_step_func = None
+            self.uistate.set_busy_cursor(False)
+        return phase_msgs
+
+    def _filter_method_label(self, gfilter):
+        """ "SQL" if any rule in ``gfilter`` resolved a precomputed match set
+        (``MatchesExpression.prepare`` sets ``selected_handles`` only when
+        it pushed the expression down to SQL), else "Python evaluation".
+        """
+        for rule in gfilter.get_rules():
+            if getattr(rule, "selected_handles", None) is not None:
+                return _("SQL")
+        return _("Python evaluation")
+
+    def _remember_history(self, expr):
+        """Append ``expr`` to history, skipping an immediate repeat."""
+        if expr and (not self.history or self.history[-1] != expr):
+            self.history.append(expr)
+            del self.history[:-HISTORY_MAX_ENTRIES]
+        self.history_index = None
+
+    def _history_back(self):
+        if not self.history:
+            return
+        if self.history_index is None:
+            self.history_draft = self._get_expr_text()
+            self.history_index = len(self.history) - 1
+        elif self.history_index > 0:
+            self.history_index -= 1
+        else:
+            return  # already at the oldest entry
+        self._set_expr_text(self.history[self.history_index])
+
+    def _history_forward(self):
+        if self.history_index is None:
+            return  # not browsing
+        if self.history_index < len(self.history) - 1:
+            self.history_index += 1
+            self._set_expr_text(self.history[self.history_index])
+        else:
+            self.history_index = None
+            self._set_expr_text(self.history_draft)
+
+    def _on_key_press(self, _widget, event):
+        # Completion first: when its popover is open, Up/Down/Enter/Escape
+        # navigate/accept/dismiss it rather than falling through to history
+        # navigation or a newline below -- see CompletionController's own
+        # key-press dispatch.
+        if self.completion.on_key_press(event):
+            return True
+
+        ctrl = bool(event.state & Gdk.ModifierType.CONTROL_MASK)
+
+        if event.keyval == Gdk.KEY_Tab:
+            # Tab is always completion, never a literal tab/space insert:
+            # self.completion.on_key_press already tried above and
+            # returned False here only because there was nothing
+            # completable -- still consume the key rather than falling
+            # back to GTK's default (inserting a tab character).
+            return True
+
+        if ctrl and event.keyval in (Gdk.KEY_Return, Gdk.KEY_KP_Enter):
+            self.find_clicked(_widget)
+            return True  # don't also insert a newline
+
+        if not ctrl and event.keyval in (Gdk.KEY_Up, Gdk.KEY_Down):
+            cursor = self.text_buffer.get_iter_at_mark(self.text_buffer.get_insert())
+            at_first_line = cursor.get_line() == 0
+            at_last_line = cursor.get_line() == self.text_buffer.get_line_count() - 1
+            if event.keyval == Gdk.KEY_Up and at_first_line:
+                self._history_back()
+                return True
+            if event.keyval == Gdk.KEY_Down and at_last_line:
+                self._history_forward()
+                return True
+
+        return False  # let GTK handle it normally
+
+    def _hide_quick_search_bar(self):
+        """Close the view's own quick-search bar, if open.
+
+        ``ListView.build_tree()`` only reads ``generic_filter`` when its
+        quick-search bar (the small text-search box built into every list
+        view, independent of this gramplet) is hidden -- otherwise it uses
+        *that* bar's own filter instead and ``generic_filter`` is silently
+        ignored. The bar auto-hides when the view's Sidebar pane is toggled
+        on, but this gramplet may just as well be docked in the bottombar,
+        so hide it explicitly rather than depending on where the user put
+        the gramplet.
+        """
+        search_bar = getattr(self.gui.view, "search_bar", None)
+        if search_bar is not None and search_bar.is_visible():
+            search_bar.hide()
+
+    def _build_generic_filter(self, expr):
+        """A ``GenericFilter`` for ``expr``, or ``None`` if it fails to compile.
+
+        Validates ``expr`` up front so a bad expression reports a clear error
+        here rather than silently matching nothing -- ``RULE_CLASS.prepare()``
+        recompiles it a second time when the filter is applied, since a
+        ``Rule`` only ever receives its arguments as plain strings.
+        """
+        try:
+            compile_expr(self.NAMESPACE, expr)
+        except QueryLangError as err:
+            self._set_message(str(err))
+            return None
+        gfilter = GenericFilterFactory(self.NAMESPACE)()
+        gfilter.add_rule(self.RULE_CLASS([expr]))
+        return gfilter
+
+    def find_clicked(self, _obj):
+        expr = self._get_expr_text()
+        self._set_message("")
+        if not expr:
+            self.reset_clicked(_obj)
+            return
+        gfilter = self._build_generic_filter(expr)
+        if gfilter is None:
+            return
+        self._remember_history(expr)
+        phase_msgs = []
+        try:
+            self._hide_quick_search_bar()
+            self.gui.view.generic_filter = gfilter
+
+            def do_build_tree():
+                self.gui.view.build_tree()
+
+            phase_msgs = self._run_with_filter_progress(do_build_tree)
+        except Exception as err:  # never let a click silently fail
+            LOG.exception("GOQL Filter gramplet: Find failed")
+            self._set_message(_("Error applying filter: %s") % err)
+            return
+        model = self.gui.view.model
+        summary = _("Showing %(shown)d of %(total)d (%(method)s)") % {
+            "shown": model.displayed(),
+            "total": model.total(),
+            "method": self._filter_method_label(gfilter),
+        }
+        self._set_message("\n".join(phase_msgs + [summary]))
+
+    def reset_clicked(self, _obj):
+        self._set_expr_text("")
+        try:
+            self._hide_quick_search_bar()
+            self.gui.view.generic_filter = None
+            self.gui.view.build_tree()
+        except Exception as err:
+            LOG.exception("GOQL Filter gramplet: Reset failed")
+            self._set_message(_("Error resetting filter: %s") % err)
+            return
+        self._set_message("")
+
+    def define_clicked(self, _obj):
+        expr = self._get_expr_text()
+        if not expr:
+            self._set_message(_("Enter an expression first"))
+            return
+        try:
+            compile_expr(self.NAMESPACE, expr)
+        except QueryLangError as err:
+            self._set_message(str(err))
+            return
+        self._set_message("")
+        self._remember_history(expr)
+
+        gfilter = GenericFilterFactory(self.NAMESPACE)()
+        gfilter.add_rule(self.RULE_CLASS([expr]))
+        comment = _("Created by the GOQL Filter gramplet on {today}").format(
+            today=time.strftime("%Y-%m-%d", time.localtime())
+        )
+        gfilter.set_comment(comment)
+
+        EditFilter(
+            self.NAMESPACE,
+            self.dbstate,
+            self.uistate,
+            [],
+            gfilter,
+            CustomFilters,
+            selection_callback=self._filter_defined,
+        )
+
+    def _filter_defined(self, filterdb, _filter_name):
+        filterdb.save()
+        reload_custom_filters()
+        self.uistate.emit("filters-changed", (self.NAMESPACE,))
+
+    def help_clicked(self, _obj):
+        """Open this gramplet's registered ``help_url`` in a browser.
+
+        ``self.gui.help_url`` is set from the ``.gpr.py`` registration's
+        ``help_url=`` (``GuiGramplet.__init__``, ``gui/widgets/
+        grampletpane.py``) -- the same attribute the built-in "Help" menu
+        item on every gramplet tab already reads, via the same
+        ``http(s)://`` vs. wiki-page-name dispatch used there
+        (``grampletpane.py``/``grampletbar.py``'s own right-click "Help").
+        """
+        help_url = getattr(self.gui, "help_url", None)
+        if not help_url:
+            return
+        if help_url.startswith(("http://", "https://")):
+            display_url(help_url)
+        else:
+            display_help(help_url)
+
+
+# -------------------------------------------------------------------------
+#
+# Per-type gramplets
+#
+# -------------------------------------------------------------------------
+class PersonQueryFilter(QueryFilter):
+    NAMESPACE = "Person"
+    RULE_CLASS = PersonMatchesExpression
+
+
+class FamilyQueryFilter(QueryFilter):
+    NAMESPACE = "Family"
+    RULE_CLASS = FamilyMatchesExpression
+
+
+class EventQueryFilter(QueryFilter):
+    NAMESPACE = "Event"
+    RULE_CLASS = EventMatchesExpression
+
+
+class PlaceQueryFilter(QueryFilter):
+    NAMESPACE = "Place"
+    RULE_CLASS = PlaceMatchesExpression
+
+
+class RepositoryQueryFilter(QueryFilter):
+    NAMESPACE = "Repository"
+    RULE_CLASS = RepositoryMatchesExpression
+
+
+class SourceQueryFilter(QueryFilter):
+    NAMESPACE = "Source"
+    RULE_CLASS = SourceMatchesExpression
+
+
+class CitationQueryFilter(QueryFilter):
+    NAMESPACE = "Citation"
+    RULE_CLASS = CitationMatchesExpression
+
+
+class MediaQueryFilter(QueryFilter):
+    NAMESPACE = "Media"
+    RULE_CLASS = MediaMatchesExpression
+
+
+class NoteQueryFilter(QueryFilter):
+    NAMESPACE = "Note"
+    RULE_CLASS = NoteMatchesExpression

--- a/GOQLFilter/goql_completion.py
+++ b/GOQLFilter/goql_completion.py
@@ -1,0 +1,142 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""GOQL-specific completion source for ``goql_completion_popup``'s
+``CompletionController``.
+
+Kept free of GTK imports, mirroring ``GrampyScript/completion.py``'s own
+"testable without a display" convention -- ``goql.py`` is responsible for
+turning a ``Gtk.TextBuffer`` cursor position into ``(source, line, column)``.
+
+Deliberately not jedi-based, unlike GrampyScript's completion engine: a
+where-expression is never executed, has no live namespace of real Python
+objects to introspect, and its grammar is a small closed set (see
+``gramps_object_query_language.query_lang``'s module docstring) -- general
+Python completion would suggest names (arbitrary methods, ``import``, ...)
+that are simply invalid here. This only ever offers two things, matching
+what was actually asked for:
+
+- At the top level (no ``.`` immediately before the word being typed): the
+  current namespace's own vocabulary -- flat column names, relationship
+  names (``birth``, ``father``, ...), collection names (``children``,
+  ``events``, ...), the where-expression keywords (``and``/``or``/``not``/
+  ``in``/``like``/``Date``/``exists``/``count``), the comparison operators
+  (``==``/``!=``/``<``/``<=``/``>``/``>=``) -- included even though most are
+  a single character and so only ever surface with an empty prefix (Tab on
+  its own), not because they're likely to be *typed* out via completion --
+  and the constant class names themselves (``Person``, ``EventType``, ...)
+  so typing far enough to reach one and then ``.`` is a smooth continuation.
+- Right after ``ClassName.``, where ``ClassName`` is one of the constant
+  classes ``query_lang.py`` recognizes on the value side of a comparison
+  (``Person.MALE``, ``EventType.BIRTH``, ...): that class's own ALL_CAPS
+  int constants.
+
+Anything else (e.g. completing a nested JSON field inside
+``primary_name.``) returns no completions -- out of scope for now, not a
+silent failure to fix.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Set
+
+# `_RELATIONSHIPS`/`_COLLECTIONS` (query.py) and `_CONSTANT_CLASSES`/
+# `_CONSTANTS` (query_lang.py) are module-private -- there is no public way
+# to *enumerate* every relationship/collection/constant name for a spec
+# (only to resolve one given name, via the public `resolve_collection`/
+# `resolve_column_path`). Reaching into them here is a deliberate, narrow
+# exception for exactly this reason, not an oversight; if
+# gramps-object-query-language grows a public enumeration API, switch to it.
+from gramps_object_query_language_copy.query import _COLLECTIONS, _RELATIONSHIPS
+from gramps_object_query_language_copy.query_lang import (
+    QueryLangError,
+    _CONSTANT_CLASSES,
+    _CONSTANTS,
+    resolve_namespace,
+)
+
+from goql_vocabulary import COMPARISON_OPERATORS, KEYWORDS
+
+_DOTTED_RE = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)\.([A-Za-z0-9_]*)$")
+_WORD_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _text_before_cursor(source: str, line: int, column: int) -> str:
+    """``source`` truncated to the cursor position.
+
+    ``line`` is 1-indexed, ``column`` is a 0-indexed character offset
+    within that line -- the same convention ``CompletionController`` uses
+    (``GrampyScript/completion_popup.py``'s ``_cursor_line_column``,
+    matching ``Gtk.TextIter.get_line() + 1`` / ``get_line_offset()``).
+    """
+    lines = source.split("\n")
+    index = max(0, min(line - 1, len(lines) - 1)) if lines else 0
+    before_lines = lines[:index]
+    current_line = lines[index] if lines else ""
+    return "\n".join(before_lines + [current_line[:column]])
+
+
+def _top_level_names(namespace: str) -> Set[str]:
+    try:
+        spec = resolve_namespace(namespace)
+    except QueryLangError:
+        return set()
+    names: Set[str] = set(spec.columns)
+    names.update(_RELATIONSHIPS.get(spec.table, {}).keys())
+    names.update(_COLLECTIONS.get(spec.table, {}).keys())
+    names.update(KEYWORDS)
+    names.update(COMPARISON_OPERATORS)
+    names.update(_CONSTANT_CLASSES.keys())
+    return names
+
+
+def _constant_names(class_name: str) -> Set[str]:
+    return set(_CONSTANTS.get(class_name, {}).keys())
+
+
+def get_completion_items(
+    source: str, line: int, column: int, namespace: str
+) -> List[Dict[str, Any]]:
+    """Candidate completions at ``(line, column)`` in ``source``, for the
+    given GOQL ``namespace`` ("Person", "Family", ...).
+
+    Same return shape as ``GrampyScript/completion.py``'s
+    ``get_completion_items`` -- ``{"name": ..., "complete": ..., "cursor_offset":
+    0}`` dicts -- so ``goql_completion_popup.CompletionController`` (adapted
+    from ``GrampyScript/completion_popup.py``) can drive either unchanged.
+    Always flat: no attempt to parse the surrounding expression's grammar,
+    only what immediately precedes the word being completed.
+    """
+    text_before = _text_before_cursor(source, line, column)
+    dotted = _DOTTED_RE.search(text_before)
+    if dotted:
+        class_name, prefix = dotted.group(1), dotted.group(2)
+        names = _constant_names(class_name)
+    else:
+        word = _WORD_RE.search(text_before)
+        prefix = word.group(0) if word else ""
+        names = _top_level_names(namespace)
+
+    matches = sorted(name for name in names if name.startswith(prefix))
+    return [
+        {"name": name, "complete": name[len(prefix) :], "cursor_offset": 0}
+        for name in matches
+    ]

--- a/GOQLFilter/goql_completion_popup.py
+++ b/GOQLFilter/goql_completion_popup.py
@@ -1,0 +1,336 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2025      Doug Blank
+# Copyright (C) 2026       Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""A Tab-triggered, live-filtering completion popover for a ``Gtk.TextView``.
+
+Vendored from the ``GrampyScript`` addon's ``completion_popup.py``
+(``CompletionController``), which is deliberately GTK-only and
+completion-source-agnostic already -- its own docstring says it's "kept as
+a standalone controller... so it can be driven directly against a plain
+Gtk.TextView", touching its jedi-based backend through exactly one import
+(``from completion import get_completion_items``). That's the only line
+changed here: swapped for ``goql_completion``'s namespace-aware, non-jedi
+source (see that module's docstring for why a where-expression can't reuse
+GrampyScript's actual completion engine, only its popup).
+
+Named differently from GrampyScript's own ``completion_popup.py``/
+``completion.py`` on purpose -- if both addons are ever installed at once,
+Gramps' plugin loader puts each addon's own directory on ``sys.path``, and
+a bare ``import completion_popup`` here could resolve to whichever one
+happened to be imported first instead of this file (the same
+namespace-collision hazard as Mantis 12691, just at the addon-to-addon
+level instead of within one addon).
+
+Two further deltas from the vendored original, both because this editor's
+Tab key has no fallback behavior to protect (GrampyScript's Tab inserts 4
+spaces when nothing is completable; this one never inserts anything):
+
+- ``_is_completable_context`` always returns True here -- GrampyScript
+  gates completion on the preceding character (alnum/``_``/``.``/``]``) so
+  Tab's whitespace-insert fallback doesn't fire in a confusing spot; this
+  editor has no such fallback to protect, and "Tab on an empty buffer
+  shows every top-level name for the current namespace" is exactly the
+  wanted behavior, not an edge case to guard against.
+- Callers are expected to unconditionally consume ``Gdk.KEY_Tab``
+  themselves (return ``True``) regardless of what ``on_key_press`` reports,
+  rather than falling back to inserting a tab character the way
+  GrampyScript's own key handler does.
+
+Wiring it into a host widget requires forwarding four things:
+    textview "key-press-event"   -> controller.on_key_press(event)
+                                     (if it returns True, treat the event
+                                     as handled and stop further processing)
+    buffer   "changed"           -> controller.on_buffer_changed()
+    textview "button-press-event"/"focus-out-event" -> controller.close()
+"""
+
+import logging
+
+from gi.repository import Gdk, Gtk
+
+from goql_completion import get_completion_items
+
+_LOG = logging.getLogger(".GOQLFilter.completion")
+
+_NAVIGATION_KEYS = (
+    Gdk.KEY_Left,
+    Gdk.KEY_Right,
+    Gdk.KEY_Home,
+    Gdk.KEY_End,
+    Gdk.KEY_Page_Up,
+    Gdk.KEY_Page_Down,
+)
+
+
+class CompletionController:
+    def __init__(self, textview, get_namespace):
+        """
+        `textview`: the Gtk.TextView to attach completion to.
+        `get_namespace`: zero-arg callable returning the current GOQL
+        namespace string ("Person", "Family", ...) for
+        `get_completion_items()`; called fresh on every request so it
+        always reflects whichever gramplet/rule this controller is
+        attached to.
+        """
+        self.textview = textview
+        self.buffer = textview.get_buffer()
+        self.get_namespace = get_namespace
+        self.popover = None
+        self.listbox = None
+        self.scrolled = None
+        self.items = []
+        self.selected_index = 0
+
+    # ---- public event entry points -----------------------------------
+
+    def on_key_press(self, event):
+        """Return True if the event was consumed and should not be
+        processed any further by the caller."""
+        try:
+            return self._on_key_press(event)
+        except Exception:
+            # Never let a bug here swallow the keypress entirely -- that
+            # would leave GTK's own default handler to run instead, which
+            # looks like "completion silently does nothing." Log and fall
+            # back to "not handled" instead.
+            _LOG.exception("completion on_key_press failed")
+            self.close()
+            return False
+
+    def _on_key_press(self, event):
+        keyval = event.keyval
+        _LOG.debug(
+            "on_key_press keyval=%s open=%s", Gdk.keyval_name(keyval), self.is_open()
+        )
+        if keyval == Gdk.KEY_Tab:
+            if self.is_open():
+                self.accept()
+                return True
+            return self.trigger()
+        if self.is_open():
+            if keyval == Gdk.KEY_Up:
+                self.move_selection(-1)
+                return True
+            if keyval == Gdk.KEY_Down:
+                self.move_selection(1)
+                return True
+            if keyval in (Gdk.KEY_Return, Gdk.KEY_KP_Enter):
+                self.accept()
+                return True
+            if keyval == Gdk.KEY_Escape:
+                self.close()
+                return True
+            if keyval in _NAVIGATION_KEYS:
+                # The cursor is about to move out from under the popover;
+                # let it move normally, just stop completing at this spot.
+                self.close()
+                return False
+        return False
+
+    def on_buffer_changed(self):
+        if not self.is_open():
+            return
+        try:
+            self.refresh()
+        except Exception:
+            _LOG.exception("completion refresh failed")
+            self.close()
+
+    def is_open(self):
+        return self.popover is not None
+
+    # ---- core -----------------------------------------------------------
+
+    def _cursor_iter(self):
+        return self.buffer.get_iter_at_mark(self.buffer.get_insert())
+
+    def _cursor_line_column(self):
+        it = self._cursor_iter()
+        return it.get_line() + 1, it.get_line_offset()
+
+    def _word_prefix(self):
+        it = self._cursor_iter()
+        start = it.copy()
+        while start.backward_char():
+            ch = start.get_char()
+            if ch.isalnum() or ch == "_":
+                continue
+            start.forward_char()
+            break
+        return self.buffer.get_text(start, it, True)
+
+    def _is_completable_context(self):
+        # Always True here -- see this module's docstring for why, unlike
+        # GrampyScript's version, this editor has no whitespace-insert
+        # fallback to protect Tab from firing into.
+        return True
+
+    def _compute_items(self):
+        source = self.buffer.get_text(
+            self.buffer.get_start_iter(), self.buffer.get_end_iter(), True
+        )
+        line, column = self._cursor_line_column()
+        prefix = self._word_prefix()
+        _LOG.debug(
+            "computing completions at line=%s column=%s prefix=%r", line, column, prefix
+        )
+        try:
+            namespace = self.get_namespace()
+            items = get_completion_items(source, line, column, namespace)
+        except Exception:
+            _LOG.exception("building completion items failed")
+            return []
+        if not prefix.startswith("_"):
+            items = [item for item in items if not item["name"].startswith("_")]
+        _LOG.debug(
+            "found %d completion(s): %s", len(items), [i["name"] for i in items[:10]]
+        )
+        return items
+
+    def trigger(self):
+        """Try to complete at the cursor. Returns True if there was
+        something completable to show. A single match is inserted
+        directly instead of opening a popover with one row in it;
+        multiple matches open the popover as usual."""
+        if not self._is_completable_context():
+            return False
+        items = self._compute_items()
+        if not items:
+            _LOG.debug("trigger: no completions")
+            return False
+        self.items = items
+        self.selected_index = 0
+        if len(items) == 1:
+            _LOG.debug(
+                "trigger: single match, inserting directly: %s", items[0]["name"]
+            )
+            self.accept()
+            return True
+        self._open_popover()
+        return True
+
+    def refresh(self):
+        """Recompute matches for an already-open popover, following the
+        cursor as the user keeps typing. Closes if nothing matches
+        anymore."""
+        items = self._compute_items()
+        if not items:
+            self.close()
+            return
+        self.items = items
+        self.selected_index = min(self.selected_index, len(items) - 1)
+        self._rebuild_listbox()
+        self._reposition()
+
+    def move_selection(self, delta):
+        if not self.items:
+            return
+        self.selected_index = max(
+            0, min(len(self.items) - 1, self.selected_index + delta)
+        )
+        self._update_row_selection()
+
+    def accept(self):
+        if self.items:
+            item = self.items[self.selected_index]
+            self.buffer.insert(self._cursor_iter(), item["complete"])
+            offset = item.get("cursor_offset", 0)
+            if offset:
+                it = self._cursor_iter()
+                it.backward_chars(offset)
+                self.buffer.place_cursor(it)
+        self.close()
+
+    def close(self):
+        if self.popover is not None:
+            self.popover.destroy()
+        self.popover = None
+        self.listbox = None
+        self.scrolled = None
+        self.items = []
+        self.selected_index = 0
+
+    # ---- widget building --------------------------------------------------
+
+    def _open_popover(self):
+        self.popover = Gtk.Popover()
+        self.popover.set_relative_to(self.textview)
+        self.popover.set_modal(False)
+        self.popover.set_position(Gtk.PositionType.BOTTOM)
+
+        self.scrolled = Gtk.ScrolledWindow()
+        self.scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        self.scrolled.set_max_content_height(200)
+        self.scrolled.set_propagate_natural_height(True)
+
+        self.listbox = Gtk.ListBox()
+        self.listbox.set_activate_on_single_click(True)
+        self.listbox.connect("row-activated", self._on_row_activated)
+        self.scrolled.add(self.listbox)
+        self.popover.add(self.scrolled)
+
+        self._rebuild_listbox()
+        self.popover.show_all()
+        self._reposition()
+        self.popover.popup()
+
+    def _rebuild_listbox(self):
+        for child in self.listbox.get_children():
+            self.listbox.remove(child)
+        for item in self.items:
+            label = Gtk.Label(label=item["name"], xalign=0)
+            label.set_margin_start(6)
+            label.set_margin_end(6)
+            row = Gtk.ListBoxRow()
+            row.add(label)
+            self.listbox.add(row)
+        self.listbox.show_all()
+        self._update_row_selection()
+
+    def _update_row_selection(self):
+        row = self.listbox.get_row_at_index(self.selected_index)
+        if row is not None:
+            self.listbox.select_row(row)
+            self._scroll_to_row(row)
+
+    def _scroll_to_row(self, row):
+        alloc = row.get_allocation()
+        adj = self.scrolled.get_vadjustment()
+        if alloc.y < adj.get_value():
+            adj.set_value(alloc.y)
+        elif alloc.y + alloc.height > adj.get_value() + adj.get_page_size():
+            adj.set_value(alloc.y + alloc.height - adj.get_page_size())
+
+    def _reposition(self):
+        rect = self.textview.get_iter_location(self._cursor_iter())
+        x, y = self.textview.buffer_to_window_coords(
+            Gtk.TextWindowType.WIDGET, rect.x, rect.y
+        )
+        pointing = Gdk.Rectangle()
+        pointing.x = x
+        pointing.y = y
+        pointing.width = 1
+        pointing.height = rect.height
+        self.popover.set_pointing_to(pointing)
+
+    def _on_row_activated(self, listbox, row):
+        self.selected_index = row.get_index()
+        self.accept()

--- a/GOQLFilter/goql_highlight.py
+++ b/GOQLFilter/goql_highlight.py
@@ -1,0 +1,100 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Token-span classification for GOQL where-expression syntax highlighting.
+
+Kept free of GTK imports -- same "testable without a display" convention as
+``goql_completion.py`` -- ``goql.py`` is responsible for turning a span into
+a ``Gtk.TextTag`` range.
+
+Uses Python's own ``tokenize`` module rather than a hand-written lexer: a
+where-expression's tokens (names, string/number literals, comparison
+operators) are a strict subset of Python's own, so there's no new grammar
+to maintain here -- just a classification on top of what ``tokenize``
+already produces. This is lexical only (keyword/string/number/operator/
+known-constant-class recognition from token text alone), not a real parse
+-- it never rejects anything ``query_lang.py`` wouldn't also accept or
+reject on its own; ``compile_expr``'s own error message is still the
+source of truth for whether an expression is valid.
+"""
+
+from __future__ import annotations
+
+import io
+import tokenize
+from typing import Iterator, Tuple
+
+from gramps_object_query_language_copy.query_lang import _CONSTANT_CLASSES
+
+from goql_vocabulary import COMPARISON_OPERATORS, KEYWORDS
+
+# (start_line, start_col, end_line, end_col, category) -- 0-indexed lines,
+# matching Gtk.TextIter's own convention (tokenize's rows are 1-indexed).
+Span = Tuple[int, int, int, int, str]
+
+
+def classify_tokens(source: str) -> Iterator[Span]:
+    """Yield a ``Span`` for each highlightable token in ``source``.
+
+    Incomplete/invalid source -- the normal state of this buffer while
+    still being typed, not an error case -- is handled by
+    ``_tokenize_best_effort``: whatever ``tokenize`` managed to produce
+    before hitting the unparseable part is still yielded.
+    """
+    for tok in _tokenize_best_effort(source):
+        category = _classify(tok)
+        if category is None:
+            continue
+        start_line, start_col = tok.start
+        end_line, end_col = tok.end
+        yield (start_line - 1, start_col, end_line - 1, end_col, category)
+
+
+def _classify(tok) -> str | None:
+    if tok.type == tokenize.STRING:
+        return "string"
+    if tok.type == tokenize.NUMBER:
+        return "number"
+    if tok.type == tokenize.NAME:
+        if tok.string in KEYWORDS:
+            return "keyword"
+        if tok.string in _CONSTANT_CLASSES:
+            return "constant-class"
+        return None
+    if tok.type == tokenize.OP and tok.string in COMPARISON_OPERATORS:
+        return "operator"
+    return None
+
+
+def _tokenize_best_effort(source: str):
+    """``tokenize.generate_tokens`` raises on unterminated strings,
+    unbalanced brackets, or an expression that just stops mid-line -- all
+    routine while typing, not something to surface as a highlighting
+    failure. Whatever was already yielded before the exception is kept
+    (the loop below appends token-by-token, so a raise partway through
+    only truncates the tail, not the whole result).
+    """
+    tokens = []
+    try:
+        for tok in tokenize.generate_tokens(io.StringIO(source).readline):
+            tokens.append(tok)
+    except Exception:
+        pass
+    return tokens

--- a/GOQLFilter/goql_vocabulary.py
+++ b/GOQLFilter/goql_vocabulary.py
@@ -1,0 +1,37 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Shared where-expression token vocabulary.
+
+The small, fixed set of non-column tokens a where-expression can use --
+``goql_completion.py`` (Tab completion) and ``goql_highlight.py`` (syntax
+coloring) both need this same list and previously each kept their own
+copy, which is exactly the kind of thing that quietly drifts apart when
+one gets updated and the other doesn't. One source of truth instead.
+
+``and``/``or``/``not``/``in`` are real Python keywords (and thus real
+where_expr operators); ``like``/``Date``/``exists``/``count`` are the
+whitelisted function-call forms ``gramps_object_query_language.query_lang``
+recognizes -- see that module's docstring.
+"""
+
+KEYWORDS = frozenset({"and", "or", "not", "in", "like", "Date", "exists", "count"})
+
+COMPARISON_OPERATORS = frozenset({"==", "!=", "<", "<=", ">", ">="})

--- a/GOQLFilter/gramps_object_query_language_copy/LICENSE
+++ b/GOQLFilter/gramps_object_query_language_copy/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/GOQLFilter/gramps_object_query_language_copy/__init__.py
+++ b/GOQLFilter/gramps_object_query_language_copy/__init__.py
@@ -29,7 +29,7 @@ handle.
 VENDORED COPY -- do not edit directly. This is a verbatim copy of the
 "gramps_object_query_language" package (PyPI: gramps-object-query-language,
 https://github.com/dsblank/gramps-object-query-language), pinned at
-version 0.4.0 / commit de157c9e12ac1c758b36bebd17007ae56275d116, imported
+version 0.4.1 / commit b717eab575e99d8dc1dad958bf44442fe64f4276, imported
 here as "gramps_object_query_language_copy" (not the upstream package name)
 so it can't collide with a real pip-installed copy of the same library on
 the same interpreter.

--- a/GOQLFilter/gramps_object_query_language_copy/__init__.py
+++ b/GOQLFilter/gramps_object_query_language_copy/__init__.py
@@ -1,0 +1,54 @@
+#
+# gramps-object-query-language - Object query language and SQL compiler for Gramps data
+#
+# Copyright (C) 2026      Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Object query language and SQL compiler for Gramps data.
+
+Standalone, privacy-agnostic: compiles a structured query (select/where/
+order_by/limit/after) or an "almost Python" expression string into
+parameterized SQL against Gramps' flattened secondary columns. Carries no
+knowledge of proxies, permissions, or Gramps Web API request handling --
+callers are responsible for only invoking it against an unproxied database
+handle.
+
+VENDORED COPY -- do not edit directly. This is a verbatim copy of the
+"gramps_object_query_language" package (PyPI: gramps-object-query-language,
+https://github.com/dsblank/gramps-object-query-language), pinned at
+version 0.4.0 / commit de157c9e12ac1c758b36bebd17007ae56275d116, imported
+here as "gramps_object_query_language_copy" (not the upstream package name)
+so it can't collide with a real pip-installed copy of the same library on
+the same interpreter.
+
+Why vendored instead of a plain `pip install gramps-object-query-language`
+dependency (which is what the gramps61 branch of this addon uses, via
+`requires_mod`): pip installs of pure-Python addon dependencies are
+unreliable across Gramps 6.0's various AIO installers, so this gramps60
+branch bundles the library directly instead.
+
+To refresh this copy: replace every file in this directory (except this
+notice) with the corresponding file from a newer gramps_object_query_language
+release, update the pinned version/commit above, and re-run GOQLFilter's
+test suite.
+
+Licensed AGPL-3.0-or-later, same as upstream (see LICENSE in this
+directory) -- GOQLFilter's own files are GPL-2.0-or-later ("or later"),
+which is what makes combining the two into one distributed addon permitted
+under AGPLv3's own compatibility clause (AGPLv3 section 13). This has not
+been reviewed by a lawyer; flag it for review before this addon is
+released more broadly.
+"""

--- a/GOQLFilter/gramps_object_query_language_copy/evaluator.py
+++ b/GOQLFilter/gramps_object_query_language_copy/evaluator.py
@@ -64,7 +64,6 @@ from .query import (
     ObjectTypeSpec,
     Or,
     RelatedObject,
-    WholeJsonData,
 )
 
 # Real getter method name for each `ObjectTypeSpec.table`, used to fetch a
@@ -204,10 +203,6 @@ def resolve_column_ref(db: Any, obj: Any, ref: ColumnRef, spec: ObjectTypeSpec) 
         return resolve_column_ref(db, related_obj, ref.field, ref.target)
     if isinstance(ref, JsonPath):
         return get_json_path(obj, ref)
-    if isinstance(ref, WholeJsonData):
-        if ref.base_column != "json_data":
-            raise ValueError(f"unsupported JsonPath base column: {ref.base_column!r}")
-        return json_utils.object_to_dict(obj)
     if isinstance(ref, CollectionCount):
         return _collection_count(db, obj, ref)
     if isinstance(ref, FlatColumnRef):

--- a/GOQLFilter/gramps_object_query_language_copy/evaluator.py
+++ b/GOQLFilter/gramps_object_query_language_copy/evaluator.py
@@ -1,0 +1,420 @@
+#
+# gramps-object-query-language - Object query language and SQL compiler for Gramps data
+#
+# Copyright (C) 2026      Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Evaluate `query.py`'s AST directly against real Gramps objects.
+
+`query.py` compiles a `Query`/`where` expression to SQL, which is only safe
+to run against an *unproxied* database -- it has no notion of privacy or any
+other proxy-applied rule, and reimplementing one in SQL is exactly the
+mistake this module exists to avoid (see `query.py`'s module docstring).
+This module instead walks the same AST and evaluates it directly against a
+real object, fetched through whatever `db` the caller passes in. When `db`
+is a proxy, every object this module ever sees -- the row object itself and
+anything reached via a `RelatedObject` hop, at any depth -- has already been
+through that proxy's own `include_*`/`sanitize_*` rules. Correctness follows
+from that alone: there is no separate privacy guard here the way
+`Comparison.compile()` needs a `CASE WHEN` guard for NULL-safe `Eq`/`Ne` --
+a masked field already reads back as whatever the proxy's `sanitize_*` left
+it as (typically `None`), and plain Python `==`/`!=`/`is None` against that
+already-correct value is automatically the right, non-leaking answer.
+
+Not fast: no SQL push-down, no keyset narrowing before objects are fetched.
+Intended for the proxied path, where the query's result set is expected to
+be small relative to the table, or where correctness matters more than
+p99 latency -- see `object_query.py`'s dispatch.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Optional
+
+from gramps.gen.errors import HandleError
+from gramps.gen.lib import json_utils
+
+from .query import (
+    And,
+    Collection,
+    CollectionCount,
+    ColumnIndex,
+    ColumnRef,
+    Comparison,
+    Contains,
+    Exists,
+    FlatColumnRef,
+    In,
+    JsonPath,
+    Not,
+    ObjectTypeSpec,
+    Or,
+    RelatedObject,
+    WholeJsonData,
+)
+
+# Real getter method name for each `ObjectTypeSpec.table`, used to fetch a
+# `RelatedObject` hop's target through `db` (whatever proxy or plain
+# database that is) -- never a direct/unproxied lookup.
+GETTER_BY_TABLE: dict[str, str] = {
+    "person": "get_person_from_handle",
+    "family": "get_family_from_handle",
+    "event": "get_event_from_handle",
+    "place": "get_place_from_handle",
+    "repository": "get_repository_from_handle",
+    "source": "get_source_from_handle",
+    "citation": "get_citation_from_handle",
+    "media": "get_media_from_handle",
+    "note": "get_note_from_handle",
+    "tag": "get_tag_from_handle",
+}
+
+
+def _given_name(obj: Any) -> str:
+    primary_name = obj.get_primary_name()
+    return primary_name.get_first_name() if primary_name else ""
+
+
+def _surname(obj: Any) -> str:
+    primary_name = obj.get_primary_name()
+    if not primary_name:
+        return ""
+    surname_list = primary_name.get_surname_list()
+    if not surname_list or not surname_list[0]:
+        return ""
+    return surname_list[0].surname
+
+
+def _enclosed_by(obj: Any) -> str:
+    for placeref in obj.get_placeref_list():
+        return placeref.ref
+    return ""
+
+
+# `given_name`/`surname`/`enclosed_by` are real SQL columns (populated by the
+# DB layer at write time), but not real attributes on the in-memory object --
+# mirrors gramps core's `gen/db/generic.py` `DbGeneric._get_person_data`/
+# `_get_place_data` exactly, the functions that populate those same columns.
+_DERIVED_COLUMNS: dict[str, dict[str, Any]] = {
+    "person": {"given_name": _given_name, "surname": _surname},
+    "place": {"enclosed_by": _enclosed_by},
+}
+
+
+def get_flat_column(obj: Any, column: str, spec: ObjectTypeSpec) -> Any:
+    """A flat column's value straight off a real object.
+
+    `getattr` for anything `get_secondary_fields()` already exposes as a
+    real attribute (`gramps_id`, `gender`, `private`, `handle`,
+    `father_handle`, `place`, ...) -- which is everything except the small,
+    fixed set of derived columns above.
+    """
+    derived = _DERIVED_COLUMNS.get(spec.table, {})
+    if column in derived:
+        return derived[column](obj)
+    return getattr(obj, column)
+
+
+def _walk_json_path(data: Any, segments: Any, root_obj: Any) -> Any:
+    """Walk `JsonPath.segments` against `data` (an `object_to_dict()` dict).
+
+    A `ColumnIndex` segment resolves against `root_obj` -- the row the path
+    started from -- not whatever `data` has been narrowed to by that point,
+    mirroring `_render_handle_ref`'s "this row's `<column>`" semantics
+    exactly (only ever appears as a `RelatedObject.handle_ref` segment, so
+    this only matters one level deep in practice).
+    """
+    current = data
+    for segment in segments:
+        if current is None:
+            return None
+        if isinstance(segment, ColumnIndex):
+            index = getattr(root_obj, segment.column)
+            if index is None or index < 0:
+                return None
+            segment = index
+        if isinstance(segment, int):
+            if not isinstance(current, list) or not -len(current) <= segment < len(current):
+                return None
+            current = current[segment]
+        else:
+            if not isinstance(current, dict):
+                return None
+            current = current.get(segment)
+    return current
+
+
+def get_json_path(obj: Any, path: JsonPath) -> Any:
+    """`JsonPath.segments` extracted from `obj`'s real, in-memory data.
+
+    `object_to_dict()` is the same JSON-shaped structure the compiled SQL
+    path navigates via `json_extract`/`->` against the stored `json_data`
+    column -- using it here keeps the two paths interpreting a `JsonPath`
+    identically without hand-duplicating that shape.
+    """
+    if path.base_column != "json_data":
+        raise ValueError(f"unsupported JsonPath base column: {path.base_column!r}")
+    data = json_utils.object_to_dict(obj)
+    return _walk_json_path(data, path.segments, obj)
+
+
+def _resolve_related_object(
+    db: Any, obj: Any, ref: RelatedObject, spec: ObjectTypeSpec
+) -> Any:
+    if isinstance(ref.handle_ref, JsonPath):
+        handle = get_json_path(obj, ref.handle_ref)
+    else:
+        handle = get_flat_column(obj, ref.handle_ref, spec)
+    if not handle:
+        return None
+    getter = getattr(db, GETTER_BY_TABLE[ref.target.table])
+    try:
+        return getter(handle)
+    except HandleError:
+        return None
+
+
+def resolve_column_ref(db: Any, obj: Any, ref: ColumnRef, spec: ObjectTypeSpec) -> Any:
+    """`query.py`'s `_render_column`, evaluated in Python against a real
+    object instead of rendered as SQL.
+
+    `db` is whatever the caller is running under (proxy or plain) --
+    every `RelatedObject` hop is fetched through it (`_resolve_related_object`),
+    so the same rules that applied to `obj` itself apply to everything
+    reached from it, at any depth, with no separate handling needed here.
+    """
+    if obj is None:
+        return None
+    if isinstance(ref, RelatedObject):
+        related_obj = _resolve_related_object(db, obj, ref, spec)
+        return resolve_column_ref(db, related_obj, ref.field, ref.target)
+    if isinstance(ref, JsonPath):
+        return get_json_path(obj, ref)
+    if isinstance(ref, WholeJsonData):
+        if ref.base_column != "json_data":
+            raise ValueError(f"unsupported JsonPath base column: {ref.base_column!r}")
+        return json_utils.object_to_dict(obj)
+    if isinstance(ref, CollectionCount):
+        return _collection_count(db, obj, ref)
+    if isinstance(ref, FlatColumnRef):
+        return get_flat_column(obj, ref.name, spec)
+    return get_flat_column(obj, ref, spec)
+
+
+def _collection_handles(obj: Any, collection: Collection) -> list:
+    """The list of related handles for `collection` on `obj` -- a plain
+    handle string per element (`notes`), or each element's `ref_field`
+    pulled out (`children`'s `ChildRef.ref`) -- mirrors `query.py`'s
+    `_collection_source_sqlite`/`_collection_source_postgresql` exactly, just
+    walking the real in-memory list instead of rendering SQL to iterate it.
+    """
+    items = get_json_path(obj, collection.list_path) or []
+    if collection.ref_field:
+        return [item.get(collection.ref_field) for item in items if item]
+    return [item for item in items if item]
+
+
+def _collection_count(db: Any, obj: Any, count: CollectionCount) -> int:
+    """How many related rows in `count.collection` match `count.condition`
+    (every related row at all, if `condition` is `None`) -- the evaluator
+    counterpart to `query.py`'s `CollectionCount` SQL rendering. Unlike
+    `Exists`'s short-circuit on the first match, this has to walk every
+    related row, matching `COUNT(*)`'s own semantics.
+    """
+    getter = getattr(db, GETTER_BY_TABLE[count.collection.target.table])
+    matched = 0
+    for handle in _collection_handles(obj, count.collection):
+        try:
+            related = getter(handle)
+        except HandleError:
+            continue
+        if count.condition is None or evaluate_where(
+            db, related, count.condition, count.collection.target
+        ):
+            matched += 1
+    return matched
+
+
+def _like_to_regex(pattern: str) -> re.Pattern:
+    """Translate a SQL `LIKE` pattern (`%`/`_` wildcards) to a regex.
+
+    Case-insensitive, matching SQLite's default `LIKE` behavior for ASCII --
+    the backend every test fixture and single-tree/dev deployment actually
+    runs (see `object_query.py`'s `_resolve_dialect`). Any other character
+    is escaped literally via `re.escape` before the wildcard translation.
+    """
+    out = []
+    for char in pattern:
+        if char == "%":
+            out.append(".*")
+        elif char == "_":
+            out.append(".")
+        else:
+            out.append(re.escape(char))
+    return re.compile("^" + "".join(out) + "$", re.IGNORECASE)
+
+
+_ORDERING_OPS = {
+    "<": lambda a, b: a < b,
+    "<=": lambda a, b: a <= b,
+    ">": lambda a, b: a > b,
+    ">=": lambda a, b: a >= b,
+}
+
+
+def _compare(op: str, left: Any, right: Any) -> Optional[bool]:
+    """`None` means SQL's `UNKNOWN` -- see `_evaluate_tri`'s docstring for
+    why this three-valued result matters, not just a plain `bool`.
+    """
+    if op == "=":
+        return left == right
+    if op == "!=":
+        return left != right
+    if op == "LIKE":
+        if left is None or right is None:
+            return None
+        return _like_to_regex(str(right)).match(str(left)) is not None
+    if op == "REGEXP":
+        # Mirrors gramps core's `dbapi/sqlite.py` `regexp(expr, value)` UDF
+        # exactly (`re.search(expr, value, re.MULTILINE)`) -- an unanchored,
+        # case-sensitive search, not `_like_to_regex`'s case-insensitive
+        # full-match -- so this evaluator path and a real SQLite backend
+        # agree on every row. `right` is the pattern (`Regex.value`), `left`
+        # the haystack, same left/right convention as `LIKE` above.
+        if left is None or right is None:
+            return None
+        return re.search(str(right), str(left), re.MULTILINE) is not None
+    if op in _ORDERING_OPS:
+        # SQL's ordering comparisons against a NULL operand are UNKNOWN, not
+        # False, under standard three-valued logic -- Python raises
+        # TypeError instead, so this has to be explicit. Collapsing this
+        # straight to False here (rather than in `_evaluate_tri`, one layer
+        # up) would be indistinguishable from a genuine False to `Not`,
+        # which needs to leave UNKNOWN as UNKNOWN rather than flip it to
+        # True -- see `_evaluate_tri`.
+        if left is None or right is None:
+            return None
+        return _ORDERING_OPS[op](left, right)
+    raise ValueError(f"unsupported operator: {op!r}")
+
+
+def _evaluate_tri(db: Any, obj: Any, expr: Any, spec: ObjectTypeSpec) -> Optional[bool]:
+    """`evaluate_where`'s actual recursion, in SQL's three-valued logic
+    (`True`/`False`/`None` for `UNKNOWN`) rather than a plain `bool`.
+
+    A leaf comparison against a missing value (a masked field, or a path/
+    relationship that doesn't resolve) is `UNKNOWN`, not `False` -- SQL's
+    `NOT UNKNOWN` is still `UNKNOWN`, not `True`, so if this collapsed to a
+    definite `False` at each leaf the way a plain `bool` would force it to,
+    `Not` wrapping that leaf would incorrectly flip it to `True` where SQL
+    would still exclude the row. Recursing in three-valued logic here, and
+    collapsing to a real `bool` exactly once -- in `evaluate_where`, at the
+    very end -- keeps `Not`/`And`/`Or` behaving the same as their compiled-
+    SQL counterparts at any nesting depth, not just one level deep.
+
+    `And`/`Or` follow SQL's own precedence for combining three values:
+    a definite `False` always wins an `And` (regardless of any `UNKNOWN`
+    sibling), a definite `True` always wins an `Or` the same way -- checked
+    first, before falling back to "`UNKNOWN` if any operand is, else the
+    identity value" -- matching `AND`/`OR`'s truth tables exactly, not just
+    "any/all treat `None` as falsy" (which would get the dominance wrong).
+    """
+    if expr is None:
+        return True
+    if isinstance(expr, And):
+        results = [_evaluate_tri(db, obj, e, spec) for e in expr.exprs]
+        if any(r is False for r in results):
+            return False
+        if any(r is None for r in results):
+            return None
+        return True
+    if isinstance(expr, Or):
+        results = [_evaluate_tri(db, obj, e, spec) for e in expr.exprs]
+        if any(r is True for r in results):
+            return True
+        if any(r is None for r in results):
+            return None
+        return False
+    if isinstance(expr, Not):
+        result = _evaluate_tri(db, obj, expr.expr, spec)
+        return None if result is None else not result
+    if isinstance(expr, Exists):
+        # Always a definite True/False, never UNKNOWN -- matching SQL's own
+        # EXISTS/NOT EXISTS, which never propagates NULL from a subquery
+        # row that fails its WHERE, it's simply not counted. Unlike every
+        # other branch here, there's no missing-value case to collapse to
+        # None for.
+        collection = expr.collection
+        getter = getattr(db, GETTER_BY_TABLE[collection.target.table])
+        for handle in _collection_handles(obj, collection):
+            try:
+                related = getter(handle)
+            except HandleError:
+                continue
+            if expr.condition is None or evaluate_where(
+                db, related, expr.condition, collection.target
+            ):
+                return True
+        return False
+    if isinstance(expr, In):
+        value = resolve_column_ref(db, obj, expr.column, spec)
+        if value is None:
+            return None
+        return value in expr.values
+    if isinstance(expr, Contains):
+        # A plain substring test -- unlike `Like`'s SQL-pattern matching
+        # (`_like_to_regex`), `expr.value` (when a literal) has no wildcard
+        # characters to reinterpret, so a direct (case-insensitive, matching
+        # SQLite's default `LIKE` behavior) Python `in` check is both
+        # correct and simpler than routing through the LIKE/regex machinery.
+        # `expr.value` can also be a `JsonPath`/`RelatedObject` -- a
+        # field-vs-field substring test -- resolved the same way `expr.column`
+        # is; a missing needle (as opposed to a missing haystack) is just as
+        # much "unknown" as a missing haystack, so it collapses to the same
+        # `None` (SQL's `LIKE` against a NULL pattern is `UNKNOWN` too).
+        value = resolve_column_ref(db, obj, expr.column, spec)
+        if value is None:
+            return None
+        if isinstance(expr.value, (JsonPath, RelatedObject, FlatColumnRef)):
+            substring = resolve_column_ref(db, obj, expr.value, spec)
+            if substring is None:
+                return None
+        else:
+            substring = expr.value
+        return str(substring).lower() in str(value).lower()
+    if isinstance(expr, Comparison):
+        left = resolve_column_ref(db, obj, expr.column, spec)
+        if isinstance(expr.value, (JsonPath, RelatedObject, FlatColumnRef)):
+            right = resolve_column_ref(db, obj, expr.value, spec)
+        else:
+            right = expr.value
+        return _compare(expr.op, left, right)
+    raise TypeError(f"unsupported where expression: {expr!r}")
+
+
+def evaluate_where(db: Any, obj: Any, expr: Any, spec: ObjectTypeSpec) -> bool:
+    """`query.py`'s `.compile()` tree, evaluated in Python against a real
+    object instead of rendered as SQL. See module docstring for why no
+    privacy guard is needed here the way `Comparison.compile()` needs one.
+
+    Delegates the actual recursion to `_evaluate_tri`, which tracks SQL's
+    three-valued logic (`True`/`False`/`UNKNOWN`) rather than a plain
+    `bool` -- collapsed to a real `bool` here, exactly once, the same way
+    a SQL `WHERE` clause only keeps rows that are definitely `True`,
+    treating `UNKNOWN` the same as `False`.
+    """
+    return _evaluate_tri(db, obj, expr, spec) is True

--- a/GOQLFilter/gramps_object_query_language_copy/proxied_query.py
+++ b/GOQLFilter/gramps_object_query_language_copy/proxied_query.py
@@ -55,9 +55,14 @@ section's recommended v1:
   path's own `order_by` already has (a `JsonPath`/`RelatedObject` column
   can't be sorted by there either), so this path doesn't leapfrog ahead of
   what SQL itself can do.
-- Collation is ASCII/codepoint only (plain Python `<`/`>`) -- SQL's
-  locale-aware `COLLATE` has no Python-side equivalent here. Documented
-  gap, not attempted.
+- Collation matches the SQL path's own default exactly, not full locale
+  parity: `_null_safe_cmp` ASCII-case-folds any `str` operand before
+  comparing (`_nocase_key`), the same folding SQLite's built-in `NOCASE`
+  collation does (`query.py`'s `_column_expr` default -- see ROADMAP.md's
+  "Default `NOCASE` collation on the SQL path"). Only the 26 ASCII letters
+  fold; accented/non-Latin letters don't, on either path, so the two stay
+  in agreement. A real locale-aware `COLLATE` still has no Python-side
+  equivalent here -- that remains a documented gap.
 
 `NULL` placement, for both plain sorting and keyset seeking, matches
 SQLite's own verified default (confirmed empirically, not assumed): `NULL`
@@ -78,6 +83,7 @@ by sorting and seeking on both this path and the SQL path, not two.
 from __future__ import annotations
 
 import functools
+import string
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from gramps.gen.filters import GenericFilterFactory
@@ -92,7 +98,7 @@ from .query import (
     effective_order_by,
     order_by_key,
     resolve_order_by,
-    resolve_select_ref_string,
+    resolve_ref_string,
 )
 
 # Core `Filter` namespace for each `ObjectTypeSpec.table` that has one.
@@ -151,11 +157,31 @@ class _PredicateRule(Rule):
         return matched
 
 
+_ASCII_NOCASE_TABLE = str.maketrans(string.ascii_uppercase, string.ascii_lowercase)
+
+
+def _nocase_key(value: str) -> str:
+    """ASCII-only case fold, matching SQLite's built-in `NOCASE` collation --
+    the SQL path's own default for text `ORDER BY` columns (`query.py`'s
+    `_column_expr`). Deliberately not `str.lower()`: Python's `.lower()`
+    case-folds far beyond ASCII (e.g. accented letters), which would fold
+    values `NOCASE` leaves alone and put the two paths back out of
+    agreement -- see this module's own docstring.
+    """
+    return value.translate(_ASCII_NOCASE_TABLE)
+
+
 def _null_safe_cmp(a: Any, b: Any, direction: str) -> int:
     """Column-level three-way compare matching SQLite's verified `ORDER BY`
     default: `NULL` sorts as the smallest value regardless of direction, so
-    `DESC` is the exact reverse of `ASC`, `NULL`s included.
+    `DESC` is the exact reverse of `ASC`, `NULL`s included. String operands
+    are ASCII-case-folded first (`_nocase_key`), matching the SQL path's own
+    `NOCASE` default so the two paths agree on order.
     """
+    if isinstance(a, str):
+        a = _nocase_key(a)
+    if isinstance(b, str):
+        b = _nocase_key(b)
     if a is None and b is None:
         cmp = 0
     elif a is None:
@@ -233,9 +259,9 @@ def run_query(
     for each handle, never an unproxied lookup.
 
     `order_by`/`limit`/`after` mean exactly what they mean on `Query`/
-    `compile_query` -- see this module's own docstring for the two scope
-    caps (flat-column `order_by` only, ASCII-only collation) and the NULL
-    placement policies used. A trailing `handle` tiebreaker is always
+    `compile_query` -- see this module's own docstring for the scope cap
+    (flat-column `order_by` only) and its ASCII-`NOCASE` collation/NULL
+    placement policies. A trailing `handle` tiebreaker is always
     applied (via `effective_order_by`), even when `order_by` is empty, so
     the result is always in a fully deterministic order, matching the SQL
     path's own always-present `ORDER BY`.
@@ -296,7 +322,7 @@ def run_query(
         # rejected -- a flat column against `spec.columns`, a JSON path
         # against the type's own Gramps schema -- just with a better error.
         columns = [
-            resolve_select_ref_string(spec, column) if isinstance(column, str) else column
+            resolve_ref_string(spec, column) if isinstance(column, str) else column
             for column in select
         ]
         return [

--- a/GOQLFilter/gramps_object_query_language_copy/proxied_query.py
+++ b/GOQLFilter/gramps_object_query_language_copy/proxied_query.py
@@ -1,0 +1,306 @@
+#
+# gramps-object-query-language - Object query language and SQL compiler for Gramps data
+#
+# Copyright (C) 2026      Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""Run a `where` expression against a possibly-proxied `db`.
+
+Compiles a `Query.where` expression into a Gramps `Rule`, wrapped in the
+matching core `Filter` class (`GenericFilterFactory`), and calls
+`Filter.apply(db)` -- the same mechanism Gramps' own Custom Filters use.
+`Filter.apply()` fetches each candidate through `db` before testing it
+(`GenericFilter.get_object`), so when `db` is a proxy, everything this
+module ever hands to `evaluate_where` has already been through that
+proxy's own `include_*`/`sanitize_*` rules, at any relationship depth --
+see `evaluator.py`'s module docstring for why that's sufficient on its own,
+with no separate privacy handling needed here.
+
+Not fast: `Filter.apply()` enumerates every handle of the type before
+narrowing, and every enumerated handle is fetched (deserialized) to test
+it. See `object_query.py`'s dispatch for when this path is used instead of
+`query.py`'s SQL compiler.
+
+`Filter.apply()` only ever returns handles, not the objects it built and
+tested them with -- `_PredicateRule` holds onto each matched object itself
+(`matched_objects`, keyed by handle) so `run_query` can hand them back
+directly instead of fetching (and re-sanitizing) every match a second
+time. Confirmed via profiling that this second fetch was ~70% of this
+module's entire overhead relative to a hand-written equivalent loop: under
+a proxy, re-fetching a handle means re-running the proxy's own
+`sanitize_*`, not a cheap cache hit.
+
+`run_query` also implements `order_by`/`limit`/`after` (keyset pagination)
+and `select`, entirely in Python over the already-fetched match list, so a
+`Query` means the same thing on this path as it does through `query.py`'s
+SQL compiler -- see `ROADMAP.md`'s "Evaluator-path pagination/sort parity"
+section for the gap this closes. Two deliberate scope caps, matching that
+section's recommended v1:
+
+- `order_by` is restricted to flat columns (`OrderBy.column` is always a
+  plain string, checked against `spec.columns`) -- the same cap the SQL
+  path's own `order_by` already has (a `JsonPath`/`RelatedObject` column
+  can't be sorted by there either), so this path doesn't leapfrog ahead of
+  what SQL itself can do.
+- Collation is ASCII/codepoint only (plain Python `<`/`>`) -- SQL's
+  locale-aware `COLLATE` has no Python-side equivalent here. Documented
+  gap, not attempted.
+
+`NULL` placement, for both plain sorting and keyset seeking, matches
+SQLite's own verified default (confirmed empirically, not assumed): `NULL`
+sorts as the smallest value in both directions, so `DESC` is the exact
+reverse of `ASC`, `NULL`s included. Keyset seeking (`after`) mirrors
+`query.py`'s `_compile_keyset` SQL, which (after its own NULL-safety fix --
+see that function's docstring) applies this identical NULL-is-smallest rule
+to the seek predicate too, rather than relying on SQL's raw three-valued
+comparison semantics -- a plain `col > ?`/`col < ?` against a real `NULL`
+is always `UNKNOWN`, which silently produced wrong seek results in two
+different ways before that fix (a cursor taken from a `NULL` row couldn't
+seek past it at all; a `desc`-sorted `NULL` row was silently dropped from
+every later page regardless of the cursor). `_matches_keyset` below reuses
+`_null_safe_cmp` directly for exactly this reason -- one NULL rule, shared
+by sorting and seeking on both this path and the SQL path, not two.
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from gramps.gen.filters import GenericFilterFactory
+from gramps.gen.filters.rules import Rule
+
+from .evaluator import GETTER_BY_TABLE, evaluate_where, resolve_column_ref
+from .query import (
+    ColumnRef,
+    ObjectTypeSpec,
+    OrderBy,
+    QueryError,
+    effective_order_by,
+    order_by_key,
+    resolve_order_by,
+    resolve_select_ref_string,
+)
+
+# Core `Filter` namespace for each `ObjectTypeSpec.table` that has one.
+# `Tag` is deliberately absent: `GenericFilterFactory("Tag")` returns `None`
+# (Gramps core has no Filter class for it), and it has no privacy concept to
+# delegate to a proxy for anyway (`TAG.has_privacy` is `False`) -- see the
+# fallback in `run_query`.
+_FILTER_NAMESPACE_BY_TABLE: dict[str, str] = {
+    "person": "Person",
+    "family": "Family",
+    "event": "Event",
+    "place": "Place",
+    "repository": "Repository",
+    "source": "Source",
+    "citation": "Citation",
+    "media": "Media",
+    "note": "Note",
+}
+
+
+class _PredicateRule(Rule):
+    """A `Rule` wrapping an already-compiled `where` expression.
+
+    Not a new rule "language" -- `apply_to_one` just hands `obj` to the same
+    `Query.where` AST evaluator every query endpoint already builds
+    (`evaluator.evaluate_where`), so a query's `where`/`where_expr` means
+    exactly the same thing on both the SQL and proxied paths.
+
+    Also doubles as the match-object cache `run_query` reads afterward
+    (`matched_objects`) -- `apply_to_one` is hand the real, already-fetched-
+    and-sanitized object anyway, so keeping a reference here is free, and
+    saves `run_query` from fetching (and re-sanitizing, under a proxy) every
+    match a second time just to get the object back.
+    """
+
+    def __init__(self, where: Any, spec: ObjectTypeSpec) -> None:
+        super().__init__([])
+        self._where = where
+        self._spec = spec
+        self.matched_objects: Dict[str, Any] = {}
+
+    def apply_to_one(self, db: Any, obj: Any) -> bool:
+        # `obj is None` means this handle was excluded by whatever proxy
+        # `db` is (or genuinely doesn't resolve) -- never a match,
+        # regardless of `where` (an empty/`None` where means "match
+        # everything", which must still exclude a row that isn't there).
+        # Relying on every proxy's handle enumeration to have already
+        # filtered this out before `Filter.apply()` ever calls this would be
+        # exactly the kind of unverified cross-proxy assumption this
+        # redesign exists to avoid -- see `evaluator.py`'s module docstring.
+        if obj is None:
+            return False
+        matched = evaluate_where(db, obj, self._where, self._spec)
+        if matched:
+            self.matched_objects[obj.handle] = obj
+        return matched
+
+
+def _null_safe_cmp(a: Any, b: Any, direction: str) -> int:
+    """Column-level three-way compare matching SQLite's verified `ORDER BY`
+    default: `NULL` sorts as the smallest value regardless of direction, so
+    `DESC` is the exact reverse of `ASC`, `NULL`s included.
+    """
+    if a is None and b is None:
+        cmp = 0
+    elif a is None:
+        cmp = -1
+    elif b is None:
+        cmp = 1
+    elif a < b:
+        cmp = -1
+    elif a > b:
+        cmp = 1
+    else:
+        cmp = 0
+    return -cmp if direction == "desc" else cmp
+
+
+def _sort_key_row(
+    db: Any, obj: Any, ordering: Sequence[OrderBy], spec: ObjectTypeSpec
+) -> Tuple[Any, ...]:
+    return tuple(resolve_column_ref(db, obj, ob.column, spec) for ob in ordering)
+
+
+def _sort_matches(
+    db: Any, matches: List[Any], ordering: Sequence[OrderBy], spec: ObjectTypeSpec
+) -> List[Tuple[Tuple[Any, ...], Any]]:
+    """`matches` paired with its resolved sort-key row, sorted per `ordering`."""
+    keyed = [(_sort_key_row(db, obj, ordering, spec), obj) for obj in matches]
+
+    def compare(row_a: Tuple[Any, ...], row_b: Tuple[Any, ...]) -> int:
+        key_a, _ = row_a
+        key_b, _ = row_b
+        for value_a, value_b, ob in zip(key_a, key_b, ordering):
+            result = _null_safe_cmp(value_a, value_b, ob.direction)
+            if result != 0:
+                return result
+        return 0
+
+    keyed.sort(key=functools.cmp_to_key(compare))
+    return keyed
+
+
+def _matches_keyset(
+    key_row: Sequence[Any], after: Sequence[Any], ordering: Sequence[OrderBy]
+) -> bool:
+    """Python equivalent of `query._compile_keyset`'s NULL-safe seek
+    predicate, after its own NULL-safety fix -- "ranks strictly after the
+    cursor" reuses `_null_safe_cmp`'s own total order (`NULL` is the
+    smallest value in both directions, the same rule plain sorting uses),
+    rather than SQL's raw three-valued comparison semantics. A tie always
+    uses `"asc"` regardless of that column's own direction, since equality
+    itself isn't direction-dependent (`_null_safe_cmp` returns `0` for a tie
+    under either direction -- only strict ordering flips).
+    """
+    for i, ob in enumerate(ordering):
+        if any(_null_safe_cmp(key_row[j], after[j], "asc") != 0 for j in range(i)):
+            continue
+        if _null_safe_cmp(key_row[i], after[i], ob.direction) > 0:
+            return True
+    return False
+
+
+def run_query(
+    db: Any,
+    spec: ObjectTypeSpec,
+    where: Any,
+    *,
+    order_by: Sequence[OrderBy] = (),
+    limit: Optional[int] = None,
+    after: Optional[Sequence[Any]] = None,
+    select: Optional[Sequence[ColumnRef]] = None,
+) -> List[Any]:
+    """Every real object of `spec`'s type matching `where`, fetched through `db`.
+
+    `db` may be a proxy or a plain database -- either way, the returned
+    objects (and match decisions) reflect whatever `db` itself would return
+    for each handle, never an unproxied lookup.
+
+    `order_by`/`limit`/`after` mean exactly what they mean on `Query`/
+    `compile_query` -- see this module's own docstring for the two scope
+    caps (flat-column `order_by` only, ASCII-only collation) and the NULL
+    placement policies used. A trailing `handle` tiebreaker is always
+    applied (via `effective_order_by`), even when `order_by` is empty, so
+    the result is always in a fully deterministic order, matching the SQL
+    path's own always-present `ORDER BY`.
+
+    `select`, when given, projects the final page into a list of value
+    tuples (one per entry in `select`, resolved via `resolve_column_ref`)
+    instead of returning full objects -- the evaluator-path equivalent of
+    the SQL path's `SELECT` list. Omitting `select` (the default) keeps
+    returning full objects, unchanged from before this parameter existed.
+    """
+    getter = getattr(db, GETTER_BY_TABLE[spec.table])
+    namespace = _FILTER_NAMESPACE_BY_TABLE.get(spec.table)
+    if namespace is None:
+        handles = getattr(db, f"get_{spec.table}_handles")()
+        matches = [
+            obj
+            for handle in handles
+            if (obj := getter(handle)) is not None and evaluate_where(db, obj, where, spec)
+        ]
+    else:
+        filter_class = GenericFilterFactory(namespace)
+        gfilter = filter_class()
+        rule = _PredicateRule(where, spec)
+        gfilter.add_rule(rule)
+        matched_handles = gfilter.apply(db)
+        matches = [
+            rule.matched_objects[handle]
+            for handle in matched_handles
+            if handle in rule.matched_objects
+        ]
+
+    # Resolved, not whitelist-checked: `order_by` takes the same
+    # `ColumnRef`s `select` does, and `_sort_key_row` already resolves
+    # whatever it's given via `resolve_column_ref`. The Python sort needs
+    # no CAST hint the way the SQL path does -- `<`/`>` on the extracted
+    # values already compare by their own types.
+    ordering = effective_order_by(resolve_order_by(spec, order_by))
+    keyed = _sort_matches(db, matches, ordering, spec)
+
+    if after is not None:
+        if len(after) != len(ordering):
+            raise QueryError(
+                f"after cursor has {len(after)} values, expected "
+                f"{len(ordering)} "
+                f"({', '.join(order_by_key(ob.column) for ob in ordering)})"
+            )
+        keyed = [(key, obj) for key, obj in keyed if _matches_keyset(key, after, ordering)]
+
+    matches = [obj for _, obj in keyed]
+    if limit is not None:
+        matches = matches[:limit]
+
+    if select is not None:
+        # Resolve exactly as the SQL path's `compile_query` does, rather
+        # than whitelist-checking strings here: a path entry
+        # ("birth.place.title") has to mean the same thing on both paths.
+        # `resolve_ref_string` still rejects everything `check_columns`
+        # rejected -- a flat column against `spec.columns`, a JSON path
+        # against the type's own Gramps schema -- just with a better error.
+        columns = [
+            resolve_select_ref_string(spec, column) if isinstance(column, str) else column
+            for column in select
+        ]
+        return [
+            tuple(resolve_column_ref(db, obj, column, spec) for column in columns)
+            for obj in matches
+        ]
+    return matches

--- a/GOQLFilter/gramps_object_query_language_copy/query.py
+++ b/GOQLFilter/gramps_object_query_language_copy/query.py
@@ -225,8 +225,6 @@ def ref_value_type(spec: ObjectTypeSpec, ref: "ColumnRef") -> Any:
         return path_value_type(spec, ref.segments)
     if isinstance(ref, CollectionCount):
         return "integer"
-    if isinstance(ref, WholeJsonData):
-        return "object"
     return None
 
 
@@ -377,30 +375,6 @@ class JsonPath:
                 continue
             if isinstance(segment, bool) or not isinstance(segment, (str, int)):
                 raise QueryError(f"invalid JsonPath segment: {segment!r}")
-
-
-@dataclass(frozen=True)
-class WholeJsonData:
-    """The entire JSON-blob secondary column, selected whole -- spelled
-    `"."` as a path string (`resolve_ref_string(spec, ".")`), the one path
-    text that isn't a valid dotted/bracketed `JsonPath` spelling.
-
-    A separate class from `JsonPath` rather than an empty-segments
-    `JsonPath(())`, deliberately -- `JsonPath` requires at least one
-    segment (`test_jsonpath_requires_at_least_one_segment`) precisely so an
-    empty/malformed path stays a caller error there; giving "the whole
-    object, on purpose" its own type keeps that guarantee intact instead of
-    overloading the same shape to mean two different things depending on
-    how it was reached.
-
-    Renders as a bare reference to `base_column` (see `_render_column`) --
-    `json_data` is stored as JSON-encoded TEXT already on both backends
-    (see `JsonPath`'s docstring), so the whole blob is exactly what
-    `SELECT json_data` returns; no extraction function needed the way a
-    `JsonPath` needs `json_extract`/`jsonb_extract_path_text`.
-    """
-
-    base_column: str = "json_data"
 
 
 @dataclass(frozen=True)
@@ -751,29 +725,8 @@ def resolve_ref_string(spec: ObjectTypeSpec, text: str) -> "ColumnRef":
     a `RelatedObject` crossing a relationship. There is no special case for
     a single segment: `gendr` is rejected because the Gramps schema has no
     such field, not because of any rule about dots.
-
-    Used for `order_by` and (via `json_column_to_ref`) `where` column
-    references too -- `"."` (see `resolve_select_ref_string`) is
-    deliberately *not* handled here, so filtering or sorting on the whole
-    object stays a `QueryError` (`parse_path_string` rejects `"."` as two
-    empty path segments) rather than silently compiling into a comparison
-    or `ORDER BY` against a serialized JSON blob.
     """
     return resolve_column_path(spec, parse_path_string(text))
-
-
-def resolve_select_ref_string(spec: ObjectTypeSpec, text: str) -> "ColumnRef":
-    """`resolve_ref_string`, plus `"."` as a `select`-only spelling of "the
-    whole `json_data` blob" (`WholeJsonData`) -- not a dotted path at all,
-    so it's checked before `parse_path_string` ever sees it (`"."` splits
-    into two empty path segments, neither a valid identifier, and would
-    otherwise just raise). Used only where a `select` entry string is
-    resolved (`compile_query`, `run_query`) -- see `resolve_ref_string`'s
-    docstring for why `order_by`/`where` don't get this same case.
-    """
-    if text == ".":
-        return WholeJsonData()
-    return resolve_ref_string(spec, text)
 
 
 def default_ref_key(ref: "ColumnRef") -> str:
@@ -797,8 +750,6 @@ def default_ref_key(ref: "ColumnRef") -> str:
         return ref.name
     if isinstance(ref, RelatedObject):
         return f"{ref.name}.{default_ref_key(ref.field)}"
-    if isinstance(ref, WholeJsonData):
-        return "."
     if isinstance(ref, JsonPath):
         parts: List[str] = []
         for segment in ref.segments:
@@ -841,12 +792,11 @@ class FlatColumnRef:
 
 # A column reference is either a plain (whitelisted) column name, a path
 # into one column's JSON content, a field reached via a relationship (see
-# `RelatedObject`/`resolve_column_path`), a whole JSON-blob column
-# (`WholeJsonData`), or (value-position only, see `FlatColumnRef`) a flat
-# column marked as a field rather than a literal -- `field: ColumnRef` on
-# `RelatedObject` makes this recursive, so a chain like `birth.place.title`
-# is itself a valid `ColumnRef`.
-ColumnRef = Union[str, JsonPath, RelatedObject, CollectionCount, FlatColumnRef, WholeJsonData]
+# `RelatedObject`/`resolve_column_path`), or (value-position only, see
+# `FlatColumnRef`) a flat column marked as a field rather than a literal --
+# `field: ColumnRef` on `RelatedObject` makes this recursive, so a chain
+# like `birth.place.title` is itself a valid `ColumnRef`.
+ColumnRef = Union[str, JsonPath, RelatedObject, CollectionCount, FlatColumnRef]
 SelectRef = ColumnRef
 
 
@@ -1154,11 +1104,6 @@ def _render_column(
         sql, params = _render_json_path(column, _require_dialect(dialect, column), value)
     elif isinstance(column, CollectionCount):
         sql, params = _render_collection_count(column, spec.table, dialect, treeid)
-    elif isinstance(column, WholeJsonData):
-        # No extraction function needed -- the column already *is* the
-        # whole JSON blob, on both dialects (see `WholeJsonData`'s
-        # docstring), so this renders identically regardless of `dialect`.
-        sql, params = _quote_column(column.base_column, dialect), []
     else:
         if isinstance(column, FlatColumnRef):
             column = column.name
@@ -1816,12 +1761,10 @@ class Query:
     already-resolved `JsonPath`/`RelatedObject`/`CollectionCount`, or a
     dotted/bracketed *path string* (`"birth.place.title"`,
     `"primary_name.surname_list[0].surname"`), resolved by `compile_query`
-    through `resolve_select_ref_string` (the same `resolve_column_path` a
-    `where_expr` path goes through, for every spelling except one). A
-    single-segment string stays a strict flat-column reference -- see
-    `resolve_ref_string`. `"."` is that one exception: the whole `json_data`
-    blob (`WholeJsonData`), a `select`-only spelling -- `order_by`/`where`
-    reject it. Omitting `select` returns every flat column, sorted.
+    through the same `resolve_column_path` a `where_expr` path goes
+    through. A single-segment string stays a strict flat-column reference
+    -- see `resolve_ref_string`. Omitting `select` returns every flat
+    column, sorted.
 
     `default_ref_key` gives each entry its canonical response key, and
     `query_lang.parse_select` parses a list of entry strings (with optional
@@ -1901,12 +1844,32 @@ def _column_expr(
     reference to a column in `_POSTGRESQL_PHYSICAL_COLUMN_OVERRIDES` (e.g.
     `Media.desc`) needs the same physical-name mapping a `SELECT`/`WHERE`
     reference does.
+
+    When `collation` isn't given, text columns on SQLite (`dialect` is
+    `Dialect.SQLITE` or omitted -- SQLite is the default target) fall back
+    to `COLLATE NOCASE` rather than no `COLLATE` clause at all. Plain
+    binary/codepoint comparison sorts every lowercase letter after every
+    uppercase one, so a surname stored with an uncapitalized prefix
+    ("de Vos", "von Hebel") sorts after every "Z..." surname instead of
+    interleaving with them the way Gramps Desktop's locale-aware collator
+    does -- see ROADMAP.md's "Default NOCASE collation" note. `NOCASE` is
+    ASCII-only case folding, not full locale parity (it won't fold
+    accented letters), but it's built into SQLite and needs no connection
+    setup, unlike a real locale collation (`resources/object_query.py`'s
+    `_resolve_collation`), so it's a safe default with no caller wiring
+    required. PostgreSQL has no built-in `NOCASE` collation, so this
+    fallback is SQLite-only; an explicit `collation` is still required
+    there for the same fix.
     """
     sql, params = _render_column(
         column, spec, dialect, value=_cast_hint(ref_value_type(spec, column)), treeid=treeid
     )
-    if collation and _is_text_ref(column, spec):
-        return f'{sql} COLLATE "{collation}"', params
+    if _is_text_ref(column, spec):
+        effective_collation = collation or (
+            "NOCASE" if dialect in (None, Dialect.SQLITE) else None
+        )
+        if effective_collation:
+            return f'{sql} COLLATE "{effective_collation}"', params
     return sql, params
 
 
@@ -2107,7 +2070,13 @@ def compile_query(
     `collation`, if given, names a locale collation already ensured to exist
     on the connection (see `resources/object_query.py`'s `_resolve_collation`)
     and is applied to every text-typed `ORDER BY` column (and the matching
-    keyset comparisons) via `COLLATE "<collation>"`.
+    keyset comparisons) via `COLLATE "<collation>"`. Omitted (the default),
+    text columns still get `COLLATE "NOCASE"` on SQLite (see `_column_expr`)
+    -- ASCII case-folding built into SQLite itself, not full locale parity,
+    but enough to keep an uncapitalized surname prefix ("de Vos") from
+    sorting after every "Z..." surname instead of interleaving with them.
+    PostgreSQL has no built-in `NOCASE`, so an explicit `collation` is still
+    needed there for the same fix.
 
     A `select` entry given as a dotted/bracketed path string is resolved
     here (via `resolve_ref_string`) before rendering, so the same text
@@ -2126,7 +2095,7 @@ def compile_query(
     table, no `JsonPath`/`RelatedObject`); it is not safe in general.
     """
     columns = [
-        resolve_select_ref_string(spec, entry) if isinstance(entry, str) else entry
+        resolve_ref_string(spec, entry) if isinstance(entry, str) else entry
         for entry in (query.select if query.select else sorted(spec.columns))
     ]
 

--- a/GOQLFilter/gramps_object_query_language_copy/query.py
+++ b/GOQLFilter/gramps_object_query_language_copy/query.py
@@ -1,0 +1,2193 @@
+#
+# gramps-object-query-language - Object query language and SQL compiler for Gramps data
+#
+# Copyright (C) 2026      Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""A small, closed query AST and SQL compiler for fast object queries.
+
+This is not a general query language, not GraphQL, and not a raw-SQL
+passthrough. Only `where` and `order_by` have tree structure; `select`,
+`limit`, and `after` stay flat. Every column name is checked against a
+fixed per-type whitelist (`ObjectTypeSpec.columns`, derived from the
+secondary columns already flattened server-side for that object's table)
+before the compiler ever touches it, and values are always bound as `?`
+parameters -- there is no path from client input to a raw SQL string.
+
+This module is pure and does no database access, so it is unit-testable
+without a running server. Keyset pagination (`Query.after`) expects the
+*resolved* sort-column values for the cursor row, not just a handle --
+resolving a client-supplied handle into that tuple (one extra lookup) is
+the caller's job; see `after_columns()`.
+"""
+
+from __future__ import annotations
+
+import enum
+import re
+from dataclasses import dataclass
+from typing import Any, Iterable, List, Optional, Sequence, Tuple, Union
+
+from gramps.gen.lib import (
+    Citation,
+    Event,
+    Family,
+    Media,
+    Note,
+    Person,
+    Place,
+    Repository,
+    Source,
+    Tag,
+)
+from gramps.gen.lib.tableobj import TableObject
+
+
+@dataclass(frozen=True)
+class ObjectTypeSpec:
+    """Table + whitelist for one Gramps object type's flat secondary columns,
+    plus the Gramps class itself, whose `get_schema()` describes the *JSON*
+    side of the same object (see `walk_schema`).
+
+    `cls` is what makes a `JsonPath` checkable rather than trusted: the
+    flat columns are whitelisted by `columns`, and everything reachable
+    inside `json_data` is whitelisted by the class's own JSON Schema.
+    """
+
+    table: str
+    columns: frozenset[str]
+    text_columns: frozenset[str]
+    cls: type[TableObject]
+
+
+def _spec_for(
+    cls: type[TableObject], extra_columns: frozenset[str] = frozenset()
+) -> ObjectTypeSpec:
+    """Build an `ObjectTypeSpec` from a Gramps object class's secondary fields.
+
+    Kept in sync with core rather than hardcoded, since this *is* the set of
+    columns that exist as real SQL columns on the table. `text_columns` (the
+    subset eligible for a locale `COLLATE` clause -- see `compile_query`) is
+    derived the same way: every `extra_columns` entry is text today
+    (`given_name`/`surname`/`enclosed_by`), and `get_secondary_fields()`
+    already tags each field's SQL type.
+    """
+    fields = list(cls.get_secondary_fields())
+    columns = frozenset(field for field, _, _ in fields) | extra_columns
+    text_columns = (
+        frozenset(field for field, schema_type, _ in fields if schema_type == "string")
+        | extra_columns
+    )
+    return ObjectTypeSpec(
+        table=cls.__name__.lower(),
+        columns=columns,
+        text_columns=text_columns,
+        cls=cls,
+    )
+
+
+# One spec per object type, each wired to a `.../query/` endpoint (see
+# `resources/object_query.py`).
+PERSON = _spec_for(Person, extra_columns=frozenset({"given_name", "surname"}))
+FAMILY = _spec_for(Family)
+EVENT = _spec_for(Event)
+PLACE = _spec_for(Place, extra_columns=frozenset({"enclosed_by"}))
+REPOSITORY = _spec_for(Repository)
+SOURCE = _spec_for(Source)
+CITATION = _spec_for(Citation)
+MEDIA = _spec_for(Media)
+NOTE = _spec_for(Note)
+TAG = _spec_for(Tag)
+
+
+# --- JSON schema: whitelisting the `json_data` side --------------------------
+
+
+#: Fields Gramps *serializes* into `json_data` but omits from the matching
+#: class's `get_schema()`. Verified against Gramps 6.0.8 by round-tripping a
+#: real instance of all 45 schema-carrying classes in `gramps.gen.lib`
+#: against its own schema -- these three were the only mismatches, and each
+#: is a genuine, queryable stored field, not a serialization artifact.
+#:
+#: Without this table a path like `birth.date.format` -- real data, present
+#: in every serialized `Date` -- would be rejected as unknown. The test
+#: `test_schema_gaps_are_still_gaps` re-derives this set from live Gramps
+#: and fails if a gap closes upstream (or a new one opens), so this can't
+#: quietly rot into a stale hardcoded list.
+_SCHEMA_GAPS: dict = {
+    "Date": {"format": {"type": ["integer", "null"], "title": "Format"}},
+    "Family": {"complete": {"type": "integer", "title": "Complete"}},
+    "Media": {"thumb": {"type": ["string", "null"], "title": "Thumbnail"}},
+}
+
+
+def _schema_properties(schema: dict) -> dict:
+    """`schema`'s own properties, plus any `_SCHEMA_GAPS` entries for the
+    class it describes. Keyed off the schema's `title`, which is how a
+    nested schema node names its class (`{"type": "object", "title":
+    "Date", ...}`) -- there's no class reference to follow at that depth.
+    """
+    properties = dict(schema.get("properties", {}))
+    properties.update(_SCHEMA_GAPS.get(schema.get("title", ""), {}))
+    return properties
+
+
+def _describe_schema(schema: dict) -> str:
+    return schema.get("title") or schema.get("type") or "value"
+
+
+def walk_schema(spec: ObjectTypeSpec, segments: Sequence[Union[str, int]]) -> dict:
+    """Walk `segments` through `spec`'s Gramps JSON Schema, returning the
+    schema node for the value the path lands on. Raises `QueryError` -- with
+    the field names that *would* have worked -- if the path doesn't exist.
+
+    This is what makes a `JsonPath` a checked reference rather than a
+    hopeful one. `json_data`'s contents are not arbitrary: every Gramps
+    primary object class publishes a complete, recursive `get_schema()`
+    (no `$ref`s, fully inlined), so `primary_name.surname_list[0].surname`
+    can be verified statically, exactly like a flat column name is verified
+    against `spec.columns`. A path that doesn't exist is a mistake, and
+    saying so at compile time beats returning `NULL` for every row.
+
+    A string segment indexes an object's properties; an integer segment
+    indexes an array's `items`. Mismatches (a key into a scalar, an index
+    into an object) are errors too, not just unknown names.
+    """
+    schema = spec.cls.get_schema()
+    walked: List[str] = []
+    for segment in segments:
+        if isinstance(segment, int):
+            if schema.get("type") != "array":
+                raise QueryError(
+                    f"{'.'.join(walked) or spec.table!r} is "
+                    f"{_describe_schema(schema)}, not a list -- "
+                    f"[{segment}] doesn't apply to it"
+                )
+            schema = schema.get("items", {})
+            walked.append(f"[{segment}]")
+            continue
+        properties = _schema_properties(schema)
+        if not properties:
+            raise QueryError(
+                f"{'.'.join(walked) or spec.table!r} is "
+                f"{_describe_schema(schema)}, which has no fields -- "
+                f"{segment!r} doesn't apply to it"
+            )
+        if segment not in properties:
+            known = sorted(name for name in properties if not name.startswith("_"))
+            raise QueryError(
+                f"unknown field {segment!r} on "
+                f"{_describe_schema(schema)} -- known fields: "
+                f"{', '.join(known)}"
+            )
+        schema = properties[segment]
+        walked.append(segment)
+    return schema
+
+
+def path_value_type(spec: ObjectTypeSpec, segments: Sequence[Union[str, int]]) -> Any:
+    """The JSON type a path resolves to (`"string"`, `"integer"`, `"object"`,
+    `"array"`, or a list of them for a nullable field), or `None` if the
+    schema doesn't say.
+
+    Callers use this to know a value's shape *before* running the query --
+    in particular whether it's a composite (`"object"`/`"array"`), which is
+    the case a SQLite caller has to JSON-decode on the way back out, since
+    `json_extract` hands those back as JSON text while PostgreSQL's `jsonb`
+    hands back a parsed value.
+    """
+    return walk_schema(spec, segments).get("type")
+
+
+def ref_value_type(spec: ObjectTypeSpec, ref: "ColumnRef") -> Any:
+    """The JSON type a whole `ColumnRef` lands on, following a
+    `RelatedObject` chain into its target type's schema.
+
+    `None` for a flat column: those are real SQL columns whose type the
+    database already knows, so nothing here needs to say it.
+    """
+    if isinstance(ref, RelatedObject):
+        return ref_value_type(ref.target, ref.field)
+    if isinstance(ref, JsonPath):
+        return path_value_type(spec, ref.segments)
+    if isinstance(ref, CollectionCount):
+        return "integer"
+    if isinstance(ref, WholeJsonData):
+        return "object"
+    return None
+
+
+def is_composite_type(value_type: Any) -> bool:
+    """Does `value_type` (from `path_value_type`) denote an object/array --
+    a value that arrives JSON-encoded from SQLite and parsed from
+    PostgreSQL? A nullable field's type is a list, hence the membership
+    test rather than an equality check.
+    """
+    if isinstance(value_type, list):
+        return any(item in ("object", "array") for item in value_type)
+    return value_type in ("object", "array")
+
+
+class QueryError(ValueError):
+    """Raised when a query references an unknown column or is malformed."""
+
+
+def _check_column(column: str, whitelist: frozenset[str]) -> None:
+    if column not in whitelist:
+        raise QueryError(f"unknown or disallowed column: {column!r}")
+
+
+# Column names that collide with reserved SQL words -- currently just
+# `Media.desc` (PostgreSQL reserves DESC; SQLite doesn't). Mirrors
+# addons-source's `PostgreSQL`/`SharedPostgreSQL` `_quote_column()` list (see
+# PLAN grounding notes); remove once gramps core PR #2178 makes this
+# core-provided instead of addon- and caller-side.
+_RESERVED_SQL_WORDS = frozenset({"desc", "order", "where", "select"})
+
+# PostgreSQL-only physical-column-name overrides, keyed by logical column
+# name (the name `get_secondary_fields()` uses, same as every other
+# backend). Existing (and newly created -- see shareddbapi.py's own
+# `_quote_column()`) `SharedPostgreSQL` databases physically name these
+# columns this way: legacy artifacts of that addon's *former*
+# `Connection.execute()`, which used to blindly string-replace
+# "desc" -> "desc_" on every query it ran, not just its own -- so a plain,
+# unquoted logical name like `description` used to come out the other end
+# already corrected to the real physical `desc_ription`, no override
+# needed here.
+#
+# addons-source PR #1001 removed that blind rewrite (rightly -- it
+# corrupted any identifier containing "desc" as a substring) in favor of a
+# `_quote_column()` used only inside the addon's own generated SQL
+# (schema creation, its `ORDER BY`/`UPDATE` paths). It was never wired up
+# to also cover SQL built by an external caller like this module, so the
+# free auto-correction this compiler used to (silently, fragilely) depend
+# on is gone: confirmed live post-#1001, a plain `description`/`desc`
+# reference now 500s with `psycopg2.errors.UndefinedColumn` instead of
+# reaching the real column. This override table replaces that dependency
+# with an explicit one, owned here instead of incidentally supplied by a
+# side effect two repos away.
+#
+# SQLite never had this hack -- its columns are named exactly like every
+# other backend's logical name, so nothing is mapped for
+# `Dialect.SQLITE`/no dialect.
+_POSTGRESQL_PHYSICAL_COLUMN_OVERRIDES: dict[str, str] = {
+    "desc": "desc_",
+    "description": "desc_ription",
+}
+
+
+def _quote_column(column: str, dialect: Optional["Dialect"] = None) -> str:
+    """Render a column identifier for the given dialect.
+
+    PostgreSQL: a column in `_POSTGRESQL_PHYSICAL_COLUMN_OVERRIDES` is
+    rendered as its real physical name (see that dict's note); anything
+    else that collides with a reserved SQL word is double-quoted.
+
+    SQLite (or no dialect given): always the bare logical name, quoted only
+    if it collides with a reserved SQL word -- matching prior output
+    exactly for every caller that doesn't pass a dialect.
+    """
+    if dialect == Dialect.POSTGRESQL and column in _POSTGRESQL_PHYSICAL_COLUMN_OVERRIDES:
+        return _POSTGRESQL_PHYSICAL_COLUMN_OVERRIDES[column]
+    return f'"{column}"' if column in _RESERVED_SQL_WORDS else column
+
+
+class Dialect(str, enum.Enum):
+    """SQL dialect for backend-specific rendering.
+
+    `JsonPath` is the first thing this compiler emits that needs to know
+    which backend it's talking to -- everything else (`?`-parameterized
+    comparisons, `AND`/`OR`, keyset seek expressions, `COLLATE`) is
+    dialect-neutral SQL that already works unchanged on both backends.
+    """
+
+    SQLITE = "sqlite"
+    POSTGRESQL = "postgresql"
+
+
+@dataclass(frozen=True)
+class ColumnIndex:
+    """A `JsonPath` segment whose integer value comes from another column
+    on the *current* row, not a compile-time literal -- e.g.
+    `event_ref_list[N]` where `N` is this row's `birth_ref_index`. Only
+    meaningful inside a `RelatedObject.handle_ref` (see there). `-1` means
+    "no such entry" by Gramps' own convention for `birth_ref_index`/
+    `death_ref_index`, so rendering code guards this column with `>= 0` --
+    required, not defensive: confirmed live that PostgreSQL's `->`
+    operator treats a negative array index as "count from the end" rather
+    than invalid -- without the guard, a row with no such entry but
+    *something else* in the list would silently resolve to that unrelated
+    entry.
+    """
+
+    column: str
+
+
+@dataclass(frozen=True)
+class JsonPath:
+    """A path into a JSON-blob secondary column (default: `json_data`).
+
+    Whitelisted, like a plain column name -- just against a different
+    list. `json_data`'s content is *not* arbitrary: every Gramps class
+    publishes a complete recursive JSON Schema, so `resolve_column_path`
+    checks each path against it (`walk_schema`) before building a
+    `JsonPath` at all. A path this class can be constructed with directly,
+    bypassing that resolver, is trusted the way any hand-built AST node is.
+
+    Two further guarantees hold regardless of where the path came from:
+    every segment is individually type-checked (`str` keys, non-bool `int`
+    array indices, or a `ColumnIndex` -- see there), and `str`/`int`
+    segments are always bound as query parameters, never interpolated into
+    SQL text -- see `_render_json_path`. (A `ColumnIndex` segment is inherently a raw SQL
+    column reference, not a bindable value -- see `_render_handle_ref`,
+    the only place a `JsonPath` containing one is ever rendered; its
+    `column` always comes from the fixed internal `_RELATIONSHIPS`
+    registry, never from parsed user input, so this is safe.)
+
+    Usable in `order_by`/keyset pagination as well as `select`/`where`.
+    That needed a static type for the value, which the class's own JSON
+    Schema now supplies (`path_value_type`): PostgreSQL casts a numeric
+    path so it doesn't sort lexicographically, and `COLLATE` is applied
+    only when the schema says the value is text -- `text_columns` can't
+    answer that for a path, which is why sorting on one was previously out
+    of scope. No index backs the extraction, so this is a real scan.
+    """
+
+    segments: Tuple[Union[str, int, ColumnIndex], ...]
+    base_column: str = "json_data"
+
+    def __post_init__(self) -> None:
+        if not self.segments:
+            raise QueryError("JsonPath requires at least one segment")
+        for segment in self.segments:
+            if isinstance(segment, ColumnIndex):
+                continue
+            if isinstance(segment, bool) or not isinstance(segment, (str, int)):
+                raise QueryError(f"invalid JsonPath segment: {segment!r}")
+
+
+@dataclass(frozen=True)
+class WholeJsonData:
+    """The entire JSON-blob secondary column, selected whole -- spelled
+    `"."` as a path string (`resolve_ref_string(spec, ".")`), the one path
+    text that isn't a valid dotted/bracketed `JsonPath` spelling.
+
+    A separate class from `JsonPath` rather than an empty-segments
+    `JsonPath(())`, deliberately -- `JsonPath` requires at least one
+    segment (`test_jsonpath_requires_at_least_one_segment`) precisely so an
+    empty/malformed path stays a caller error there; giving "the whole
+    object, on purpose" its own type keeps that guarantee intact instead of
+    overloading the same shape to mean two different things depending on
+    how it was reached.
+
+    Renders as a bare reference to `base_column` (see `_render_column`) --
+    `json_data` is stored as JSON-encoded TEXT already on both backends
+    (see `JsonPath`'s docstring), so the whole blob is exactly what
+    `SELECT json_data` returns; no extraction function needed the way a
+    `JsonPath` needs `json_extract`/`jsonb_extract_path_text`.
+    """
+
+    base_column: str = "json_data"
+
+
+@dataclass(frozen=True)
+class RelatedObject:
+    """A field reached by following a relationship from the current row to
+    another table -- a `Family`'s father (-> `Person`), a `Person`'s birth
+    event (-> `Event`), an `Event`'s place (-> `Place`), and so on.
+    Resolved via a *correlated scalar subquery*, not a `JOIN`: each
+    `RelatedObject`'s subquery is a fully independent SQL scope with its
+    own `FROM <target.table>`, correlated back to whatever row it's
+    reached from by that table's own (never aliased) name -- confirmed
+    live this composes correctly at any depth: sibling subqueries hitting
+    the same table (father vs. mother, both `FROM person`) don't collide,
+    and chains (nested subqueries, for `birth.place.title`-style paths)
+    correlate correctly across levels regardless of nesting -- see
+    `_render_related_object`.
+
+    `name`: the relationship's name as used in a path (`"birth"`,
+        `"father"`, ...) -- kept for error messages and deriving a default
+        response key (`"birth.date.sortval"`); not used by the SQL itself.
+    `target`: the `ObjectTypeSpec` of the related table.
+    `handle_ref`: how to find the related row's handle on the row this
+        `RelatedObject` is reached from -- a plain column name for a
+        direct foreign key (`"father_handle"`), or a `JsonPath` with
+        exactly one `ColumnIndex` segment for a dynamic, per-row index
+        (`event_ref_list[<ref_index_column>].ref`).
+    `field`: what to pull from the related row once found -- a plain
+        (whitelisted) column name, a `JsonPath` into its `json_data`, or
+        another `RelatedObject` to keep chaining.
+
+    Usable in `order_by`/keyset pagination too. A per-row dynamic
+    `handle_ref` is no obstacle: the sort and seek predicates re-render the
+    whole correlated subquery wherever the value is needed, rather than
+    assuming it lives in the base table. Correct, but a subquery per row
+    per comparison -- the slowest thing this compiler emits.
+    """
+
+    name: str
+    target: ObjectTypeSpec
+    handle_ref: ColumnRef
+    field: ColumnRef
+
+
+# Registry of relationship roots, keyed by the *current* table -- the only
+# thing that varies per relationship is which table it targets and how to
+# find the related row's handle; what to extract from that row (`field`) is
+# supplied by whatever's left of the path once the relationship name is
+# consumed (see `resolve_column_path`). Adding a new relationship (e.g. a
+# Citation's source) is one registry entry, not new rendering code.
+_RELATIONSHIPS: dict[str, dict[str, Tuple[ObjectTypeSpec, ColumnRef]]] = {
+    PERSON.table: {
+        "birth": (
+            EVENT,
+            JsonPath(("event_ref_list", ColumnIndex("birth_ref_index"), "ref")),
+        ),
+        "death": (
+            EVENT,
+            JsonPath(("event_ref_list", ColumnIndex("death_ref_index"), "ref")),
+        ),
+    },
+    FAMILY.table: {
+        "father": (PERSON, "father_handle"),
+        "mother": (PERSON, "mother_handle"),
+    },
+    EVENT.table: {
+        "place": (PLACE, "place"),
+    },
+    CITATION.table: {
+        "source": (SOURCE, "source_handle"),
+    },
+    PLACE.table: {
+        # Self-referencing (Place -> Place), the first entry in this row's
+        # own placeref_list -- a real, indexed flat column in Gramps' own
+        # DBAPI schema (`enclosed_by VARCHAR(50)`), already exposed via
+        # PLACE's extra_columns but never registered as a relationship
+        # until now. Distinct from the `enclosing_places` Collection
+        # (one-to-many, the full placeref_list with its date ranges) --
+        # this is just the one, denormalized "primary enclosing place"
+        # handle Gramps' own backend maintains for fast lookups.
+        "enclosed_by": (PLACE, "enclosed_by"),
+    },
+}
+
+
+@dataclass(frozen=True)
+class Collection:
+    """A one-to-many relationship -- a list of handles (or handle-bearing ref
+    objects) reached from the current row, e.g. a `Family`'s children.
+
+    Unlike `RelatedObject`, never appears as a dotted-path segment (`children.
+    surname` would be ambiguous -- which child?) -- only as `Exists`'s target,
+    looked up via `resolve_collection`, a separate namespace from
+    `_RELATIONSHIPS` on purpose.
+
+    `list_path`: where the list of related items lives in the current row's
+        `json_data` (always a single top-level key today, e.g.
+        `child_ref_list`, `note_list`).
+    `ref_field`: the sub-key that holds each item's handle, for a list of ref
+        objects (`"ref"`, for `ChildRef`/`EventRef`/... entries) -- `None`
+        for a list that's already plain handle strings (`note_list`,
+        `tag_list`).
+    """
+
+    name: str
+    target: ObjectTypeSpec
+    list_path: JsonPath
+    ref_field: Optional[str]
+
+
+@dataclass(frozen=True)
+class CollectionCount:
+    """How many rows in a `Collection` match an optional `condition` -- the
+    value-returning counterpart to `Exists` (a boolean). `count(children) > 2`
+    compiles to an ordinary `Gt(CollectionCount(children, None), 2)` -- no new
+    `Comparison` subclass needed, unlike `Exists`, which has to be its own
+    top-level boolean AST node since a bare `exists(...)` *is* the condition.
+
+    `condition=None` means "count every related row" -- `count(children)`,
+    not narrowed by any field of the children themselves.
+
+    Shares `Exists`'s subquery body (`_collection_subquery_body`) verbatim,
+    just wrapped as `(SELECT COUNT(*) FROM ...)` instead of
+    `EXISTS (SELECT 1 FROM ...)` -- see `_render_collection_count`.
+    """
+
+    collection: Collection
+    condition: Optional[Any] = None
+
+
+def _generic_collections(
+    *, notes: bool = False, citations: bool = False, media: bool = False, tags: bool = False
+) -> dict[str, Collection]:
+    """The subset of `note_list`/`citation_list`/`media_list`/`tag_list`
+    a given object type actually has -- these four recur across most of the
+    ten primary types (every type inheriting `NoteBase`/`CitationBase`/
+    `MediaBase`/`TagBase` in Gramps core), but not uniformly: e.g. `Source`
+    has no `citation_list` (a source doesn't cite other citations), and
+    `Repository` has neither `citation_list` nor `media_list`. Each caller
+    below passes only the flags matching what that type's Gramps class
+    actually inherits (verified against `gramps/gen/lib/*.py`, not guessed).
+
+    `note_list`/`citation_list`/`tag_list` are flat handle lists
+    (`ref_field=None`); `media_list` is a list of `MediaRef` objects
+    (`ref_field="ref"`) -- the two `Collection` shapes `children`/`notes`
+    already proved out.
+    """
+    entries: dict[str, Collection] = {}
+    if notes:
+        entries["notes"] = Collection("notes", NOTE, JsonPath(("note_list",)), None)
+    if citations:
+        entries["citations"] = Collection(
+            "citations", CITATION, JsonPath(("citation_list",)), None
+        )
+    if media:
+        entries["media"] = Collection("media", MEDIA, JsonPath(("media_list",)), "ref")
+    if tags:
+        entries["tags"] = Collection("tags", TAG, JsonPath(("tag_list",)), None)
+    return entries
+
+
+# Registry of one-to-many collection roots, keyed by the *current* table --
+# mirrors `_RELATIONSHIPS`'s shape, but for `EXISTS`-style membership tests
+# (see `Exists`) rather than a single correlated scalar subquery.
+#
+# Every entry here is one of exactly two shapes (`children`/`notes` proved
+# both out first): a ref-object list needing `.ref` extraction
+# (`ref_field="ref"` -- `child_ref_list`, `event_ref_list`, `person_ref_list`,
+# `media_list`, `placeref_list`, `reporef_list`), or a flat handle list that's
+# already the handle itself (`ref_field=None` -- `note_list`,
+# `citation_list`, `tag_list`, `family_list`, `parent_family_list`). Adding
+# each was confirmed against the real Gramps object model
+# (`gramps/gen/lib/*.py`'s base classes and field definitions), not assumed
+# from naming alone.
+_COLLECTIONS: dict[str, dict[str, Collection]] = {
+    PERSON.table: {
+        **_generic_collections(notes=True, citations=True, media=True, tags=True),
+        "families": Collection("families", FAMILY, JsonPath(("family_list",)), None),
+        "parent_families": Collection(
+            "parent_families", FAMILY, JsonPath(("parent_family_list",)), None
+        ),
+        "associations": Collection(
+            "associations", PERSON, JsonPath(("person_ref_list",)), "ref"
+        ),
+        "events": Collection("events", EVENT, JsonPath(("event_ref_list",)), "ref"),
+    },
+    FAMILY.table: {
+        "children": Collection("children", PERSON, JsonPath(("child_ref_list",)), "ref"),
+        **_generic_collections(notes=True, citations=True, media=True, tags=True),
+        "events": Collection("events", EVENT, JsonPath(("event_ref_list",)), "ref"),
+    },
+    EVENT.table: {
+        **_generic_collections(notes=True, citations=True, media=True, tags=True),
+    },
+    PLACE.table: {
+        **_generic_collections(notes=True, citations=True, media=True, tags=True),
+        "enclosing_places": Collection(
+            "enclosing_places", PLACE, JsonPath(("placeref_list",)), "ref"
+        ),
+    },
+    SOURCE.table: {
+        **_generic_collections(notes=True, media=True, tags=True),
+        "repositories": Collection(
+            "repositories", REPOSITORY, JsonPath(("reporef_list",)), "ref"
+        ),
+    },
+    CITATION.table: {
+        **_generic_collections(notes=True, media=True, tags=True),
+    },
+    REPOSITORY.table: {
+        **_generic_collections(notes=True, tags=True),
+    },
+    MEDIA.table: {
+        **_generic_collections(notes=True, citations=True, tags=True),
+    },
+    NOTE.table: {
+        **_generic_collections(tags=True),
+    },
+}
+
+
+def _check_no_collection_relationship_name_collisions() -> None:
+    for table, collections in _COLLECTIONS.items():
+        overlap = set(collections) & set(_RELATIONSHIPS.get(table, {}))
+        if overlap:
+            raise QueryError(
+                f"name collides between a relationship and a collection on "
+                f"{table!r}: {sorted(overlap)}"
+            )
+
+
+_check_no_collection_relationship_name_collisions()
+
+
+def resolve_collection(spec: ObjectTypeSpec, name: str) -> Collection:
+    """Look up a `Collection` by name on `spec`'s table -- `exists(...)`'s
+    first argument, resolved the same way `resolve_column_path` resolves a
+    `_RELATIONSHIPS` name, just from the separate `_COLLECTIONS` namespace.
+    """
+    collections = _COLLECTIONS.get(spec.table, {})
+    if name not in collections:
+        raise QueryError(
+            f"unknown collection {name!r} on {spec.table!r} "
+            f"(known: {', '.join(sorted(collections)) or 'none'})"
+        )
+    return collections[name]
+
+
+def resolve_column_path(
+    spec: ObjectTypeSpec, segments: Sequence[Union[str, int]]
+) -> ColumnRef:
+    """Resolve a dotted/indexed path against `spec` into a `ColumnRef`.
+
+    Recursively walks relationship roots (`_RELATIONSHIPS`) as far as the
+    path goes -- `birth.date.sortval` consumes `"birth"` as a relationship
+    (`Person` -> `Event`), then resolves the remaining `("date", "sortval")`
+    against `EVENT`, which isn't a relationship there, so it becomes a
+    `JsonPath`. `birth.place.title` keeps going: `"place"` is *also* a
+    relationship (`Event` -> `Place`), consumed the same way, leaving just
+    `("title",)` to resolve against `PLACE` (a real flat column there).
+
+    `select`/`where`/`where_expr` (`object_query.py`, `query_lang.py`) all
+    funnel through this one resolver, so a path means the same thing
+    everywhere it's written.
+
+    A relationship name with nothing after it (`segments == ("birth",)`)
+    is rejected explicitly -- there's no value to return for "the related
+    row itself", only for a field of it.
+    """
+    if not segments:
+        raise QueryError("empty column path")
+    head, *rest = segments
+    relationships = _RELATIONSHIPS.get(spec.table, {})
+    if isinstance(head, str) and head in relationships:
+        if not rest:
+            raise QueryError(
+                f"{head!r} is a relationship on {spec.table!r}, not a value on its "
+                f"own -- use {head}.<field>, e.g. {head}.gramps_id"
+            )
+        target_spec, handle_ref = relationships[head]
+        field = resolve_column_path(target_spec, rest)
+        return RelatedObject(name=head, target=target_spec, handle_ref=handle_ref, field=field)
+    if len(segments) == 1 and isinstance(head, str) and head in spec.columns:
+        return head
+    # Not a flat column and not a relationship -- so it's a path into
+    # `json_data`, checked against the type's own Gramps JSON Schema
+    # before it's built (see `walk_schema`). An unknown path is a mistake,
+    # and this is the one place every JsonPath-producing surface
+    # (`select`, `where`, `where_expr`) funnels through, so checking here
+    # covers all of them at once.
+    walk_schema(spec, segments)
+    return JsonPath(tuple(segments))
+
+
+_PATH_SEGMENT_RE = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)((?:\[[0-9]+\])*)\Z")
+_PATH_INDEX_RE = re.compile(r"\[([0-9]+)\]")
+
+
+def parse_path_string(text: str) -> Tuple[Union[str, int], ...]:
+    """Parse a dotted/bracketed path string into `resolve_column_path`
+    segments -- `"primary_name.surname_list[0].surname"` becomes
+    `("primary_name", "surname_list", 0, "surname")`.
+
+    The string equivalent of `query_lang.py`'s `_translate_path` (which
+    walks a real Python `ast` instead), kept here rather than there because
+    `compile_query` itself needs it and `query_lang` imports *this* module,
+    not the other way round. The two grammars are deliberately identical,
+    so a path means the same thing typed into `select` as typed into
+    `where_expr`:
+
+    - segments are separated by `.`, each an identifier
+      (`[A-Za-z_][A-Za-z0-9_]*`)
+    - a segment may be followed by one or more `[<int>]` subscripts
+    - the index must be a non-negative integer literal. Negative indices
+      are rejected for parity with `_translate_path` (Python's `ast` makes
+      `[-1]` a `UnaryOp`, not the `Constant` it requires) *and* because
+      PostgreSQL's `->` reads a negative index as "count from the end"
+      while SQLite's JSONPath rejects it outright -- a silently
+      dialect-dependent meaning, which is exactly the trap `ColumnIndex`
+      already documents guarding against.
+
+    Raises `QueryError` on anything else: this parses raw, untrusted input
+    (a client-supplied `select` entry), so a malformed path has to fail
+    loudly rather than degrade into a path that quietly matches nothing.
+    """
+    if not text or not text.strip():
+        raise QueryError("empty column path")
+    segments: List[Union[str, int]] = []
+    for part in text.split("."):
+        match = _PATH_SEGMENT_RE.match(part)
+        if not match:
+            raise QueryError(
+                f"invalid path segment {part!r} in {text!r} -- expected a name, "
+                f"optionally followed by [<index>]"
+            )
+        name, subscripts = match.group(1), match.group(2)
+        segments.append(name)
+        segments.extend(int(index) for index in _PATH_INDEX_RE.findall(subscripts))
+    return tuple(segments)
+
+
+def resolve_ref_string(spec: ObjectTypeSpec, text: str) -> "ColumnRef":
+    """Resolve a bare string column reference against `spec`.
+
+    One code path for every spelling: `"gramps_id"`, `"primary_name"`, and
+    `"birth.place.title"` all go through `parse_path_string` and then
+    `resolve_column_path`, so a string means exactly what the same text
+    means in `where_expr` -- a flat column, a schema-checked `JsonPath`, or
+    a `RelatedObject` crossing a relationship. There is no special case for
+    a single segment: `gendr` is rejected because the Gramps schema has no
+    such field, not because of any rule about dots.
+
+    Used for `order_by` and (via `json_column_to_ref`) `where` column
+    references too -- `"."` (see `resolve_select_ref_string`) is
+    deliberately *not* handled here, so filtering or sorting on the whole
+    object stays a `QueryError` (`parse_path_string` rejects `"."` as two
+    empty path segments) rather than silently compiling into a comparison
+    or `ORDER BY` against a serialized JSON blob.
+    """
+    return resolve_column_path(spec, parse_path_string(text))
+
+
+def resolve_select_ref_string(spec: ObjectTypeSpec, text: str) -> "ColumnRef":
+    """`resolve_ref_string`, plus `"."` as a `select`-only spelling of "the
+    whole `json_data` blob" (`WholeJsonData`) -- not a dotted path at all,
+    so it's checked before `parse_path_string` ever sees it (`"."` splits
+    into two empty path segments, neither a valid identifier, and would
+    otherwise just raise). Used only where a `select` entry string is
+    resolved (`compile_query`, `run_query`) -- see `resolve_ref_string`'s
+    docstring for why `order_by`/`where` don't get this same case.
+    """
+    if text == ".":
+        return WholeJsonData()
+    return resolve_ref_string(spec, text)
+
+
+def default_ref_key(ref: "ColumnRef") -> str:
+    """The canonical response key for a column reference -- the dotted/
+    bracketed string that would resolve back to it.
+
+    `primary_name.surname_list[0]` for a plain `JsonPath`, `birth.date.sortval`
+    for a `RelatedObject` chain (recursing through `.field`, prefixing each
+    hop's `.name`), the name itself for a flat column. Round-trips with
+    `resolve_ref_string` for every reference either can express, which is
+    what lets a caller spell a `select` entry either way (a path string or
+    a resolved ref) and get the same response key for it.
+
+    A `CollectionCount` has no path to derive a name from, so it has no
+    default key -- callers must supply one (see `query_lang.parse_select`,
+    which requires an explicit alias for `count(...)`).
+    """
+    if isinstance(ref, str):
+        return ref
+    if isinstance(ref, FlatColumnRef):
+        return ref.name
+    if isinstance(ref, RelatedObject):
+        return f"{ref.name}.{default_ref_key(ref.field)}"
+    if isinstance(ref, WholeJsonData):
+        return "."
+    if isinstance(ref, JsonPath):
+        parts: List[str] = []
+        for segment in ref.segments:
+            if isinstance(segment, ColumnIndex):
+                raise QueryError(
+                    "a ColumnIndex path segment has no response-key spelling"
+                )
+            if isinstance(segment, int):
+                parts.append(f"[{segment}]")
+            else:
+                parts.append(f".{segment}" if parts else str(segment))
+        return "".join(parts)
+    raise QueryError(f"no default response key for {ref!r} -- supply one explicitly")
+
+
+@dataclass(frozen=True)
+class FlatColumnRef:
+    """A flat column referenced as a comparison's *value* -- the right-hand
+    side of a field-vs-field comparison whose column happens to be a plain
+    (same-table) flat column rather than a `JsonPath`/`RelatedObject`.
+
+    `Comparison.value` (and `Contains.value`) already support a field
+    reference on the value side -- but only ever recognize `JsonPath`/
+    `RelatedObject` as one (see `Comparison`'s docstring: "a bare string is
+    exactly as likely to be a literal value... as a column name, and
+    there's no way to tell which was meant"). A flat column resolves to a
+    bare `str`, identical in shape to an ordinary string literal -- so
+    without this wrapper, "given_name == surname" would silently compile to
+    comparing `given_name` against the *literal text* `"surname"`, not the
+    two columns against each other. This wraps a flat column specifically
+    for that one role, so `is_field_comparison`-style checks can tell it
+    apart from a real literal the same way they already can for `JsonPath`/
+    `RelatedObject`. Renders identically to a plain column reference --
+    `name` is unwrapped and passed straight through wherever a bare `str`
+    column already worked (see `_render_column`, `resolve_column_ref`).
+    """
+
+    name: str
+
+
+# A column reference is either a plain (whitelisted) column name, a path
+# into one column's JSON content, a field reached via a relationship (see
+# `RelatedObject`/`resolve_column_path`), a whole JSON-blob column
+# (`WholeJsonData`), or (value-position only, see `FlatColumnRef`) a flat
+# column marked as a field rather than a literal -- `field: ColumnRef` on
+# `RelatedObject` makes this recursive, so a chain like `birth.place.title`
+# is itself a valid `ColumnRef`.
+ColumnRef = Union[str, JsonPath, RelatedObject, CollectionCount, FlatColumnRef, WholeJsonData]
+SelectRef = ColumnRef
+
+
+def _require_dialect(dialect: Optional[Dialect], path: JsonPath) -> Dialect:
+    if dialect is None:
+        raise QueryError(
+            f"a dialect is required to compile a JsonPath ({path!r}), but none was given"
+        )
+    return dialect
+
+
+def _render_json_path(
+    path: JsonPath, dialect: Dialect, value: Any = None
+) -> Tuple[str, list]:
+    """Render a `JsonPath` into a dialect-specific SQL expression + bound params.
+
+    SQLite: `json_extract(json_data, ?)` with a single bound JSONPath-syntax
+    string (`$.primary_name.surname_list[0].surname`). SQLite's `json_extract`
+    already returns a properly-typed SQLite value (INTEGER/REAL/TEXT) matching
+    the JSON value's own type, so no cast is needed here for correct ordering
+    comparisons.
+
+    PostgreSQL: `jsonb_extract_path_text(json_data::jsonb, ?, ?, ...)` with
+    one bound parameter per path segment -- `json_data` is stored as `TEXT`
+    on both backends (no native `jsonb` column), hence the cast. Confirmed
+    live against a real PostgreSQL 16 instance: `jsonb_extract_path_text`
+    treats a numeric-looking text segment (e.g. `"0"`) as a JSON array
+    index, so integer segments are simply stringified, not cast separately.
+
+    `jsonb_extract_path_text` always returns `TEXT`, though, which is wrong
+    for `Lt`/`Gt`/etc. against a numeric or boolean `value` -- PostgreSQL
+    compares text lexicographically, not numerically (`'10' < '9'` is true).
+    `value` -- the Python value already in hand on the comparison, e.g.
+    `Gt(json_path, 5).value` -- picks the cast: `bool` -> `BOOLEAN`, `int`/
+    `float` -> `NUMERIC` (via the non-`_text` `jsonb_extract_path` + `CAST`,
+    mirroring the pattern in gramps' `SQLiteWithSelect` addon's
+    `sql_generator.py`), otherwise `TEXT` as before. This is driven by the
+    already-known comparison value rather than a separate static
+    type-inference pass.
+    """
+    if dialect == Dialect.SQLITE:
+        jsonpath = "$" + "".join(
+            f"[{segment}]" if isinstance(segment, int) else f".{segment}"
+            for segment in path.segments
+        )
+        return f"json_extract({path.base_column}, ?)", [jsonpath]
+    if dialect == Dialect.POSTGRESQL:
+        placeholders = ", ".join(["?"] * len(path.segments))
+        params = [str(segment) for segment in path.segments]
+        if isinstance(value, bool):
+            extract = f"jsonb_extract_path({path.base_column}::jsonb, {placeholders})"
+            return f"CAST({extract} AS BOOLEAN)", params
+        if isinstance(value, (int, float)):
+            extract = f"jsonb_extract_path({path.base_column}::jsonb, {placeholders})"
+            return f"CAST({extract} AS NUMERIC)", params
+        return (
+            f"jsonb_extract_path_text({path.base_column}::jsonb, {placeholders})",
+            params,
+        )
+    raise QueryError(f"unsupported dialect: {dialect!r}")
+
+
+def _sqlite_handle_ref_path_sql(
+    segments: Sequence[Union[str, int, ColumnIndex]], outer_table: str
+) -> str:
+    """Build the SQL expression for a JSONPath string used as a `handle_ref`,
+    substituting any `ColumnIndex` segment with the live value of that
+    column via `||` concatenation, e.g.
+    `'$.event_ref_list[' || person.birth_ref_index || '].ref'`. A path with
+    no `ColumnIndex` segment collapses to a single literal string, same as
+    a normal compile-time-static path.
+    """
+    fragments: list = []
+    literal = "$"
+    for segment in segments:
+        if isinstance(segment, ColumnIndex):
+            literal += "["
+            fragments.append(f"'{literal}'")
+            fragments.append(f"{outer_table}.{segment.column}")
+            literal = "]"
+        elif isinstance(segment, int):
+            literal += f"[{segment}]"
+        else:
+            literal += f".{segment}"
+    fragments.append(f"'{literal}'")
+    return " || ".join(fragments)
+
+
+def _postgresql_handle_ref_path_sql(
+    segments: Sequence[Union[str, int, ColumnIndex]], outer_table: str
+) -> str:
+    """Build the `->`/`->>` chain for a `handle_ref`, substituting any
+    `ColumnIndex` segment with the *unquoted* live value of that column --
+    PostgreSQL's `->` operator needs an actual integer (not a quoted
+    string) to use its array-index overload rather than its object-key
+    overload, confirmed live; a plain `int` literal segment gets the same
+    treatment for the same reason.
+    """
+    expr = f"{outer_table}.json_data::jsonb"
+    last_index = len(segments) - 1
+    for i, segment in enumerate(segments):
+        op = "->>" if i == last_index else "->"
+        if isinstance(segment, ColumnIndex):
+            expr += f" {op} {outer_table}.{segment.column}"
+        elif isinstance(segment, int):
+            expr += f" {op} {segment}"
+        else:
+            expr += f" {op} '{segment}'"
+    return expr
+
+
+def _render_handle_ref(
+    handle_ref: ColumnRef, outer_table: str, dialect: Dialect
+) -> Tuple[str, Optional[str]]:
+    """Render the SQL expression that finds a related row's handle from the
+    current row, plus the name of the column to guard with `>= 0` if
+    `handle_ref` uses a dynamic `ColumnIndex` segment (`None` for a direct
+    foreign key -- a `NULL` handle already fails the equality comparison
+    naturally, confirmed live, no guard needed).
+    """
+    if isinstance(handle_ref, str):
+        return f"{outer_table}.{_quote_column(handle_ref, dialect)}", None
+    if isinstance(handle_ref, JsonPath):
+        index_columns = [
+            segment.column
+            for segment in handle_ref.segments
+            if isinstance(segment, ColumnIndex)
+        ]
+        if len(index_columns) > 1:
+            raise QueryError(
+                "a handle reference supports at most one dynamic index segment"
+            )
+        guard_column = index_columns[0] if index_columns else None
+        if dialect == Dialect.SQLITE:
+            path_expr = _sqlite_handle_ref_path_sql(handle_ref.segments, outer_table)
+            return f"json_extract({outer_table}.json_data, {path_expr})", guard_column
+        if dialect == Dialect.POSTGRESQL:
+            return (
+                _postgresql_handle_ref_path_sql(handle_ref.segments, outer_table),
+                guard_column,
+            )
+        raise QueryError(f"unsupported dialect: {dialect!r}")
+    raise QueryError(f"invalid handle reference: {handle_ref!r}")
+
+
+def _guarded_handle_ref_sql(
+    handle_ref: ColumnRef, outer_table: str, dialect: Dialect
+) -> str:
+    """`_render_handle_ref`'s SQL expression, with the dynamic-index `>= 0`
+    guard already applied when needed -- see `_render_related_object`.
+    """
+    handle_sql, guard_column = _render_handle_ref(handle_ref, outer_table, dialect)
+    if guard_column is not None:
+        handle_sql = (
+            f"CASE WHEN {outer_table}.{guard_column} >= 0 THEN {handle_sql} ELSE NULL END"
+        )
+    return handle_sql
+
+
+def _render_related_object(
+    related: RelatedObject,
+    outer_table: str,
+    dialect: Optional[Dialect],
+    treeid: Optional[int],
+    value: Any = None,
+    _depth: int = 0,
+) -> Tuple[str, list]:
+    """Render a `RelatedObject` as a correlated scalar subquery.
+
+    ```sql
+    (SELECT <field extraction> FROM <target.table> AS <target.table>__hop<depth>
+     WHERE <target.table>__hop<depth>.handle = <handle_ref, CASE-guarded if dynamic>
+       AND <target.table>__hop<depth>.treeid = ?     -- when treeid is given
+     LIMIT 1)
+    ```
+
+    Not a `JOIN` -- a self-contained SQL scope with its own `FROM`,
+    correlated back to `outer_table` by name. Confirmed live this composes
+    correctly at any depth: sibling subqueries referencing the same table
+    (father vs. mother, both targeting `person`) don't collide with each
+    other, and a chain (nested `SELECT`s, for a path like `birth.place.title`)
+    correlates correctly across levels -- each `RelatedObject`'s subquery is
+    an independent scope regardless of how deep it's nested.
+
+    **Every level is aliased unconditionally** (`_depth` increments by one
+    per level of `RelatedObject` chaining), not just when a same-table
+    collision is detected -- confirmed *necessary*, not just defensive, for
+    a self-referencing relationship (`Place.enclosed_by` -> `Place`, the
+    first one registered): without an alias, a nested subquery's own
+    `FROM place` shadows any ancestor scope that also happens to be
+    `place`, so a bare `place.enclosed_by` reference inside the subquery's
+    own `WHERE` resolves to the *subquery's own* row, not the correlated
+    ancestor's -- silently making `place.handle = place.enclosed_by` true
+    only for a (nonexistent) place that encloses itself, so the whole
+    relationship matches nothing, for every row, regardless of real data.
+    Confirmed empirically before fixing (`enclosed_by.title == 'Cook
+    County'` matched zero rows against a real 3-level place hierarchy where
+    it should have matched one) -- the same class of bug as `Collection`
+    self-reference (`Person.associations`, see Done above), just one level
+    more subtle since `RelatedObject` nests arbitrarily deep rather than
+    being a single flat subquery, so a *fixed* alias suffix (which was
+    sufficient there) isn't enough here -- two nested self-referencing hops
+    (`enclosed_by.enclosed_by`) would still collide with each other under a
+    fixed suffix; only a depth-varying one guarantees every level distinct.
+
+    `treeid` scoping applies to *this* subquery's own row, not the outer
+    query -- a related row in another tree makes this field come back
+    `null`, not exclude the outer row from the results entirely. This
+    compiler carries no privacy predicate at all: it only ever runs
+    against an unproxied database (see `object_query.py`'s dispatch), so
+    there is nothing to guard here that the caller isn't already permitted
+    to see, at any depth.
+
+    `value` (a `where`-comparison's right-hand value, `None` for `select`)
+    only affects rendering when `field` is a `JsonPath` -- forwarded to
+    `_render_json_path` for the same numeric/boolean cast selection
+    already used for a plain `JsonPath` column. A `field` that's a plain
+    column ignores it (no text-vs-numeric ambiguity for a real column); a
+    `field` that's another (chained) `RelatedObject` forwards it one more
+    level down to wherever the leaf comparison actually happens.
+    """
+    if dialect is None:
+        raise QueryError(
+            f"a dialect is required to compile a relationship path ({related.name!r}), "
+            "but none was given"
+        )
+    target_table = related.target.table
+    target_alias = f"{target_table}__hop{_depth}"
+
+    handle_sql = _guarded_handle_ref_sql(related.handle_ref, outer_table, dialect)
+
+    if isinstance(related.field, RelatedObject):
+        field_sql, field_params = _render_related_object(
+            related.field, target_alias, dialect, treeid, value, _depth=_depth + 1
+        )
+    elif isinstance(related.field, JsonPath):
+        field_sql, field_params = _render_json_path(related.field, dialect, value)
+    else:
+        _check_column(related.field, related.target.columns)
+        field_sql, field_params = _quote_column(related.field, dialect), []
+
+    subquery_where = [f"{target_alias}.handle = ({handle_sql})"]
+    where_params: list = []
+    if treeid is not None:
+        subquery_where.append(f"{target_alias}.treeid = ?")
+        where_params.append(treeid)
+
+    subquery = (
+        f"(SELECT {field_sql} FROM {target_table} AS {target_alias} "
+        f"WHERE {' AND '.join(subquery_where)} LIMIT 1)"
+    )
+    return subquery, field_params + where_params
+
+
+def _check_bindings(sql: str, params: Sequence[Any], what: str) -> None:
+    """Every `?` in `sql` must have exactly one value in `params`.
+
+    A structural invariant, checked rather than assumed. SQL text and bound
+    values are assembled as two separate lists that are matched up by
+    position at execution time, so any drift between them is a real class
+    of bug -- and one that only *sometimes* announces itself: a count
+    mismatch is caught by the driver, but a same-length mis-ordering can
+    execute happily and return plausible, wrong rows.
+
+    This can't catch a mis-ordering (both lists still have the same
+    length); it catches the drift that causes most of them, at the moment
+    it happens, naming the fragment rather than surfacing as the driver's
+    context-free "Incorrect number of bindings supplied" later on. The
+    semantic half of this guard is the SQL-vs-evaluator parity matrix in
+    `test_proxied_query.py`, which re-derives every result a second way.
+
+    Safe as written because no literal `?` is ever emitted into SQL text:
+    every value reaches the query as a bound parameter, and the only
+    inlined literals are internally-generated JSONPath fragments (see
+    `_sqlite_handle_ref_path_sql`).
+    """
+    expected = sql.count("?")
+    if expected != len(params):
+        raise QueryError(
+            f"internal error: {what} has {expected} placeholder(s) but "
+            f"{len(params)} bound value(s) -- SQL: {sql!r} params: {params!r}"
+        )
+
+
+def _render_column(
+    column: ColumnRef,
+    spec: ObjectTypeSpec,
+    dialect: Optional[Dialect],
+    value: Any = None,
+    treeid: Optional[int] = None,
+) -> Tuple[str, list]:
+    """Render a column reference (plain name, `JsonPath`, or `RelatedObject`).
+
+    Used for both `SELECT` list entries (no right-hand value to bind,
+    `value` stays `None`) and `WHERE` comparisons. `value`, when given, is
+    the comparison's right-hand Python value -- used only to pick a
+    `JsonPath`/`RelatedObject` cast (see `_render_json_path`/
+    `_render_related_object`); ignored for plain column names. `treeid` is
+    only used by `RelatedObject`, whose correlated subquery needs its own
+    tree-scoping independent of the outer query's.
+    """
+    if isinstance(column, RelatedObject):
+        sql, params = _render_related_object(column, spec.table, dialect, treeid, value)
+    elif isinstance(column, JsonPath):
+        sql, params = _render_json_path(column, _require_dialect(dialect, column), value)
+    elif isinstance(column, CollectionCount):
+        sql, params = _render_collection_count(column, spec.table, dialect, treeid)
+    elif isinstance(column, WholeJsonData):
+        # No extraction function needed -- the column already *is* the
+        # whole JSON blob, on both dialects (see `WholeJsonData`'s
+        # docstring), so this renders identically regardless of `dialect`.
+        sql, params = _quote_column(column.base_column, dialect), []
+    else:
+        if isinstance(column, FlatColumnRef):
+            column = column.name
+        _check_column(column, spec.columns)
+        sql, params = _quote_column(column, dialect), []
+    # Checked per fragment, not only on the finished query: a column
+    # reference is re-rendered in up to four places for a paged sort
+    # (select list, both seek branches, ORDER BY), so catching drift here
+    # names the reference that caused it.
+    _check_bindings(sql, params, f"column reference {order_by_key(column)}")
+    return sql, params
+
+
+# --- WHERE: comparison leaves -----------------------------------------------
+
+
+#: Operators for which a field-vs-field comparison gets a numeric-cast hint
+#: (see `Comparison.compile`) -- ordering only, not equality.
+_ORDERING_OPS = frozenset({"<", "<=", ">", ">="})
+
+#: `=`/`!=` render as `IS [NOT] DISTINCT FROM` instead -- NULL-safe
+#: equality, so a missing value is treated as a distinct, comparable value
+#: rather than "unknown" (SQL's default three-valued-logic behavior for
+#: `=`/`!=`, which silently drops any row where either side is NULL from
+#: *both* an `eq` and an `ne` count). This matters most for field-vs-field
+#: comparisons -- "born and died in different places" should include
+#: "died in an unknown place", not silently exclude it -- but applies
+#: uniformly to literal comparisons too, for the same reason. Requires
+#: SQLite 3.39+ (2022-06-25); standard, unconditionally supported on
+#: PostgreSQL.
+_NULL_SAFE_OPS = {"=": "IS NOT DISTINCT FROM", "!=": "IS DISTINCT FROM"}
+
+
+class Comparison:
+    """Base class for single-column comparison leaves (`Eq`, `Lt`, ...).
+
+    `value` is normally a literal, always bound as a `?` parameter. It can
+    also be another `JsonPath`/`RelatedObject`/`FlatColumnRef` -- a
+    *field-vs-field* comparison, e.g. "families where the mother's death
+    date is before the father's" (`Lt(mother_death_sortval,
+    father_death_sortval)`). Plain `str` is deliberately never treated as a
+    field reference here (only `JsonPath`/`RelatedObject`/`FlatColumnRef`
+    are) -- a bare string is exactly as likely to be a literal value
+    (`Eq("surname", "Smith")`) as a column name, and there's no way to tell
+    which was meant; a same-table flat column being compared as a field
+    (not a literal) has to be wrapped in `FlatColumnRef` for exactly this
+    reason -- see its docstring. `JsonPath`/`RelatedObject`/`FlatColumnRef`
+    carry no such ambiguity; nothing constructs a bare `str` to represent a
+    field reference.
+    """
+
+    op: str
+
+    def __init__(self, column: ColumnRef, value: Any):
+        self.column = column
+        self.value = value
+
+    def compile(
+        self,
+        spec: ObjectTypeSpec,
+        dialect: Optional[Dialect] = None,
+        treeid: Optional[int] = None,
+    ) -> Tuple[str, list]:
+        is_field_comparison = isinstance(self.value, (JsonPath, RelatedObject, FlatColumnRef))
+        # A field-vs-field comparison has no literal runtime value to infer
+        # a numeric/boolean cast from (unlike field-vs-value) -- pick it
+        # structurally instead: an *ordering* comparison between two paths
+        # is overwhelmingly a numeric/date comparison in practice (e.g. two
+        # `sortval`s), so hint numeric via a dummy int (only its *type* is
+        # inspected by `_render_json_path`/`_render_related_object`, never
+        # its value). Equality doesn't need this: an exact TEXT match is
+        # correct whether the underlying value is numeric or textual, as
+        # long as both sides extract the same way -- which they do, so
+        # `cast_hint` naturally falls back to `self.value` there (a
+        # JsonPath/RelatedObject instance, neither bool nor numeric, so it
+        # still renders as TEXT on both sides via the existing type checks).
+        cast_hint = 0 if is_field_comparison and self.op in _ORDERING_OPS else self.value
+        sql_op = _NULL_SAFE_OPS.get(self.op, self.op)
+        column_sql, column_params = _render_column(
+            self.column, spec, dialect, value=cast_hint, treeid=treeid
+        )
+        if is_field_comparison:
+            value_sql, value_params = _render_column(
+                self.value, spec, dialect, value=cast_hint, treeid=treeid
+            )
+            comparison_sql = f"{column_sql} {sql_op} {value_sql}"
+            comparison_params = column_params + value_params
+        else:
+            comparison_sql = f"{column_sql} {sql_op} ?"
+            comparison_params = column_params + [self.value]
+        return comparison_sql, comparison_params
+
+    def __eq__(self, other: object) -> bool:
+        return (
+            type(self) is type(other)
+            and self.column == other.column  # type: ignore[attr-defined]
+            and self.value == other.value  # type: ignore[attr-defined]
+        )
+
+    def __repr__(self) -> str:
+        return f"{type(self).__name__}({self.column!r}, {self.value!r})"
+
+
+class Eq(Comparison):
+    op = "="
+
+
+class Ne(Comparison):
+    op = "!="
+
+
+class Lt(Comparison):
+    op = "<"
+
+
+class Lte(Comparison):
+    op = "<="
+
+
+class Gt(Comparison):
+    op = ">"
+
+
+class Gte(Comparison):
+    op = ">="
+
+
+class Like(Comparison):
+    op = "LIKE"
+
+
+class Regex(Comparison):
+    """WHERE column REGEXP <pattern> (SQLite) / column ~ <pattern> (PostgreSQL)
+    -- an unanchored, case-sensitive regex search (`re.search` semantics, not
+    `re.fullmatch`), not a plain SQL operator, so it needs a dialect to
+    compile at all (like `JsonPath`/`RelatedObject`).
+
+    SQLite has no built-in `REGEXP` operator, but gramps core's
+    `dbapi/sqlite.py` `Connection.__init__` already registers one as a UDF
+    on every connection it opens (`regexp(expr, value)`, calling Python's
+    `re.search(expr, value, re.MULTILINE)`), so `column REGEXP ?` works
+    there for free -- no schema/connection change needed by this module.
+    PostgreSQL's native `~` operator has the same unanchored, case-sensitive
+    substring-search semantics, so no extension is needed there either.
+
+    The two engines don't speak the same regex dialect, though: SQLite's UDF
+    is literally Python's `re` (so it agrees exactly with `evaluator.py`'s
+    in-memory `_compare`), while PostgreSQL uses POSIX ARE -- no
+    lookahead/lookbehind, no `(?P<name>...)` named groups. A pattern meant
+    to behave identically on both backends should stick to the intersection
+    (character classes, `\\d`/`\\w`/`\\s`, quantifiers, alternation, plain
+    groups, anchors).
+
+    SQLite's UDF is also not NULL-safe, unlike every native operator this
+    module otherwise relies on: `re.search(None, ...)`/`re.search(..., None)`
+    both raise `TypeError` in plain Python, which `sqlite3` surfaces as a
+    hard `OperationalError: user-defined function raised exception` instead
+    of SQL's usual "NULL propagates to NULL" -- confirmed live against
+    gramps core's registered `regexp()` UDF. `compile()` guards both
+    operands with a `CASE` on SQLite so a missing haystack or (field-vs-field)
+    pattern comes back `NULL`/`UNKNOWN`, same as every other operator here,
+    rather than crashing the query outright. PostgreSQL's native `~`
+    NULL-propagates correctly on its own, so no guard is needed there.
+    """
+
+    op = "REGEXP"
+
+    def compile(
+        self,
+        spec: ObjectTypeSpec,
+        dialect: Optional[Dialect] = None,
+        treeid: Optional[int] = None,
+    ) -> Tuple[str, list]:
+        if dialect == Dialect.SQLITE:
+            sql_op = "REGEXP"
+        elif dialect == Dialect.POSTGRESQL:
+            sql_op = "~"
+        else:
+            raise QueryError(
+                f"a dialect is required to compile a Regex, but got {dialect!r}"
+            )
+        # Always a TEXT extraction -- same reasoning as Contains, just below:
+        # there's no numeric/boolean form of a regex match.
+        column_sql, column_params = _render_column(
+            self.column, spec, dialect, value="", treeid=treeid
+        )
+        if isinstance(self.value, (JsonPath, RelatedObject, FlatColumnRef)):
+            value_sql, value_params = _render_column(
+                self.value, spec, dialect, value="", treeid=treeid
+            )
+        else:
+            value_sql, value_params = "?", [self.value]
+        if dialect == Dialect.SQLITE:
+            sql = (
+                f"(CASE WHEN {column_sql} IS NULL OR {value_sql} IS NULL "
+                f"THEN NULL ELSE {column_sql} {sql_op} {value_sql} END)"
+            )
+            return sql, (column_params + value_params) * 2
+        return f"{column_sql} {sql_op} {value_sql}", column_params + value_params
+
+
+class Contains(Comparison):
+    """WHERE column LIKE '%<value>%' ESCAPE '\\' -- a plain substring test
+    (`'Jan' in given_name`), as opposed to `Like`'s user-authored SQL pattern
+    with real `%`/`_` wildcards. `value` is normally the literal substring
+    being searched for -- any `%`, `_`, or `\\` it contains is escaped here
+    so it matches literally instead of being reinterpreted as a wildcard.
+
+    `value` can also be a `JsonPath`/`RelatedObject`/`FlatColumnRef` -- a
+    *field-vs-field* substring test (`other_field in field`). The substring
+    is then only known at query *execution* time, not compile time, so the
+    escaping that Python's `.replace(...)` does up front for a literal has
+    to happen in SQL instead, via nested `REPLACE(...)` in the same order
+    (backslash first, so it doesn't double-escape the `%`/`_` replacements
+    that follow it) -- both dialects support `REPLACE`/`||` identically, so
+    there's no per-dialect branch needed here, unlike most of this module's
+    other field-crossing rendering.
+    """
+
+    op = "LIKE"
+
+    def compile(
+        self,
+        spec: ObjectTypeSpec,
+        dialect: Optional[Dialect] = None,
+        treeid: Optional[int] = None,
+    ) -> Tuple[str, list]:
+        if isinstance(self.value, (JsonPath, RelatedObject, FlatColumnRef)):
+            # Any string content works as the cast hint here -- Contains
+            # always wants a TEXT extraction (LIKE has no numeric/boolean
+            # form), never the numeric/boolean cast `_render_json_path`
+            # would otherwise pick for an ordering comparison.
+            column_sql, column_params = _render_column(
+                self.column, spec, dialect, value="", treeid=treeid
+            )
+            value_sql, value_params = _render_column(
+                self.value, spec, dialect, value="", treeid=treeid
+            )
+            escaped = (
+                f"REPLACE(REPLACE(REPLACE({value_sql}, '\\', '\\\\'), "
+                f"'%', '\\%'), '_', '\\_')"
+            )
+            return (
+                f"{column_sql} LIKE '%' || {escaped} || '%' ESCAPE '\\'",
+                column_params + value_params,
+            )
+        escaped = (
+            self.value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        )
+        pattern = f"%{escaped}%"
+        column_sql, column_params = _render_column(
+            self.column, spec, dialect, value=pattern, treeid=treeid
+        )
+        return f"{column_sql} LIKE ? ESCAPE '\\'", column_params + [pattern]
+
+
+class In:
+    """WHERE column IN (values...)."""
+
+    def __init__(self, column: ColumnRef, values: Sequence[Any]):
+        if not values:
+            raise QueryError("In() requires at least one value")
+        self.column = column
+        self.values = list(values)
+
+    def compile(
+        self,
+        spec: ObjectTypeSpec,
+        dialect: Optional[Dialect] = None,
+        treeid: Optional[int] = None,
+    ) -> Tuple[str, list]:
+        column_sql, column_params = _render_column(
+            self.column, spec, dialect, value=self.values[0], treeid=treeid
+        )
+        placeholders = ", ".join(["?"] * len(self.values))
+        return f"{column_sql} IN ({placeholders})", column_params + list(self.values)
+
+    def __eq__(self, other: object) -> bool:
+        return (
+            type(self) is type(other)
+            and self.column == other.column  # type: ignore[attr-defined]
+            and self.values == other.values  # type: ignore[attr-defined]
+        )
+
+    def __repr__(self) -> str:
+        return f"In({self.column!r}, {self.values!r})"
+
+
+# --- WHERE: boolean combinators ---------------------------------------------
+
+
+class And:
+    def __init__(self, *exprs: Any):
+        if not exprs:
+            raise QueryError("And() requires at least one expression")
+        self.exprs = exprs
+
+    def compile(
+        self,
+        spec: ObjectTypeSpec,
+        dialect: Optional[Dialect] = None,
+        treeid: Optional[int] = None,
+    ) -> Tuple[str, list]:
+        parts = []
+        params: list = []
+        for expr in self.exprs:
+            sql, p = expr.compile(spec, dialect, treeid)
+            parts.append(f"({sql})")
+            params.extend(p)
+        return " AND ".join(parts), params
+
+    def __repr__(self) -> str:
+        return f"And{self.exprs!r}"
+
+
+class Or:
+    def __init__(self, *exprs: Any):
+        if not exprs:
+            raise QueryError("Or() requires at least one expression")
+        self.exprs = exprs
+
+    def compile(
+        self,
+        spec: ObjectTypeSpec,
+        dialect: Optional[Dialect] = None,
+        treeid: Optional[int] = None,
+    ) -> Tuple[str, list]:
+        parts = []
+        params: list = []
+        for expr in self.exprs:
+            sql, p = expr.compile(spec, dialect, treeid)
+            parts.append(f"({sql})")
+            params.extend(p)
+        return " OR ".join(parts), params
+
+    def __repr__(self) -> str:
+        return f"Or{self.exprs!r}"
+
+
+class Not:
+    def __init__(self, expr: Any):
+        self.expr = expr
+
+    def compile(
+        self,
+        spec: ObjectTypeSpec,
+        dialect: Optional[Dialect] = None,
+        treeid: Optional[int] = None,
+    ) -> Tuple[str, list]:
+        sql, params = self.expr.compile(spec, dialect, treeid)
+        return f"NOT ({sql})", params
+
+    def __repr__(self) -> str:
+        return f"Not({self.expr!r})"
+
+
+# --- EXISTS (one-to-many membership) -----------------------------------------
+
+
+def _collection_source_sqlite(collection: Collection, outer_table: str) -> Tuple[str, str, list]:
+    """`(from_fragment, handle_expr, params)` for iterating `collection` on
+    SQLite, via `json_each` as a table-valued function.
+
+    `json_each`'s own `value` column already holds a plain string for a
+    flat-handle-list element (`note_list`) -- no extraction needed -- and the
+    serialized JSON text of the element for a ref-object one (`child_ref_list`),
+    which `json_extract` then reads `ref_field` out of directly, the same way
+    it would against a real `json_data` column.
+    """
+    (key,) = collection.list_path.segments
+    source = f"json_each({outer_table}.json_data, ?) AS je"
+    if collection.ref_field:
+        handle_expr = f"json_extract(je.value, '$.{collection.ref_field}')"
+    else:
+        handle_expr = "je.value"
+    return source, handle_expr, [f"$.{key}"]
+
+
+def _collection_source_postgresql(collection: Collection, outer_table: str) -> Tuple[str, str, list]:
+    """`(from_fragment, handle_expr, params)` for iterating `collection` on
+    PostgreSQL.
+
+    A ref-object list uses `jsonb_array_elements` (keeps each element as
+    `jsonb`, so `->> ref_field` can pull the handle back out); a flat-handle
+    list uses `jsonb_array_elements_text` instead -- `->>` has no meaning
+    against a bare jsonb scalar, but `_text` already unwraps each element to
+    plain SQL text directly.
+    """
+    (key,) = collection.list_path.segments
+    if collection.ref_field:
+        source = f"jsonb_array_elements({outer_table}.json_data::jsonb -> '{key}') AS je(value)"
+        handle_expr = f"je.value ->> '{collection.ref_field}'"
+    else:
+        source = f"jsonb_array_elements_text({outer_table}.json_data::jsonb -> '{key}') AS je(value)"
+        handle_expr = "je.value"
+    return source, handle_expr, []
+
+
+def _collection_subquery_body(
+    collection: Collection,
+    outer_table: str,
+    condition: Optional[Any],
+    dialect: Dialect,
+    treeid: Optional[int],
+) -> Tuple[str, list]:
+    """`<target_table> AS <alias>, <source> WHERE <handle correlation>
+    [ AND (<condition>)][ AND <alias>.treeid = ?]` -- the subquery body
+    shared by `Exists` (`EXISTS (SELECT 1 FROM <body>)`) and
+    `CollectionCount` (`(SELECT COUNT(*) FROM <body>)`) alike; only the
+    wrapper differs.
+
+    The target row is *always* aliased, even when `target_table !=
+    outer_table` (the common case) -- a self-referencing collection (e.g.
+    `Person`'s own `associations`, `Person` -> `PersonRef` -> `Person`)
+    would otherwise reintroduce the very same bare table name already bound
+    to the outer, correlated row, inside this same `FROM` clause, shadowing
+    it: `source`'s `json_each(<outer_table>.json_data, ...)`/
+    `jsonb_array_elements(<outer_table>.json_data, ...)` would then resolve
+    against the newly-introduced *local* binding instead of the outer row,
+    silently breaking correlation -- confirmed empirically: `Person
+    "exists(associations, ...)"` matched zero rows for every person, even
+    ones with a real matching association, before this alias was added.
+    Aliasing unconditionally (not just when the names happen to collide)
+    keeps this one code path correct regardless of which collection targets
+    its own table, rather than needing a separate self-reference check.
+    """
+    target = collection.target
+    target_table = target.table
+    target_alias = f"{target_table}__target"
+
+    if dialect == Dialect.SQLITE:
+        source, handle_expr, source_params = _collection_source_sqlite(collection, outer_table)
+    elif dialect == Dialect.POSTGRESQL:
+        source, handle_expr, source_params = _collection_source_postgresql(
+            collection, outer_table
+        )
+    else:
+        raise QueryError(f"unsupported dialect: {dialect!r}")
+
+    where_parts = [f"{target_alias}.handle = {handle_expr}"]
+    params = list(source_params)
+    if condition is not None:
+        cond_sql, cond_params = condition.compile(target, dialect, treeid)
+        where_parts.append(f"({cond_sql})")
+        params.extend(cond_params)
+    if treeid is not None:
+        where_parts.append(f"{target_alias}.treeid = ?")
+        params.append(treeid)
+
+    body = f"{target_table} AS {target_alias}, {source} WHERE {' AND '.join(where_parts)}"
+    return body, params
+
+
+def _render_collection_count(
+    count: "CollectionCount",
+    outer_table: str,
+    dialect: Optional[Dialect],
+    treeid: Optional[int],
+) -> Tuple[str, list]:
+    """`(SELECT COUNT(*) FROM <body>)` -- `CollectionCount`'s rendering,
+    dispatched from `_render_column` the same way `RelatedObject`/`JsonPath`
+    dispatch to their own renderers.
+    """
+    if dialect is None:
+        raise QueryError(
+            f"a dialect is required to compile count({count.collection.name!r}, ...), "
+            "but none was given"
+        )
+    body, params = _collection_subquery_body(
+        count.collection, outer_table, count.condition, dialect, treeid
+    )
+    return f"(SELECT COUNT(*) FROM {body})", params
+
+
+class Exists:
+    """`EXISTS (SELECT 1 FROM <target> JOIN <list> ... WHERE ...)` -- a
+    one-to-many membership test over a `Collection` (see there), optionally
+    narrowed by a `condition` compiled against the collection's target type.
+
+    Not a correlated *scalar* subquery like `RelatedObject` -- `handle_ref`
+    there names a single related row; here there can be any number, so the
+    subquery iterates the JSON array (`json_each`/`jsonb_array_elements`)
+    joined against the target table by handle, and asks only whether at
+    least one such row -- matching `condition`, if given -- exists.
+
+    `condition=None` means "at least one related row at all," regardless of
+    its fields (`exists(children)`).
+
+    SQL's `EXISTS`/`NOT EXISTS` are never `UNKNOWN` the way an ordinary
+    comparison against a missing value is -- a row that doesn't satisfy the
+    inner `WHERE` just isn't returned by the subquery, it doesn't propagate a
+    `NULL` outward. `evaluator.py` mirrors this: `Exists` always resolves to
+    a definite `True`/`False`, never `None`, so `not exists(...)` needs no
+    three-valued-logic special case at all.
+    """
+
+    def __init__(self, collection: Collection, condition: Optional[Any] = None):
+        self.collection = collection
+        self.condition = condition
+
+    def compile(
+        self,
+        spec: ObjectTypeSpec,
+        dialect: Optional[Dialect] = None,
+        treeid: Optional[int] = None,
+    ) -> Tuple[str, list]:
+        if dialect is None:
+            raise QueryError(
+                f"a dialect is required to compile exists({self.collection.name!r}, ...), "
+                "but none was given"
+            )
+        body, params = _collection_subquery_body(
+            self.collection, spec.table, self.condition, dialect, treeid
+        )
+        return f"EXISTS (SELECT 1 FROM {body})", params
+
+    def __repr__(self) -> str:
+        return f"Exists({self.collection.name!r}, {self.condition!r})"
+
+
+# --- ORDER BY ----------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class OrderBy:
+    """One sort column and its direction.
+
+    `column` is any `ColumnRef`: a flat column name, a path string
+    (`"birth.date.sortval"`, resolved by `compile_query`/`run_query` the
+    same way a `select` entry is), or an already-resolved
+    `JsonPath`/`RelatedObject`/`CollectionCount`. Sorting on a non-flat
+    column costs what selecting one costs -- a JSON extraction or a
+    correlated subquery per row, with no index behind it -- so it is
+    materially slower than sorting on a real SQL column, not merely
+    different.
+    """
+
+    column: Any = "handle"
+    direction: str = "asc"
+
+    def __post_init__(self) -> None:
+        if self.direction not in ("asc", "desc"):
+            raise QueryError(f"invalid sort direction: {self.direction!r}")
+
+
+def order_by_key(column: "ColumnRef") -> str:
+    """A readable name for a sort column, for error messages and for
+    `after_columns`' own reporting -- `default_ref_key` where one exists,
+    `repr` otherwise (a `CollectionCount` has no path spelling).
+    """
+    try:
+        return default_ref_key(column)
+    except QueryError:
+        return repr(column)
+
+
+def resolve_order_by(
+    spec: ObjectTypeSpec, order_by: Sequence[OrderBy]
+) -> Tuple[OrderBy, ...]:
+    """`order_by` with every string column resolved to a `ColumnRef`, the
+    same way `compile_query` resolves a `select` entry -- so
+    `OrderBy("birth.date.sortval")` means what it says, and a typo is
+    caught here rather than sorting every row by NULL.
+
+    Applied by both `compile_query` and `run_query`, so the two paths sort
+    on the same resolved references.
+    """
+    return tuple(
+        OrderBy(
+            resolve_ref_string(spec, ob.column) if isinstance(ob.column, str) else ob.column,
+            ob.direction,
+        )
+        for ob in order_by
+    )
+
+
+def effective_order_by(order_by: Sequence[OrderBy]) -> Tuple[OrderBy, ...]:
+    """`order_by` with a trailing `handle` tiebreaker appended if not present.
+
+    Guarantees a stable, fully-determined order for both `ORDER BY` emission
+    and keyset pagination, even when the caller specifies no sort at all.
+    Public (not underscore-prefixed) since `proxied_query.py`'s Python-side
+    sort/seek needs the exact same effective order the SQL path compiles,
+    not just the column names `after_columns()` exposes.
+    """
+    if any(ob.column == "handle" for ob in order_by):
+        return tuple(order_by)
+    return tuple(order_by) + (OrderBy("handle", "asc"),)
+
+
+def after_columns(order_by: Sequence[OrderBy]) -> Tuple[Any, ...]:
+    """Column references, in order, that a resolved `after` cursor tuple
+    must supply.
+
+    Wiring code turns a client-supplied `after=<handle>` into a `Query.after`
+    tuple by looking up these columns for that row (one extra lookup) before
+    compiling -- this module does no database access itself.
+
+    Entries are `ColumnRef`s, not necessarily plain names: a sort on
+    `birth.date.sortval` needs that path's value for the cursor row, which
+    can't be read by interpolating a column name into SQL. Pass them
+    straight to `compile_query` as a `select` against the cursor row's
+    handle -- `compile_after_lookup` does exactly that.
+    """
+    return tuple(ob.column for ob in effective_order_by(order_by))
+
+
+def compile_after_lookup(
+    spec: ObjectTypeSpec,
+    order_by: Sequence[OrderBy],
+    handle: str,
+    *,
+    dialect: Optional[Dialect] = None,
+    treeid: Optional[int] = None,
+) -> Tuple[str, list]:
+    """Compile the one-row lookup that turns a client-supplied
+    `after=<handle>` cursor into the value tuple `Query.after` wants.
+
+    Returns `(sql, params)` selecting `after_columns(order_by)` for that
+    handle -- the row's own sort values, in sort order. Exists because a
+    non-flat sort column can't be read by interpolating its name into a
+    `SELECT`: `birth.date.sortval` is a correlated subquery with bound
+    params, so resolving the cursor has to go through the same compiler the
+    query itself does.
+    """
+    resolved = resolve_order_by(spec, order_by)
+    return compile_query(
+        spec,
+        Query(select=list(after_columns(resolved)), where=Eq("handle", handle), limit=1),
+        dialect=dialect,
+        treeid=treeid,
+    )
+
+
+def check_columns(columns: Iterable[str], spec: ObjectTypeSpec) -> None:
+    """Raise `QueryError` if any of `columns` is not in `spec.columns`.
+
+    Exposed for wiring code that needs to validate columns before they can
+    safely appear in a raw SQL fragment built outside `compile_query` --
+    e.g. resolving an `after` cursor's row values, which necessarily happens
+    before compilation.
+    """
+    for column in columns:
+        _check_column(column, spec.columns)
+
+
+# --- Top level ---------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Query:
+    """A structured query: what to return, which rows, in what order.
+
+    `select` entries are `SelectRef`s -- a plain flat column name, an
+    already-resolved `JsonPath`/`RelatedObject`/`CollectionCount`, or a
+    dotted/bracketed *path string* (`"birth.place.title"`,
+    `"primary_name.surname_list[0].surname"`), resolved by `compile_query`
+    through `resolve_select_ref_string` (the same `resolve_column_path` a
+    `where_expr` path goes through, for every spelling except one). A
+    single-segment string stays a strict flat-column reference -- see
+    `resolve_ref_string`. `"."` is that one exception: the whole `json_data`
+    blob (`WholeJsonData`), a `select`-only spelling -- `order_by`/`where`
+    reject it. Omitting `select` returns every flat column, sorted.
+
+    `default_ref_key` gives each entry its canonical response key, and
+    `query_lang.parse_select` parses a list of entry strings (with optional
+    `as <key>` aliases) into `(ref, key)` pairs.
+    """
+
+    select: Optional[Sequence[SelectRef]] = None
+    where: Optional[Any] = None
+    order_by: Sequence[OrderBy] = ()
+    limit: int = 50
+    after: Optional[Sequence[Any]] = None
+
+    def __post_init__(self) -> None:
+        if self.limit is not None and self.limit <= 0:
+            raise QueryError(f"limit must be positive: {self.limit!r}")
+
+
+#: Cast hints for `_render_json_path`, keyed by the JSON type the schema
+#: says a path lands on. `_render_json_path` picks PostgreSQL's cast from a
+#: comparison's right-hand *value* (`Gt(path, 5)` -> `NUMERIC`), which works
+#: because a comparison always has one in hand. An `ORDER BY` has no such
+#: value, so the schema supplies a stand-in of the right Python type -- the
+#: value itself is never bound, only its type is read. Without this,
+#: PostgreSQL sorts `jsonb_extract_path_text`'s TEXT result
+#: lexicographically, putting 10 before 9.
+_CAST_HINT_BY_TYPE = {"boolean": False, "integer": 0, "number": 0.0}
+
+
+def _cast_hint(value_type: Any) -> Any:
+    """A representative value of `value_type`, for `_render_json_path`'s
+    cast selection. `None` (no cast hint) for text and for anything the
+    schema doesn't pin down -- including a nullable field, whose type is a
+    list: `["integer", "null"]` is not reliably numeric, and guessing wrong
+    is worse than sorting it as text.
+    """
+    if isinstance(value_type, str):
+        return _CAST_HINT_BY_TYPE.get(value_type)
+    return None
+
+
+def _is_text_ref(ref: "ColumnRef", spec: ObjectTypeSpec) -> bool:
+    """Is `ref` a text value, and so eligible for a locale `COLLATE` clause?
+
+    Applying `COLLATE` to a non-text value is a SQL error on PostgreSQL, so
+    this has to be right rather than permissive. A flat column is checked
+    against `spec.text_columns` as before; a `JsonPath`/`RelatedObject` is
+    checked against the schema type it lands on -- which is exactly what
+    used to be unavailable, and why `JsonPath` sort columns were previously
+    out of scope for collation.
+    """
+    value_type = ref_value_type(spec, ref)
+    if value_type is not None:
+        return value_type == "string"
+    if isinstance(ref, FlatColumnRef):
+        ref = ref.name
+    return isinstance(ref, str) and ref in spec.text_columns
+
+
+def _column_expr(
+    column: "ColumnRef",
+    spec: ObjectTypeSpec,
+    collation: Optional[str],
+    dialect: Optional[Dialect] = None,
+    treeid: Optional[int] = None,
+) -> Tuple[str, list]:
+    """A sort/seek column reference: SQL expression + bound params, with a
+    locale `COLLATE` clause when the value is text (`_is_text_ref`).
+
+    Any `ColumnRef` works here, not just a flat column name -- a `JsonPath`
+    or `RelatedObject` renders through the same `_render_column` a `SELECT`
+    or `WHERE` reference does, so `ORDER BY birth.date.sortval` emits the
+    identical expression selecting it would. The one thing sorting needs
+    that comparing doesn't is a cast hint, since there's no right-hand
+    value to infer one from -- see `_cast_hint`.
+
+    `dialect` is forwarded to `_quote_column` -- an `ORDER BY`/keyset
+    reference to a column in `_POSTGRESQL_PHYSICAL_COLUMN_OVERRIDES` (e.g.
+    `Media.desc`) needs the same physical-name mapping a `SELECT`/`WHERE`
+    reference does.
+    """
+    sql, params = _render_column(
+        column, spec, dialect, value=_cast_hint(ref_value_type(spec, column)), treeid=treeid
+    )
+    if collation and _is_text_ref(column, spec):
+        return f'{sql} COLLATE "{collation}"', params
+    return sql, params
+
+
+def _keyset_tie_sql(
+    column_expr: str, column_params: Sequence[Any], value: Any
+) -> Tuple[str, list]:
+    """NULL-safe "ties with the cursor" fragment for an earlier-in-order
+    `order_by` column. A bound `NULL` parameter makes plain `col = ?`
+    `UNKNOWN` (never `TRUE`), so a cursor value of `None` needs `col IS NULL`
+    instead, to correctly express "this row's earlier columns match the
+    cursor row's" when the cursor row itself had a `NULL` there.
+
+    `column_params` are `column_expr`'s own bound values (a sort column may
+    be a JSON path or a correlated subquery, not a bare name). They're
+    emitted here, once per occurrence of `column_expr` in the fragment
+    returned -- the count of those occurrences is this function's business,
+    not the caller's. See `_keyset_leg_sql` for why that matters.
+    """
+    if value is None:
+        return f"{column_expr} IS NULL", list(column_params)
+    return f"{column_expr} = ?", list(column_params) + [value]
+
+
+def _keyset_leg_sql(
+    column_expr: str, column_params: Sequence[Any], direction: str, value: Any
+) -> Optional[Tuple[str, list]]:
+    """NULL-safe "ranks strictly after the cursor" fragment for the one
+    `order_by` column a seek's OR-term actually advances past, matching
+    `ORDER BY`'s own verified default total order (`NULL` is the smallest
+    value in both directions -- see `_null_safe_cmp` in `proxied_query.py`,
+    which mirrors this same order for the evaluator path).
+
+    A plain `col > ?`/`col < ?` against a real SQL `NULL` is always
+    `UNKNOWN`, which gets this wrong in two different ways a naive
+    translation misses:
+
+    - `asc`, cursor value `None` -- nothing is "greater than NULL" in plain
+      SQL, but under `NULL`-is-smallest ordering *every* non-`NULL` value
+      ranks after it. Needs `col IS NOT NULL`, not `col > ?` against a bound
+      `NULL` (which would just be `UNKNOWN` for every row).
+    - `desc`, *any* cursor value -- `NULL` sorts last in `desc`, so a `NULL`
+      row always ranks after a non-`NULL` cursor -- but plain `col < ?` is
+      `UNKNOWN`, not `TRUE`, when `col` is `NULL`, silently dropping those
+      rows from every later page regardless of what the cursor itself was.
+      Needs `(col IS NULL OR col < ?)`.
+
+    Returns `None` when the condition can never hold at all (`desc`, cursor
+    value `None` -- nothing ranks after the minimum value already), so the
+    caller can drop this leg from the `OR` entirely instead of emitting a
+    fragment that's always false.
+
+    `column_params` are `column_expr`'s own bound values, emitted once per
+    occurrence of `column_expr` below. The `desc` branch is why this has to
+    live here rather than in the caller: it is the one fragment that names
+    the column *twice* (`col IS NULL OR col < ?`), so a caller adding those
+    params once -- the obvious thing to do, and what this originally did --
+    leaves the SQL a placeholder short. That drift is caught by
+    `_check_bindings`; the same mistake between two *same-length* fragments
+    would not be, which is why the count is derived here from the fragment
+    itself instead of assumed anywhere.
+    """
+    if direction == "asc":
+        if value is None:
+            return f"{column_expr} IS NOT NULL", list(column_params)
+        return f"{column_expr} > ?", list(column_params) + [value]
+    if value is None:
+        return None
+    return (
+        f"({column_expr} IS NULL OR {column_expr} < ?)",
+        list(column_params) + list(column_params) + [value],
+    )
+
+
+def _compile_keyset(
+    effective_order_by: Sequence[OrderBy],
+    after: Sequence[Any],
+    spec: ObjectTypeSpec,
+    collation: Optional[str],
+    dialect: Optional[Dialect] = None,
+    treeid: Optional[int] = None,
+) -> Tuple[str, list]:
+    """Seek-method WHERE fragment for keyset pagination.
+
+    Expands to an OR-of-ANDs (`(c1 > v1) OR (c1 = v1 AND c2 > v2) OR ...`)
+    rather than a row-constructor comparison, so mixed asc/desc multi-column
+    sorts stay correct on both SQLite and PostgreSQL. Comparisons use the
+    same `COLLATE` clause as the matching `ORDER BY` column -- otherwise a
+    row could satisfy a binary-comparison seek predicate while sorting
+    differently under collation, corrupting page boundaries.
+
+    NULL-safe throughout (`_keyset_tie_sql`/`_keyset_leg_sql`) -- verified
+    empirically against real SQLite before fixing (not just reasoned about):
+    the original plain-comparison version silently returned zero further
+    rows when seeking past a cursor whose own sort value was `NULL`, and
+    separately, silently dropped `NULL` rows from every later page of a
+    `desc`-sorted column regardless of the cursor, since `NULL`'s own
+    three-valued comparison semantics (`UNKNOWN`, not `TRUE`/`FALSE`) don't
+    match `ORDER BY`'s "`NULL` is smallest" total order on their own.
+    """
+    if len(after) != len(effective_order_by):
+        raise QueryError(
+            f"after cursor has {len(after)} values, expected "
+            f"{len(effective_order_by)} "
+            f"({', '.join(order_by_key(ob.column) for ob in effective_order_by)})"
+        )
+    or_terms = []
+    params: list = []
+    for i, ob in enumerate(effective_order_by):
+        # A non-flat sort column's expression carries its own bound params
+        # (a JSONPath string, a subquery's segments), and it's re-emitted
+        # once per OR-term it appears in -- so its params are collected
+        # alongside each occurrence, in the same left-to-right order the
+        # placeholders are rendered, not once up front.
+        leg_expr, leg_expr_params = _column_expr(ob.column, spec, collation, dialect, treeid)
+        leg = _keyset_leg_sql(leg_expr, leg_expr_params, ob.direction, after[i])
+        if leg is None:
+            continue
+        and_terms = []
+        and_params: list = []
+        for j in range(i):
+            tie_expr, tie_expr_params = _column_expr(
+                effective_order_by[j].column, spec, collation, dialect, treeid
+            )
+            tie_sql, tie_params = _keyset_tie_sql(tie_expr, tie_expr_params, after[j])
+            and_terms.append(tie_sql)
+            and_params.extend(tie_params)
+        leg_sql, leg_params = leg
+        and_terms.append(leg_sql)
+        and_params.extend(leg_params)
+        or_terms.append("(" + " AND ".join(and_terms) + ")")
+        params.extend(and_params)
+    if not or_terms:
+        # Every leg was structurally impossible (e.g. a lone `desc` column
+        # whose cursor value is already `None`, the minimum -- nothing can
+        # rank after it). Correctly means "no further rows", not an error.
+        return "0 = 1", []
+    keyset_sql = " OR ".join(or_terms)
+    _check_bindings(keyset_sql, params, "keyset seek predicate")
+    return keyset_sql, params
+
+
+def _where_clauses(
+    spec: ObjectTypeSpec,
+    where: Optional[Any],
+    dialect: Optional[Dialect] = None,
+    treeid: Optional[int] = None,
+) -> Tuple[list, list]:
+    """Shared `WHERE`-clause + tree-scoping predicate building.
+
+    Used by both `compile_query` and `compile_count_query`, so the two can't
+    drift on how tree-scoping is enforced. Carries no privacy predicate at
+    all -- this compiler only ever runs against an unproxied database, see
+    `object_query.py`'s dispatch.
+
+    `treeid`, when given, appends `AND treeid = ?` -- required on shared
+    multi-tree backends (`SharedPostgreSQL`), whose tables hold every tree's
+    rows together with `treeid` as part of the primary key. Nothing applies
+    this filter automatically at the connection level; every one of
+    `SharedDBAPI`'s own query methods (`get_person_handles`, etc.) adds it
+    by hand, so this compiler must too, or it silently returns rows from
+    every tree sharing the instance -- not just the caller's own. `None`
+    (the default) omits the clause entirely, for single-tree-per-database
+    backends (`SQLite`, the single-user `PostgreSQL` addon) that have no
+    `treeid` column at all -- see `resources/object_query.py`'s
+    `_resolve_treeid`.
+    """
+    clauses = []
+    params: list = []
+    if where is not None:
+        sql, p = where.compile(spec, dialect, treeid)
+        clauses.append(f"({sql})")
+        params.extend(p)
+    if treeid is not None:
+        clauses.append("treeid = ?")
+        params.append(treeid)
+    return clauses, params
+
+
+def compile_query(
+    spec: ObjectTypeSpec,
+    query: Query,
+    *,
+    collation: Optional[str] = None,
+    dialect: Optional[Dialect] = None,
+    treeid: Optional[int] = None,
+) -> Tuple[str, list]:
+    """Compile a `Query` into a parameterized `SELECT ... FROM <spec.table>` statement.
+
+    Returns `(sql, params)` where `sql` uses `?` placeholders and `params` is
+    the positional parameter list, matching `db.dbapi.execute(sql, params)`.
+
+    Carries no privacy predicate: only ever call this against an unproxied
+    database (see `object_query.py`'s dispatch) -- a proxied query runs
+    through Gramps' own `Filter`/`Rule` machinery instead
+    (`proxied_query.py`), never this compiler. `AND treeid = ?` is appended
+    unconditionally whenever `treeid` is given -- see `_where_clauses`.
+
+    `collation`, if given, names a locale collation already ensured to exist
+    on the connection (see `resources/object_query.py`'s `_resolve_collation`)
+    and is applied to every text-typed `ORDER BY` column (and the matching
+    keyset comparisons) via `COLLATE "<collation>"`.
+
+    A `select` entry given as a dotted/bracketed path string is resolved
+    here (via `resolve_ref_string`) before rendering, so the same text
+    means the same thing in `select` as it does in a `where_expr` -- a
+    `QueryError` from an unknown column or a malformed path surfaces from
+    this call, not from the database.
+
+    `dialect` selects which backend-specific SQL to render for any `select`
+    or `where` entry that's a `JsonPath` or a `RelatedObject` (see
+    `_render_json_path`/`_render_related_object`), and also which physical
+    name a plain column gets if it's in `_POSTGRESQL_PHYSICAL_COLUMN_OVERRIDES`
+    (e.g. `Media.desc`) -- that applies to `order_by`/keyset pagination too,
+    not just `select`/`where`, since PostgreSQL's physical table has the
+    same renamed column either way. Omitting `dialect` is safe for a query
+    that touches none of the above (plain columns not in that override
+    table, no `JsonPath`/`RelatedObject`); it is not safe in general.
+    """
+    columns = [
+        resolve_select_ref_string(spec, entry) if isinstance(entry, str) else entry
+        for entry in (query.select if query.select else sorted(spec.columns))
+    ]
+
+    ordering = effective_order_by(resolve_order_by(spec, query.order_by))
+
+    select_parts = []
+    params: list = []
+    for column in columns:
+        sql_frag, p = _render_column(column, spec, dialect, treeid=treeid)
+        select_parts.append(sql_frag)
+        params.extend(p)
+
+    where_clauses, where_params = _where_clauses(spec, query.where, dialect, treeid)
+    params.extend(where_params)
+
+    if query.after is not None:
+        sql, p = _compile_keyset(ordering, query.after, spec, collation, dialect, treeid)
+        where_clauses.append(f"({sql})")
+        params.extend(p)
+
+    # Built before assembly, not inline: a non-flat sort column contributes
+    # bound params of its own, and they belong after the WHERE/keyset params
+    # and before `LIMIT`'s -- the order the placeholders appear in the SQL.
+    order_parts = []
+    order_params: list = []
+    for ob in ordering:
+        order_sql, p = _column_expr(ob.column, spec, collation, dialect, treeid)
+        order_parts.append(f"{order_sql} {ob.direction.upper()}")
+        order_params.extend(p)
+
+    sql = f"SELECT {', '.join(select_parts)} FROM {spec.table}"
+    if where_clauses:
+        sql += " WHERE " + " AND ".join(where_clauses)
+    sql += " ORDER BY " + ", ".join(order_parts)
+    params.extend(order_params)
+    if query.limit is not None:
+        sql += " LIMIT ?"
+        params.append(query.limit)
+
+    _check_bindings(sql, params, "compiled query")
+    return sql, params
+
+
+def compile_count_query(
+    spec: ObjectTypeSpec,
+    query: Query,
+    *,
+    dialect: Optional[Dialect] = None,
+    treeid: Optional[int] = None,
+) -> Tuple[str, list]:
+    """Compile a `Query` into a parameterized `SELECT COUNT(*) FROM <spec.table>`.
+
+    Uses the same `where` and tree-scoping logic as `compile_query` -- see
+    there for details -- but ignores `select`/`order_by`/`limit`/`after`,
+    since a count has no columns, sort order, or page to return. In
+    particular this is a count of *all* matching rows, not of just the
+    current keyset page.
+    """
+    where_clauses, params = _where_clauses(spec, query.where, dialect, treeid)
+    sql = f"SELECT COUNT(*) FROM {spec.table}"
+    if where_clauses:
+        sql += " WHERE " + " AND ".join(where_clauses)
+    _check_bindings(sql, params, "compiled count query")
+    return sql, params

--- a/GOQLFilter/gramps_object_query_language_copy/query_lang.py
+++ b/GOQLFilter/gramps_object_query_language_copy/query_lang.py
@@ -1,0 +1,1268 @@
+#
+# gramps-object-query-language - Object query language and SQL compiler for Gramps data
+#
+# Copyright (C) 2026      Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+"""An "almost Python" expression language, parsed into `object_query.py`'s
+JSON `where` shape -- e.g. `"primary_name.surname_list[0].surname == 'Smith'"`
+becomes `[{"column": {"json_path": [...]}, "op": "eq", "value": "Smith"}]`.
+
+Uses `ast.parse(expr, mode="eval")` as pure syntax, never `eval()` or
+`compile()` -- the tree is inspected and translated node-by-node into plain
+JSON, never executed. Safety comes from whitelisting node *shapes*, not
+blacklisting names: any AST node this module doesn't explicitly recognize
+(function calls other than the whitelisted `like(...)`/`regex(...)`/
+`any(...)`/`len(...)` forms, lambdas, attribute access building toward
+dunder names, imports, walrus, f-strings, ...) is rejected by
+`_translate_*` simply never handling it and falling through to a
+`QueryLangError`.
+
+The one exception to "parsed, never rewritten": `any(cond for x in rel [if
+...])` and `len([... for x in rel if ...])` are comprehension *sugar* for
+`exists(rel, cond)`/`count(rel, cond)`, desugared by a dedicated AST pass
+(`_desugar_comprehensions`, see the "comprehension sugar" section below)
+before any `_translate_*` function runs -- every other comprehension shape
+(bare `[...]`/`{...}`/`{...: ...}`, more than one `for` clause, tuple-unpack
+targets, ...) still falls through to the same `QueryLangError` any other
+unrecognized node shape gets.
+
+Deliberately not wired to any HTTP endpoint yet -- see `query.py`'s
+`JsonPath`, which followed the same build-it-standalone-first,
+wire-it-up-later path this session.
+
+Current scope, matching what `object_query.py`'s wire format actually
+supports today:
+
+- Top level is a boolean expression of comparisons combined with `and`/`or`/
+  `not`, nested however Python's own precedence and grouping resolves it
+  (`not` binds tightest, then `and`, then `or`, and parentheses group as
+  usual) -- `not a == b and c > d or e == f` parses the same way real
+  Python would. The wire shape stays a flat list of leaf conditions,
+  implicitly AND'd, for any expression that doesn't use `or`/`not` at all
+  -- byte-identical to before either was supported. An expression that
+  does use them gets an `{"or": [...]}`/`{"and": [...]}`/`{"not": node}`
+  node in place of a leaf wherever it's needed -- see
+  `_translate_top_level`/`_translate_bool_or_leaf`.
+- A comparison is `OPERAND OP OPERAND` where `OP` is one of
+  `== != < <= > >=`, `is`/`is not`, or Python's `in`/`not in`
+  (`path in [v1, v2, ...]`) -- these are all the same `ast.Compare` node
+  shape, just different `ops`. `is`/`is not` are pure sugar for `==`/`!=`
+  (no notion of object identity here, only value equality) and `not in`
+  is pure sugar for wrapping `in`'s own translation in `{"not": ...}` --
+  none of the three introduce a new wire shape.
+- Either side of `==`/`!=`/`</`/`<=`/`>`/`>=` may be the path and the other
+  the value -- `5 < gender` and `gender > 5` compile to the identical wire
+  node, via `_FLIP_OP` (`lt`<->`gt`, `lte`<->`gte`, `eq`/`ne` unchanged) --
+  the wire shape always renders the path as `"column"`, regardless of which
+  side of the source expression it was written on. `count(...)` stays an
+  exception on purpose: it's only ever recognized when it's *the* left-hand
+  operand, per its own left-hand-side-only v1 scope (see
+  `_translate_column_or_count`) -- `2 < count(children)` doesn't flip into
+  a supported shape, unlike `2 < gender`.
+- `in` has a second shape too: `'substring' in path` (a string literal on
+  the left, a path on the right) is a plain substring test (`Contains`),
+  disambiguated from `path in [...]` purely by the right-hand node's shape
+  (`ast.List` vs. a path) -- the same `ast.Compare`/`ast.In` node either way.
+- `like(path, 'pattern%')` and `regex(path, 'pattern')` are whitelisted
+  function-call forms, for the two operators (`Like`, `Regex`) that aren't
+  Python operators.
+- A path is a bare identifier optionally followed by `.attr` / `[index]`
+  segments, e.g. `gender` or `primary_name.surname_list[0].surname`.
+  Single-segment paths that match the target type's flat column whitelist
+  resolve to a plain column reference (a real indexed SQL column); every
+  other path becomes a `{"json_path": [...]}` reference.
+- On the *value* side of a comparison, `ClassName.CONST` (e.g. `Person.MALE`,
+  `Note.FLOWED`, `Date.MOD_ABOUT`, `EventType.BIRTH`) resolves to the real
+  value read off the actual Gramps class -- see `_CONSTANTS` -- so
+  `gender == Person.MALE` and `gender == 1` compile identically. Only a
+  `Name.Attribute` shape one level deep is recognized (not `a.b.CONST`).
+  Covers both flat-column fields (`Person.gender`, `Citation.confidence`,
+  `Note.format`) and fields that only live nested in `json_data`
+  (`birth.date.modifier == Date.MOD_ABOUT`, `type.value == EventType.BIRTH`)
+  -- the constant class list is unrelated to where the field it's compared
+  against happens to live.
+- Also on the value side, `Date('Jan 1, 1968')` -- another whitelisted call
+  form -- parses a human date string with Gramps' own
+  date parser and resolves to `.sortval`, a plain comparable integer
+  (Julian day number), so `event.date.sortval >= Date('Jan 1, 1968')` and
+  `birth.date.sortval >= Date('Jan 1, 1968')` both work with ordinary
+  `>=`/`<=`/`<`/`>`.
+- A path may cross a relationship, not just index into one column's own
+  `json_data` -- `birth`/`death` (`Person` -> `Event`), `father`/`mother`
+  (`Family` -> `Person`), `place` (`Event` -> `Place`) are resolved by
+  `query.py`'s `resolve_column_path()`, which this module's path
+  translation defers to entirely (see `_translate_column`) rather than
+  duplicating any relationship knowledge here. `birth.date.sortval`,
+  `father.surname`, and `birth.place.title` are all valid paths this way.
+"""
+
+from __future__ import annotations
+
+import ast
+from typing import Any, List, Sequence, Tuple, Union
+
+from gramps.gen.datehandler import parser as _date_parser
+from gramps.gen.lib import (
+    AttributeType,
+    ChildRefType,
+    Citation,
+    Date,
+    EventRoleType,
+    EventType,
+    FamilyRelType,
+    MarkerType,
+    NameOriginType,
+    NameType,
+    Note,
+    NoteType,
+    Person,
+    PlaceType,
+    RepositoryType,
+    SourceMediaType,
+    SrcAttributeType,
+    StyledTextTagType,
+    UrlType,
+)
+
+from .query import (
+    CITATION,
+    EVENT,
+    FAMILY,
+    MEDIA,
+    NOTE,
+    PERSON,
+    PLACE,
+    REPOSITORY,
+    SOURCE,
+    TAG,
+    And,
+    CollectionCount,
+    ColumnRef,
+    Contains,
+    Eq,
+    Exists,
+    FlatColumnRef,
+    Gt,
+    Gte,
+    In,
+    Like,
+    Lt,
+    Lte,
+    Ne,
+    Not,
+    ObjectTypeSpec,
+    Or,
+    QueryError,
+    Regex,
+    SelectRef,
+    WholeJsonData,
+    default_ref_key,
+    resolve_collection,
+    resolve_column_path,
+    resolve_ref_string,
+)
+
+# Namespace -> ObjectTypeSpec. Both the lowercase form and the actual Gramps
+# class-name casing (Person, Family, ...) are accepted; no single-letter
+# aliases -- those aren't what was asked for, and Gramps' own gramps_id
+# prefixes (P = Place, I = Person, ...) don't line up with the object names
+# anyway, so a letter scheme here would just invite confusion.
+_NAMES = {
+    "person": PERSON,
+    "family": FAMILY,
+    "event": EVENT,
+    "place": PLACE,
+    "repository": REPOSITORY,
+    "source": SOURCE,
+    "citation": CITATION,
+    "media": MEDIA,
+    "note": NOTE,
+    "tag": TAG,
+}
+_NAMESPACES: dict[str, ObjectTypeSpec] = {
+    **_NAMES,
+    **{name.capitalize(): spec for name, spec in _NAMES.items()},
+}
+
+# `ClassName.CONST` value constants, e.g. `gender == Person.MALE`,
+# `type.value == EventType.BIRTH`, `birth.date.modifier == Date.MOD_ABOUT`.
+# Values are read off the real Gramps classes, never hardcoded, so they
+# can't drift out of sync with core if a constant's underlying value ever
+# changes -- see `_int_constants`. Covers both constants that attach to a
+# *flat* column (`Person.gender`, `Citation.confidence`, `Note.format`) and
+# ones that only live nested in `json_data` (`Event.type` is stored as
+# `{"_class": "EventType", "value": 12, "string": ""}`, so the constant is
+# compared against `type.value`, not `type` itself) -- `_translate_constant`
+# doesn't care which; that distinction is entirely in how the *path* side of
+# the comparison resolves (`resolve_column_path`).
+#
+# Deliberately still not covering arbitrary user-defined custom type values
+# (a `PlaceType` of "Ranch", say) -- those have no fixed constant to name in
+# the first place, only ever a per-tree string paired with `.CUSTOM`.
+_CONSTANT_CLASSES: dict[str, type] = {
+    "Person": Person,
+    "Citation": Citation,
+    "Note": Note,
+    "Date": Date,
+    "AttributeType": AttributeType,
+    "ChildRefType": ChildRefType,
+    "EventRoleType": EventRoleType,
+    "EventType": EventType,
+    "FamilyRelType": FamilyRelType,
+    "MarkerType": MarkerType,
+    "NameOriginType": NameOriginType,
+    "NameType": NameType,
+    "NoteType": NoteType,
+    "PlaceType": PlaceType,
+    "RepositoryType": RepositoryType,
+    "SourceMediaType": SourceMediaType,
+    "SrcAttributeType": SrcAttributeType,
+    "StyledTextTagType": StyledTextTagType,
+    "UrlType": UrlType,
+}
+
+
+def _int_constants(cls: type) -> dict[str, int]:
+    """Every ALL_CAPS `int` class attribute on `cls`, e.g. `{"MALE": 1,
+    "FEMALE": 0, ...}` for `Person`.
+
+    Auto-derived rather than hand-listed so a new constant added to a
+    Gramps class (or the value of an existing one changing) shows up here
+    automatically instead of silently drifting out of sync. `bool` is
+    excluded despite being an `int` subclass -- no Gramps class defines a
+    meaningful all-caps boolean constant, and including it would risk
+    picking up something like a stray `True`/`False` class attribute as if
+    it were a real value.
+    """
+    return {
+        name: value
+        for name in dir(cls)
+        if name.isupper() and not name.startswith("_")
+        for value in [getattr(cls, name)]
+        if isinstance(value, int) and not isinstance(value, bool)
+    }
+
+
+_CONSTANTS: dict[str, dict[str, Any]] = {
+    class_name: _int_constants(cls) for class_name, cls in _CONSTANT_CLASSES.items()
+}
+
+
+class QueryLangError(ValueError):
+    """Raised when an expression doesn't parse or uses unsupported syntax."""
+
+
+def resolve_namespace(namespace: str) -> ObjectTypeSpec:
+    """Look up the `ObjectTypeSpec` for a namespace string (`"person"` or `"Person"`, ...)."""
+    try:
+        return _NAMESPACES[namespace]
+    except KeyError:
+        raise QueryLangError(f"unknown namespace: {namespace!r}") from None
+
+
+def _translate_constant(class_name: str, const_name: str) -> Any:
+    try:
+        constants = _CONSTANTS[class_name]
+    except KeyError:
+        raise QueryLangError(
+            f"unknown constant namespace: {class_name!r} "
+            f"(known: {', '.join(sorted(_CONSTANTS))})"
+        ) from None
+    try:
+        return constants[const_name]
+    except KeyError:
+        raise QueryLangError(
+            f"unknown constant: {class_name}.{const_name} "
+            f"(known: {', '.join(class_name + '.' + n for n in constants)})"
+        ) from None
+
+
+_FLIP_OP: dict[str, str] = {
+    # For "value OP field" (the literal written on the left, e.g.
+    # "Date(...) < mother.birth.sortval") -- the wire shape always puts the
+    # column first, so the operator has to flip to keep the same meaning:
+    # "A < B" becomes "B > A" once B (the field) is what's rendered as
+    # "column". eq/ne are symmetric and flip to themselves.
+    "eq": "eq",
+    "ne": "ne",
+    "lt": "gt",
+    "lte": "gte",
+    "gt": "lt",
+    "gte": "lte",
+}
+
+
+_COMPARE_OPS: dict[type, str] = {
+    ast.Eq: "eq",
+    ast.NotEq: "ne",
+    ast.Lt: "lt",
+    ast.LtE: "lte",
+    ast.Gt: "gt",
+    ast.GtE: "gte",
+    ast.In: "in",
+    # `is`/`is not` are pure sugar for `==`/`!=` here -- this language has no
+    # notion of object identity distinct from value equality, so `gender is
+    # None` and `gender == None` compile to the exact same wire node. Reusing
+    # "eq"/"ne" verbatim (rather than a dedicated "is"/"is not" wire op) means
+    # every existing "eq"/"ne" code path -- field-vs-field, count(...), the
+    # SQL/evaluator dialects -- already handles them with no new branches.
+    ast.Is: "eq",
+    ast.IsNot: "ne",
+}
+
+
+def _translate_path(node: ast.AST) -> List[Union[str, int]]:
+    """Walk a `Name`/`Attribute`/`Subscript` chain into an ordered segment list.
+
+    `a.b[0].c` is nested as `Attribute(Attribute(Subscript(Attribute(Name)))...)`
+    with the outermost node being the *last* segment -- recurse to the base
+    `Name` first, then build the list root-to-leaf.
+    """
+    if isinstance(node, ast.Name):
+        return [node.id]
+    if isinstance(node, ast.Attribute):
+        return _translate_path(node.value) + [node.attr]
+    if isinstance(node, ast.Subscript):
+        index_node = node.slice
+        if not isinstance(index_node, ast.Constant) or not isinstance(
+            index_node.value, int
+        ) or isinstance(index_node.value, bool):
+            raise QueryLangError(
+                f"subscript index must be a plain integer literal: {ast.dump(node)}"
+            )
+        return _translate_path(node.value) + [index_node.value]
+    raise QueryLangError(f"invalid path expression: {ast.dump(node)}")
+
+
+def _translate_column(node: ast.AST, spec: ObjectTypeSpec) -> Union[str, dict]:
+    """Translate a path into a wire column reference: a plain string if it's
+    a single segment matching a real flat column, `{"json_path": [...]}`
+    otherwise.
+
+    No relationship-specific knowledge lives here -- a multi-segment path
+    like `birth.date.sortval` or `father.surname` becomes
+    `{"json_path": ["birth", "date", "sortval"]}` the same way any other
+    multi-segment path does; `object_query.py`'s `_parse_column_ref` is
+    what actually recognizes `"birth"`/`"father"`/etc. as relationship
+    roots (via `query.py`'s `resolve_column_path`) once it receives that
+    wire form. A bare relationship name with nothing after it
+    (`"birth"` alone) isn't a real flat column, so it falls through to
+    `{"json_path": ["birth"]}` here too -- `resolve_column_path` rejects
+    that with a clear error downstream, just one layer later than a
+    dedicated check here would.
+    """
+    segments = _translate_path(node)
+    if len(segments) == 1 and isinstance(segments[0], str) and segments[0] in spec.columns:
+        return segments[0]
+    return {"json_path": segments}
+
+
+def _translate_count_call(node: ast.Call, spec: ObjectTypeSpec) -> dict:
+    """Translate `count(relationship[, condition])` into
+    `{"count_of": {"relationship": ..., "where": [...]}}` -- the *value*-
+    producing counterpart to `exists(...)`'s leaf-producing
+    `_translate_exists_call`. Appears as a comparison's column
+    (`count(children) > 2`), never as a leaf on its own -- a bare
+    `count(children)` with no comparison isn't a boolean, so it's rejected
+    the same way a bare path (`gender`, with no `== ...`) already is.
+
+    `relationship`/`condition` resolve exactly like `exists(...)`'s do --
+    same `resolve_collection` lookup, same recursive `_translate_top_level`
+    against the collection's target type for the optional condition.
+    """
+    if not 1 <= len(node.args) <= 2 or node.keywords:
+        raise QueryLangError(
+            "count(relationship[, condition]) takes 1 or 2 positional arguments"
+        )
+    name_node = node.args[0]
+    if not isinstance(name_node, ast.Name):
+        raise QueryLangError(
+            f"count(...)'s first argument must be a bare relationship name: "
+            f"{ast.dump(name_node)}"
+        )
+    try:
+        collection = resolve_collection(spec, name_node.id)
+    except QueryError as error:
+        raise QueryLangError(str(error)) from error
+    payload: dict = {"relationship": name_node.id}
+    if len(node.args) == 2:
+        payload["where"] = _translate_top_level(node.args[1], collection.target)
+    return {"count_of": payload}
+
+
+def _is_count_call(node: ast.AST) -> bool:
+    """Is `node` a `count(...)` call, without translating it? Used to
+    classify a comparison's operand as column-like *before* deciding how to
+    translate it -- see `_translate_compare`'s left/right classification.
+    """
+    return isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "count"
+
+
+def _translate_column_or_count(node: ast.AST, spec: ObjectTypeSpec) -> Union[str, dict]:
+    """A comparison's column-like side: an ordinary path (`_translate_column`),
+    or a `count(...)` call -- the one place a "column" can be a *computed*
+    value rather than a path, verbatim. `count(...)` is deliberately not
+    recognized anywhere `_translate_column` itself is called directly (a
+    plain field on the other side of a comparison, `'in'`'s list/substring
+    branches) -- v1 scope only ever treats `count(...)` as *the* column,
+    never as something compared against another field, matching `len()`'s
+    own planned restriction (see ROADMAP.md).
+    """
+    if _is_count_call(node):
+        return _translate_count_call(node, spec)
+    return _translate_column(node, spec)
+
+
+def _translate_date_call(node: ast.Call) -> int:
+    """Translate `Date('Jan 1, 1968')` into its `.sortval` (a comparable
+    Julian day number), via Gramps' own date parser -- not a custom one.
+    """
+    if len(node.args) != 1 or node.keywords:
+        raise QueryLangError("Date(...) takes exactly 1 positional string argument")
+    text = _translate_value(node.args[0])
+    if not isinstance(text, str):
+        raise QueryLangError("Date(...)'s argument must be a string literal")
+    parsed = _date_parser.parse(text)
+    if not parsed.is_valid():
+        raise QueryLangError(f"could not parse {text!r} as a date")
+    return parsed.sortval
+
+
+def _translate_value(node: ast.AST) -> Any:
+    """Translate a literal: string / int / float / bool / None, `-<number>`,
+    a `ClassName.CONST` value constant (e.g. `Person.MALE`, see `_CONSTANTS`),
+    or `Date('...')` (see `_translate_date_call`).
+    """
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+        inner = _translate_value(node.operand)
+        if not isinstance(inner, (int, float)) or isinstance(inner, bool):
+            raise QueryLangError(f"unary '-' only supported on numeric literals: {ast.dump(node)}")
+        return -inner
+    if isinstance(node, ast.Constant):
+        return node.value
+    if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
+        return _translate_constant(node.value.id, node.attr)
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "Date"
+    ):
+        return _translate_date_call(node)
+    raise QueryLangError(f"invalid literal: {ast.dump(node)}")
+
+
+def _translate_list(node: ast.AST) -> List[Any]:
+    if not isinstance(node, ast.List):
+        raise QueryLangError(f"expected a list literal, e.g. [1, 2, 3]: {ast.dump(node)}")
+    return [_translate_value(elt) for elt in node.elts]
+
+
+def _is_path_node(node: ast.AST) -> bool:
+    """Is `node` a path reference (`Name`/`Attribute`/`Subscript` chain),
+    rather than a literal/`Date(...)`/`ClassName.CONST`?
+
+    The one ambiguous shape is a single-level `Attribute(Name, attr)` --
+    `Person.MALE` (a constant) and `father.surname` (a path) look
+    identical syntactically. Disambiguated the same way `_translate_value`
+    already does: whether the base `Name` is a known constant class
+    (`_CONSTANT_CLASSES`). Anything deeper (`a.b.c`, `a[0].b`) is
+    unambiguously a path -- that shape is never valid for a constant
+    (`_translate_value` only recognizes exactly one `Attribute` level).
+    """
+    if isinstance(node, (ast.Name, ast.Subscript)):
+        return True
+    if isinstance(node, ast.Attribute):
+        if isinstance(node.value, ast.Name) and node.value.id in _CONSTANT_CLASSES:
+            return False
+        return True
+    return False
+
+
+def _translate_compare(node: ast.Compare, spec: ObjectTypeSpec) -> dict:
+    if len(node.ops) != 1 or len(node.comparators) != 1:
+        # `a < b < c` -- Python allows chained comparisons, desugaring to
+        # pairwise "and": `a < b and b < c` (real Python evaluates each
+        # operand at most once; this translator only ever reads a path's
+        # *value* at query time, never re-evaluates a Python expression, so
+        # that subtlety doesn't apply here -- splitting into independent
+        # legs is exactly equivalent). Each leg is an ordinary two-term
+        # `ast.Compare`, translated by recursing into this same function --
+        # chaining introduces no new comparison semantics of its own, so
+        # every leg transparently supports whatever a plain comparison
+        # already does (operand ordering, is/is not/in, field-vs-field,
+        # even mixed operators like `1 < gender != 3`).
+        operands = [node.left, *node.comparators]
+        legs = [
+            ast.Compare(left=left, ops=[op], comparators=[right])
+            for left, op, right in zip(operands, node.ops, operands[1:])
+        ]
+        return {"and": [_translate_compare(leg, spec) for leg in legs]}
+    op_type = type(node.ops[0])
+    # "not in" reuses "in"'s own translation below verbatim, then wraps the
+    # result in "not" at the very end -- `not (x in y)` already compiles and
+    # evaluates correctly (see Done above: the Not/missing-value three-valued
+    # logic fix), so there's no new semantics to add here, just sugar for a
+    # shape users could already write with explicit parens.
+    negate = op_type is ast.NotIn
+    lookup_type = ast.In if negate else op_type
+    if lookup_type not in _COMPARE_OPS:
+        raise QueryLangError(
+            f"unsupported comparison operator {op_type.__name__!r} "
+            "(supported: == != < <= > >= is 'is not' in 'not in')"
+        )
+    op = _COMPARE_OPS[lookup_type]
+    rhs = node.comparators[0]
+    if op == "in":
+        if isinstance(rhs, ast.List):
+            # "field in [v1, v2, ...]" -- list membership.
+            column = _translate_column_or_count(node.left, spec)
+            value = _translate_list(rhs)
+            if not value:
+                raise QueryLangError("'in' requires a non-empty list")
+            leaf = {"column": column, "op": "in", "value": value}
+        elif _is_path_node(rhs):
+            # "'substring' in field" / "other_field in field" -- a plain
+            # substring test, mirroring what `in` already means for two real
+            # Python strings. The field being searched is on the *right*
+            # here (unlike every other operator), since that's what makes
+            # `'Jan' in given_name` read the same as it would in real Python.
+            column = _translate_column(rhs, spec)
+            if _is_path_node(node.left):
+                # "other_field in field" -- field-vs-field: the needle is
+                # itself a path, only known at query execution time, not a
+                # literal to bind now.
+                value_column = _translate_column(node.left, spec)
+                leaf = {"column": column, "op": "contains", "value_column": value_column}
+            else:
+                substring = _translate_value(node.left)
+                if not isinstance(substring, str):
+                    raise QueryLangError(
+                        "'... in path' (substring test) requires a string literal "
+                        "or a field path on the left, e.g. \"'Jan' in given_name\" "
+                        f"or \"nickname in given_name\": {ast.dump(node)}"
+                    )
+                leaf = {"column": column, "op": "contains", "value": substring}
+        else:
+            raise QueryLangError(
+                "'in' requires either a list literal ('field in [1, 2]') or a "
+                f"field path on the right ('... in field', a substring test): {ast.dump(node)}"
+            )
+    else:
+        left = node.left
+        if _is_path_node(left) or _is_count_call(left):
+            # "field OP value" / "field OP field" -- the shape this function
+            # always assumed until operand-ordering was generalized. `left`
+            # is the column (or `count(...)`); `rhs` is either another field
+            # (`value_column`) or an ordinary value.
+            column = _translate_column_or_count(left, spec)
+            if _is_path_node(rhs):
+                if isinstance(column, dict) and "count_of" in column:
+                    # count(...) is left-hand-side-only, against a literal (v1
+                    # scope, see ROADMAP.md) -- field-vs-field against a count
+                    # isn't supported, so reject explicitly rather than
+                    # silently building a value_column nothing downstream
+                    # can render.
+                    raise QueryLangError(
+                        f"count(...) only supports comparison against a literal value, "
+                        f"not a field: {ast.dump(node)}"
+                    )
+                # Field-vs-field: "families where mother.death.date.sortval <
+                # father.death.date.sortval" -- the right-hand side is itself
+                # a path, not a value to bind.
+                value_column = _translate_column(rhs, spec)
+                leaf = {"column": column, "op": op, "value_column": value_column}
+            else:
+                value = _translate_value(rhs)
+                leaf = {"column": column, "op": op, "value": value}
+        elif _is_path_node(rhs):
+            # "value OP field", e.g. "Date('Jan 1, 1968') < mother.birth.sortval"
+            # -- the literal happened to be written on the left. Flip the
+            # operator so the column still renders on the wire's left, the
+            # one shape query.py/evaluator.py know how to read -- count(...)
+            # is deliberately not accepted here (see
+            # `_translate_column_or_count`'s docstring): only a plain path
+            # qualifies as "the column" on this side, matching count(...)'s
+            # existing left-hand-side-only v1 scope untouched.
+            value = _translate_value(left)
+            column = _translate_column(rhs, spec)
+            leaf = {"column": column, "op": _FLIP_OP[op], "value": value}
+        else:
+            raise QueryLangError(
+                "a comparison must have a field path on at least one side "
+                f"(count(...) is only supported on the left): {ast.dump(node)}"
+            )
+    return {"not": leaf} if negate else leaf
+
+
+def _translate_like_call(node: ast.Call, spec: ObjectTypeSpec) -> dict:
+    if len(node.args) != 2 or node.keywords:
+        raise QueryLangError("like(path, 'pattern') takes exactly 2 positional arguments")
+    column = _translate_column(node.args[0], spec)
+    pattern = _translate_value(node.args[1])
+    if not isinstance(pattern, str):
+        raise QueryLangError("like(...)'s second argument must be a string literal")
+    return {"column": column, "op": "like", "value": pattern}
+
+
+def _translate_regex_call(node: ast.Call, spec: ObjectTypeSpec) -> dict:
+    if len(node.args) != 2 or node.keywords:
+        raise QueryLangError("regex(path, 'pattern') takes exactly 2 positional arguments")
+    column = _translate_column(node.args[0], spec)
+    pattern = _translate_value(node.args[1])
+    if not isinstance(pattern, str):
+        raise QueryLangError("regex(...)'s second argument must be a string literal")
+    return {"column": column, "op": "regex", "value": pattern}
+
+
+def _translate_exists_call(node: ast.Call, spec: ObjectTypeSpec) -> dict:
+    """Translate `exists(relationship[, condition])` into
+    `{"exists": {"relationship": ..., "where": [...]}}` -- `where` omitted
+    entirely when no condition is given (`exists(children)`, "at least one
+    related row at all").
+
+    `relationship`'s target type comes from `query.py`'s `_COLLECTIONS`
+    registry (via `resolve_collection`), the same way a `_RELATIONSHIPS`
+    name's target drives `resolve_column_path` -- `condition`, if given, is
+    itself a full `where_expr` boolean expression, just parsed against that
+    target type instead of `spec`, via the same `_translate_top_level` this
+    module already uses for the top-level expression.
+    """
+    if not 1 <= len(node.args) <= 2 or node.keywords:
+        raise QueryLangError(
+            "exists(relationship[, condition]) takes 1 or 2 positional arguments"
+        )
+    name_node = node.args[0]
+    if not isinstance(name_node, ast.Name):
+        raise QueryLangError(
+            f"exists(...)'s first argument must be a bare relationship name: "
+            f"{ast.dump(name_node)}"
+        )
+    try:
+        collection = resolve_collection(spec, name_node.id)
+    except QueryError as error:
+        raise QueryLangError(str(error)) from error
+    payload: dict = {"relationship": name_node.id}
+    if len(node.args) == 2:
+        payload["where"] = _translate_top_level(node.args[1], collection.target)
+    return {"exists": payload}
+
+
+def _translate_comparison_like_node(node: ast.AST, spec: ObjectTypeSpec) -> dict:
+    """A single leaf: a `Compare`, or a whitelisted
+    `like(...)`/`regex(...)`/`exists(...)` call."""
+    if isinstance(node, ast.Compare):
+        return _translate_compare(node, spec)
+    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
+        if node.func.id == "like":
+            return _translate_like_call(node, spec)
+        if node.func.id == "regex":
+            return _translate_regex_call(node, spec)
+        if node.func.id == "exists":
+            return _translate_exists_call(node, spec)
+    raise QueryLangError(
+        f"expected a comparison (a == b, a in [...], like(a, 'pat'), "
+        f"regex(a, 'pat'), exists(rel, cond)), got: {ast.dump(node)}"
+    )
+
+
+def _translate_bool_or_leaf(node: ast.AST, spec: ObjectTypeSpec) -> dict:
+    """Translate one node of a (possibly nested) boolean expression: a leaf
+    comparison/`like(...)` call, or an `and`/`or`/`not` of further such nodes.
+
+    `ast.parse` has already resolved Python's own `and`/`or`/`not`
+    precedence and grouping into correctly nested `BoolOp`/`UnaryOp` nodes
+    (`not` binds tighter than `and`, which binds tighter than `or`, so
+    `not a and b or c` arrives as `BoolOp(Or, [BoolOp(And, [UnaryOp(Not, a),
+    b]), c])`) -- this only walks whatever shape it's handed, it doesn't
+    re-implement precedence itself. Any other `ast.UnaryOp` (`+a`, `~a`) has
+    no case here and falls through to `_translate_comparison_like_node`,
+    which rejects it with a clear error, the same as any other unrecognized
+    node shape.
+    """
+    if isinstance(node, ast.BoolOp):
+        key = "and" if isinstance(node.op, ast.And) else "or"
+        return {key: [_translate_bool_or_leaf(value, spec) for value in node.values]}
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
+        return {"not": _translate_bool_or_leaf(node.operand, spec)}
+    return _translate_comparison_like_node(node, spec)
+
+
+def _translate_top_level(node: ast.AST, spec: ObjectTypeSpec) -> List[dict]:
+    """The whole expression, translated to `parse_expr`'s public shape: a
+    list of nodes, implicitly AND'd together.
+
+    A top-level `{"and": [...]}` -- i.e. any expression that doesn't use
+    `or`/`not` at all, including a single bare comparison -- is unwrapped
+    back into a flat list here, so the wire shape for those expressions is
+    exactly what it was before `or`/`not` support existed. An expression
+    that does use them produces a list containing an `{"or": [...]}"`/
+    `{"not": node}` node (alongside plain leaves too, e.g. `"(a or b) and
+    c"` -> `[{"or": [a, b]}, c]`), rather than changing the top-level shape
+    from a list to something else.
+    """
+    translated = _translate_bool_or_leaf(node, spec)
+    if isinstance(translated, dict) and tuple(translated) == ("and",):
+        return translated["and"]
+    return [translated]
+
+
+# --- comprehension sugar for exists(...)/count(...) -------------------------
+#
+# `any(cond for x in rel)`/`len([... for x in rel if cond])` are pure syntax
+# sugar for `exists(rel, cond)`/`count(rel, cond)` -- rewritten away entirely
+# by `_ComprehensionDesugarer` before `_translate_top_level` ever runs, so
+# every `_translate_*` function above keeps treating `exists(...)`/`count(...)`
+# as the only call shapes that carry a nested condition. Nothing downstream of
+# this section knows comprehension syntax was ever involved.
+#
+# The one piece of real work is dropping the loop variable: `where_expr`'s
+# `exists`/`count` condition is parsed directly against the collection's
+# target type, with no loop-variable prefix of its own (`exists(children,
+# given_name == 'Steve')`, not `exists(children, c.given_name == 'Steve')`),
+# so `c.given_name` has to become plain `given_name` -- `_BoundNameStripper`
+# does exactly that, once per comprehension level.
+
+
+class _BoundNameStripper(ast.NodeTransformer):
+    """Rewrites a comprehension body so every `<bound_name>.attr` /
+    `<bound_name>[i]` chain drops its `<bound_name>` root -- `c.given_name`
+    becomes plain `given_name`, `c.events` becomes plain `events` (so a
+    *nested* comprehension's already-desugared `exists(c.events, ...)`/
+    `count(c.events, ...)` call, produced one level down, loses its `c.`
+    prefix too -- this is a blind syntactic substitution, indifferent to
+    what's inside, so it composes correctly across nesting levels without
+    a symbol table).
+
+    A bare reference to `bound_name` with nothing after it (`c == x`, `c in
+    [...]`) has no equivalent -- `where_expr` conditions are always a field
+    path, never "the whole related object" -- so that's rejected with a
+    clear error rather than silently dropped.
+
+    Reusing the same loop-variable name at two nesting levels (`any(any(c.a
+    == 1 for c in c.rel) for c in top)`) works correctly without this class
+    needing to track more than one name at a time: the *inner*
+    `_BoundNameStripper` runs first (`_ComprehensionDesugarer` desugars
+    bottom-up) and either strips or errors on every reference to its own
+    `c` within its own `elt`/`ifs`, so nothing referring to "the inner `c`"
+    can survive unconsumed into the outer pass -- any `c` the outer stripper
+    later encounters (e.g. in the inner-produced call's own collection-name
+    argument) unambiguously belongs to the outer scope, exactly matching
+    real Python's own scoping rule that a comprehension's first `for`
+    clause's `iter` is evaluated in the *enclosing* scope.
+    """
+
+    def __init__(self, bound_name: str):
+        self.bound_name = bound_name
+
+    def _is_own_root(self, node: ast.AST) -> bool:
+        return isinstance(node, ast.Name) and node.id == self.bound_name
+
+    def visit_Attribute(self, node: ast.Attribute) -> ast.AST:
+        if self._is_own_root(node.value):
+            return ast.copy_location(ast.Name(id=node.attr, ctx=ast.Load()), node)
+        node.value = self.visit(node.value)
+        return node
+
+    def visit_Subscript(self, node: ast.Subscript) -> ast.AST:
+        if self._is_own_root(node.value):
+            raise QueryLangError(
+                f"can't index the loop variable directly: {ast.dump(node)}"
+            )
+        node.value = self.visit(node.value)
+        return node
+
+    def visit_Name(self, node: ast.Name) -> ast.AST:
+        if node.id == self.bound_name:
+            raise QueryLangError(
+                f"'{self.bound_name}' can only be used as '{self.bound_name}.field', "
+                f"never compared directly (there's no whole-object comparison in "
+                f"where_expr, only field paths): {ast.dump(node)}"
+            )
+        return node
+
+    def _reject_nested_comprehension(self, node: ast.AST) -> ast.AST:
+        # By the time a condition reaches this stripper, any comprehension
+        # nested inside it should already have been rewritten into an
+        # `exists(...)`/`count(...)` call by `_ComprehensionDesugarer`
+        # running bottom-up -- a raw comprehension surviving to this point
+        # means it wasn't wrapped in a recognized `any(...)`/`len(...)`
+        # form, the same "not a whitelisted shape" rejection every other
+        # unrecognized node gets.
+        raise QueryLangError(
+            f"comprehension must be wrapped in any(...) or len([...]): {ast.dump(node)}"
+        )
+
+    visit_GeneratorExp = _reject_nested_comprehension
+    visit_ListComp = _reject_nested_comprehension
+    visit_SetComp = _reject_nested_comprehension
+    visit_DictComp = _reject_nested_comprehension
+
+
+def _comprehension_generator(comp: Union[ast.GeneratorExp, ast.ListComp], call: ast.Call) -> ast.comprehension:
+    """Validate and return the single `for x in rel` clause of a
+    comprehension being desugared -- `call` is only used for error messages
+    (the original `any(...)`/`len(...)` call, more useful to a caller than
+    the comprehension fragment alone).
+
+    Restricted on purpose to exactly what `exists(...)`/`count(...)` already
+    support written by hand: one loop variable, bound to a plain name (not a
+    tuple-unpack), iterating either a bare collection name (`children`) or
+    exactly one attribute off an *enclosing* comprehension's own loop
+    variable (`c.events`, matching how `exists(children, exists(events,
+    ...))` nests today) -- never a longer chain, so this sugar can't
+    silently become more expressive than the call syntax it stands in for.
+    """
+    if len(comp.generators) != 1:
+        raise QueryLangError(
+            f"comprehension must have exactly one 'for' clause: {ast.dump(call)}"
+        )
+    generator = comp.generators[0]
+    if generator.is_async:
+        raise QueryLangError(f"async comprehensions aren't supported: {ast.dump(call)}")
+    if not isinstance(generator.target, ast.Name):
+        raise QueryLangError(
+            f"comprehension's loop variable must be a plain name: {ast.dump(call)}"
+        )
+    iter_node = generator.iter
+    is_bare_name = isinstance(iter_node, ast.Name)
+    is_one_attr_off_a_name = isinstance(iter_node, ast.Attribute) and isinstance(
+        iter_node.value, ast.Name
+    )
+    if not (is_bare_name or is_one_attr_off_a_name):
+        raise QueryLangError(
+            "comprehension's 'in ...' must be a bare collection name, or exactly "
+            f"one attribute off an enclosing loop variable: {ast.dump(call)}"
+        )
+    return generator
+
+
+def _and_together(parts: List[ast.expr]) -> ast.expr:
+    return parts[0] if len(parts) == 1 else ast.BoolOp(op=ast.And(), values=parts)
+
+
+def _any_condition(comp: ast.GeneratorExp, bound_name: str) -> Union[ast.expr, None]:
+    """`any(...)`'s condition: `elt` *is* the boolean predicate (unlike
+    `len([...])`'s `elt`, which only ever projects), ANDed with any `if`
+    clauses on the generator itself -- `any(x.a == 1 for x in rel if x.b ==
+    2)` means the same as `any(x.a == 1 and x.b == 2 for x in rel)`. A bare
+    `elt` that's just the loop variable itself (`any(x for x in rel if
+    x.b == 2)`) carries no predicate of its own -- the condition is then
+    whatever the `if` clauses provide alone (or `None`, "no condition at
+    all", if there aren't any either -- `any(x for x in rel)` is just
+    `exists(rel)`).
+    """
+    stripper = _BoundNameStripper(bound_name)
+    parts = []
+    if not (isinstance(comp.elt, ast.Name) and comp.elt.id == bound_name):
+        parts.append(stripper.visit(comp.elt))
+    parts.extend(stripper.visit(if_node) for if_node in comp.generators[0].ifs)
+    return _and_together(parts) if parts else None
+
+
+def _len_condition(comp: ast.ListComp, bound_name: str) -> Union[ast.expr, None]:
+    """`len([...])`'s condition: unlike `any(...)`, `elt` here only ever
+    *projects* what gets collected (traditionally into the list being
+    measured), so it carries no predicate -- `len([x for x in rel if
+    x.a == 1])` counts by its `if` clause alone. `elt` itself is required to
+    be trivial (the loop variable, or a plain literal like `1`) so nothing
+    meaningful is silently thrown away by ignoring it; anything else is
+    rejected rather than guessed at.
+    """
+    elt = comp.elt
+    if not (
+        (isinstance(elt, ast.Name) and elt.id == bound_name)
+        or isinstance(elt, ast.Constant)
+    ):
+        raise QueryLangError(
+            "len([...])'s projection must be the loop variable or a plain "
+            f"literal (e.g. 'len([1 for x in rel if ...])'): {ast.dump(elt)}"
+        )
+    stripper = _BoundNameStripper(bound_name)
+    ifs = [stripper.visit(if_node) for if_node in comp.generators[0].ifs]
+    return _and_together(ifs) if ifs else None
+
+
+def _make_call(name: str, iter_node: ast.expr, condition: Union[ast.expr, None]) -> ast.Call:
+    args = [iter_node] if condition is None else [iter_node, condition]
+    return ast.Call(func=ast.Name(id=name, ctx=ast.Load()), args=args, keywords=[])
+
+
+class _ComprehensionDesugarer(ast.NodeTransformer):
+    """Rewrites `any(cond for x in rel [if ...])` into `exists(rel, cond)`,
+    and `len([... for x in rel if ...])` into `count(rel, ...)`, run once
+    over the whole tree before `_translate_top_level` -- see this section's
+    module-level comment above.
+
+    Runs bottom-up (`generic_visit` before inspecting the current node), so
+    a comprehension nested inside another gets desugared first -- by the
+    time the outer level's own condition is stripped of its loop variable
+    (`_BoundNameStripper`), any inner `exists(...)`/`count(...)` call
+    already sitting in it gets its own loop-variable prefix (`c.events` ->
+    `events`) stripped along with everything else, with no special-casing
+    needed for "this child happens to be a call I generated a moment ago."
+    """
+
+    def visit_Call(self, node: ast.Call) -> ast.AST:
+        self.generic_visit(node)
+        if not isinstance(node.func, ast.Name) or node.keywords:
+            return node
+        name = node.func.id
+        if name == "any":
+            if len(node.args) != 1 or not isinstance(node.args[0], ast.GeneratorExp):
+                raise QueryLangError(
+                    "any(...) is only supported wrapping a generator comprehension, "
+                    f"e.g. any(x.field == 1 for x in rel): {ast.dump(node)}"
+                )
+            comp = node.args[0]
+            generator = _comprehension_generator(comp, node)
+            condition = _any_condition(comp, generator.target.id)
+            return ast.copy_location(_make_call("exists", generator.iter, condition), node)
+        if name == "len":
+            if len(node.args) != 1 or not isinstance(node.args[0], ast.ListComp):
+                raise QueryLangError(
+                    "len(...) is only supported wrapping a list comprehension, "
+                    f"e.g. len([1 for x in rel if x.field == 1]): {ast.dump(node)}"
+                )
+            comp = node.args[0]
+            generator = _comprehension_generator(comp, node)
+            condition = _len_condition(comp, generator.target.id)
+            return ast.copy_location(_make_call("count", generator.iter, condition), node)
+        return node
+
+
+def _desugar_comprehensions(node: ast.AST) -> ast.AST:
+    rewritten = _ComprehensionDesugarer().visit(node)
+    return ast.fix_missing_locations(rewritten)
+
+
+def parse_expr_for_spec(spec: ObjectTypeSpec, expr: str) -> List[dict]:
+    """Parse an "almost Python" expression against an already-known `ObjectTypeSpec`.
+
+    For callers that already know their target type and don't need (or
+    want) a namespace string -- e.g. `resources/object_query.py`'s
+    `where_expr` field, where each endpoint's own `self.spec` already fixes
+    the type; asking the client to also name it via a namespace string would
+    be redundant. `parse_expr()` below is the namespace-string-based
+    equivalent, for standalone/library use where there's no such context.
+    """
+    try:
+        tree = ast.parse(expr, mode="eval")
+    except SyntaxError as error:
+        raise QueryLangError(f"invalid syntax: {error}") from error
+    body = _desugar_comprehensions(tree.body)
+    return _translate_top_level(body, spec)
+
+
+def parse_expr(namespace: str, expr: str) -> List[dict]:
+    """Parse an "almost Python" expression into a `where` condition list.
+
+    >>> parse_expr("person", "gender == 1")
+    [{'column': 'gender', 'op': 'eq', 'value': 1}]
+
+    >>> parse_expr("person", "primary_name.surname_list[0].surname == 'Smith'")
+    [{'column': {'json_path': ['primary_name', 'surname_list', 0, 'surname']}, 'op': 'eq', 'value': 'Smith'}]
+
+    The result is ready to drop directly into a `POST .../query/` request
+    body's `"where"` field. Raises `QueryLangError` on anything outside the
+    supported grammar -- never executes the input (`ast.parse` only, no
+    `eval`/`compile`/`exec`).
+    """
+    spec = resolve_namespace(namespace)
+    return parse_expr_for_spec(spec, expr)
+
+
+# --- expr -> query.py AST ----------------------------------------------------
+#
+# `parse_expr`/`parse_expr_for_spec` stop at the JSON wire shape, since that's
+# all `object_query.py`'s `where_expr` request field ever needs. A caller that
+# wants to actually *run* a where-expression string (this module's tests, the
+# docs, or any standalone/library use with a real `db` connection) needs that
+# JSON turned into `query.py`'s `Eq`/`And`/`RelatedObject`-based AST instead --
+# `compile_expr`/`compile_expr_for_spec` are that bridge, built entirely out of
+# `query.py`'s own exported pieces (no new AST shape of its own).
+
+_OP_CLASSES: dict[str, type] = {
+    "eq": Eq,
+    "ne": Ne,
+    "lt": Lt,
+    "lte": Lte,
+    "gt": Gt,
+    "gte": Gte,
+}
+
+# Every leaf `op` a condition dict can carry -- `_OP_CLASSES`'s keys plus
+# "in"/"like"/"regex"/"contains" (special-cased in `_condition_from_json`, not
+# plain `Comparison` subclasses). Public so `object_query.py`'s own
+# `where`-body schema validates against this directly instead of a second,
+# hand-copied whitelist that can (and did) drift -- new ops added here are
+# then automatically valid for a raw `where` JSON body too, no
+# gramps-web-api change needed (though gramps-web-api's own `value_column`
+# restriction for "in"/"like"/"regex" is a separate, hand-maintained check --
+# see its `_validate_leaf_condition`).
+VALID_LEAF_OPS = frozenset(_OP_CLASSES) | {"in", "like", "regex", "contains"}
+
+
+def json_column_to_ref(column: Union[str, dict], spec: ObjectTypeSpec) -> ColumnRef:
+    """A wire-format column reference (plain string, `{"json_path": [...]}`,
+    or `{"count_of": {...}}`), resolved to a `ColumnRef` -- via
+    `resolve_column_path`, so a path crossing a relationship
+    (`{"json_path": ["birth", "date", "sortval"]}`) becomes a `RelatedObject`
+    the same way it would coming from `object_query.py`, not a literal
+    `JsonPath(("birth", "date", "sortval"))` that would (harmlessly, but
+    incorrectly) look for a `birth` key inside `json_data` instead.
+    `{"count_of": {"relationship": ..., "where": [...]}}` resolves to a
+    `CollectionCount` the same way `_node_from_json`'s `"exists"` case
+    resolves to an `Exists` -- same `resolve_collection` lookup, same
+    recursive `where_list_to_ast` for the optional condition.
+
+    A plain string goes through `resolve_ref_string`, so a *dotted* one
+    (`"birth.date.sortval"`) means the same thing here as the identical
+    text does inside a `where_expr`, rather than being rejected as an
+    unknown flat column. A single-segment string stays a flat column
+    reference, whitelist-checked -- see `resolve_ref_string`.
+    """
+    if isinstance(column, str):
+        return resolve_ref_string(spec, column)
+    if "count_of" in column:
+        payload = column["count_of"]
+        collection = resolve_collection(spec, payload["relationship"])
+        condition = (
+            where_list_to_ast(payload["where"], collection.target)
+            if "where" in payload
+            else None
+        )
+        return CollectionCount(collection, condition)
+    return resolve_column_path(spec, column["json_path"])
+
+
+def _condition_from_json(condition: dict, spec: ObjectTypeSpec) -> Any:
+    """One `parse_expr`-shaped condition dict, translated to a `query.py`
+    comparison object (`Eq`, `Lt`, `In`, `Like`, `Regex`, `Contains`, ...)."""
+    column = json_column_to_ref(condition["column"], spec)
+    op = condition["op"]
+    if op == "in":
+        return In(column, condition["value"])
+    if op == "like":
+        return Like(column, condition["value"])
+    if op == "regex":
+        # Literal pattern only, same as "like" just above -- a pattern only
+        # known at row-execution time (via "value_column") can't be
+        # validated as a compilable regex ahead of time, so it's not
+        # supported here (gramps-web-api's `_validate_leaf_condition`
+        # enforces the same restriction on a raw `where` JSON body).
+        return Regex(column, condition["value"])
+    if "value_column" in condition:
+        # Field-vs-field, e.g. "mother.death.date.sortval < father.death.date.sortval",
+        # or (for "contains") "other_field in field".
+        value = json_column_to_ref(condition["value_column"], spec)
+        if isinstance(value, str):
+            # A flat (same-table) column resolves to a bare str here --
+            # identical in shape to an ordinary literal, which
+            # Comparison/Contains would otherwise (silently, wrongly) treat
+            # this as. Wrap it so it's unambiguously "a field", the same
+            # way a JsonPath/RelatedObject already unambiguously is -- see
+            # FlatColumnRef's docstring.
+            value = FlatColumnRef(value)
+    else:
+        value = condition["value"]
+    if op == "contains":
+        return Contains(column, value)
+    return _OP_CLASSES[op](column, value)
+
+
+def where_list_to_ast(conditions: List[dict], spec: ObjectTypeSpec) -> Any:
+    """A `parse_expr`-shaped list of top-level conditions (implicitly AND'd),
+    translated to a single `query.py` boolean expression -- shared by
+    `compile_expr_for_spec` and `_node_from_json`'s `"exists"` case, whose
+    `where` payload is exactly this same shape, just against the collection's
+    target type instead of the outer spec.
+
+    Public (no leading underscore) specifically so gramps-web-api's
+    `object_query.py` can call it directly for its own `where`/`where_expr`
+    request bodies, rather than maintaining a second, hand-written copy of
+    this same JSON -> AST translation that can (and did) drift out of sync
+    every time this module gains a feature -- e.g. missing 'and'/'exists'/
+    'count_of' support, and silently mishandling same-table field-vs-field
+    comparisons that need `FlatColumnRef` wrapping (see `_condition_from_json`).
+    Raises `QueryError` (not `QueryLangError` -- there's no parsing here,
+    only already-parsed JSON) on a malformed condition; callers building
+    `where` from raw, untrusted client JSON (as opposed to this module's own
+    `parse_expr_for_spec` output, always well-formed by construction) are
+    responsible for their own leaf-shape validation first -- see
+    `object_query.py`'s `_validate_leaf_condition` for what that needs to
+    cover that this function intentionally doesn't re-check.
+    """
+    asts = [_node_from_json(condition, spec) for condition in conditions]
+    return asts[0] if len(asts) == 1 else And(*asts)
+
+
+def _node_from_json(node: dict, spec: ObjectTypeSpec) -> Any:
+    """One `parse_expr`-shaped node -- a leaf condition, or an `{"and"/"or":
+    [...]}`/`{"not": node}`/`{"exists": {...}}` combinator -- translated to a
+    `query.py` boolean expression (`Eq`/`Lt`/`In`/... for a leaf, `And`/`Or`/
+    `Not`/`Exists` for a combinator), recursing into each child the same way.
+    """
+    if "and" in node:
+        return And(*(_node_from_json(child, spec) for child in node["and"]))
+    if "or" in node:
+        return Or(*(_node_from_json(child, spec) for child in node["or"]))
+    if "not" in node:
+        return Not(_node_from_json(node["not"], spec))
+    if "exists" in node:
+        payload = node["exists"]
+        collection = resolve_collection(spec, payload["relationship"])
+        condition = (
+            where_list_to_ast(payload["where"], collection.target)
+            if "where" in payload
+            else None
+        )
+        return Exists(collection, condition)
+    return _condition_from_json(node, spec)
+
+
+def compile_expr_for_spec(spec: ObjectTypeSpec, expr: str) -> Any:
+    """Parse and translate a where-expression string into a `query.py` `where`
+    AST (a single comparison, or an `And`/`Or` tree of them), ready for
+    `compile_query`/`compile_count_query`. For callers that already have
+    `spec` -- see `parse_expr_for_spec`.
+    """
+    conditions = parse_expr_for_spec(spec, expr)
+    return where_list_to_ast(conditions, spec)
+
+
+def compile_expr(namespace: str, expr: str) -> Tuple[ObjectTypeSpec, Any]:
+    """Parse and translate a where-expression string into `(spec, where)`,
+    ready to pass straight to `compile_query(spec, Query(where=where), ...)`.
+
+    >>> spec, where = compile_expr("person", "gender == 1")
+    >>> where
+    Eq('gender', 1)
+
+    Field-vs-field paths on both sides of a comparison work the same way
+    `object_query.py` resolves them -- e.g. `"mother.death.date.sortval <
+    father.death.date.sortval"` becomes `Lt(RelatedObject(...), RelatedObject(...))`.
+    """
+    spec = resolve_namespace(namespace)
+    return spec, compile_expr_for_spec(spec, expr)
+
+
+# --- select entries ----------------------------------------------------------
+
+
+#: Separator between a `select` entry's expression and its response-key
+#: alias (`"birth.place.title as birthplace"`). Not valid inside a Python
+#: expression, so it's split off before `ast.parse` ever sees the text --
+#: the same reason SQL needs a keyword here rather than an operator.
+_SELECT_ALIAS_SEPARATOR = " as "
+
+
+def parse_select_entry(spec: ObjectTypeSpec, entry: str) -> Tuple[SelectRef, str]:
+    """Parse one `select` entry string into `(column_ref, response_key)`.
+
+    The entry is a column expression in the same "almost Python" grammar
+    `where_expr` uses for a comparison's column side -- a flat column
+    (`gramps_id`), a JSON path (`primary_name.surname_list[0].surname`), a
+    path crossing relationships (`birth.place.title`), `"."` for the whole
+    `json_data` blob (`WholeJsonData`), or a
+    `count(relationship[, condition])` call -- optionally followed by
+    `as <key>` to name it in the response.
+
+    Without an alias the key is `default_ref_key`'s canonical spelling of
+    the reference, which for every path is the path text itself. A
+    `count(...)` entry has no path to derive a name from, so it falls back
+    to its own source text (`"count(events)"`); an explicit alias is the
+    way to get a tidier key than that.
+
+    Deliberately not a general expression parser -- `select` takes column
+    references, not arithmetic or comparisons, matching what `SelectRef`
+    can actually represent. Anything else fails here rather than compiling
+    into something surprising.
+    """
+    text = entry.strip()
+    if not text:
+        raise QueryLangError("empty select entry")
+    alias = None
+    if _SELECT_ALIAS_SEPARATOR in text:
+        text, _, alias = text.partition(_SELECT_ALIAS_SEPARATOR)
+        text, alias = text.strip(), alias.strip()
+        if not text or not alias:
+            raise QueryLangError(
+                f"malformed select alias in {entry!r} -- expected "
+                f"'<column> as <key>'"
+            )
+        if _SELECT_ALIAS_SEPARATOR in alias or not alias.isidentifier():
+            raise QueryLangError(
+                f"invalid select alias {alias!r} in {entry!r} -- a response key "
+                f"must be a plain name"
+            )
+
+    if text == ".":
+        # Not valid Python syntax (`ast.parse(".")` is a `SyntaxError`), so
+        # this has to be caught before the parser ever sees it -- the one
+        # select entry that isn't an expression at all, just a literal
+        # stand-in for "the whole `json_data` blob".
+        ref: SelectRef = WholeJsonData()
+    else:
+        try:
+            node = ast.parse(text, mode="eval").body
+        except SyntaxError as error:
+            raise QueryLangError(
+                f"could not parse select entry {entry!r}: {error}"
+            ) from error
+
+        try:
+            ref = json_column_to_ref(_translate_column_or_count(node, spec), spec)
+        except (QueryLangError, QueryError) as error:
+            raise QueryLangError(f"invalid select entry {entry!r}: {error}") from error
+
+    if alias is not None:
+        return ref, alias
+    try:
+        return ref, default_ref_key(ref)
+    except QueryError:
+        # No path to name it after (a `count(...)` entry) -- fall back to
+        # the entry's own text, whitespace-normalized. Not pretty as a
+        # response key, but it's what the caller wrote, it can't collide
+        # with a differently-written entry, and two counts over the same
+        # collection with different conditions stay distinct (which a
+        # derived name like `events_count` would not). An explicit
+        # `as <key>` is still the way to get a tidy name.
+        return ref, " ".join(text.split())
+
+
+def parse_select(
+    spec: ObjectTypeSpec, entries: Sequence[str]
+) -> List[Tuple[SelectRef, str]]:
+    """Parse a `select` list of entry strings into `(column_ref, key)` pairs,
+    ready for `Query(select=[ref, ...])` plus the response keys to zip each
+    result row against.
+
+    >>> from gramps_object_query_language.query import PERSON
+    >>> parse_select(PERSON, ["handle", "birth.place.title as birthplace"])
+    [('handle', 'handle'), (RelatedObject(...), 'birthplace')]
+
+    Duplicate response keys are rejected: two entries writing to the same
+    key would silently drop one of them from every result row, and which
+    one won would depend on nothing the caller can see.
+    """
+    parsed = [parse_select_entry(spec, entry) for entry in entries]
+    seen: set = set()
+    for _, key in parsed:
+        if key in seen:
+            raise QueryLangError(f"duplicate select key: {key!r}")
+        seen.add(key)
+    return parsed

--- a/GOQLFilter/gramps_object_query_language_copy/query_lang.py
+++ b/GOQLFilter/gramps_object_query_language_copy/query_lang.py
@@ -169,7 +169,6 @@ from .query import (
     QueryError,
     Regex,
     SelectRef,
-    WholeJsonData,
     default_ref_key,
     resolve_collection,
     resolve_column_path,
@@ -1176,8 +1175,7 @@ def parse_select_entry(spec: ObjectTypeSpec, entry: str) -> Tuple[SelectRef, str
     The entry is a column expression in the same "almost Python" grammar
     `where_expr` uses for a comparison's column side -- a flat column
     (`gramps_id`), a JSON path (`primary_name.surname_list[0].surname`), a
-    path crossing relationships (`birth.place.title`), `"."` for the whole
-    `json_data` blob (`WholeJsonData`), or a
+    path crossing relationships (`birth.place.title`), or a
     `count(relationship[, condition])` call -- optionally followed by
     `as <key>` to name it in the response.
 
@@ -1210,24 +1208,15 @@ def parse_select_entry(spec: ObjectTypeSpec, entry: str) -> Tuple[SelectRef, str
                 f"must be a plain name"
             )
 
-    if text == ".":
-        # Not valid Python syntax (`ast.parse(".")` is a `SyntaxError`), so
-        # this has to be caught before the parser ever sees it -- the one
-        # select entry that isn't an expression at all, just a literal
-        # stand-in for "the whole `json_data` blob".
-        ref: SelectRef = WholeJsonData()
-    else:
-        try:
-            node = ast.parse(text, mode="eval").body
-        except SyntaxError as error:
-            raise QueryLangError(
-                f"could not parse select entry {entry!r}: {error}"
-            ) from error
+    try:
+        node = ast.parse(text, mode="eval").body
+    except SyntaxError as error:
+        raise QueryLangError(f"could not parse select entry {entry!r}: {error}") from error
 
-        try:
-            ref = json_column_to_ref(_translate_column_or_count(node, spec), spec)
-        except (QueryLangError, QueryError) as error:
-            raise QueryLangError(f"invalid select entry {entry!r}: {error}") from error
+    try:
+        ref = json_column_to_ref(_translate_column_or_count(node, spec), spec)
+    except (QueryLangError, QueryError) as error:
+        raise QueryLangError(f"invalid select entry {entry!r}: {error}") from error
 
     if alias is not None:
         return ref, alias

--- a/GOQLFilter/po/de-local.po
+++ b/GOQLFilter/po/de-local.po
@@ -1,0 +1,90 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: de\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-04 08:52-0700\n"
+"PO-Revision-Date: 2026-08-05 18:01+0000\n"
+"Last-Translator: Mirko Leonhäuser <mirko@leonhaeuser.de>\n"
+"Language-Team: German <https://hosted.weblate.org/projects/gramps-project/"
+"addons/de/>\n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+"X-Generator: Weblate 2026.8.1.dev0\n"
+
+msgid "Person GOQL Filter"
+msgstr "GOQL-Filter für Personen"
+
+msgid "Gramplet providing a gramps-object-query-language person filter"
+msgstr ""
+"Gramplet, das einen Personenfilter für die Gramps-Objekt-Abfragesprache "
+"bereitstellt"
+
+msgid "GOQL Filter"
+msgstr "GOQL Filter"
+
+msgid "Family GOQL Filter"
+msgstr "GOQL-Filter für Familien"
+
+msgid "Gramplet providing a gramps-object-query-language family filter"
+msgstr ""
+"Gramplet, das einen Familienfilter für die Gramps-Objekt-Abfragesprache "
+"bereitstellt"
+
+msgid "Event GOQL Filter"
+msgstr "GOQL-Filter für Ereignisse"
+
+msgid "Gramplet providing a gramps-object-query-language event filter"
+msgstr ""
+"Gramplet, das einen Ereignisfilter für die Gramps-Objekt-Abfragesprache "
+"bereitstellt"
+
+msgid "Place GOQL Filter"
+msgstr "GOQL-Filter für Orte"
+
+msgid "Gramplet providing a gramps-object-query-language place filter"
+msgstr ""
+"Gramplet, das einen Ortefilter für die Gramps-Objekt-Abfragesprache "
+"bereitstellt"
+
+msgid "Repository GOQL Filter"
+msgstr "GOQL-Filter für Aufbewahrungsorte"
+
+msgid "Gramplet providing a gramps-object-query-language repository filter"
+msgstr ""
+"Gramplet, das einen Aufbewahrungsortefilter für die Gramps-Objekt-"
+"Abfragesprache bereitstellt"
+
+msgid "Source GOQL Filter"
+msgstr "GOQL-Filter für Quellen"
+
+msgid "Gramplet providing a gramps-object-query-language source filter"
+msgstr ""
+"Gramplet, das einen Quellenfilter für die Gramps-Objekt-Abfragesprache "
+"bereitstellt"
+
+msgid "Citation GOQL Filter"
+msgstr "GOQL-Filter für Quellenangaben"
+
+msgid "Gramplet providing a gramps-object-query-language citation filter"
+msgstr ""
+"Gramplet, das einen Quellenangabenfilter für die Gramps-Objekt-"
+"Abfragesprache bereitstellt"
+
+msgid "Media GOQL Filter"
+msgstr "GOQL-Filter für Medien"
+
+msgid "Gramplet providing a gramps-object-query-language media filter"
+msgstr ""
+"Gramplet, das einen Medienfilter für die Gramps-Objekt-Abfragesprache "
+"bereitstellt"
+
+msgid "Note GOQL Filter"
+msgstr "GOQL-Filter für Notizen"
+
+msgid "Gramplet providing a gramps-object-query-language note filter"
+msgstr ""
+"Gramplet, das einen Notizenfilter für die Gramps-Objekt-Abfragesprache "
+"bereitstellt"

--- a/GOQLFilter/po/he-local.po
+++ b/GOQLFilter/po/he-local.po
@@ -1,0 +1,135 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Gramps 5.2.0 – mediamerge\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-04 08:52-0700\n"
+"PO-Revision-Date: 2026-08-05 18:01+0000\n"
+"Last-Translator: Avi Markovitz <avi.markovitz@gmail.com>\n"
+"Language-Team: Hebrew <https://hosted.weblate.org/projects/gramps-project/"
+"addons/he/>\n"
+"Language: he\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=(n == 1) ? 0 : ((n == 2) ? 1 : ((n > 10 && "
+"n % 10 == 0) ? 2 : 3));\n"
+"X-Generator: Weblate 2026.8.1.dev0\n"
+
+msgid ""
+"Matches objects for which the given gramps-object-query-language where-"
+"expression evaluates to true"
+msgstr ""
+"התאמת עצמים שבהם ביטוי where בשפת־שאילתות־עצמי־גרמפס (GOQL), הוא 'true'"
+
+msgid "Person GOQL Filter"
+msgstr "מסנן GOQL לאדם"
+
+msgid "Gramplet providing a gramps-object-query-language person filter"
+msgstr "גרמפלט שמספק מסנן אדם בשפת־שאילתות־עצמי־גרמפס (GOQL)"
+
+msgid "GOQL Filter"
+msgstr "מסנן GOQL"
+
+msgid "Family GOQL Filter"
+msgstr "מסנן GOQL למשפחה"
+
+msgid "Gramplet providing a gramps-object-query-language family filter"
+msgstr "גרמפלט שמספק מסנן משפחה בשפת־שאילתות־עצמי־גרמפס (GOQL)"
+
+msgid "Event GOQL Filter"
+msgstr "מסנן GOQL לאירוע"
+
+msgid "Gramplet providing a gramps-object-query-language event filter"
+msgstr "ברמפלט שמספר מסנן אירועים בשפת־שאילתות־עצמי־גרמפס (GOQL)"
+
+msgid "Place GOQL Filter"
+msgstr "מסנן מקומות GOQL"
+
+msgid "Gramplet providing a gramps-object-query-language place filter"
+msgstr "גרמפלט שמספק מסנן מקומות בשפת־שאילתות־עצמי־גרמפס (GOQL)"
+
+msgid "Repository GOQL Filter"
+msgstr "מסנן מאגרים GOQL"
+
+msgid "Gramplet providing a gramps-object-query-language repository filter"
+msgstr "גרמפלט שמספק מסנן מאגרים בשפת־שאילתות־עצמי־גרמפס (GOQL)"
+
+msgid "Source GOQL Filter"
+msgstr "מסנן מקור GOQL"
+
+msgid "Gramplet providing a gramps-object-query-language source filter"
+msgstr "גרמפלט שמספק מסנן מקורות בשפת־שאילתות־עצמי־גרמפס (GOQL)"
+
+msgid "Citation GOQL Filter"
+msgstr "מסנן מובאה GOQL"
+
+msgid "Gramplet providing a gramps-object-query-language citation filter"
+msgstr "גרמפלט שמספק מסנן מובאות בשפת־שאילתות־עצמי־גרמפס (GOQL)"
+
+msgid "Media GOQL Filter"
+msgstr "מסנן מדיה GOQL"
+
+msgid "Gramplet providing a gramps-object-query-language media filter"
+msgstr "גרמפלט שמספק מסנן מדיה בשפת־שאילתות־עצמי־גרמפס (GOQL)"
+
+msgid "Note GOQL Filter"
+msgstr "מסנן הערה GOQL"
+
+msgid "Gramplet providing a gramps-object-query-language note filter"
+msgstr "גרמפלט שמספק מסנן הערות בשפת־שאילתות־עצמי־גרמפס (GOQL)"
+
+msgid "A gramps-object-query-language where-expression, e.g.\n"
+msgstr "ביטוי where בשפת־שאילתות־עצמי־גרמפס (GOQL), לדוגמה\n"
+
+msgid ""
+"Matches people for which the given gramps-object-query-language where-"
+"expression evaluates to true"
+msgstr ""
+"התאמת אנשים שבהם ביטוי where בשפת־שאילתות־עצמי־גרמפס (GOQL), הוא 'true'"
+
+msgid ""
+"Matches families for which the given gramps-object-query-language where-"
+"expression evaluates to true"
+msgstr ""
+"התאמת משפחות שבהן ביטוי where בשפת־שאילתות־עצמי־גרמפס (GOQL), הוא 'true'"
+
+msgid ""
+"Matches events for which the given gramps-object-query-language where-"
+"expression evaluates to true"
+msgstr ""
+"התאמת אירועים שבהם ביטוי where בשפת־שאילתות־עצמי־גרמפס (GOQL), הוא 'true'"
+
+msgid ""
+"Matches places for which the given gramps-object-query-language where-"
+"expression evaluates to true"
+msgstr ""
+"התאמת מקומות שבהם ביטוי where בשפת־שאילתות־עצמי־גרמפס (GOQL), הוא 'true'"
+
+msgid ""
+"Matches repositories for which the given gramps-object-query-language where-"
+"expression evaluates to true"
+msgstr ""
+"התאמת אגרים שבהם ביטוי where בשפת־שאילתות־עצמי־גרמפס (GOQL), הוא 'true'"
+
+msgid ""
+"Matches sources for which the given gramps-object-query-language where-"
+"expression evaluates to true"
+msgstr ""
+"התאמת מקורות שבהם ביטוי where בשפת־שאילתות־עצמי־גרמפס (GOQL), הוא 'true'"
+
+msgid ""
+"Matches citations for which the given gramps-object-query-language where-"
+"expression evaluates to true"
+msgstr ""
+"התאמת מובאות שבהן ביטוי where בשפת־שאילתות־עצמי־גרמפס (GOQL), הוא 'true'"
+
+msgid ""
+"Matches media for which the given gramps-object-query-language where-"
+"expression evaluates to true"
+msgstr "התאמת מדיה שבהן ביטוי where בשפת־שאילתות־עצמי־גרמפס (GOQL), הוא 'true'"
+
+msgid ""
+"Matches notes for which the given gramps-object-query-language where-"
+"expression evaluates to true"
+msgstr ""
+"התאמת הערות שבהן ביטוי where בשפת־שאילתות־עצמי־גרמפס (GOQL), הוא 'true'"

--- a/GOQLFilter/po/sk-local.po
+++ b/GOQLFilter/po/sk-local.po
@@ -1,0 +1,224 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: GRAMPS 3.1.3\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-04 08:52-0700\n"
+"PO-Revision-Date: 2026-08-05 18:02+0000\n"
+"Last-Translator: Milan <mobrcian@hotmail.com>\n"
+"Language-Team: Slovak <https://hosted.weblate.org/projects/gramps-project/"
+"addons/sk/>\n"
+"Language: sk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=((n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2);\n"
+"X-Generator: Weblate 2026.8.1.dev0\n"
+
+msgid "GOQL expression"
+msgstr "Výraz GOQL"
+
+msgid ""
+"Matches objects for which the given gramps-object-query-language where-"
+"expression evaluates to true"
+msgstr ""
+"Zodpovedá objektom, pre ktoré sa daný výraz WHERE v Gramps Object Query "
+"Language vyhodnotí ako pravdivý"
+
+msgid "People matching the <GOQL expression>"
+msgstr "Ľudia zodpovedajúci <výrazu GOQL>"
+
+msgid "Families matching the <GOQL expression>"
+msgstr "Rodiny zodpovedajúce <výrazu GOQL>"
+
+msgid "Events matching the <GOQL expression>"
+msgstr "Udalosti zodpovedajúce <výrazu GOQL>"
+
+msgid "Places matching the <GOQL expression>"
+msgstr "Miesta zodpovedajúce <výrazu GOQL>"
+
+msgid "Repositories matching the <GOQL expression>"
+msgstr "Repozitáre zodpovedajúce <výrazu GOQL>"
+
+msgid "Sources matching the <GOQL expression>"
+msgstr "Zdroje zodpovedajúce <výrazu GOQL>"
+
+msgid "Citations matching the <GOQL expression>"
+msgstr "Citácie zodpovedajúce <výrazu GOQL>"
+
+msgid "Media matching the <GOQL expression>"
+msgstr "Médiá zodpovedajúce <výrazu GOQL>"
+
+msgid "Notes matching the <GOQL expression>"
+msgstr "Poznámky zodpovedajúce <výrazu GOQL>"
+
+msgid "Person GOQL Filter"
+msgstr "Filter GOQL pre osoby"
+
+msgid "Gramplet providing a gramps-object-query-language person filter"
+msgstr "Gramplet poskytujúci filter osôb v Gramps Object Query Language"
+
+msgid "GOQL Filter"
+msgstr "Filter GOQL"
+
+msgid "Family GOQL Filter"
+msgstr "Filter GOQL pre rodiny"
+
+msgid "Gramplet providing a gramps-object-query-language family filter"
+msgstr "Gramplet poskytujúci filter rodín v Gramps Object Query Language"
+
+msgid "Event GOQL Filter"
+msgstr "Filter GOQL pre udalosti"
+
+msgid "Gramplet providing a gramps-object-query-language event filter"
+msgstr "Gramplet poskytujúci filter udalostí v Gramps Object Query Language"
+
+msgid "Place GOQL Filter"
+msgstr "Filter GOQL pre miesta"
+
+msgid "Gramplet providing a gramps-object-query-language place filter"
+msgstr "Gramplet poskytujúci filter miest v Gramps Object Query Language"
+
+msgid "Repository GOQL Filter"
+msgstr "Filter GOQL pre repozitáre"
+
+msgid "Gramplet providing a gramps-object-query-language repository filter"
+msgstr "Gramplet poskytujúci filter repozitárov v Gramps Object Query Language"
+
+msgid "Source GOQL Filter"
+msgstr "Filter GOQL pre zdroje"
+
+msgid "Gramplet providing a gramps-object-query-language source filter"
+msgstr "Gramplet poskytujúci filter zdrojov v Gramps Object Query Language"
+
+msgid "Citation GOQL Filter"
+msgstr "Filter GOQL pre citácie"
+
+msgid "Gramplet providing a gramps-object-query-language citation filter"
+msgstr "Gramplet poskytujúci filter citácií v Gramps Object Query Language"
+
+msgid "Media GOQL Filter"
+msgstr "Filter GOQL pre médiá"
+
+msgid "Gramplet providing a gramps-object-query-language media filter"
+msgstr "Gramplet poskytujúci filter médií v Gramps Object Query Language"
+
+msgid "Note GOQL Filter"
+msgstr "Filter GOQL pre poznámky"
+
+msgid "Gramplet providing a gramps-object-query-language note filter"
+msgstr "Gramplet poskytujúci filter poznámok v Gramps Object Query Language"
+
+msgid "A gramps-object-query-language where-expression, e.g.\n"
+msgstr "Výraz WHERE (kde) v Gramps Object Query Language, napr.\n"
+
+msgid "Enter inserts a newline; Ctrl+Enter runs Find.\n"
+msgstr "Enter vloží nový riadok; Ctrl+Enter spustí Hľadať.\n"
+
+msgid "Up/Down at the first/last line recalls previous expressions.\n"
+msgstr ""
+"Šípky hore/dole na prvom/poslednom riadku pripomenú predchádzajúce výrazy.\n"
+
+msgid "Tab always completes -- it never inserts a tab character."
+msgstr "Tab vždy dopĺňa -- nikdy nevloží znak tabulátora."
+
+#, python-format
+msgid "%s filter"
+msgstr "filter %s"
+
+msgid "This resets the filter parameters to empty state."
+msgstr "Toto resetuje parametre filtra do prázdneho stavu."
+
+msgid "This opens a dialog to save the current expression as a named filter."
+msgstr ""
+"Toto otvorí dialóg na uloženie aktuálneho výrazu ako pomenovaného filtra."
+
+msgid "Open this gramplet's help page in a browser."
+msgstr "Otvoriť stránku nápovedy tohto grampletu v prehliadači."
+
+msgid "SQL"
+msgstr "SQL"
+
+msgid "Python evaluation"
+msgstr "Vyhodnotenie v Pythone"
+
+#, python-format
+msgid "Error applying filter: %s"
+msgstr "Chyba pri aplikovaní filtra: %s"
+
+#, python-format
+msgid "Showing %(shown)d of %(total)d (%(method)s)"
+msgstr "Zobrazené %(shown)d z %(total)d (%(method)s)"
+
+#, python-format
+msgid "Error resetting filter: %s"
+msgstr "Chyba pri resetovaní filtra: %s"
+
+msgid "Enter an expression first"
+msgstr "Najprv zadajte výraz"
+
+#, python-brace-format
+msgid "Created by the GOQL Filter gramplet on {today}"
+msgstr "Vytvorené grampletom Filter GOQL na {today}"
+
+msgid ""
+"Matches people for which the given gramps-object-query-language where-"
+"expression evaluates to true"
+msgstr ""
+"Zodpovedá osobám, pre ktoré sa daný výraz WHERE v Gramps Object Query "
+"Language vyhodnotí ako pravdivý"
+
+msgid ""
+"Matches families for which the given gramps-object-query-language where-"
+"expression evaluates to true"
+msgstr ""
+"Zodpovedá rodinám, pre ktoré sa daný výraz WHERE v Gramps Object Query "
+"Language vyhodnotí ako pravdivý"
+
+msgid ""
+"Matches events for which the given gramps-object-query-language where-"
+"expression evaluates to true"
+msgstr ""
+"Zodpovedá udalostiam, pre ktoré sa daný výraz WHERE v Gramps Object Query "
+"Language vyhodnotí ako pravdivý"
+
+msgid ""
+"Matches places for which the given gramps-object-query-language where-"
+"expression evaluates to true"
+msgstr ""
+"Zodpovedá miestam, pre ktoré sa daný výraz WHERE v Gramps Object Query "
+"Language vyhodnotí ako pravdivý"
+
+msgid ""
+"Matches repositories for which the given gramps-object-query-language where-"
+"expression evaluates to true"
+msgstr ""
+"Zodpovedá repozitárom, pre ktoré sa daný výraz WHERE v Gramps Object Query "
+"Language vyhodnotí ako pravdivý"
+
+msgid ""
+"Matches sources for which the given gramps-object-query-language where-"
+"expression evaluates to true"
+msgstr ""
+"Zodpovedá zdrojom, pre ktoré sa daný výraz WHERE v Gramps Object Query "
+"Language vyhodnotí ako pravdivý"
+
+msgid ""
+"Matches citations for which the given gramps-object-query-language where-"
+"expression evaluates to true"
+msgstr ""
+"Zodpovedá citáciám, pre ktoré sa daný výraz WHERE v Gramps Object Query "
+"Language vyhodnotí ako pravdivý"
+
+msgid ""
+"Matches media for which the given gramps-object-query-language where-"
+"expression evaluates to true"
+msgstr ""
+"Zodpovedá médiám, pre ktoré sa daný výraz WHERE v Gramps Object Query "
+"Language vyhodnotí ako pravdivý"
+
+msgid ""
+"Matches notes for which the given gramps-object-query-language where-"
+"expression evaluates to true"
+msgstr ""
+"Zodpovedá poznámkam, pre ktoré sa daný výraz WHERE v Gramps Object Query "
+"Language vyhodnotí ako pravdivý"

--- a/GOQLFilter/po/template.pot
+++ b/GOQLFilter/po/template.pot
@@ -1,0 +1,287 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-08-04 08:52-0700\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: GOQLFilter/whereexprrule.py:212
+msgid "GOQL expression"
+msgstr ""
+
+#: GOQLFilter/whereexprrule.py:214
+msgid ""
+"Matches objects for which the given gramps-object-query-language where-"
+"expression evaluates to true"
+msgstr ""
+
+#: GOQLFilter/whereexprrule.py:217
+msgid "General filters"
+msgstr ""
+
+#: GOQLFilter/whereexprrule.py:261 GOQLFilter/whereexprrule.gpr.py:30
+msgid "People matching the <GOQL expression>"
+msgstr ""
+
+#: GOQLFilter/whereexprrule.py:266 GOQLFilter/whereexprrule.gpr.py:50
+msgid "Families matching the <GOQL expression>"
+msgstr ""
+
+#: GOQLFilter/whereexprrule.py:271 GOQLFilter/whereexprrule.gpr.py:70
+msgid "Events matching the <GOQL expression>"
+msgstr ""
+
+#: GOQLFilter/whereexprrule.py:276 GOQLFilter/whereexprrule.gpr.py:90
+msgid "Places matching the <GOQL expression>"
+msgstr ""
+
+#: GOQLFilter/whereexprrule.py:281 GOQLFilter/whereexprrule.gpr.py:110
+msgid "Repositories matching the <GOQL expression>"
+msgstr ""
+
+#: GOQLFilter/whereexprrule.py:286 GOQLFilter/whereexprrule.gpr.py:130
+msgid "Sources matching the <GOQL expression>"
+msgstr ""
+
+#: GOQLFilter/whereexprrule.py:291 GOQLFilter/whereexprrule.gpr.py:150
+msgid "Citations matching the <GOQL expression>"
+msgstr ""
+
+#: GOQLFilter/whereexprrule.py:296 GOQLFilter/whereexprrule.gpr.py:170
+msgid "Media matching the <GOQL expression>"
+msgstr ""
+
+#: GOQLFilter/whereexprrule.py:301 GOQLFilter/whereexprrule.gpr.py:190
+msgid "Notes matching the <GOQL expression>"
+msgstr ""
+
+#: GOQLFilter/goql.gpr.py:31
+msgid "Person GOQL Filter"
+msgstr ""
+
+#: GOQLFilter/goql.gpr.py:32
+msgid "Gramplet providing a gramps-object-query-language person filter"
+msgstr ""
+
+#: GOQLFilter/goql.gpr.py:39 GOQLFilter/goql.gpr.py:58
+#: GOQLFilter/goql.gpr.py:77 GOQLFilter/goql.gpr.py:96
+#: GOQLFilter/goql.gpr.py:117 GOQLFilter/goql.gpr.py:136
+#: GOQLFilter/goql.gpr.py:155 GOQLFilter/goql.gpr.py:174
+#: GOQLFilter/goql.gpr.py:193
+msgid "GOQL Filter"
+msgstr ""
+
+#: GOQLFilter/goql.gpr.py:50
+msgid "Family GOQL Filter"
+msgstr ""
+
+#: GOQLFilter/goql.gpr.py:51
+msgid "Gramplet providing a gramps-object-query-language family filter"
+msgstr ""
+
+#: GOQLFilter/goql.gpr.py:69
+msgid "Event GOQL Filter"
+msgstr ""
+
+#: GOQLFilter/goql.gpr.py:70
+msgid "Gramplet providing a gramps-object-query-language event filter"
+msgstr ""
+
+#: GOQLFilter/goql.gpr.py:88
+msgid "Place GOQL Filter"
+msgstr ""
+
+#: GOQLFilter/goql.gpr.py:89
+msgid "Gramplet providing a gramps-object-query-language place filter"
+msgstr ""
+
+#: GOQLFilter/goql.gpr.py:107
+msgid "Repository GOQL Filter"
+msgstr ""
+
+#: GOQLFilter/goql.gpr.py:109
+msgid "Gramplet providing a gramps-object-query-language repository filter"
+msgstr ""
+
+#: GOQLFilter/goql.gpr.py:128
+msgid "Source GOQL Filter"
+msgstr ""
+
+#: GOQLFilter/goql.gpr.py:129
+msgid "Gramplet providing a gramps-object-query-language source filter"
+msgstr ""
+
+#: GOQLFilter/goql.gpr.py:147
+msgid "Citation GOQL Filter"
+msgstr ""
+
+#: GOQLFilter/goql.gpr.py:148
+msgid "Gramplet providing a gramps-object-query-language citation filter"
+msgstr ""
+
+#: GOQLFilter/goql.gpr.py:166
+msgid "Media GOQL Filter"
+msgstr ""
+
+#: GOQLFilter/goql.gpr.py:167
+msgid "Gramplet providing a gramps-object-query-language media filter"
+msgstr ""
+
+#: GOQLFilter/goql.gpr.py:185
+msgid "Note GOQL Filter"
+msgstr ""
+
+#: GOQLFilter/goql.gpr.py:186
+msgid "Gramplet providing a gramps-object-query-language note filter"
+msgstr ""
+
+#: GOQLFilter/goql.py:186
+msgid "A gramps-object-query-language where-expression, e.g.\n"
+msgstr ""
+
+#: GOQLFilter/goql.py:188
+msgid "Enter inserts a newline; Ctrl+Enter runs Find.\n"
+msgstr ""
+
+#: GOQLFilter/goql.py:189
+msgid "Up/Down at the first/last line recalls previous expressions.\n"
+msgstr ""
+
+#: GOQLFilter/goql.py:190
+msgid "Tab always completes -- it never inserts a tab character."
+msgstr ""
+
+#: GOQLFilter/goql.py:213
+#, python-format
+msgid "%s filter"
+msgstr ""
+
+#: GOQLFilter/goql.py:225
+msgid "_Find"
+msgstr ""
+
+#: GOQLFilter/goql.py:227
+msgid "This updates the view with the current filter parameters."
+msgstr ""
+
+#: GOQLFilter/goql.py:231
+msgid "Reset"
+msgstr ""
+
+#: GOQLFilter/goql.py:233
+msgid "This resets the filter parameters to empty state."
+msgstr ""
+
+#: GOQLFilter/goql.py:237
+msgid "Define filter"
+msgstr ""
+
+#: GOQLFilter/goql.py:239
+msgid "This opens a dialog to save the current expression as a named filter."
+msgstr ""
+
+#: GOQLFilter/goql.py:243
+msgid "Help"
+msgstr ""
+
+#: GOQLFilter/goql.py:244
+msgid "Open this gramplet's help page in a browser."
+msgstr ""
+
+#: GOQLFilter/goql.py:402
+msgid "SQL"
+msgstr ""
+
+#: GOQLFilter/goql.py:403
+msgid "Python evaluation"
+msgstr ""
+
+#: GOQLFilter/goql.py:523
+#, python-format
+msgid "Error applying filter: %s"
+msgstr ""
+
+#: GOQLFilter/goql.py:526
+#, python-format
+msgid "Showing %(shown)d of %(total)d (%(method)s)"
+msgstr ""
+
+#: GOQLFilter/goql.py:541
+#, python-format
+msgid "Error resetting filter: %s"
+msgstr ""
+
+#: GOQLFilter/goql.py:548
+msgid "Enter an expression first"
+msgstr ""
+
+#: GOQLFilter/goql.py:560
+#, python-brace-format
+msgid "Created by the GOQL Filter gramplet on {today}"
+msgstr ""
+
+#: GOQLFilter/whereexprrule.gpr.py:32
+msgid ""
+"Matches people for which the given gramps-object-query-language where-"
+"expression evaluates to true"
+msgstr ""
+
+#: GOQLFilter/whereexprrule.gpr.py:52
+msgid ""
+"Matches families for which the given gramps-object-query-language where-"
+"expression evaluates to true"
+msgstr ""
+
+#: GOQLFilter/whereexprrule.gpr.py:72
+msgid ""
+"Matches events for which the given gramps-object-query-language where-"
+"expression evaluates to true"
+msgstr ""
+
+#: GOQLFilter/whereexprrule.gpr.py:92
+msgid ""
+"Matches places for which the given gramps-object-query-language where-"
+"expression evaluates to true"
+msgstr ""
+
+#: GOQLFilter/whereexprrule.gpr.py:112
+msgid ""
+"Matches repositories for which the given gramps-object-query-language where-"
+"expression evaluates to true"
+msgstr ""
+
+#: GOQLFilter/whereexprrule.gpr.py:132
+msgid ""
+"Matches sources for which the given gramps-object-query-language where-"
+"expression evaluates to true"
+msgstr ""
+
+#: GOQLFilter/whereexprrule.gpr.py:152
+msgid ""
+"Matches citations for which the given gramps-object-query-language where-"
+"expression evaluates to true"
+msgstr ""
+
+#: GOQLFilter/whereexprrule.gpr.py:172
+msgid ""
+"Matches media for which the given gramps-object-query-language where-"
+"expression evaluates to true"
+msgstr ""
+
+#: GOQLFilter/whereexprrule.gpr.py:192
+msgid ""
+"Matches notes for which the given gramps-object-query-language where-"
+"expression evaluates to true"
+msgstr ""

--- a/GOQLFilter/tests/test_goql.py
+++ b/GOQLFilter/tests/test_goql.py
@@ -1,0 +1,593 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Mocked unit tests for the ``QueryFilter`` gramplet's click handlers.
+
+No live Gramps window, no database on disk -- ``self.gui``/``self.dbstate``/
+``self.uistate`` are replaced with mocks (``PersonQueryFilter.__new__``
+bypasses ``Gramplet.__init__``, the same pattern
+``Form/tests/test_editform_save_guards.py`` uses to avoid needing a running
+main window). ``compile_expr``/``GenericFilterFactory`` run for real --
+they're pure/fast and need no display.
+
+Run with::
+
+    python3 -m unittest GOQLFilter.tests.test_goql -v
+"""
+
+import os
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+ADDON_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ADDON_DIR not in sys.path:
+    sys.path.insert(0, ADDON_DIR)
+
+try:
+    import gi  # noqa: F401
+    from gi.repository import Gdk
+except ImportError as err:
+    raise unittest.SkipTest("PyGObject not available: %s" % err)
+
+try:
+    import goql as goql_gramplet
+except ImportError as exc:
+    raise unittest.SkipTest(
+        "goql import failed (likely missing gramps-object-query-language): %s" % exc
+    )
+
+
+def _make_gramplet(initial_text=""):
+    """A ``PersonQueryFilter`` with only the attributes its click handlers
+    touch -- bypasses ``Gramplet.__init__``, which wants a live
+    ``GuiGramplet``/``dbstate``/``uistate`` and builds real widgets against
+    a running Gramps window. ``_get_expr_text``/``_set_expr_text`` stand in
+    for the real ``Gtk.TextBuffer``-backed versions -- what they read from
+    and write to is exactly the seam ``find_clicked``/``reset_clicked``/
+    ``define_clicked``/history navigation go through.
+    """
+    gramplet = goql_gramplet.PersonQueryFilter.__new__(goql_gramplet.PersonQueryFilter)
+    text = {"value": initial_text}
+    gramplet._get_expr_text = MagicMock(side_effect=lambda: text["value"].strip())
+    gramplet._set_expr_text = MagicMock(
+        side_effect=lambda t: text.__setitem__("value", t)
+    )
+    gramplet.msg_label = MagicMock()
+    gramplet.dbstate = MagicMock()
+    gramplet.uistate = MagicMock()
+    gramplet.gui = MagicMock()
+    gramplet.history = []
+    gramplet.history_index = None
+    gramplet.history_draft = ""
+    gramplet.completion = MagicMock()
+    gramplet.completion.on_key_press.return_value = False
+    return gramplet
+
+
+def _key_event(keyval, ctrl=False):
+    return types.SimpleNamespace(
+        keyval=keyval,
+        state=(Gdk.ModifierType.CONTROL_MASK if ctrl else Gdk.ModifierType(0)),
+    )
+
+
+# ------------------------------------------------------------
+#
+# DefineFilterCallbackTest
+#
+# ------------------------------------------------------------
+class DefineFilterCallbackTest(unittest.TestCase):
+    """Regression test: interactively, "Define filter" -> OK raised
+    ``TypeError: QueryFilter._filter_defined() missing 2 required
+    positional arguments: 'filterdb' and '_filter_name'``.
+
+    Cause: ``define_clicked`` passed ``_filter_defined`` to ``EditFilter``'s
+    ``update`` parameter, which ``EditFilter.on_ok_clicked`` calls with zero
+    arguments (``self.update()``). The two-argument call
+    (``self.selection_callback(self.filterdb, self.filter.get_name())``)
+    is a separate parameter, ``selection_callback`` -- see
+    ``gramps/gui/editors/filtereditor.py``. Fixed by passing
+    ``_filter_defined`` as ``selection_callback`` instead.
+    """
+
+    def test_define_clicked_uses_selection_callback_not_update(self):
+        gramplet = _make_gramplet("gender == Person.MALE")
+
+        with patch.object(goql_gramplet, "EditFilter") as mock_edit_filter:
+            gramplet.define_clicked(None)
+
+        mock_edit_filter.assert_called_once()
+        _args, kwargs = mock_edit_filter.call_args
+        # Bound methods aren't identical objects across separate attribute
+        # accesses even for the same instance+function, so compare by
+        # equality (bound methods implement __eq__), not identity.
+        self.assertEqual(kwargs.get("selection_callback"), gramplet._filter_defined)
+        self.assertIsNone(kwargs.get("update"))
+
+    def test_filter_defined_matches_editfilter_call_signature(self):
+        """``EditFilter.on_ok_clicked`` calls
+        ``self.selection_callback(self.filterdb, self.filter.get_name())``
+        -- ``_filter_defined`` must accept exactly that shape and use it to
+        persist + reload the custom filter list.
+        """
+        gramplet = _make_gramplet()
+        filterdb = MagicMock()
+
+        with patch.object(goql_gramplet, "reload_custom_filters") as mock_reload:
+            gramplet._filter_defined(filterdb, "My Filter")
+
+        filterdb.save.assert_called_once()
+        mock_reload.assert_called_once()
+        gramplet.uistate.emit.assert_called_once_with("filters-changed", ("Person",))
+
+    def test_define_clicked_reports_compile_error_without_opening_dialog(self):
+        gramplet = _make_gramplet("this is not valid GOQL !!")
+
+        with patch.object(goql_gramplet, "EditFilter") as mock_edit_filter:
+            gramplet.define_clicked(None)
+
+        mock_edit_filter.assert_not_called()
+        gramplet.msg_label.set_text.assert_called()
+
+
+# ------------------------------------------------------------
+#
+# FindResetTest
+#
+# ------------------------------------------------------------
+class FindResetTest(unittest.TestCase):
+    """Happy-path coverage for the Find/Reset mechanism itself: setting
+    ``view.generic_filter`` and calling ``view.build_tree()`` -- the same
+    two calls core's own ``plugins/gramplet/filter.py`` uses.
+    """
+
+    def test_find_clicked_sets_generic_filter_and_rebuilds(self):
+        gramplet = _make_gramplet("gender == Person.MALE")
+        gramplet.gui.view.search_bar.is_visible.return_value = False
+
+        gramplet.find_clicked(None)
+
+        self.assertIsNotNone(gramplet.gui.view.generic_filter)
+        gramplet.gui.view.build_tree.assert_called_once()
+
+    def test_find_clicked_reports_compile_error_without_touching_view(self):
+        gramplet = _make_gramplet("this is not valid GOQL !!")
+
+        gramplet.find_clicked(None)
+
+        gramplet.gui.view.build_tree.assert_not_called()
+        gramplet.msg_label.set_text.assert_called()
+
+    def test_find_clicked_with_empty_expression_resets_instead(self):
+        gramplet = _make_gramplet("   ")
+        gramplet.gui.view.search_bar.is_visible.return_value = False
+
+        gramplet.find_clicked(None)
+
+        gramplet._set_expr_text.assert_called_once_with("")
+        self.assertIsNone(gramplet.gui.view.generic_filter)
+        gramplet.gui.view.build_tree.assert_called_once()
+
+    def test_reset_clicked_clears_filter_and_rebuilds(self):
+        gramplet = _make_gramplet()
+        gramplet.gui.view.search_bar.is_visible.return_value = False
+
+        gramplet.reset_clicked(None)
+
+        gramplet._set_expr_text.assert_called_once_with("")
+        self.assertIsNone(gramplet.gui.view.generic_filter)
+        gramplet.gui.view.build_tree.assert_called_once()
+
+    def test_hide_quick_search_bar_hides_when_visible(self):
+        gramplet = _make_gramplet()
+        gramplet.gui.view.search_bar.is_visible.return_value = True
+
+        gramplet._hide_quick_search_bar()
+
+        gramplet.gui.view.search_bar.hide.assert_called_once()
+
+    def test_hide_quick_search_bar_leaves_hidden_bar_alone(self):
+        gramplet = _make_gramplet()
+        gramplet.gui.view.search_bar.is_visible.return_value = False
+
+        gramplet._hide_quick_search_bar()
+
+        gramplet.gui.view.search_bar.hide.assert_not_called()
+
+    def test_hide_quick_search_bar_tolerates_a_view_without_one(self):
+        gramplet = _make_gramplet()
+        del gramplet.gui.view.search_bar  # e.g. a non-ListView pageview
+
+        gramplet._hide_quick_search_bar()  # must not raise
+
+
+def _make_gramplet_for_keypress(cursor_line=0, line_count=1):
+    """A gramplet with a mocked ``text_buffer`` reporting a fixed cursor
+    line / line count, and mocked ``find_clicked``/``_history_back``/
+    ``_history_forward`` -- enough to test ``_on_key_press``'s dispatch in
+    isolation, without constructing a real ``Gtk.TextView`` (needs a real
+    display connection to construct at all, which the documented test
+    invocation's ``GDK_BACKEND=-`` deliberately does without -- see
+    ``HistoryNavigationTest`` for the text-content-level coverage this
+    dispatch-only test doesn't duplicate).
+    """
+    gramplet = goql_gramplet.PersonQueryFilter.__new__(goql_gramplet.PersonQueryFilter)
+    cursor_iter = MagicMock()
+    cursor_iter.get_line.return_value = cursor_line
+    gramplet.text_buffer = MagicMock()
+    gramplet.text_buffer.get_iter_at_mark.return_value = cursor_iter
+    gramplet.text_buffer.get_line_count.return_value = line_count
+    gramplet.find_clicked = MagicMock()
+    gramplet._history_back = MagicMock()
+    gramplet._history_forward = MagicMock()
+    gramplet.completion = MagicMock()
+    gramplet.completion.on_key_press.return_value = False
+    return gramplet
+
+
+# ------------------------------------------------------------
+#
+# HistoryNavigationTest
+#
+# ------------------------------------------------------------
+class HistoryNavigationTest(unittest.TestCase):
+    """``_remember_history``/``_history_back``/``_history_forward`` in
+    isolation, through the ``_get_expr_text``/``_set_expr_text`` seam.
+    """
+
+    def test_remember_history_appends_and_resets_index(self):
+        gramplet = _make_gramplet()
+        gramplet.history_index = 0  # pretend we were mid-browse
+
+        gramplet._remember_history("gender == Person.MALE")
+
+        self.assertEqual(gramplet.history, ["gender == Person.MALE"])
+        self.assertIsNone(gramplet.history_index)
+
+    def test_remember_history_skips_immediate_repeat(self):
+        gramplet = _make_gramplet()
+        gramplet._remember_history("gender == Person.MALE")
+        gramplet._remember_history("gender == Person.MALE")
+
+        self.assertEqual(gramplet.history, ["gender == Person.MALE"])
+
+    def test_remember_history_ignores_empty_expression(self):
+        gramplet = _make_gramplet()
+        gramplet._remember_history("")
+
+        self.assertEqual(gramplet.history, [])
+
+    def test_history_back_recalls_most_recent_first_and_saves_draft(self):
+        gramplet = _make_gramplet("draft in progress")
+        gramplet.history = ["first", "second"]
+
+        gramplet._history_back()
+
+        self.assertEqual(gramplet._get_expr_text(), "second")
+        self.assertEqual(gramplet.history_draft, "draft in progress")
+
+    def test_history_back_twice_walks_further_back(self):
+        gramplet = _make_gramplet()
+        gramplet.history = ["first", "second"]
+
+        gramplet._history_back()
+        gramplet._history_back()
+
+        self.assertEqual(gramplet._get_expr_text(), "first")
+
+    def test_history_back_stops_at_oldest_entry(self):
+        gramplet = _make_gramplet()
+        gramplet.history = ["only"]
+
+        gramplet._history_back()
+        gramplet._history_back()
+
+        self.assertEqual(gramplet._get_expr_text(), "only")
+
+    def test_history_back_with_empty_history_is_a_no_op(self):
+        gramplet = _make_gramplet("still typing")
+
+        gramplet._history_back()
+
+        self.assertEqual(gramplet._get_expr_text(), "still typing")
+
+    def test_history_forward_returns_to_draft_past_newest(self):
+        gramplet = _make_gramplet("draft in progress")
+        gramplet.history = ["first", "second"]
+        gramplet._history_back()  # -> "second", saves the draft
+
+        gramplet._history_forward()
+
+        self.assertEqual(gramplet._get_expr_text(), "draft in progress")
+        self.assertIsNone(gramplet.history_index)
+
+    def test_history_forward_without_browsing_is_a_no_op(self):
+        gramplet = _make_gramplet("still typing")
+
+        gramplet._history_forward()
+
+        self.assertEqual(gramplet._get_expr_text(), "still typing")
+
+
+# ------------------------------------------------------------
+#
+# KeyPressTest
+#
+# ------------------------------------------------------------
+class KeyPressTest(unittest.TestCase):
+    """``_on_key_press``'s dispatch: completion gets first look at every key
+    (so its popover's Up/Down/Enter/Escape work); Ctrl+Enter runs Find;
+    Tab is always consumed -- it never inserts a tab character, even when
+    there was nothing to complete; Up/Down (when completion didn't
+    consume them) only recall history at the first/last line of the
+    buffer, so normal cursor movement inside a multi-line expression
+    still works.
+    """
+
+    def test_ctrl_enter_runs_find_and_is_consumed(self):
+        gramplet = _make_gramplet_for_keypress()
+
+        handled = gramplet._on_key_press(None, _key_event(Gdk.KEY_Return, ctrl=True))
+
+        self.assertTrue(handled)
+        gramplet.find_clicked.assert_called_once()
+
+    def test_plain_enter_is_not_consumed(self):
+        gramplet = _make_gramplet_for_keypress()
+
+        handled = gramplet._on_key_press(None, _key_event(Gdk.KEY_Return, ctrl=False))
+
+        self.assertFalse(handled)
+        gramplet.find_clicked.assert_not_called()
+
+    def test_up_at_first_line_of_single_line_buffer_recalls_history(self):
+        gramplet = _make_gramplet_for_keypress(cursor_line=0, line_count=1)
+
+        handled = gramplet._on_key_press(None, _key_event(Gdk.KEY_Up))
+
+        self.assertTrue(handled)
+        gramplet._history_back.assert_called_once()
+
+    def test_up_on_a_later_line_of_a_multiline_buffer_is_not_consumed(self):
+        gramplet = _make_gramplet_for_keypress(cursor_line=1, line_count=2)
+
+        handled = gramplet._on_key_press(None, _key_event(Gdk.KEY_Up))
+
+        self.assertFalse(handled)
+        gramplet._history_back.assert_not_called()
+
+    def test_down_on_an_earlier_line_of_a_multiline_buffer_is_not_consumed(self):
+        gramplet = _make_gramplet_for_keypress(cursor_line=0, line_count=2)
+
+        handled = gramplet._on_key_press(None, _key_event(Gdk.KEY_Down))
+
+        self.assertFalse(handled)
+        gramplet._history_forward.assert_not_called()
+
+    def test_down_at_last_line_recalls_history(self):
+        gramplet = _make_gramplet_for_keypress(cursor_line=1, line_count=2)
+
+        handled = gramplet._on_key_press(None, _key_event(Gdk.KEY_Down))
+
+        self.assertTrue(handled)
+        gramplet._history_forward.assert_called_once()
+
+    def test_tab_is_consumed_even_with_nothing_to_complete(self):
+        gramplet = _make_gramplet_for_keypress()
+        gramplet.completion.on_key_press.return_value = False  # nothing completable
+
+        handled = gramplet._on_key_press(None, _key_event(Gdk.KEY_Tab))
+
+        self.assertTrue(handled)  # never falls back to inserting a tab
+
+    def test_tab_delegates_to_completion_first(self):
+        gramplet = _make_gramplet_for_keypress()
+        gramplet.completion.on_key_press.return_value = True  # triggered/accepted
+
+        handled = gramplet._on_key_press(None, _key_event(Gdk.KEY_Tab))
+
+        self.assertTrue(handled)
+        gramplet.completion.on_key_press.assert_called_once()
+
+    def test_completion_open_intercepts_up_before_history_navigation(self):
+        """When the completion popover is open, Up/Down navigate it, not
+        history -- CompletionController.on_key_press itself decides this
+        (returns True while open); this just checks _on_key_press honors
+        that decision instead of also running its own Up/Down handling.
+        """
+        gramplet = _make_gramplet_for_keypress(cursor_line=0, line_count=1)
+        gramplet.completion.on_key_press.return_value = True
+
+        handled = gramplet._on_key_press(None, _key_event(Gdk.KEY_Up))
+
+        self.assertTrue(handled)
+        gramplet._history_back.assert_not_called()
+
+
+# ------------------------------------------------------------
+#
+# HistoryPersistenceTest
+#
+# ------------------------------------------------------------
+class HistoryPersistenceTest(unittest.TestCase):
+    """``on_load``/``on_save`` round-trip history through ``self.gui.data``
+    -- the same per-instance saved-placement mechanism core gramplets like
+    ``plugins/gramplet/pedigreegramplet.py`` use for their own persisted
+    options (``Gramplet.__init__`` calls ``init()`` then ``on_load()``;
+    ``GrampletBar.on_delete`` calls ``on_save()`` before writing
+    ``self.gui.data`` to the gramplet's saved-placement .ini file).
+    """
+
+    def test_on_load_restores_history_from_gui_data(self):
+        gramplet = goql_gramplet.PersonQueryFilter.__new__(
+            goql_gramplet.PersonQueryFilter
+        )
+        gramplet.gui = MagicMock()
+        gramplet.gui.data = ["first", "second"]
+
+        gramplet.on_load()
+
+        self.assertEqual(gramplet.history, ["first", "second"])
+
+    def test_on_save_writes_history_to_gui_data(self):
+        gramplet = _make_gramplet()
+        gramplet.history = ["first", "second"]
+
+        gramplet.on_save()
+
+        self.assertEqual(gramplet.gui.data, ["first", "second"])
+
+    def test_remember_history_caps_at_max_entries(self):
+        gramplet = _make_gramplet()
+        total = goql_gramplet.HISTORY_MAX_ENTRIES + 5
+        for i in range(total):
+            gramplet._remember_history("expr %d" % i)
+
+        self.assertEqual(len(gramplet.history), goql_gramplet.HISTORY_MAX_ENTRIES)
+        self.assertEqual(gramplet.history[0], "expr 5")
+        self.assertEqual(gramplet.history[-1], "expr %d" % (total - 1))
+
+
+# ------------------------------------------------------------
+#
+# FilterProgressTest
+#
+# ------------------------------------------------------------
+class FilterProgressTest(unittest.TestCase):
+    """``_run_with_filter_progress``/``_filter_method_label`` -- the
+    Prepare-time/Apply-time + SQL-vs-eval diagnostics mirrored from
+    ``gui/filters/sidebar/_sidebarfilter.py``'s ``clicked()``.
+    ``GenericFilter.apply()`` already reports those phase timings via
+    ``user.notify(...)``; without ``uistate.filter_print_func`` wired up,
+    ``gui/user.py``'s ``User._gui_print`` sends them to stdout instead of
+    any widget -- which is exactly why they only ever showed up in a
+    terminal before this.
+    """
+
+    def test_run_with_filter_progress_wires_and_clears_the_hooks(self):
+        gramplet = _make_gramplet()
+        seen = {}
+
+        def action():
+            seen["print_func_during"] = gramplet.uistate.filter_print_func
+            seen["step_func_during"] = gramplet.uistate.filter_step_func
+
+        gramplet._run_with_filter_progress(action)
+
+        self.assertIsNotNone(seen["print_func_during"])
+        self.assertIsNotNone(seen["step_func_during"])
+        self.assertIsNone(gramplet.uistate.filter_print_func)
+        self.assertIsNone(gramplet.uistate.filter_step_func)
+
+    def test_run_with_filter_progress_clears_hooks_even_on_exception(self):
+        gramplet = _make_gramplet()
+
+        def action():
+            raise RuntimeError("boom")
+
+        with self.assertRaises(RuntimeError):
+            gramplet._run_with_filter_progress(action)
+
+        self.assertIsNone(gramplet.uistate.filter_print_func)
+        self.assertIsNone(gramplet.uistate.filter_step_func)
+
+    def test_run_with_filter_progress_collects_messages(self):
+        gramplet = _make_gramplet()
+
+        def action():
+            gramplet.uistate.filter_print_func("Prepare time: 0.01s")
+            gramplet.uistate.filter_print_func("Apply time: 0.02s")
+
+        phase_msgs = gramplet._run_with_filter_progress(action)
+
+        self.assertEqual(phase_msgs, ["Prepare time: 0.01s", "Apply time: 0.02s"])
+
+    def test_filter_method_label_reports_sql_when_a_rule_has_selected_handles(self):
+        gramplet = _make_gramplet()
+        rule = MagicMock()
+        rule.selected_handles = {"h1"}
+        gfilter = MagicMock()
+        gfilter.get_rules.return_value = [rule]
+
+        self.assertEqual(gramplet._filter_method_label(gfilter), "SQL")
+
+    def test_filter_method_label_reports_eval_when_no_rule_has_selected_handles(self):
+        gramplet = _make_gramplet()
+        rule = MagicMock()
+        rule.selected_handles = None
+        gfilter = MagicMock()
+        gfilter.get_rules.return_value = [rule]
+
+        self.assertEqual(gramplet._filter_method_label(gfilter), "Python evaluation")
+
+
+# ------------------------------------------------------------
+#
+# HelpButtonTest
+#
+# ------------------------------------------------------------
+class HelpButtonTest(unittest.TestCase):
+    """``self.gui.help_url`` is set from the ``.gpr.py`` registration's
+    ``help_url=`` -- the same attribute/dispatch the built-in per-gramplet
+    "Help" menu item already uses (``gui/widgets/grampletpane.py``/
+    ``grampletbar.py``).
+    """
+
+    def test_help_clicked_opens_wiki_page_for_a_non_url_help_url(self):
+        gramplet = _make_gramplet()
+        gramplet.gui.help_url = "Addon:GrampsObjectQueryLanguage"
+
+        with patch.object(goql_gramplet, "display_help") as mock_help, patch.object(
+            goql_gramplet, "display_url"
+        ) as mock_url:
+            gramplet.help_clicked(None)
+
+        mock_help.assert_called_once_with("Addon:GrampsObjectQueryLanguage")
+        mock_url.assert_not_called()
+
+    def test_help_clicked_opens_a_raw_url_directly(self):
+        gramplet = _make_gramplet()
+        gramplet.gui.help_url = "https://example.org/help"
+
+        with patch.object(goql_gramplet, "display_help") as mock_help, patch.object(
+            goql_gramplet, "display_url"
+        ) as mock_url:
+            gramplet.help_clicked(None)
+
+        mock_url.assert_called_once_with("https://example.org/help")
+        mock_help.assert_not_called()
+
+    def test_help_clicked_with_no_help_url_does_nothing(self):
+        gramplet = _make_gramplet()
+        gramplet.gui.help_url = None
+
+        with patch.object(goql_gramplet, "display_help") as mock_help, patch.object(
+            goql_gramplet, "display_url"
+        ) as mock_url:
+            gramplet.help_clicked(None)
+
+        mock_help.assert_not_called()
+        mock_url.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/GOQLFilter/tests/test_goql_completion.py
+++ b/GOQLFilter/tests/test_goql_completion.py
@@ -1,0 +1,125 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Tests for ``goql_completion.py``'s completion source -- pure logic, no
+GTK, no database, matching the module's own "no display needed" design.
+
+Run with::
+
+    python3 -m unittest GOQLFilter.tests.test_goql_completion -v
+"""
+
+import os
+import sys
+import unittest
+
+ADDON_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ADDON_DIR not in sys.path:
+    sys.path.insert(0, ADDON_DIR)
+
+try:
+    from goql_completion import get_completion_items
+except ImportError as exc:
+    raise unittest.SkipTest(
+        "goql_completion import failed (likely missing "
+        "gramps-object-query-language): %s" % exc
+    )
+
+
+def _names(source, line, column, namespace):
+    return sorted(
+        item["name"] for item in get_completion_items(source, line, column, namespace)
+    )
+
+
+# ------------------------------------------------------------
+#
+# TopLevelCompletionTest
+#
+# ------------------------------------------------------------
+class TopLevelCompletionTest(unittest.TestCase):
+    def test_person_top_level_includes_columns_relationships_and_keywords(self):
+        names = _names("", 1, 0, "Person")
+        for expected in ("gender", "birth", "death", "families", "and", "or", "not"):
+            self.assertIn(expected, names)
+
+    def test_person_top_level_includes_constant_class_names(self):
+        names = _names("", 1, 0, "Person")
+        self.assertIn("Person", names)
+        self.assertIn("EventType", names)
+
+    def test_top_level_includes_comparison_operators(self):
+        """A blank Tab press shows the comparison operators too -- most are
+        a single character, so they only ever surface with an empty
+        prefix, but they should still be there to see."""
+        names = _names("", 1, 0, "Person")
+        for op in ("==", "!=", "<", "<=", ">", ">="):
+            self.assertIn(op, names)
+
+    def test_family_namespace_differs_from_person(self):
+        family_names = _names("", 1, 0, "Family")
+        self.assertIn("father", family_names)
+        self.assertIn("mother", family_names)
+        self.assertIn("children", family_names)
+        self.assertNotIn("birth", family_names)
+        self.assertNotIn("death", family_names)
+
+    def test_top_level_prefix_filters_matches(self):
+        names = _names("gen", 1, 3, "Person")
+        self.assertIn("gender", names)
+        self.assertNotIn("birth", names)
+
+    def test_unknown_namespace_returns_no_completions(self):
+        names = _names("", 1, 0, "NotARealType")
+        self.assertEqual(names, [])
+
+
+# ------------------------------------------------------------
+#
+# DottedConstantCompletionTest
+#
+# ------------------------------------------------------------
+class DottedConstantCompletionTest(unittest.TestCase):
+    def test_person_dot_lists_gender_constants(self):
+        source = "gender == Person."
+        names = _names(source, 1, len(source), "Person")
+        self.assertEqual(names, sorted(["FEMALE", "MALE", "OTHER", "UNKNOWN"]))
+
+    def test_person_dot_prefix_filters_to_matching_constants(self):
+        source = "gender == Person.MA"
+        items = get_completion_items(source, 1, len(source), "Person")
+        self.assertEqual([(i["name"], i["complete"]) for i in items], [("MALE", "LE")])
+
+    def test_unrecognized_class_name_before_dot_returns_no_completions(self):
+        source = "primary_name."
+        names = _names(source, 1, len(source), "Person")
+        self.assertEqual(names, [])
+
+    def test_dotted_completion_ignores_the_active_namespace(self):
+        """`Date.MOD_ABOUT` is valid regardless of which namespace
+        (Person/Family/...) the expression is being written for -- the
+        constant-class table isn't namespace-scoped."""
+        source = "birth.date.modifier == Date."
+        names = _names(source, 1, len(source), "Family")
+        self.assertIn("MOD_ABOUT", names)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/GOQLFilter/tests/test_goql_completion_popup.py
+++ b/GOQLFilter/tests/test_goql_completion_popup.py
@@ -1,0 +1,215 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Tests for ``goql_completion_popup.CompletionController``'s decision
+logic, driven with a mocked ``Gtk.TextView``/``Gtk.TextBuffer`` rather than
+real ones -- ``Gtk.TextView()`` needs an actual display connection just to
+construct (see ``test_goql.py``'s ``KeyPressTest`` fixtures for the same
+constraint under this repo's documented ``GDK_BACKEND=-`` test invocation).
+Real-popover paths (multi-match) aren't covered here for the same reason;
+``_compute_items`` is patched directly to isolate ``trigger()``'s own
+single/zero-match branching from how items get computed.
+
+Run with::
+
+    python3 -m unittest GOQLFilter.tests.test_goql_completion_popup -v
+"""
+
+import os
+import sys
+import types
+import unittest
+from unittest.mock import MagicMock
+
+ADDON_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ADDON_DIR not in sys.path:
+    sys.path.insert(0, ADDON_DIR)
+
+try:
+    import gi  # noqa: F401
+    from gi.repository import Gdk
+except ImportError as err:
+    raise unittest.SkipTest("PyGObject not available: %s" % err)
+
+try:
+    from goql_completion_popup import CompletionController
+except ImportError as exc:
+    raise unittest.SkipTest(
+        "goql_completion_popup import failed (likely missing "
+        "gramps-object-query-language): %s" % exc
+    )
+
+
+def _make_controller():
+    textview = MagicMock()
+    buffer = MagicMock()
+    textview.get_buffer.return_value = buffer
+    controller = CompletionController(textview, get_namespace=lambda: "Person")
+    return controller, buffer
+
+
+def _key_event(keyval):
+    return types.SimpleNamespace(keyval=keyval, state=Gdk.ModifierType(0))
+
+
+# ------------------------------------------------------------
+#
+# TriggerTest
+#
+# ------------------------------------------------------------
+class TriggerTest(unittest.TestCase):
+    def test_single_match_inserts_directly_without_opening_a_popover(self):
+        controller, buffer = _make_controller()
+        controller._compute_items = MagicMock(
+            return_value=[{"name": "MALE", "complete": "LE", "cursor_offset": 0}]
+        )
+
+        handled = controller.trigger()
+
+        self.assertTrue(handled)
+        self.assertFalse(controller.is_open())
+        buffer.insert.assert_called_once()
+        self.assertEqual(buffer.insert.call_args.args[1], "LE")
+
+    def test_no_matches_is_a_no_op(self):
+        controller, buffer = _make_controller()
+        controller._compute_items = MagicMock(return_value=[])
+
+        handled = controller.trigger()
+
+        self.assertFalse(handled)
+        self.assertFalse(controller.is_open())
+        buffer.insert.assert_not_called()
+
+
+# ------------------------------------------------------------
+#
+# AcceptCloseTest
+#
+# ------------------------------------------------------------
+class AcceptCloseTest(unittest.TestCase):
+    def test_accept_inserts_the_selected_items_complete_text(self):
+        controller, buffer = _make_controller()
+        controller.items = [
+            {"name": "count(...)", "complete": "count()", "cursor_offset": 0}
+        ]
+        controller.selected_index = 0
+
+        controller.accept()
+
+        buffer.insert.assert_called_once()
+        self.assertEqual(buffer.insert.call_args.args[1], "count()")
+
+    def test_accept_moves_cursor_back_by_cursor_offset(self):
+        controller, buffer = _make_controller()
+        controller.items = [
+            {"name": "count(...)", "complete": "count()", "cursor_offset": 1}
+        ]
+        controller.selected_index = 0
+        cursor_iter = MagicMock()
+        buffer.get_iter_at_mark.return_value = cursor_iter
+
+        controller.accept()
+
+        cursor_iter.backward_chars.assert_called_once_with(1)
+        buffer.place_cursor.assert_called_once_with(cursor_iter)
+
+    def test_close_resets_state(self):
+        controller, _buffer = _make_controller()
+        controller.items = [{"name": "x", "complete": "", "cursor_offset": 0}]
+        controller.selected_index = 2
+        controller.popover = MagicMock()
+
+        controller.close()
+
+        self.assertIsNone(controller.popover)
+        self.assertEqual(controller.items, [])
+        self.assertEqual(controller.selected_index, 0)
+
+
+# ------------------------------------------------------------
+#
+# OnKeyPressTest
+#
+# ------------------------------------------------------------
+class OnKeyPressTest(unittest.TestCase):
+    """Mirrors GOQLFilter/goql.py's own reliance on this dispatch: Tab
+    triggers when closed and accepts when open; Up/Down/Enter/Escape only
+    do anything while the popover is open, so a closed controller leaves
+    them for the host widget (goql.py's own history navigation) to handle.
+    """
+
+    def test_tab_triggers_when_closed(self):
+        controller, _buffer = _make_controller()
+        controller.trigger = MagicMock(return_value=True)
+
+        handled = controller.on_key_press(_key_event(Gdk.KEY_Tab))
+
+        self.assertTrue(handled)
+        controller.trigger.assert_called_once()
+
+    def test_tab_accepts_when_open(self):
+        controller, _buffer = _make_controller()
+        controller.popover = MagicMock()  # is_open() -> True
+        controller.accept = MagicMock()
+
+        handled = controller.on_key_press(_key_event(Gdk.KEY_Tab))
+
+        self.assertTrue(handled)
+        controller.accept.assert_called_once()
+
+    def test_escape_closes_when_open(self):
+        controller, _buffer = _make_controller()
+        controller.popover = MagicMock()
+        controller.close = MagicMock()
+
+        handled = controller.on_key_press(_key_event(Gdk.KEY_Escape))
+
+        self.assertTrue(handled)
+        controller.close.assert_called_once()
+
+    def test_up_is_not_consumed_when_closed(self):
+        controller, _buffer = _make_controller()
+
+        handled = controller.on_key_press(_key_event(Gdk.KEY_Up))
+
+        self.assertFalse(handled)
+
+    def test_up_moves_selection_when_open(self):
+        controller, _buffer = _make_controller()
+        controller.popover = MagicMock()
+        controller.move_selection = MagicMock()
+
+        handled = controller.on_key_press(_key_event(Gdk.KEY_Up))
+
+        self.assertTrue(handled)
+        controller.move_selection.assert_called_once_with(-1)
+
+    def test_never_propagates_an_exception(self):
+        controller, _buffer = _make_controller()
+        controller.trigger = MagicMock(side_effect=RuntimeError("boom"))
+
+        handled = controller.on_key_press(_key_event(Gdk.KEY_Tab))
+
+        self.assertFalse(handled)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/GOQLFilter/tests/test_goql_highlight.py
+++ b/GOQLFilter/tests/test_goql_highlight.py
@@ -1,0 +1,110 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Tests for ``goql_highlight.py``'s token classification -- pure logic, no
+GTK, no database.
+
+Run with::
+
+    python3 -m unittest GOQLFilter.tests.test_goql_highlight -v
+"""
+
+import os
+import sys
+import unittest
+
+ADDON_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ADDON_DIR not in sys.path:
+    sys.path.insert(0, ADDON_DIR)
+
+try:
+    from goql_highlight import classify_tokens
+except ImportError as exc:
+    raise unittest.SkipTest(
+        "goql_highlight import failed (likely missing "
+        "gramps-object-query-language): %s" % exc
+    )
+
+
+def _spans_by_text(source):
+    """(category, matched substring) pairs, in source order -- easier to
+    assert against than raw line/column spans."""
+    lines = source.splitlines()
+    result = []
+    for start_line, start_col, end_line, end_col, category in classify_tokens(source):
+        text = (
+            lines[start_line][start_col:end_col]
+            if start_line == end_line
+            else "<multiline>"
+        )
+        result.append((category, text))
+    return result
+
+
+# ------------------------------------------------------------
+#
+# ClassifyTokensTest
+#
+# ------------------------------------------------------------
+class ClassifyTokensTest(unittest.TestCase):
+    def test_classifies_operator_constant_class_keyword_string_and_number(self):
+        source = "gender == Person.MALE and 'Anderson' in primary_name.surname_list[0].surname"
+        spans = _spans_by_text(source)
+        self.assertIn(("operator", "=="), spans)
+        self.assertIn(("constant-class", "Person"), spans)
+        self.assertIn(("keyword", "and"), spans)
+        self.assertIn(("string", "'Anderson'"), spans)
+        self.assertIn(("keyword", "in"), spans)
+        self.assertIn(("number", "0"), spans)
+
+    def test_plain_field_names_are_not_classified(self):
+        spans = _spans_by_text("gender == Person.MALE")
+        categories_by_text = dict((text, category) for category, text in spans)
+        self.assertNotIn("gender", categories_by_text)
+
+    def test_incomplete_expression_still_yields_tokens_before_the_break(self):
+        """An unterminated string is the normal state of this buffer mid-typing,
+        not an error to surface -- whatever tokenized cleanly before it is
+        still returned."""
+        spans = _spans_by_text("gender == Person.MALE and 'Anders")
+        self.assertIn(("operator", "=="), spans)
+        self.assertIn(("constant-class", "Person"), spans)
+        self.assertIn(("keyword", "and"), spans)
+
+    def test_empty_source_yields_no_spans(self):
+        self.assertEqual(list(classify_tokens("")), [])
+
+    def test_like_date_exists_count_are_keywords(self):
+        spans = _spans_by_text(
+            "like(x, 'A%') and exists(children) and count(events) > 1"
+        )
+        categories_by_text = dict((text, category) for category, text in spans)
+        self.assertEqual(categories_by_text.get("like"), "keyword")
+        self.assertEqual(categories_by_text.get("exists"), "keyword")
+        self.assertEqual(categories_by_text.get("count"), "keyword")
+
+    def test_comparison_operators_are_all_recognized(self):
+        for op in ("==", "!=", "<", "<=", ">", ">="):
+            spans = _spans_by_text("gender %s 1" % op)
+            self.assertIn(("operator", op), spans, "missing operator %r" % op)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/GOQLFilter/tests/test_integration_whereexprrule.py
+++ b/GOQLFilter/tests/test_integration_whereexprrule.py
@@ -1,0 +1,264 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Integration tests for ``whereexprrule.py``.
+
+Drives the rule the same way ``GenericFilter.apply()`` does -- through a
+real ``GenericFilter``/``CacheProxyDb`` against a real temp SQLite db, since
+that composition (Rule -> GenericFilter -> what a gramplet hands to
+``view.generic_filter``) is the thing actually being tested, not the GOQL
+compiler in isolation (already covered by gramps-object-query-language's
+own test suite). DB-backed, so this is Linux-only in CI (``test_integration_``
+prefix) rather than the plain ``test_`` prefix.
+
+Run with::
+
+    python3 -m unittest GOQLFilter.tests.test_integration_whereexprrule -v
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+
+ADDON_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ADDON_DIR not in sys.path:
+    sys.path.insert(0, ADDON_DIR)
+
+try:
+    import gi
+except ImportError as err:
+    raise unittest.SkipTest("PyGObject not available: %s" % err)
+
+try:
+    from whereexprrule import (
+        FamilyMatchesExpression,
+        PersonMatchesExpression,
+        _resolve_dialect,
+        _unwrap_cache_proxy,
+    )
+except ImportError as exc:
+    raise unittest.SkipTest(
+        "whereexprrule import failed (likely missing "
+        "gramps-object-query-language): %s" % exc
+    )
+
+from gramps.gen.db import DbTxn
+from gramps.gen.db.utils import make_database
+from gramps.gen.filters import GenericFilterFactory
+from gramps.gen.lib import Family, Name, Person, Surname
+from gramps.gen.proxy import CacheProxyDb, PrivateProxyDb
+from gramps_object_query_language_copy.query import Dialect
+
+
+def _name(given, surname):
+    name = Name()
+    name.set_first_name(given)
+    surn = Surname()
+    surn.set_surname(surname)
+    name.set_surname_list([surn])
+    return name
+
+
+# ------------------------------------------------------------
+#
+# WhereExprRuleTest
+#
+# ------------------------------------------------------------
+class WhereExprRuleTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp(prefix="goql_addon_")
+        self.db = make_database("sqlite")
+        self.db.load(self.tmp_dir)
+
+        self.handles = {}
+        with DbTxn("build test db", self.db) as trans:
+            father = Person()
+            father.set_primary_name(_name("Karl", "Anderson"))
+            father.set_gender(Person.MALE)
+            self.handles["father"] = self.db.add_person(father, trans)
+
+            mother = Person()
+            mother.set_primary_name(_name("Lena", "Baker"))
+            mother.set_gender(Person.FEMALE)
+            self.handles["mother"] = self.db.add_person(mother, trans)
+
+            son = Person()
+            son.set_primary_name(_name("Otto", "Anderson"))
+            son.set_gender(Person.MALE)
+            self.handles["son"] = self.db.add_person(son, trans)
+
+            family = Family()
+            family.set_father_handle(self.handles["father"])
+            family.set_mother_handle(self.handles["mother"])
+            self.handles["family"] = self.db.add_family(family, trans)
+
+    def tearDown(self):
+        self.db.close()
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+    def _apply_person_filter(self, expr):
+        gfilter = GenericFilterFactory("Person")()
+        gfilter.add_rule(PersonMatchesExpression([expr]))
+        cdb = CacheProxyDb(self.db)
+        return set(gfilter.apply(cdb, self.db.get_person_handles()))
+
+    def test_flat_column_match(self):
+        matched = self._apply_person_filter("gender == Person.MALE")
+        self.assertEqual(matched, {self.handles["father"], self.handles["son"]})
+
+    def test_json_path_and_boolean_combination(self):
+        matched = self._apply_person_filter(
+            "gender == Person.MALE and "
+            "'Anderson' in primary_name.surname_list[0].surname"
+        )
+        self.assertEqual(matched, {self.handles["father"], self.handles["son"]})
+
+    def test_no_match(self):
+        matched = self._apply_person_filter("gender == Person.UNKNOWN")
+        self.assertEqual(matched, set())
+
+    def test_empty_expression_matches_nothing(self):
+        matched = self._apply_person_filter("")
+        self.assertEqual(matched, set())
+
+    def test_invalid_expression_matches_nothing_rather_than_raising(self):
+        matched = self._apply_person_filter("this is not valid GOQL !!")
+        self.assertEqual(matched, set())
+
+    def test_family_related_object_path(self):
+        gfilter = GenericFilterFactory("Family")()
+        gfilter.add_rule(FamilyMatchesExpression(["father.surname == 'Anderson'"]))
+        cdb = CacheProxyDb(self.db)
+        matched = set(gfilter.apply(cdb, self.db.get_family_handles()))
+        self.assertEqual(matched, {self.handles["family"]})
+
+
+# ------------------------------------------------------------
+#
+# SqlPushDownTest
+#
+# ------------------------------------------------------------
+class SqlPushDownTest(unittest.TestCase):
+    """Regression coverage for two bugs found wiring up SQL push-down:
+
+    1. ``_resolve_dialect`` used to do ``isinstance(db, SQLite)``, but
+       Gramps' plugin loader imports ``sqlite.py`` as a bare top-level
+       module named ``sqlite``, not via ``gramps.plugins.db.dbapi.sqlite``
+       -- so a live ``dbstate.db``'s class is never ``isinstance``-
+       compatible with a normally-imported ``SQLite``, and dialect
+       resolution silently fell through every time. Fixed by matching
+       ``type(db).__name__`` instead of ``isinstance``.
+    2. Every real filter application wraps ``db`` in ``CacheProxyDb``
+       (``gui/views/treemodels/flatbasemodel.py``'s ``_rebuild_filter``:
+       ``cdb = CacheProxyDb(self.db); self.search.apply(cdb, ...)``), which
+       is not a ``ProxyDbBase`` subclass and forwards attribute access via
+       ``__getattr__``. Left unpeeled, that defeats the
+       ``isinstance(db, ProxyDbBase)`` privacy check whenever a real
+       privacy proxy is nested *underneath* it
+       (``CacheProxyDb(PrivateProxyDb(db))``) -- SQL would run straight
+       past privacy filtering. Fixed with ``_unwrap_cache_proxy``.
+    """
+
+    def setUp(self):
+        self.tmp_dir = tempfile.mkdtemp(prefix="goql_sql_pushdown_")
+        self.db = make_database("sqlite")
+        self.db.load(self.tmp_dir)
+        with DbTxn("build test db", self.db) as trans:
+            father = Person()
+            father.set_primary_name(_name("Karl", "Anderson"))
+            father.set_gender(Person.MALE)
+            self.father_handle = self.db.add_person(father, trans)
+
+            mother = Person()
+            mother.set_primary_name(_name("Lena", "Baker"))
+            mother.set_gender(Person.FEMALE)
+            self.mother_handle = self.db.add_person(mother, trans)
+
+    def tearDown(self):
+        self.db.close()
+        shutil.rmtree(self.tmp_dir, ignore_errors=True)
+
+    def test_resolve_dialect_matches_live_sqlite_db_by_class_name(self):
+        self.assertEqual(_resolve_dialect(self.db), Dialect.SQLITE)
+
+    def test_resolve_dialect_is_none_for_an_unrecognized_backend(self):
+        self.assertIsNone(_resolve_dialect(object()))
+
+    def test_unwrap_cache_proxy_peels_to_the_raw_db(self):
+        cdb = CacheProxyDb(self.db)
+        self.assertIs(_unwrap_cache_proxy(cdb), self.db)
+
+    def test_unwrap_cache_proxy_stops_at_a_nested_privacy_proxy(self):
+        pdb = PrivateProxyDb(self.db)
+        cdb = CacheProxyDb(pdb)
+        self.assertIs(_unwrap_cache_proxy(cdb), pdb)
+
+    def test_sql_push_down_engages_through_the_cache_proxy_wrapping(self):
+        """The exact wrapping every real GenericFilter.apply() call uses."""
+        cdb = CacheProxyDb(self.db)
+        rule = PersonMatchesExpression(["gender == Person.MALE"])
+
+        rule.prepare(cdb, None)
+
+        self.assertEqual(rule.selected_handles, {self.father_handle})
+
+    def test_privacy_proxy_nested_under_cache_proxy_disables_sql_push_down(self):
+        cdb = CacheProxyDb(PrivateProxyDb(self.db))
+        rule = PersonMatchesExpression(["gender == Person.MALE"])
+
+        rule.prepare(cdb, None)
+
+        self.assertIsNone(rule.selected_handles)
+        # Still correct via the per-object eval fallback:
+        father = cdb.get_person_from_handle(self.father_handle)
+        mother = cdb.get_person_from_handle(self.mother_handle)
+        self.assertTrue(rule.apply_to_one(cdb, father))
+        self.assertFalse(rule.apply_to_one(cdb, mother))
+
+    def test_optimizer_recognizes_selected_handles(self):
+        """Regression test for the actual ~8s "Apply time" bug: the
+        precomputed match set used to be stored as ``_matched_handles``,
+        a name ``gen.filters.optimizer.Optimizer`` doesn't look for.
+        ``compute_potential_handles_for_rule`` only checks
+        ``hasattr(rule, "selected_handles")`` -- anything else is
+        invisible to it, so ``GenericFilter.apply()`` fetched and
+        deserialized every candidate via ``get_object()`` before
+        ``apply_to_one`` ever ran, no matter how fast ``apply_to_one``
+        itself was. Renaming the attribute to what the Optimizer actually
+        checks for is the fix; this asserts that contract directly rather
+        than just re-checking ``apply_to_one``'s own behavior.
+        """
+        from gramps.gen.filters.optimizer import Optimizer
+
+        cdb = CacheProxyDb(self.db)
+        rule = PersonMatchesExpression(["gender == Person.MALE"])
+        rule.prepare(cdb, None)
+
+        optimizer = Optimizer(GenericFilterFactory("Person")())
+        handles_in, handles_out = optimizer.compute_potential_handles_for_rule(rule)
+
+        self.assertEqual(handles_in, {self.father_handle})
+        self.assertIsNone(handles_out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/GOQLFilter/whereexprrule.gpr.py
+++ b/GOQLFilter/whereexprrule.gpr.py
@@ -1,0 +1,196 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Filter rules matching objects against a GOQL where-expression."""
+
+_HELP = "Addon:GrampsObjectQueryLanguage"
+_AUTHORS = ["Douglas Blank"]
+_AUTHORS_EMAIL = ["doug.blank@gmail.com"]
+
+register(
+    RULE,
+    id="PersonMatchesExpression",
+    name=_("People matching the <GOQL expression>"),
+    description=_(
+        "Matches people for which the given gramps-object-query-language "
+        "where-expression evaluates to true"
+    ),
+    version = '1.0.1',
+    gramps_target_version="6.0",
+    status=STABLE,
+    fname="whereexprrule.py",
+    ruleclass="PersonMatchesExpression",  # must be rule class name
+    namespace="Person",  # one of the primary object classes
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+)
+
+register(
+    RULE,
+    id="FamilyMatchesExpression",
+    name=_("Families matching the <GOQL expression>"),
+    description=_(
+        "Matches families for which the given gramps-object-query-language "
+        "where-expression evaluates to true"
+    ),
+    version = '1.0.1',
+    gramps_target_version="6.0",
+    status=STABLE,
+    fname="whereexprrule.py",
+    ruleclass="FamilyMatchesExpression",
+    namespace="Family",
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+)
+
+register(
+    RULE,
+    id="EventMatchesExpression",
+    name=_("Events matching the <GOQL expression>"),
+    description=_(
+        "Matches events for which the given gramps-object-query-language "
+        "where-expression evaluates to true"
+    ),
+    version = '1.0.1',
+    gramps_target_version="6.0",
+    status=STABLE,
+    fname="whereexprrule.py",
+    ruleclass="EventMatchesExpression",
+    namespace="Event",
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+)
+
+register(
+    RULE,
+    id="PlaceMatchesExpression",
+    name=_("Places matching the <GOQL expression>"),
+    description=_(
+        "Matches places for which the given gramps-object-query-language "
+        "where-expression evaluates to true"
+    ),
+    version = '1.0.1',
+    gramps_target_version="6.0",
+    status=STABLE,
+    fname="whereexprrule.py",
+    ruleclass="PlaceMatchesExpression",
+    namespace="Place",
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+)
+
+register(
+    RULE,
+    id="RepositoryMatchesExpression",
+    name=_("Repositories matching the <GOQL expression>"),
+    description=_(
+        "Matches repositories for which the given gramps-object-query-language "
+        "where-expression evaluates to true"
+    ),
+    version = '1.0.1',
+    gramps_target_version="6.0",
+    status=STABLE,
+    fname="whereexprrule.py",
+    ruleclass="RepositoryMatchesExpression",
+    namespace="Repository",
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+)
+
+register(
+    RULE,
+    id="SourceMatchesExpression",
+    name=_("Sources matching the <GOQL expression>"),
+    description=_(
+        "Matches sources for which the given gramps-object-query-language "
+        "where-expression evaluates to true"
+    ),
+    version = '1.0.1',
+    gramps_target_version="6.0",
+    status=STABLE,
+    fname="whereexprrule.py",
+    ruleclass="SourceMatchesExpression",
+    namespace="Source",
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+)
+
+register(
+    RULE,
+    id="CitationMatchesExpression",
+    name=_("Citations matching the <GOQL expression>"),
+    description=_(
+        "Matches citations for which the given gramps-object-query-language "
+        "where-expression evaluates to true"
+    ),
+    version = '1.0.1',
+    gramps_target_version="6.0",
+    status=STABLE,
+    fname="whereexprrule.py",
+    ruleclass="CitationMatchesExpression",
+    namespace="Citation",
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+)
+
+register(
+    RULE,
+    id="MediaMatchesExpression",
+    name=_("Media matching the <GOQL expression>"),
+    description=_(
+        "Matches media for which the given gramps-object-query-language "
+        "where-expression evaluates to true"
+    ),
+    version = '1.0.1',
+    gramps_target_version="6.0",
+    status=STABLE,
+    fname="whereexprrule.py",
+    ruleclass="MediaMatchesExpression",
+    namespace="Media",
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+)
+
+register(
+    RULE,
+    id="NoteMatchesExpression",
+    name=_("Notes matching the <GOQL expression>"),
+    description=_(
+        "Matches notes for which the given gramps-object-query-language "
+        "where-expression evaluates to true"
+    ),
+    version = '1.0.1',
+    gramps_target_version="6.0",
+    status=STABLE,
+    fname="whereexprrule.py",
+    ruleclass="NoteMatchesExpression",
+    namespace="Note",
+    authors=_AUTHORS,
+    authors_email=_AUTHORS_EMAIL,
+    help_url=_HELP,
+)

--- a/GOQLFilter/whereexprrule.py
+++ b/GOQLFilter/whereexprrule.py
@@ -1,0 +1,300 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026       Douglas Blank
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""Filter rule matching objects against a gramps-object-query-language
+where-expression, one subclass per primary object type.
+
+Registering these as ordinary ``RULE`` plugins (see ``whereexprrule.gpr.py``)
+lets a GOQL expression be dropped into Gramps' own Custom Filter Editor
+(``EditFilter``) as a single rule, so a filter built from one now shows up
+everywhere a normal Custom Filter would -- other views' sidebar filters,
+reports, exports -- not just in this addon's own gramplet.
+
+When ``prepare()`` sees an unproxied, DB-API-backed ``db``, it pushes the
+expression down to SQL (``gramps_object_query_language.query.compile_query``)
+instead of evaluating it per-object -- the same fast/slow split
+gramps-web-api's ``resources/object_query.py`` makes (``_post_sql`` vs.
+``_post_proxied``), just reached from ``Rule.prepare(db, user)`` instead of
+a request handler. Re-decided on every ``prepare()`` call, never cached on
+the rule instance: a saved Custom Filter can be applied against a different
+db, or the same db behind a different proxy, at any later time, and each
+application must see its own, current ``db``.
+"""
+
+# -------------------------------------------------------------------------
+#
+# Standard Python modules
+#
+# -------------------------------------------------------------------------
+import logging
+from typing import Any, Optional
+
+# -------------------------------------------------------------------------
+#
+# Gramps modules
+#
+# -------------------------------------------------------------------------
+from gramps.gen.filters.rules import Rule
+from gramps.gen.const import GRAMPS_LOCALE as glocale
+from gramps.gen.proxy import CacheProxyDb
+from gramps.gen.proxy.proxybase import ProxyDbBase
+
+# -------------------------------------------------------------------------
+#
+# gramps-object-query-language modules (vendored -- see
+# gramps_object_query_language_copy/, a bundled copy of the
+# gramps-object-query-language PyPI package, for why this gramps60 branch
+# of the addon vendors it instead of depending on `pip install
+# gramps-object-query-language`.
+#
+# -------------------------------------------------------------------------
+from gramps_object_query_language_copy.query_lang import (
+    QueryLangError,
+    compile_expr_for_spec,
+)
+from gramps_object_query_language_copy.evaluator import evaluate_where
+from gramps_object_query_language_copy.query import (
+    CITATION,
+    EVENT,
+    FAMILY,
+    MEDIA,
+    NOTE,
+    PERSON,
+    PLACE,
+    REPOSITORY,
+    SOURCE,
+    Dialect,
+    Query,
+    compile_query,
+)
+
+try:
+    _trans = glocale.get_addon_translator(__file__)
+except ValueError:
+    _trans = glocale.translation
+_ = _trans.gettext
+
+LOG = logging.getLogger(".GOQLFilter.whereexprrule")
+
+# Adapted from gramps-web-api's resources/object_query.py (_DIALECT_BY_NAME /
+# _resolve_dialect) -- core DBAPI/SQLite and the SharedPostgreSQL addon
+# don't advertise a `.dialect` attribute yet (proposed but unmerged
+# core-side: gramps-project/gramps#2178); the single-user PostgreSQL addon
+# already does (`dialect = "postgresql"`), so that's read straight off `db`
+# when present. Once core grows a real `.dialect` property, this whole
+# function collapses to `getattr(db, "dialect", None)` and this copy can be
+# deleted.
+#
+# Diverges from gramps-web-api's version in one deliberate way: that one
+# falls back to `isinstance(basedb, SQLite)` for the common case, but a live
+# `dbstate.db` here was constructed through Gramps' *plugin* loader, which
+# imports `sqlite.py` as a bare top-level module named `sqlite` -- not via
+# `gramps.plugins.db.dbapi.sqlite`, the normal package path this file (and
+# gramps-web-api) imports `SQLite` through. That makes `type(db)` a
+# *different* class object from the `SQLite` imported here even for a real
+# SQLite-backed db (confirmed live: `type(make_database("sqlite")).__module__
+# == "sqlite"`, not `"gramps.plugins.db.dbapi.sqlite"`) -- `isinstance` never
+# matches, and the dialect check would fall through silently. Matching by
+# class *name* instead sidesteps the module-identity split. Unrecognized
+# class names return `None` (never a guessed dialect) so an unknown backend
+# just skips SQL push-down rather than risking wrong-dialect SQL -- the
+# caller falls back to per-object eval either way.
+_DIALECT_BY_NAME = {
+    "sqlite": Dialect.SQLITE,
+    "postgres": Dialect.POSTGRESQL,
+    "postgresql": Dialect.POSTGRESQL,
+}
+_DIALECT_BY_CLASS_NAME = {
+    "SQLite": Dialect.SQLITE,
+    "PostgreSQL": Dialect.POSTGRESQL,
+    "SharedPostgreSQL": Dialect.POSTGRESQL,
+}
+
+
+def _resolve_dialect(db: Any) -> Optional[Dialect]:
+    name: Optional[str] = getattr(db, "dialect", None)
+    if name:
+        dialect = _DIALECT_BY_NAME.get(name)
+        if dialect is not None:
+            return dialect
+    return _DIALECT_BY_CLASS_NAME.get(type(db).__name__)
+
+
+def _unwrap_cache_proxy(db: Any) -> Any:
+    """Peel off ``CacheProxyDb`` wrapping to find what SQL-eligibility
+    checks should actually look at.
+
+    Every real call into a ``Rule`` from Gramps' own filtering goes through
+    ``CacheProxyDb`` -- ``gui/views/treemodels/flatbasemodel.py``'s
+    ``_rebuild_filter`` unconditionally does ``cdb = CacheProxyDb(self.db);
+    self.search.apply(cdb, ...)`` -- so ``db`` here is *never* the raw
+    backend object, even with no privacy proxy in play. ``CacheProxyDb``
+    has no privacy relevance (it exists purely to cache fetched objects)
+    but, unlike ``PrivateProxyDb``/``LivingProxyDb``/etc., it doesn't
+    subclass ``ProxyDbBase`` -- so both ``isinstance(db, ProxyDbBase)`` and
+    ``_resolve_dialect(db)``'s class-name lookup silently see straight past
+    a real backend/proxy underneath it without this unwrap: the former
+    would miss a nested privacy proxy entirely (treating it as
+    "unproxied"), the latter would miss the real backend's class name
+    entirely (``type(CacheProxyDb(...)).__name__ == "CacheProxyDb"``, never
+    a recognized dialect).
+
+    Stops the moment the current layer is anything other than
+    ``CacheProxyDb`` -- including a real ``ProxyDbBase`` -- so a privacy
+    proxy nested underneath (``CacheProxyDb(PrivateProxyDb(raw_db))``) is
+    correctly left in place for the caller's ``isinstance(_, ProxyDbBase)``
+    check to catch, not unwrapped past.
+    """
+    while isinstance(db, CacheProxyDb):
+        db = db.db
+    return db
+
+
+def _sql_matched_handles(db: Any, spec: Any, where: Any):
+    """Matching handles via SQL push-down, or ``None`` if not possible.
+
+    Only ever called with a ``db`` already confirmed unproxied and
+    DB-API-backed (see ``MatchesExpression.prepare``) -- mirrors
+    gramps-web-api's ``_post_sql`` dispatch, minus the privacy predicate,
+    which is exactly why an unproxied `db` is required before this runs at
+    all (see ``query.py``'s ``compile_query`` docstring: "carries no
+    privacy predicate"). Never raises: an unrecognized backend (no
+    resolvable dialect) is a routine, silent "skip the optimization";
+    a genuine compile/execute failure is logged, then also falls back to
+    per-object evaluation rather than breaking the filter outright.
+    """
+    dialect = _resolve_dialect(db)
+    if dialect is None:
+        return None
+    try:
+        query = Query(select=["handle"], where=where, limit=None)
+        sql, params = compile_query(spec, query, dialect=dialect)
+        db.dbapi.execute(sql, params)
+        return {row[0] for row in db.dbapi.fetchall()}
+    except Exception:
+        LOG.exception("GOQL SQL push-down failed; falling back to per-object eval")
+        return None
+
+
+# -------------------------------------------------------------------------
+#
+# MatchesExpression
+#
+# -------------------------------------------------------------------------
+class MatchesExpression(Rule):
+    """Base rule: true for objects a GOQL where-expression evaluates true for.
+
+    Not registered directly -- each object type needs its own registered
+    subclass (below) since a ``RULE`` plugin's ``namespace``/``ruleclass``
+    pair, and the ``ObjectTypeSpec`` GOQL needs to compile the expression
+    against, are fixed per type.
+    """
+
+    labels = [_("GOQL expression")]
+    description = _(
+        "Matches objects for which the given gramps-object-query-language "
+        "where-expression evaluates to true"
+    )
+    category = _("General filters")
+    spec: Any = None  # set by each subclass below
+
+    def prepare(self, db, user):
+        self._where = None
+        # NOT a private name: `gen.filters.optimizer.Optimizer` specifically
+        # looks for `selected_handles` (`hasattr(rule, "selected_handles")`)
+        # to narrow `possible_handles` in `GenericFilter.apply()` *before*
+        # any `get_object()` fetch -- see `apply_logical_op_to_all`. A rule
+        # holding its precomputed match set under any other name is
+        # invisible to the Optimizer: every candidate still gets fetched
+        # and deserialized before `apply_to_one` ever runs, no matter how
+        # fast `apply_to_one` itself is. This was set as `_matched_handles`
+        # originally and measured ~8s "Apply time" on a real tree as a
+        # result -- renaming it to the name the Optimizer actually checks
+        # for is the fix, not a cosmetic one.
+        self.selected_handles = None
+        expr = (self.list[0] or "").strip()
+        if not expr:
+            return
+        try:
+            self._where = compile_expr_for_spec(self.spec, expr)
+        except QueryLangError:
+            # Leave self._where as None -- an invalid/incomplete expression
+            # matches nothing rather than raising out of GenericFilter.apply().
+            self._where = None
+            return
+        # SQL push-down only when `db`, past any CacheProxyDb wrapping, is
+        # unproxied (no privacy predicate to lose) and DB-API-backed
+        # (something to push down to). Re-checked here, every call -- see
+        # this module's docstring.
+        basedb = _unwrap_cache_proxy(db)
+        if not isinstance(basedb, ProxyDbBase) and hasattr(basedb, "dbapi"):
+            self.selected_handles = _sql_matched_handles(basedb, self.spec, self._where)
+
+    def apply_to_one(self, db, obj) -> bool:
+        if self._where is None or obj is None:
+            return False
+        if self.selected_handles is not None:
+            return obj.handle in self.selected_handles
+        return evaluate_where(db, obj, self._where, self.spec)
+
+
+class PersonMatchesExpression(MatchesExpression):
+    name = _("People matching the <GOQL expression>")
+    spec = PERSON
+
+
+class FamilyMatchesExpression(MatchesExpression):
+    name = _("Families matching the <GOQL expression>")
+    spec = FAMILY
+
+
+class EventMatchesExpression(MatchesExpression):
+    name = _("Events matching the <GOQL expression>")
+    spec = EVENT
+
+
+class PlaceMatchesExpression(MatchesExpression):
+    name = _("Places matching the <GOQL expression>")
+    spec = PLACE
+
+
+class RepositoryMatchesExpression(MatchesExpression):
+    name = _("Repositories matching the <GOQL expression>")
+    spec = REPOSITORY
+
+
+class SourceMatchesExpression(MatchesExpression):
+    name = _("Sources matching the <GOQL expression>")
+    spec = SOURCE
+
+
+class CitationMatchesExpression(MatchesExpression):
+    name = _("Citations matching the <GOQL expression>")
+    spec = CITATION
+
+
+class MediaMatchesExpression(MatchesExpression):
+    name = _("Media matching the <GOQL expression>")
+    spec = MEDIA
+
+
+class NoteMatchesExpression(MatchesExpression):
+    name = _("Notes matching the <GOQL expression>")
+    spec = NOTE


### PR DESCRIPTION
## What GOQLFilter provides

GOQLFilter brings GOQL (`gramps-object-query-language`) — the same query language and compiler [gramps-web-api](https://github.com/gramps-project/gramps-web-api) uses for its fast, SQL-pushed-down object-query endpoints, and that Gramps Connect's advanced search box speaks — into Gramps Desktop, as a matched pair of filter rules and gramplets for every primary object type (Person, Family, Event, Place, Repository, Source, Citation, Media, Note). (Note: this is distinct from GQL, the separate query language used in Gramps Web's own advanced search.)

- **GUI command-line completion.** A Tab-triggered, live-filtering autocomplete popup offers column names, relationship names (`father`, `birth`, ...), collection names (`children`, `events`, ...), where-expression keywords (`and`/`or`/`not`/`in`/`like`/`Date`/`exists`/`count`), and comparison operators as you type — the same shape as a REPL's completion, not a picker widget.
- **Color syntax highlighting.** Each token (keyword/string/number/operator/known-constant-class) is classified and colored live as you type, from the same shared vocabulary the completion source uses so the two can't drift apart.
- **Fast, SQL-based queries.** A typed expression compiles through the `gramps_object_query_language` compiler to a where-AST, evaluated via `evaluate_where()` — the identical engine gramps-web-api pushes down to SQL server-side, here running locally against the open tree.
- **Reusable as an ordinary Custom Filter.** "Define filter" hands the same expression to Gramps' own `EditFilter` dialog as a single `MatchesExpression` rule, so it can be named and saved like any other Custom Filter, not just used inline in the gramplet.

In short: this is the desktop-side counterpart to the GOQL search box already available in Gramps Connect — same expression language, same underlying compiler — now available as native GTK gramplets and filter rules in Gramps Desktop.

## Summary

Ports the [GOQLFilter](https://github.com/gramps-project/addons-source/tree/maintenance/gramps61/GOQLFilter) addon (currently only on `maintenance/gramps61`) to Gramps 6.0, so the GOQL where-expression filter rules/gramplets are available there too.

The gramps61 branch depends on `pip install gramps-object-query-language` (via `requires_mod`). That's unreliable across Gramps 6.0's various AIO installers, so this branch instead vendors a copy of the library directly:

- `GOQLFilter/gramps_object_query_language_copy/` — a verbatim copy of the `gramps-object-query-language` PyPI package (pinned at v0.4.0), imported under this renamed package so it can never collide with a real pip-installed copy of the same library on the same interpreter. Its `__init__.py` documents the pinned version/commit and how to refresh it.
- Every internal import of `gramps_object_query_language.*` (in `goql.py`, `whereexprrule.py`, `goql_completion.py`, `goql_highlight.py`, and the integration test) repointed to `gramps_object_query_language_copy.*`.
- `requires_mod=["gramps_object_query_language"]` dropped from both `.gpr.py` files (9 rule registrations + 9 gramplet registrations) — nothing left to `pip install`.
- `gramps_target_version` bumped from `"6.1"` down to `"6.0"`.

## Test plan

- [x] Vendored copy imports standalone and `compile_expr()`/`evaluate_where()` work.
- [x] End-to-end: built an in-memory local sqlite Gramps db with two `Person` objects, compiled a where-expression, ran `evaluate_where()` against the real objects — correct match/non-match.
- [x] All 8 addon source files import for real (not just parse) outside the GTK-dependent paths.
- [x] `pytest tests/test_goql_highlight.py tests/test_goql_completion.py tests/test_integration_whereexprrule.py` → 29 passed.
- [ ] `test_goql.py` / `test_goql_completion_popup.py` (GTK-dependent) not exercised here — blocked locally by an unrelated GTK-version conflict in the dev environment, not by this change.
- [x] Manual smoke test inside a real Gramps 6.0 GUI (install via addon manager / drop into a plugin dir, confirm the gramplets and filter rules show up and work) — not yet done.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_017Wzor7k5iGEe8bwxkS8zBZ
