### PR TITLE
GOQLFilter: update vendored gramps-object-query-language to 0.5.0 (backlinks)

### DIFF
--- a/GOQLFilter/gramps_object_query_language_copy/__init__.py
+++ b/GOQLFilter/gramps_object_query_language_copy/__init__.py
@@ -29,7 +29,7 @@ handle.
 VENDORED COPY -- do not edit directly. This is a verbatim copy of the
 "gramps_object_query_language" package (PyPI: gramps-object-query-language,
 https://github.com/dsblank/gramps-object-query-language), pinned at
-version 0.4.1 / commit b717eab575e99d8dc1dad958bf44442fe64f4276, imported
+version 0.5.0 / commit ffdcde3a97e3a6dc194779a14dd2d234d113f4c1, imported
 here as "gramps_object_query_language_copy" (not the upstream package name)
 so it can't collide with a real pip-installed copy of the same library on
 the same interpreter.

--- a/GOQLFilter/gramps_object_query_language_copy/evaluator.py
+++ b/GOQLFilter/gramps_object_query_language_copy/evaluator.py
@@ -43,13 +43,15 @@ p99 latency -- see `object_query.py`'s dispatch.
 from __future__ import annotations
 
 import re
-from typing import Any, Optional
+from typing import Any, Iterator, Optional, Tuple
 
 from gramps.gen.errors import HandleError
 from gramps.gen.lib import json_utils
 
 from .query import (
     And,
+    BacklinkClassFilter,
+    Backlinks,
     Collection,
     CollectionCount,
     ColumnIndex,
@@ -223,6 +225,40 @@ def _collection_handles(obj: Any, collection: Collection) -> list:
     return [item for item in items if item]
 
 
+def _backlink_handles(
+    db: Any, obj: Any, condition: Optional[BacklinkClassFilter]
+) -> Iterator[Tuple[str, str]]:
+    """`(class_name, handle)` pairs for every object referencing `obj`,
+    matching `condition` (a `BacklinkClassFilter`, `Backlinks`' only
+    supported condition shape -- see query.py) if given -- the evaluator
+    counterpart to `query.py`'s `_backlinks_subquery_body`, walking
+    `db.find_backlink_handles` directly instead of joining the physical
+    `reference` table in SQL.
+
+    "eq"/"in" map straight onto `find_backlink_handles`'s own
+    `include_classes` parameter (already exactly "which classes to
+    include"); "ne" has no such shape to pass through (there's no
+    "every class except this one" parameter), so it walks the
+    unrestricted result and filters in Python instead.
+
+    Privacy comes from `db` itself, same as every other relationship this
+    module evaluates (see the module docstring): when `db` is a
+    `PrivateProxyDb`, its own `find_backlink_handles` override already
+    excludes a referrer that is itself private (`gramps/gen/proxy/
+    private.py`) before this function ever sees it -- no separate privacy
+    handling needed here.
+    """
+    if condition is None:
+        yield from db.find_backlink_handles(obj.handle)
+    elif condition.op in ("eq", "in"):
+        include_classes = [condition.value] if condition.op == "eq" else list(condition.value)
+        yield from db.find_backlink_handles(obj.handle, include_classes)
+    else:
+        for class_name, handle in db.find_backlink_handles(obj.handle):
+            if class_name != condition.value:
+                yield class_name, handle
+
+
 def _collection_count(db: Any, obj: Any, count: CollectionCount) -> int:
     """How many related rows in `count.collection` match `count.condition`
     (every related row at all, if `condition` is `None`) -- the evaluator
@@ -230,6 +266,8 @@ def _collection_count(db: Any, obj: Any, count: CollectionCount) -> int:
     `Exists`'s short-circuit on the first match, this has to walk every
     related row, matching `COUNT(*)`'s own semantics.
     """
+    if isinstance(count.collection, Backlinks):
+        return sum(1 for _ in _backlink_handles(db, obj, count.condition))
     getter = getattr(db, GETTER_BY_TABLE[count.collection.target.table])
     matched = 0
     for handle in _collection_handles(obj, count.collection):
@@ -354,6 +392,8 @@ def _evaluate_tri(db: Any, obj: Any, expr: Any, spec: ObjectTypeSpec) -> Optiona
         # other branch here, there's no missing-value case to collapse to
         # None for.
         collection = expr.collection
+        if isinstance(collection, Backlinks):
+            return any(True for _ in _backlink_handles(db, obj, expr.condition))
         getter = getattr(db, GETTER_BY_TABLE[collection.target.table])
         for handle in _collection_handles(obj, collection):
             try:

--- a/GOQLFilter/gramps_object_query_language_copy/query.py
+++ b/GOQLFilter/gramps_object_query_language_copy/query.py
@@ -497,11 +497,56 @@ class CollectionCount:
 
     Shares `Exists`'s subquery body (`_collection_subquery_body`) verbatim,
     just wrapped as `(SELECT COUNT(*) FROM ...)` instead of
-    `EXISTS (SELECT 1 FROM ...)` -- see `_render_collection_count`.
+    `EXISTS (SELECT 1 FROM ...)` -- see `_render_collection_count`. Also
+    covers `Backlinks` (defined just below), whose body comes from
+    `_backlinks_subquery_body` instead -- see `Exists`'s own docstring for
+    why.
     """
 
-    collection: Collection
+    collection: "Union[Collection, Backlinks]"
     condition: Optional[Any] = None
+
+
+@dataclass(frozen=True)
+class Backlinks:
+    """Pseudo-collection: `EXISTS`/`COUNT` against Gramps' own `reference`
+    table (`obj_handle, obj_class, ref_handle, ref_class` -- see
+    `gramps/plugins/db/dbapi/dbapi.py`'s `CREATE TABLE reference`, and
+    `find_backlink_handles()` there for the same lookup done row-by-row)
+    rather than a list living in the current row's own `json_data`. Unlike
+    `Collection`, there's no `list_path`/`ref_field` (nothing to unnest out
+    of this row) and no single `target` (a backlink's referrer can be any
+    of the ten object types at once, told apart only by `reference`'s own
+    `obj_class` column) -- so it's registered and dispatched on separately
+    everywhere a `Collection` is (`_COLLECTIONS`, `Exists.compile`,
+    `_render_collection_count`), rather than trying to squeeze it into
+    `Collection`'s shape.
+    """
+
+    name: str = "backlinks"
+
+
+@dataclass(frozen=True)
+class BacklinkClassFilter:
+    """`Backlinks`'s only supported condition shape: a single comparison
+    against the referrer's class name -- `exists(backlinks, _class ==
+    "Person")`. `_class` matches the field name every object's own
+    serialized JSON already uses for its type (gramps-web-api's
+    `NoteSchema`/etc.'s `_class`), not `obj_class` (the physical
+    `reference` row's own column name -- see `_backlinks_subquery_body`),
+    so a `where_expr` author never needs to know that table exists.
+
+    Deliberately not a general `Comparison`/boolean tree the way every
+    other collection's condition is: a backlink's referrer can be any of
+    the ten object types, so there's no single schema to resolve a richer
+    field path (`primary_name.surname`) against -- see the "Reverse
+    relationships" item in ROADMAP.md for that larger, deliberately
+    out-of-scope feature. `op` is `"eq"`/`"ne"`/`"in"`; `value` is a class
+    name string (`"eq"`/`"ne"`) or a list of them (`"in"`).
+    """
+
+    op: str
+    value: Any
 
 
 def _generic_collections(
@@ -594,6 +639,20 @@ _COLLECTIONS: dict[str, dict[str, Collection]] = {
     },
 }
 
+# Every one of the ten object types can be pointed to by something else --
+# even Tag, via any other type's own tag_list -- so "backlinks" is injected
+# into every table uniformly here, rather than repeated by hand in each
+# `_COLLECTIONS[...]` entry above the way the four optional
+# `_generic_collections()` flags (which really do vary per type) are.
+# `setdefault` also covers `TAG.table`, which -- unlike the other nine --
+# has no forward collections at all today, so it has no dict entry above yet.
+for _table in (
+    PERSON.table, FAMILY.table, EVENT.table, PLACE.table, REPOSITORY.table,
+    SOURCE.table, CITATION.table, MEDIA.table, NOTE.table, TAG.table,
+):
+    _COLLECTIONS.setdefault(_table, {})["backlinks"] = Backlinks()
+del _table
+
 
 def _check_no_collection_relationship_name_collisions() -> None:
     for table, collections in _COLLECTIONS.items():
@@ -608,10 +667,15 @@ def _check_no_collection_relationship_name_collisions() -> None:
 _check_no_collection_relationship_name_collisions()
 
 
-def resolve_collection(spec: ObjectTypeSpec, name: str) -> Collection:
-    """Look up a `Collection` by name on `spec`'s table -- `exists(...)`'s
-    first argument, resolved the same way `resolve_column_path` resolves a
-    `_RELATIONSHIPS` name, just from the separate `_COLLECTIONS` namespace.
+def resolve_collection(spec: ObjectTypeSpec, name: str) -> Union[Collection, Backlinks]:
+    """Look up a `Collection` (or `Backlinks`) by name on `spec`'s table --
+    `exists(...)`'s first argument, resolved the same way
+    `resolve_column_path` resolves a `_RELATIONSHIPS` name, just from the
+    separate `_COLLECTIONS` namespace. Every caller needs its own
+    `isinstance(..., Backlinks)` branch before touching `Collection`-only
+    fields like `.target` -- see `Exists.compile`/`_render_collection_count`
+    in this module, and `query_lang.py`'s `_translate_exists_call`/
+    `_translate_count_call`/`_node_from_json`/`json_column_to_ref`.
     """
     collections = _COLLECTIONS.get(spec.table, {})
     if name not in collections:
@@ -1557,6 +1621,46 @@ def _collection_subquery_body(
     return body, params
 
 
+def _backlinks_subquery_body(
+    outer_table: str,
+    condition: Optional["BacklinkClassFilter"],
+    treeid: Optional[int],
+) -> Tuple[str, list]:
+    """`reference WHERE reference.ref_handle = <outer_table>.handle
+    [ AND reference.obj_class {=,!=,IN} (?[, ?...])][ AND reference.treeid
+    = ?]` -- the `EXISTS`/`COUNT` body for `Backlinks`, parallel to
+    `_collection_subquery_body` but against a real relational table
+    instead of a JSON array unnested out of the current row -- identical
+    on both backends (`reference`'s columns are plain SQL columns, not
+    JSON), so (unlike every `Collection`) this needs no per-dialect source
+    function and no `dialect` argument at all. No table alias either:
+    `reference` never collides with `outer_table` (always one of the ten
+    primary tables, never literally "reference" itself), so there's
+    nothing to disambiguate.
+    """
+    where_parts = [f"reference.ref_handle = {outer_table}.handle"]
+    params: list = []
+    if condition is not None:
+        if condition.op == "in":
+            placeholders = ", ".join("?" for _ in condition.value)
+            where_parts.append(f"reference.obj_class IN ({placeholders})")
+            params.extend(condition.value)
+        else:
+            sql_op = "=" if condition.op == "eq" else "!="
+            where_parts.append(f"reference.obj_class {sql_op} ?")
+            params.append(condition.value)
+    if treeid is not None:
+        # Only meaningful under the `SharedPostgreSQL` addon, whose
+        # `reference` table (unlike the single-tree `dbapi` backend's) is
+        # itself tenant-scoped by a `treeid` column -- confirmed against
+        # that addon's own `shareddbapi.py` (`CREATE TABLE reference`, and
+        # its own `find_backlink_handles` filtering `... AND treeid = ?`).
+        where_parts.append("reference.treeid = ?")
+        params.append(treeid)
+    body = f"reference WHERE {' AND '.join(where_parts)}"
+    return body, params
+
+
 def _render_collection_count(
     count: "CollectionCount",
     outer_table: str,
@@ -1567,6 +1671,9 @@ def _render_collection_count(
     dispatched from `_render_column` the same way `RelatedObject`/`JsonPath`
     dispatch to their own renderers.
     """
+    if isinstance(count.collection, Backlinks):
+        body, params = _backlinks_subquery_body(outer_table, count.condition, treeid)
+        return f"(SELECT COUNT(*) FROM {body})", params
     if dialect is None:
         raise QueryError(
             f"a dialect is required to compile count({count.collection.name!r}, ...), "
@@ -1582,6 +1689,10 @@ class Exists:
     """`EXISTS (SELECT 1 FROM <target> JOIN <list> ... WHERE ...)` -- a
     one-to-many membership test over a `Collection` (see there), optionally
     narrowed by a `condition` compiled against the collection's target type.
+    Also covers `Backlinks` (see there), whose `EXISTS` body is rendered by
+    `_backlinks_subquery_body` instead -- a real table join rather than a
+    JSON-array unnest, since a backlink lives in Gramps' own `reference`
+    table, not in this row's own `json_data`.
 
     Not a correlated *scalar* subquery like `RelatedObject` -- `handle_ref`
     there names a single related row; here there can be any number, so the
@@ -1600,7 +1711,7 @@ class Exists:
     three-valued-logic special case at all.
     """
 
-    def __init__(self, collection: Collection, condition: Optional[Any] = None):
+    def __init__(self, collection: Union[Collection, Backlinks], condition: Optional[Any] = None):
         self.collection = collection
         self.condition = condition
 
@@ -1610,6 +1721,9 @@ class Exists:
         dialect: Optional[Dialect] = None,
         treeid: Optional[int] = None,
     ) -> Tuple[str, list]:
+        if isinstance(self.collection, Backlinks):
+            body, params = _backlinks_subquery_body(spec.table, self.condition, treeid)
+            return f"EXISTS (SELECT 1 FROM {body})", params
         if dialect is None:
             raise QueryError(
                 f"a dialect is required to compile exists({self.collection.name!r}, ...), "

--- a/GOQLFilter/gramps_object_query_language_copy/query_lang.py
+++ b/GOQLFilter/gramps_object_query_language_copy/query_lang.py
@@ -150,6 +150,8 @@ from .query import (
     SOURCE,
     TAG,
     And,
+    BacklinkClassFilter,
+    Backlinks,
     CollectionCount,
     ColumnRef,
     Contains,
@@ -381,7 +383,9 @@ def _translate_count_call(node: ast.Call, spec: ObjectTypeSpec) -> dict:
 
     `relationship`/`condition` resolve exactly like `exists(...)`'s do --
     same `resolve_collection` lookup, same recursive `_translate_top_level`
-    against the collection's target type for the optional condition.
+    against the collection's target type for the optional condition (or,
+    for `Backlinks`, `_translate_backlinks_condition` -- see
+    `_translate_exists_call`'s own docstring).
     """
     if not 1 <= len(node.args) <= 2 or node.keywords:
         raise QueryLangError(
@@ -399,7 +403,10 @@ def _translate_count_call(node: ast.Call, spec: ObjectTypeSpec) -> dict:
         raise QueryLangError(str(error)) from error
     payload: dict = {"relationship": name_node.id}
     if len(node.args) == 2:
-        payload["where"] = _translate_top_level(node.args[1], collection.target)
+        if isinstance(collection, Backlinks):
+            payload["where"] = [_translate_backlinks_condition(node.args[1])]
+        else:
+            payload["where"] = _translate_top_level(node.args[1], collection.target)
     return {"count_of": payload}
 
 
@@ -627,6 +634,67 @@ def _translate_regex_call(node: ast.Call, spec: ObjectTypeSpec) -> dict:
     return {"column": column, "op": "regex", "value": pattern}
 
 
+def _translate_backlinks_condition(node: ast.AST) -> dict:
+    """`exists(backlinks, ...)`/`count(backlinks, ...)`'s only supported
+    condition shape: a single comparison against `_class`, the referrer's
+    own class name (`_class == "Person"`) -- not routed through
+    `_translate_compare`'s general and/or/field-path machinery at all,
+    since there's no `ObjectTypeSpec` to validate a richer path against (a
+    backlink's referrer can be any of the ten object types; see `query.py`'s
+    `Backlinks`/`BacklinkClassFilter` docstrings). Chaining (`a < b < c`),
+    field-vs-field, and substring/`in`-as-membership-on-a-path are all out
+    of scope here on purpose -- only `_class`, `==`/`!=`/`is`/`is not`/`in`
+    (folded straight to `"eq"`/`"ne"`/`"in"`, matching `_COMPARE_OPS` --
+    `not in` isn't supported, there's no `{"not": ...}` wrapper for this
+    leaf shape to unwrap, see `_backlink_condition_from_json`), and a
+    string (or string-list, for `in`) literal.
+    """
+    if not isinstance(node, ast.Compare) or len(node.ops) != 1 or len(node.comparators) != 1:
+        raise QueryLangError(
+            f"exists(backlinks, ...)'s condition must be a single comparison "
+            f"against _class, e.g. _class == \"Person\": {ast.dump(node)}"
+        )
+    op = _COMPARE_OPS.get(type(node.ops[0]))
+    if op not in ("eq", "ne", "in"):
+        raise QueryLangError(
+            f"_class only supports ==, !=, is, 'is not', in -- not "
+            f"{type(node.ops[0]).__name__!r}: {ast.dump(node)}"
+        )
+
+    def _is_class_name(candidate: ast.AST) -> bool:
+        return isinstance(candidate, ast.Name) and candidate.id == "_class"
+
+    left, rhs = node.left, node.comparators[0]
+    if op == "in":
+        if not _is_class_name(left):
+            raise QueryLangError(
+                f"'in' needs _class on the left, e.g. "
+                f"_class in [\"Person\", \"Family\"]: {ast.dump(node)}"
+            )
+        values = _translate_list(rhs)
+        if not values or not all(isinstance(v, str) for v in values):
+            raise QueryLangError(
+                f"_class in [...] needs a non-empty list of string literals: {ast.dump(node)}"
+            )
+        return {"column": "_class", "op": "in", "value": values}
+    if _is_class_name(left):
+        value_node = rhs
+    elif _is_class_name(rhs):
+        value_node = left
+        op = _FLIP_OP[op]  # eq/ne flip to themselves -- kept for consistency with every other comparison
+    else:
+        raise QueryLangError(
+            f"exists(backlinks, ...)'s condition must compare _class, the "
+            f"referring object's own type: {ast.dump(node)}"
+        )
+    value = _translate_value(value_node)
+    if not isinstance(value, str):
+        raise QueryLangError(
+            f"_class must be compared against a string literal: {ast.dump(node)}"
+        )
+    return {"column": "_class", "op": op, "value": value}
+
+
 def _translate_exists_call(node: ast.Call, spec: ObjectTypeSpec) -> dict:
     """Translate `exists(relationship[, condition])` into
     `{"exists": {"relationship": ..., "where": [...]}}` -- `where` omitted
@@ -638,7 +706,11 @@ def _translate_exists_call(node: ast.Call, spec: ObjectTypeSpec) -> dict:
     name's target drives `resolve_column_path` -- `condition`, if given, is
     itself a full `where_expr` boolean expression, just parsed against that
     target type instead of `spec`, via the same `_translate_top_level` this
-    module already uses for the top-level expression.
+    module already uses for the top-level expression. `Backlinks` (see
+    `resolve_collection`'s own docstring) has no such target type, so its
+    `condition` goes through `_translate_backlinks_condition` instead,
+    wrapped in a single-element list to match `_translate_top_level`'s own
+    `List[dict]` shape.
     """
     if not 1 <= len(node.args) <= 2 or node.keywords:
         raise QueryLangError(
@@ -656,7 +728,10 @@ def _translate_exists_call(node: ast.Call, spec: ObjectTypeSpec) -> dict:
         raise QueryLangError(str(error)) from error
     payload: dict = {"relationship": name_node.id}
     if len(node.args) == 2:
-        payload["where"] = _translate_top_level(node.args[1], collection.target)
+        if isinstance(collection, Backlinks):
+            payload["where"] = [_translate_backlinks_condition(node.args[1])]
+        else:
+            payload["where"] = _translate_top_level(node.args[1], collection.target)
     return {"exists": payload}
 
 
@@ -1026,7 +1101,9 @@ def json_column_to_ref(column: Union[str, dict], spec: ObjectTypeSpec) -> Column
     `{"count_of": {"relationship": ..., "where": [...]}}` resolves to a
     `CollectionCount` the same way `_node_from_json`'s `"exists"` case
     resolves to an `Exists` -- same `resolve_collection` lookup, same
-    recursive `where_list_to_ast` for the optional condition.
+    recursive `where_list_to_ast` for the optional condition (or, when
+    `relationship` resolves to `Backlinks`, `_backlink_condition_from_json`
+    instead -- see `_node_from_json`'s own docstring for why).
 
     A plain string goes through `resolve_ref_string`, so a *dotted* one
     (`"birth.date.sortval"`) means the same thing here as the identical
@@ -1039,11 +1116,12 @@ def json_column_to_ref(column: Union[str, dict], spec: ObjectTypeSpec) -> Column
     if "count_of" in column:
         payload = column["count_of"]
         collection = resolve_collection(spec, payload["relationship"])
-        condition = (
-            where_list_to_ast(payload["where"], collection.target)
-            if "where" in payload
-            else None
-        )
+        if "where" not in payload:
+            condition = None
+        elif isinstance(collection, Backlinks):
+            condition = _backlink_condition_from_json(payload["where"])
+        else:
+            condition = where_list_to_ast(payload["where"], collection.target)
         return CollectionCount(collection, condition)
     return resolve_column_path(spec, column["json_path"])
 
@@ -1083,6 +1161,33 @@ def _condition_from_json(condition: dict, spec: ObjectTypeSpec) -> Any:
     return _OP_CLASSES[op](column, value)
 
 
+def _backlink_condition_from_json(where: List[dict]) -> BacklinkClassFilter:
+    """The `Backlinks`-specific counterpart to `where_list_to_ast` -- a
+    backlinks condition is always exactly the one leaf
+    `_translate_backlinks_condition` (or a raw `where` JSON body written by
+    hand in that same shape) produces: `{"column": "_class", "op":
+    "eq"/"ne"/"in", "value": ...}`. No `and`/`or`/`not`/nested `exists` --
+    see `BacklinkClassFilter`'s own docstring in query.py for why a
+    backlink's condition can't reach any richer than its own class name.
+    Raises `QueryError` (not `QueryLangError` -- matching `where_list_to_ast`'s
+    own convention: there's no parsing here, only already-translated/
+    already-parsed JSON).
+    """
+    if len(where) != 1:
+        raise QueryError(
+            f"a backlinks condition must be exactly one comparison against "
+            f"_class, got {len(where)}"
+        )
+    leaf = where[0]
+    op = leaf.get("op")
+    if leaf.get("column") != "_class" or op not in ("eq", "ne", "in"):
+        raise QueryError(
+            f"a backlinks condition must be a single _class ==/!=/in "
+            f"comparison, got {leaf!r}"
+        )
+    return BacklinkClassFilter(op=op, value=leaf["value"])
+
+
 def where_list_to_ast(conditions: List[dict], spec: ObjectTypeSpec) -> Any:
     """A `parse_expr`-shaped list of top-level conditions (implicitly AND'd),
     translated to a single `query.py` boolean expression -- shared by
@@ -1114,6 +1219,12 @@ def _node_from_json(node: dict, spec: ObjectTypeSpec) -> Any:
     [...]}`/`{"not": node}`/`{"exists": {...}}` combinator -- translated to a
     `query.py` boolean expression (`Eq`/`Lt`/`In`/... for a leaf, `And`/`Or`/
     `Not`/`Exists` for a combinator), recursing into each child the same way.
+    `"exists"`'s `relationship` resolving to `Backlinks` (rather than an
+    ordinary `Collection`) routes its optional `where` through
+    `_backlink_condition_from_json` instead of `where_list_to_ast` -- a
+    `Backlinks` condition is never a general boolean tree (see
+    `BacklinkClassFilter`'s docstring in query.py), so it needs no
+    `collection.target` to resolve against (it has none).
     """
     if "and" in node:
         return And(*(_node_from_json(child, spec) for child in node["and"]))
@@ -1124,11 +1235,12 @@ def _node_from_json(node: dict, spec: ObjectTypeSpec) -> Any:
     if "exists" in node:
         payload = node["exists"]
         collection = resolve_collection(spec, payload["relationship"])
-        condition = (
-            where_list_to_ast(payload["where"], collection.target)
-            if "where" in payload
-            else None
-        )
+        if "where" not in payload:
+            condition = None
+        elif isinstance(collection, Backlinks):
+            condition = _backlink_condition_from_json(payload["where"])
+        else:
+            condition = where_list_to_ast(payload["where"], collection.target)
         return Exists(collection, condition)
     return _condition_from_json(node, spec)
 


### PR DESCRIPTION
## Summary
- Refreshes the gramps60 branch's vendored copy of `gramps-object-query-language` (in `GOQLFilter/gramps_object_query_language_copy/`) from 0.4.1 (`b717eab5`) to 0.5.0 (`ffdcde3a`)
- Picks up backlinks support: `exists(backlinks, ...)` and `count(backlinks, ...)` let a `where_expr` query the referrer side of Gramps' own `reference` table (who points at this object), filtered by the referrer's class via `_class ==`/`!=`/`in`, without needing a forward relationship defined on the referencing type
- `query.py`, `query_lang.py`, and `evaluator.py` are copied verbatim from upstream per the vendoring notice in `__init__.py`; only the pinned version/commit in that notice was hand-edited

## Test plan
- [x] `python3 -m unittest GOQLFilter.tests.test_integration_whereexprrule -v` — 13 tests, all pass
- [x] Full `GOQLFilter/tests` suite run via `unittest discover` — one unrelated pre-existing failure (`test_goql.py` import errors on a GTK 3.0/4.0 namespace conflict when all test modules load in one process), not caused by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCcftyvqz1gSDMKQFHQVAW