### PR TITLE
SharedPostgreSQL: ANALYZE tables touched by a batch commit

### DIFF
--- a/SharedPostgreSQL/shareddbapi.py
+++ b/SharedPostgreSQL/shareddbapi.py
@@ -387,6 +387,8 @@ class SharedDBAPI(DbGeneric):
             # FIXME: need a User GUI update callback here:
             self.reindex_reference_map(lambda percent: percent)
         self.dbapi.commit()
+        if txn.batch:
+            self._analyze_tables(self._get_txn_tables(txn))
         if not txn.batch:
             # Now, emit signals:
             # do deletes and adds first
@@ -412,6 +414,39 @@ class SharedDBAPI(DbGeneric):
         self._after_commit(txn)
         txn.clear()
         self.has_changed += 1  # Also gives commits since startup
+
+    def _get_txn_tables(self, txn):
+        """
+        Return the names of the tables that a transaction added rows to,
+        updated, or deleted from.
+        """
+        tables = set()
+        for obj_type, _trans_type in txn:
+            if obj_type == REFERENCE_KEY:
+                tables.add("reference")
+            elif obj_type in KEY_TO_NAME_MAP:
+                tables.add(KEY_TO_NAME_MAP[obj_type])
+        return tables
+
+    def _analyze_tables(self, tables):
+        """
+        Refresh the query planner's statistics for the given tables.
+
+        On a shared database, every tree's rows live together in the same
+        tables, so autovacuum's analyze threshold -- a fixed count plus a
+        fraction of the *whole* table's row count -- is sized against all
+        trees combined. A batch transaction (import, or a bulk tool such as
+        "Check and Repair") can add or rewrite a large number of rows for
+        one tree without moving that shared threshold, so autovacuum can go
+        on indefinitely without ever analyzing the rows just written. Until
+        it does, the planner keeps using statistics that predate them and
+        can pick badly wrong plans (e.g. a secondary index instead of the
+        primary key) for the tree that was just imported. Explicitly
+        analyzing the touched tables after a batch commit avoids that wait.
+        """
+        for table in tables:
+            _LOG.debug("    DBAPI %s analyzing table '%s'", hex(id(self)), table)
+            self.dbapi.execute(f"ANALYZE {table}")
 
     def transaction_abort(self, txn):
         """

--- a/SharedPostgreSQL/tests/test_transaction_analyze.py
+++ b/SharedPostgreSQL/tests/test_transaction_analyze.py
@@ -1,0 +1,218 @@
+#
+# Gramps - a GTK+/GNOME based genealogy program
+#
+# Copyright (C) 2026 Douglas S. Blank <doug.blank@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+"""
+Unit tests for the post-batch-commit ANALYZE fix.
+
+On a shared database every tree's rows live in the same tables, so
+autovacuum's analyze threshold is sized against *all* trees' rows combined.
+A batch transaction (an import, or a bulk tool such as "Check and Repair")
+can write a large number of rows for one tree without ever crossing that
+threshold, leaving the planner working from stale statistics for the data
+just written -- see the discussion this fixes for the failure mode.
+
+These tests cover:
+  - _get_txn_tables() mapping a transaction's touched object types to table
+    names, including the REFERENCE_KEY special case
+  - _analyze_tables() issuing one ANALYZE per table
+  - transaction_commit() calling _analyze_tables() for a batch transaction
+  - transaction_commit() NOT calling it for a normal (non-batch) transaction
+
+psycopg2 is stubbed so no real database is required.
+
+Run with::
+
+    python3 -m unittest SharedPostgreSQL.tests.test_transaction_analyze -v
+"""
+
+# -------------------------------------------------------------------------
+#
+# Standard python modules
+#
+# -------------------------------------------------------------------------
+import os
+import sys
+import unittest
+from collections import defaultdict
+from unittest import mock
+
+# -------------------------------------------------------------------------
+#
+# Stub psycopg2 before the addon is imported so no real DB driver is needed
+#
+# -------------------------------------------------------------------------
+ADDON_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if ADDON_DIR not in sys.path:
+    sys.path.insert(0, ADDON_DIR)
+
+_mock_psycopg2 = mock.MagicMock()
+_mock_psycopg2.paramstyle = "format"
+_mock_psycopg2.OperationalError = Exception
+sys.modules.setdefault("psycopg2", _mock_psycopg2)
+
+# -------------------------------------------------------------------------
+#
+# Gramps modules (required by the addon's import chain)
+#
+# -------------------------------------------------------------------------
+try:
+    import gramps
+except ImportError as _err:
+    raise unittest.SkipTest("gramps package not available: %s" % _err)
+
+if "GRAMPS_RESOURCES" not in os.environ:
+    os.environ["GRAMPS_RESOURCES"] = os.path.dirname(os.path.dirname(gramps.__file__))
+
+try:
+    from SharedPostgreSQL.sharedpostgresql import SharedPostgreSQL
+except Exception as _err:
+    raise unittest.SkipTest("SharedPostgreSQL module unavailable: %s" % _err)
+
+from gramps.gen.db.dbconst import (
+    CITATION_KEY,
+    FAMILY_KEY,
+    PERSON_KEY,
+    REFERENCE_KEY,
+    TXNADD,
+    TXNDEL,
+    TXNUPD,
+)
+
+# The addon imports shareddbapi by bare name, the way Gramps loads addons, so
+# reach the base class through the MRO rather than importing it a second time.
+SharedDBAPI = SharedPostgreSQL.__bases__[0]
+
+
+# -------------------------------------------------------------------------
+#
+# Helpers
+#
+# -------------------------------------------------------------------------
+
+
+class _FakeTxn(defaultdict):
+    """
+    Minimal stand-in for a gramps.gen.db.txn.DbTxn: a defaultdict(list) keyed
+    by (obj_type, trans_type) -> [(handle, data), ...] -- missing keys read as
+    [], same as the real class -- plus the attributes transaction_commit()
+    reads.
+    """
+
+    def __init__(self, batch, initial=None):
+        super().__init__(list)
+        if initial:
+            self.update(initial)
+        self.batch = batch
+
+    def get_description(self):
+        return "Test transaction"
+
+
+def _make_dbapi_instance():
+    """A SharedDBAPI instance with every collaborator of transaction_commit
+    mocked out, so only the code under test runs."""
+    db = SharedDBAPI.__new__(SharedDBAPI)
+    db.dbapi = mock.MagicMock()
+    db.undodb = mock.MagicMock()
+    db.reindex_reference_map = mock.MagicMock()
+    db.emit = mock.MagicMock()
+    db._after_commit = mock.MagicMock()
+    db.transaction = mock.MagicMock()
+    db.has_changed = 0
+    return db
+
+
+# -------------------------------------------------------------------------
+#
+# TestGetTxnTables
+#
+# -------------------------------------------------------------------------
+class TestGetTxnTables(unittest.TestCase):
+    def test_maps_object_types_to_table_names(self):
+        db = _make_dbapi_instance()
+        txn = _FakeTxn(
+            True,
+            {
+                (PERSON_KEY, TXNADD): [("h1", None)],
+                (FAMILY_KEY, TXNUPD): [("h2", None)],
+            },
+        )
+        self.assertEqual(db._get_txn_tables(txn), {"person", "family"})
+
+    def test_reference_key_maps_to_reference_table(self):
+        db = _make_dbapi_instance()
+        txn = _FakeTxn(True, {(REFERENCE_KEY, TXNADD): [("h1", None)]})
+        self.assertEqual(db._get_txn_tables(txn), {"reference"})
+
+    def test_multiple_trans_types_same_table_deduplicated(self):
+        db = _make_dbapi_instance()
+        txn = _FakeTxn(
+            True,
+            {
+                (CITATION_KEY, TXNADD): [("h1", None)],
+                (CITATION_KEY, TXNDEL): [("h2", None)],
+            },
+        )
+        self.assertEqual(db._get_txn_tables(txn), {"citation"})
+
+    def test_empty_transaction_yields_no_tables(self):
+        db = _make_dbapi_instance()
+        self.assertEqual(db._get_txn_tables(_FakeTxn(True)), set())
+
+
+# -------------------------------------------------------------------------
+#
+# TestAnalyzeTables
+#
+# -------------------------------------------------------------------------
+class TestAnalyzeTables(unittest.TestCase):
+    def test_issues_one_analyze_per_table(self):
+        db = _make_dbapi_instance()
+        db._analyze_tables({"person", "family"})
+        executed = {call.args[0] for call in db.dbapi.execute.call_args_list}
+        self.assertEqual(executed, {"ANALYZE person", "ANALYZE family"})
+
+    def test_no_tables_no_calls(self):
+        db = _make_dbapi_instance()
+        db._analyze_tables(set())
+        db.dbapi.execute.assert_not_called()
+
+
+# -------------------------------------------------------------------------
+#
+# TestTransactionCommitAnalyzesOnlyForBatch
+#
+# -------------------------------------------------------------------------
+class TestTransactionCommitAnalyzesOnlyForBatch(unittest.TestCase):
+    def test_batch_commit_analyzes_touched_tables(self):
+        db = _make_dbapi_instance()
+        txn = _FakeTxn(True, {(PERSON_KEY, TXNADD): [("h1", None)]})
+        db.transaction_commit(txn)
+        db.dbapi.execute.assert_called_once_with("ANALYZE person")
+
+    def test_non_batch_commit_does_not_analyze(self):
+        db = _make_dbapi_instance()
+        txn = _FakeTxn(False, {(PERSON_KEY, TXNADD): [("h1", None)]})
+        db.transaction_commit(txn)
+        db.dbapi.execute.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Fixes stale query-planner statistics after importing a new tree into a `SharedPostgreSQL` install that already has other trees' data (https://github.com/gramps-project/gramps-web-api/discussions/969).
- `SharedDBAPI.transaction_commit()` now runs `ANALYZE` on the tables touched by a *batch* transaction right after it commits. `batch=True` is what Gramps' importers (GEDCOM, CSV, vCard, XML, Pro-Gen) and bulk tools (Check and Repair, Reorder IDs, etc.) already use, so this only fires for the operations that can create the row-count skew described below — ordinary single-record edits are untouched.

## Why

`SharedPostgreSQL` pools every tree's rows into shared tables (`person`, `event`, `citation`, ...) distinguished by a `treeid` column, with every index led by `(treeid, ...)`. PostgreSQL's autovacuum only re-`ANALYZE`s a table once its changed-row count crosses `autovacuum_analyze_threshold + autovacuum_analyze_scale_factor × (rows already in the table)` — 50 + 10% by default, sized against the *whole* table. On a fresh, single-tree database, an import is most of the table, so this threshold trips almost immediately. On a `SharedPostgreSQL` install that already has meaningful data across multiple trees, a new tree's import can easily be a small fraction of the pooled table — well under 10% — so autoanalyze may never fire for it. The planner then keeps using statistics that predate the new tree's rows indefinitely, and can pick a badly wrong plan (e.g. a secondary index instead of the primary key) for that tree specifically.

## Verification

Reproduced against a real PostgreSQL 16 instance: seeded a `person` table shaped like `SharedPostgreSQL`'s actual schema (`PRIMARY KEY (treeid, handle)`, secondary indexes led by `treeid`) with 200,000 rows for "tree 1", then inserted 500 rows for a new "tree 2" without running `ANALYZE`. A plain `treeid + handle` lookup used the `person_surname` secondary index (502 buffer touches, 499 rows discarded by a filter) instead of the primary key (4 buffer touches) — reproducing the reported symptom. The defaults confirm it structurally: `autovacuum_analyze_threshold=50` + `autovacuum_analyze_scale_factor=0.1` means autovacuum needs ~20,050 modified rows on that table before it re-analyzes — a 500-row single-tree import never gets close.

Then called the real (unmocked) `transaction_commit()` for a batch transaction against the same database: with no manual `ANALYZE`, the plan flipped from the bad one above to the primary key.

## Test plan

- [x] New unit tests in `SharedPostgreSQL/tests/test_transaction_analyze.py` covering `_get_txn_tables()`, `_analyze_tables()`, and that `transaction_commit()` only analyzes for batch transactions (8 tests)
- [x] Existing `SharedPostgreSQL/tests/` suite still passes (58/58 total)
- [x] End-to-end manual verification against a real PostgreSQL 16 instance (described above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JqixScuMyvWXBcARLnY3Wv